### PR TITLE
Unrolled parent access

### DIFF
--- a/src/ComputeSharp.Shaders/Translation/Models/ReadableMember.GetValue.cs
+++ b/src/ComputeSharp.Shaders/Translation/Models/ReadableMember.GetValue.cs
@@ -51,6 +51,11 @@ namespace ComputeSharp.Shaders.Translation.Models
         private delegate object Getter(object? obj);
 
         /// <summary>
+        /// Gets or sets the list of parent members to access the current one from the root instance
+        /// </summary>
+        public IEnumerable<ReadableMember>? Parents { get; set; }
+
+        /// <summary>
         /// Builds a dynamic IL method to retrieve the value of the current member
         /// </summary>
         [Pure]


### PR DESCRIPTION
Added IL generation for nested captured variables, with automatic loop unrolling to access the nested closure types. Completely removed reflections when accessing any captured member.