### PR TITLE
Fix HlslKnownSize referencing "int" twice

### DIFF
--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownSizes.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownSizes.cs
@@ -27,7 +27,7 @@ namespace ComputeSharp.SourceGenerators.Mappings
             {
                 [typeof(bool).FullName] = (4, 4),
                 [typeof(int).FullName] = (4, 4),
-                [typeof(int).FullName] = (4, 4),
+                [typeof(uint).FullName] = (4, 4),
                 [typeof(float).FullName] = (4, 4),
                 [typeof(double).FullName] = (8, 8),
 


### PR DESCRIPTION
On [this line](https://github.com/Sergio0694/ComputeSharp/blob/bd6d4928b3fdd4f6262508eff7093b591d7f94b6/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownSizes.cs#L30) you define the known HLSL type sizes. However, instead of `int` and `uint`, there's `int` twice.

FYI the HlslKnownTypes is correct. This breaks every Shader that is using `uint`.