### PR TITLE
Fix constant buffer type

### DIFF
--- a/src/ComputeSharp.Graphics/Buffers/ConstantBuffer{T}.cs
+++ b/src/ComputeSharp.Graphics/Buffers/ConstantBuffer{T}.cs
@@ -34,7 +34,7 @@ namespace ComputeSharp
         {
             int size = Unsafe.SizeOf<T>();
 
-            // Equivalent to rounding up to nearest 256. We add 255 then t
+            // Equivalent to rounding up to nearest 256. We add 255 then trim off the bits which are less significant than 256
             return (size + 255) & ~255;
         }
 

--- a/src/ComputeSharp.Graphics/Buffers/ConstantBuffer{T}.cs
+++ b/src/ComputeSharp.Graphics/Buffers/ConstantBuffer{T}.cs
@@ -24,7 +24,7 @@ namespace ComputeSharp
         /// </summary>
         /// <param name="device">The <see cref="GraphicsDevice"/> associated with the current instance</param>
         /// <param name="size">The number of items to store in the current buffer</param>
-        internal ConstantBuffer(GraphicsDevice device, int size) : base(device, size, size * GetPaddedSize() * /* what is the meaning of this magic num? */ 16, BufferType.Constant) { }
+        internal ConstantBuffer(GraphicsDevice device, int size) : base(device, size, size * GetPaddedSize(), BufferType.Constant) { }
 
         /// <summary>
         /// Gets the right padded size for <typeparamref name="T"/> elements to store in the current instance
@@ -53,10 +53,11 @@ namespace ComputeSharp
                 Map();
 
                 ref var dest = ref MemoryMarshal.GetReference(span);
+                byte* untypedSrc = (byte*)MappedResource;
                 for (var i = offset; i < count; i++)
                 {
                     // why is this exposed as an IntPtr? It should really be void*/T*/byte*
-                    Unsafe.Add(ref dest, i) = ((T*) MappedResource)[i * GetPaddedSize()];
+                    Unsafe.Add(ref dest, i) = *(T*)&untypedSrc[i * GetPaddedSize()];
                 }
 
                 Unmap();
@@ -78,10 +79,11 @@ namespace ComputeSharp
                 Map();
 
                 ref var src = ref MemoryMarshal.GetReference(span);
+                byte* untypedDest = (byte*)MappedResource;
                 for (var i = offset; i < count; i++)
                 {
                     // why is this exposed as an IntPtr? It should really be void*/T*/byte*
-                    ((T*)MappedResource)[i * GetPaddedSize()] = Unsafe.Add(ref src, i);
+                    *(T*)&untypedDest[i * GetPaddedSize()] = Unsafe.Add(ref src, i);
                 }
 
                 Unmap();


### PR DESCRIPTION
* Fix incorrect 16 byte alignment (256 is required)
* Instead of copying to a padded intermediary buffer when setting/getting data, do it directly. Means less than 50% of the memory copying is done

Tho, a couple of questions raised by it :smile:
* What is the meaning of the magic `* 16` in the ctor?
* Why is `MappedResource` exposed as an `IntPtr`?
* Why are (Span<T>, offset, count) API's exposed? :smile:  they are against the API recommendations, as Span was designed to replace the boilerplate of offset/count by the consumer using .Slice instead