### PR TITLE
HIGH_PERFORMANCE priority GPU adapters enumeration

### DIFF
--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
@@ -57,17 +57,17 @@ namespace ComputeSharp.Graphics.Helpers
                 private readonly Predicate<GraphicsDeviceInfo>? predicate;
 
                 /// <summary>
-                /// The <see cref="IDXGIFactory4"/> instance used to enumerate devices.
+                /// The <see cref="IDXGIFactory6"/> instance used to enumerate devices.
                 /// </summary>
-                private ComPtr<IDXGIFactory4> dxgiFactory4;
+                private ComPtr<IDXGIFactory6> dxgiFactory6;
 
                 /// <summary>
-                /// Indicates whether or not the enumerator has already been initialized and <see cref="dxgiFactory4"/> is set.
+                /// Indicates whether or not the enumerator has already been initialized and <see cref="dxgiFactory6"/> is set.
                 /// </summary>
                 private bool isInitialized;
 
                 /// <summary>
-                /// The current adapter index to enumerate adapters from <see cref="dxgiFactory4"/>.
+                /// The current adapter index to enumerate adapters from <see cref="dxgiFactory6"/>.
                 /// </summary>
                 private uint index;
 
@@ -103,11 +103,9 @@ namespace ComputeSharp.Graphics.Helpers
                     {
                         this.isInitialized = true;
 
-                        fixed (IDXGIFactory4** dxgiFactory4 = this.dxgiFactory4)
+                        fixed (IDXGIFactory6** dxgiFactory6 = this.dxgiFactory6)
                         {
-                            EnableDebugMode();
-
-                            FX.CreateDXGIFactory2(IDXGIFactoryCreationFlags, FX.__uuidof<IDXGIFactory4>(), (void**)dxgiFactory4).Assert();
+                            CreateDXGIFactory6(dxgiFactory6);
                         }
                     }
 
@@ -117,11 +115,11 @@ namespace ComputeSharp.Graphics.Helpers
                     {
                         using ComPtr<IDXGIAdapter1> dxgiAdapter1 = default;
 
-                        HRESULT enumAdapters1Result = this.dxgiFactory4.Get()->EnumAdapters1(this.index, dxgiAdapter1.GetAddressOf());
+                        HRESULT enumAdapters1Result = this.dxgiFactory6.Get()->EnumAdapters1(this.index, dxgiAdapter1.GetAddressOf());
 
                         if (enumAdapters1Result == FX.DXGI_ERROR_NOT_FOUND)
                         {
-                            this.dxgiFactory4.Get()->EnumWarpAdapter(FX.__uuidof<IDXGIAdapter1>(), dxgiAdapter1.GetVoidAddressOf()).Assert();
+                            this.dxgiFactory6.Get()->EnumWarpAdapter(FX.__uuidof<IDXGIAdapter1>(), dxgiAdapter1.GetVoidAddressOf()).Assert();
 
                             DXGI_ADAPTER_DESC1 dxgiDescription1;
 
@@ -205,7 +203,7 @@ namespace ComputeSharp.Graphics.Helpers
                 /// <inheritdoc/>
                 protected override void OnDispose()
                 {
-                    this.dxgiFactory4.Dispose();
+                    this.dxgiFactory6.Dispose();
                 }
             }
         }

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
@@ -9,6 +9,7 @@ using FX = TerraFX.Interop.Windows;
 using HRESULT = System.Int32;
 using static TerraFX.Interop.D3D_FEATURE_LEVEL;
 using static TerraFX.Interop.D3D_SHADER_MODEL;
+using static TerraFX.Interop.DXGI_GPU_PREFERENCE;
 
 namespace ComputeSharp.Graphics.Helpers
 {
@@ -115,7 +116,11 @@ namespace ComputeSharp.Graphics.Helpers
                     {
                         using ComPtr<IDXGIAdapter1> dxgiAdapter1 = default;
 
-                        HRESULT enumAdapters1Result = this.dxgiFactory6.Get()->EnumAdapters1(this.index, dxgiAdapter1.GetAddressOf());
+                        HRESULT enumAdapters1Result = this.dxgiFactory6.Get()->EnumAdapterByGpuPreference(
+                            this.index,
+                            DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
+                            FX.__uuidof<IDXGIAdapter1>(),
+                            dxgiAdapter1.GetVoidAddressOf());
 
                         if (enumAdapters1Result == FX.DXGI_ERROR_NOT_FOUND)
                         {

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using ComputeSharp.Core.Extensions;
+using TerraFX.Interop;
+using FX = TerraFX.Interop.Windows;
+
+namespace ComputeSharp.Graphics.Helpers
+{
+    /// <inheritdoc cref="DeviceHelper"/>
+    internal static partial class DeviceHelper
+    {
+        /// <summary>
+        /// The creation flags for <see cref="IDXGIFactory"/> instances.
+        /// </summary>
+        private const uint IDXGIFactoryCreationFlags =
+#if DEBUG
+            FX.DXGI_CREATE_FACTORY_DEBUG;
+#else
+            0;
+#endif
+
+        /// <summary>
+        /// Creates a new <see cref="IDXGIFactory6"/> instance to be used to enumerate devices.
+        /// </summary>
+        /// <param name="dxgiFactory6">The resulting <see cref="IDXGIFactory6"/> instance.</param>
+        private static unsafe void CreateDXGIFactory6(IDXGIFactory6** dxgiFactory6)
+        {
+            using ComPtr<IDXGIFactory4> dxgiFactory4 = default;
+
+            EnableDebugMode();
+
+            FX.CreateDXGIFactory2(IDXGIFactoryCreationFlags, FX.__uuidof<IDXGIFactory4>(), dxgiFactory4.GetVoidAddressOf()).Assert();
+
+            int result = dxgiFactory4.CopyTo(dxgiFactory6);
+
+            if (result == FX.S_OK)
+            {
+                return;
+            }
+
+            if (result == FX.E_NOINTERFACE)
+            {
+                IDXGIFactory4As6Backcompat.Create(dxgiFactory4.Get(), dxgiFactory6);
+
+                return;
+            }
+
+            result.Assert();
+
+            return;
+        }
+
+        /// <summary>
+        /// Enables the debug layer for DirectX APIs.
+        /// </summary>
+        [Conditional("DEBUG")]
+        private static unsafe void EnableDebugMode()
+        {
+            using ComPtr<ID3D12Debug> d3D12Debug = default;
+            using ComPtr<ID3D12Debug1> d3D12Debug1 = default;
+
+            FX.D3D12GetDebugInterface(FX.__uuidof<ID3D12Debug>(), d3D12Debug.GetVoidAddressOf()).Assert();
+
+            d3D12Debug.Get()->EnableDebugLayer();
+
+            if (FX.SUCCEEDED(d3D12Debug.CopyTo(d3D12Debug1.GetAddressOf())))
+            {
+                d3D12Debug1.Get()->SetEnableGPUBasedValidation(FX.TRUE);
+                d3D12Debug1.Get()->SetEnableSynchronizedCommandQueueValidation(FX.TRUE);
+            }
+        }
+
+        /// <summary>
+        /// A custom <see cref="IDXGIFactory6"/> fallback implementation to use on systems with no support for it.
+        /// </summary>
+        private unsafe struct IDXGIFactory4As6Backcompat
+        {
+            /// <summary>
+            /// The shared method table pointer for all <see cref="IDXGIFactory4As6Backcompat"/> instances.
+            /// </summary>
+            private static readonly void** Vtbl = InitVtbl();
+
+            /// <summary>
+            /// Builds the custom method table pointer for <see cref="IDXGIFactory4As6Backcompat"/>.
+            /// </summary>
+            /// <returns>The method table pointer for <see cref="IDXGIFactory4As6Backcompat"/>.</returns>
+            private static void** InitVtbl()
+            {
+                void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IDXGIFactory4As6Backcompat), sizeof(void*) * 30);
+
+                new Span<IntPtr>(lpVtbl, 30).Clear();
+
+                lpVtbl[2] = (delegate* unmanaged<IDXGIFactory4As6Backcompat*, uint>)&Release;
+                lpVtbl[27] = (delegate* unmanaged<IDXGIFactory4As6Backcompat*, Guid*, void**, int>)&EnumWarpAdapter;
+                lpVtbl[29] = (delegate* unmanaged<IDXGIFactory4As6Backcompat*, uint, DXGI_GPU_PREFERENCE, Guid*, void**, int>)&EnumAdapterByGpuPreference;
+
+                return lpVtbl;
+            }
+
+            /// <summary>
+            /// The method table pointer for the current instance.
+            /// </summary>
+            private void** lpVtbl;
+
+            /// <summary>
+            /// The wrapped <see cref="IDXGIFactory4"/> instance.
+            /// </summary>
+            private IDXGIFactory4* dxgiFactory4;
+
+            /// <summary>
+            /// Creates and initializes a new <see cref="IDXGIFactory4As6Backcompat"/> instance.
+            /// </summary>
+            /// <param name="dxgiFactory4">The <see cref="IDXGIFactory4"/> instance to wrap.</param>
+            /// <param name="dxgiFactory6">The resulting <see cref="IDXGIFactory6"/> instance.</param>
+            public static void Create(IDXGIFactory4* dxgiFactory4, IDXGIFactory6** dxgiFactory6)
+            {
+                IDXGIFactory4As6Backcompat* @this = (IDXGIFactory4As6Backcompat*)Marshal.AllocHGlobal(sizeof(IDXGIFactory4As6Backcompat));
+
+                @this->lpVtbl = Vtbl;
+                @this->dxgiFactory4 = dxgiFactory4;
+
+                *dxgiFactory6 = (IDXGIFactory6*)@this;
+            }
+
+            /// <inheritdoc cref="IUnknown.Release"/>
+            [UnmanagedCallersOnly]
+            public static uint Release(IDXGIFactory4As6Backcompat* @this)
+            {
+                @this->dxgiFactory4->Release();
+
+                Marshal.FreeHGlobal((IntPtr)@this);
+
+                return 0;
+            }
+
+            /// <inheritdoc cref="IDXGIFactory6.EnumWarpAdapter(Guid*, void**)"/>
+            [UnmanagedCallersOnly]
+            public static int EnumWarpAdapter(IDXGIFactory4As6Backcompat* @this, Guid* riid, void** ppvAdapter)
+            {
+                return @this->dxgiFactory4->EnumWarpAdapter(riid, ppvAdapter);
+            }
+
+            /// <inheritdoc cref="IDXGIFactory6.EnumAdapterByGpuPreference(uint, DXGI_GPU_PREFERENCE, Guid*, void**)"/>
+            [UnmanagedCallersOnly]
+            public static int EnumAdapterByGpuPreference(IDXGIFactory4As6Backcompat* @this, uint Adapter, DXGI_GPU_PREFERENCE GpuPreference, Guid* riid, void** ppvAdapter)
+            {
+                return @this->dxgiFactory4->EnumAdapters1(Adapter, (IDXGIAdapter1**)ppvAdapter);
+            }
+        }
+    }
+}

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
@@ -82,11 +82,9 @@ namespace ComputeSharp.Graphics.Helpers
         /// <returns>Whether a default device was found with the requested feature level.</returns>
         private static unsafe bool TryGetDefaultDevice(ID3D12Device** d3D12Device, IDXGIAdapter** dxgiAdapter, DXGI_ADAPTER_DESC1* dxgiDescription1)
         {
-            using ComPtr<IDXGIFactory4> dxgiFactory4 = default;
+            using ComPtr<IDXGIFactory6> dxgiFactory6 = default;
 
-            EnableDebugMode();
-
-            FX.CreateDXGIFactory2(IDXGIFactoryCreationFlags, FX.__uuidof<IDXGIFactory4>(), dxgiFactory4.GetVoidAddressOf()).Assert();
+            CreateDXGIFactory6(dxgiFactory6.GetAddressOf());
 
             uint i = 0;
 
@@ -94,7 +92,7 @@ namespace ComputeSharp.Graphics.Helpers
             {
                 using ComPtr<IDXGIAdapter1> dxgiAdapter1 = default;
 
-                HRESULT enumAdapters1Result = dxgiFactory4.Get()->EnumAdapters1(i++, dxgiAdapter1.GetAddressOf());
+                HRESULT enumAdapters1Result = dxgiFactory6.Get()->EnumAdapters1(i++, dxgiAdapter1.GetAddressOf());
 
                 if (enumAdapters1Result == FX.DXGI_ERROR_NOT_FOUND)
                 {
@@ -172,15 +170,13 @@ namespace ComputeSharp.Graphics.Helpers
         /// <returns>Whether a warp device was created successfully.</returns>
         private static unsafe bool TryGetWarpDevice(ID3D12Device** d3D12Device, IDXGIAdapter** dxgiAdapter, DXGI_ADAPTER_DESC1* dxgiDescription1)
         {
-            using ComPtr<IDXGIFactory4> dxgiFactory4 = default;
+            using ComPtr<IDXGIFactory6> dxgiFactory6 = default;
 
-            EnableDebugMode();
-
-            FX.CreateDXGIFactory2(IDXGIFactoryCreationFlags, FX.__uuidof<IDXGIFactory4>(), dxgiFactory4.GetVoidAddressOf()).Assert();
+            CreateDXGIFactory6(dxgiFactory6.GetAddressOf());
 
             using ComPtr<IDXGIAdapter1> dxgiAdapter1 = default;
 
-            dxgiFactory4.Get()->EnumWarpAdapter(FX.__uuidof<IDXGIAdapter1>(), dxgiAdapter1.GetVoidAddressOf()).Assert();
+            dxgiFactory6.Get()->EnumWarpAdapter(FX.__uuidof<IDXGIAdapter1>(), dxgiAdapter1.GetVoidAddressOf()).Assert();
             
             dxgiAdapter1.Get()->GetDesc1(dxgiDescription1).Assert();
 
@@ -193,36 +189,6 @@ namespace ComputeSharp.Graphics.Helpers
             dxgiAdapter1.CopyTo(dxgiAdapter);
 
             return FX.SUCCEEDED(createDeviceResult);
-        }
-
-        /// <summary>
-        /// The creation flags for <see cref="IDXGIFactory"/> instances.
-        /// </summary>
-        private const uint IDXGIFactoryCreationFlags =
-#if DEBUG
-            FX.DXGI_CREATE_FACTORY_DEBUG;
-#else
-            0;
-#endif
-
-        /// <summary>
-        /// Enables the debug layer for DirectX APIs.
-        /// </summary>
-        [Conditional("DEBUG")]
-        private static unsafe void EnableDebugMode()
-        {
-            using ComPtr<ID3D12Debug> d3D12Debug = default;
-            using ComPtr<ID3D12Debug1> d3D12Debug1 = default;
-
-            FX.D3D12GetDebugInterface(FX.__uuidof<ID3D12Debug>(), d3D12Debug.GetVoidAddressOf()).Assert();
-
-            d3D12Debug.Get()->EnableDebugLayer();
-
-            if (FX.SUCCEEDED(d3D12Debug.CopyTo(d3D12Debug1.GetAddressOf())))
-            {
-                d3D12Debug1.Get()->SetEnableGPUBasedValidation(FX.TRUE);
-                d3D12Debug1.Get()->SetEnableSynchronizedCommandQueueValidation(FX.TRUE);
-            }
         }
     }
 }

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using ComputeSharp.Core.Extensions;
 using ComputeSharp.Graphics.Extensions;
@@ -9,6 +8,7 @@ using FX = TerraFX.Interop.Windows;
 using HRESULT = System.Int32;
 using static TerraFX.Interop.D3D_FEATURE_LEVEL;
 using static TerraFX.Interop.D3D_SHADER_MODEL;
+using static TerraFX.Interop.DXGI_GPU_PREFERENCE;
 
 namespace ComputeSharp.Graphics.Helpers
 {
@@ -92,7 +92,11 @@ namespace ComputeSharp.Graphics.Helpers
             {
                 using ComPtr<IDXGIAdapter1> dxgiAdapter1 = default;
 
-                HRESULT enumAdapters1Result = dxgiFactory6.Get()->EnumAdapters1(i++, dxgiAdapter1.GetAddressOf());
+                HRESULT enumAdapters1Result = dxgiFactory6.Get()->EnumAdapterByGpuPreference(
+                    i++,
+                    DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
+                    FX.__uuidof<IDXGIAdapter1>(),
+                    dxgiAdapter1.GetVoidAddressOf());
 
                 if (enumAdapters1Result == FX.DXGI_ERROR_NOT_FOUND)
                 {


### PR DESCRIPTION
This PR switches to `IDXGIFactory6::EnumAdapterByGpuPreference` to enumerate devices in `HIGH_PERFORMANCE` priority, so that eg. notebooks with a dedicated GPU will use that as default device instead of the dedicated one. There is also a backcompat layer when running on devices with an older build than Windows 10 1803, which just uses `IDXGIFactory4::EnumAdapters1` as before.