### PR TITLE
Win32 sample improvements

### DIFF
--- a/samples/ComputeSharp.SwapChain/Backend/Win32ApplicationRunner.cs
+++ b/samples/ComputeSharp.SwapChain/Backend/Win32ApplicationRunner.cs
@@ -148,6 +148,12 @@ internal unsafe static class Win32ApplicationRunner
             {
                 Thread.Sleep(100);
             }
+
+            // Also listen to Escape and 'Q' to Quit.
+            if (msg.message == Windows.WM_KEYUP && (msg.wParam == Windows.VK_ESCAPE || msg.wParam == 0x51))
+            {
+                _ = Windows.DestroyWindow(hwnd);
+            }
         }
 
         tokenSource.Cancel();

--- a/samples/ComputeSharp.SwapChain/Backend/Win32ApplicationRunner.cs
+++ b/samples/ComputeSharp.SwapChain/Backend/Win32ApplicationRunner.cs
@@ -149,8 +149,8 @@ internal unsafe static class Win32ApplicationRunner
                 Thread.Sleep(100);
             }
 
-            // Also listen to Escape and 'Q' to Quit.
-            if (msg.message == Windows.WM_KEYUP && (msg.wParam == Windows.VK_ESCAPE || msg.wParam == 0x51))
+            // Also listen to Escape and 'Q' to quit
+            if (msg.message == Windows.WM_KEYUP && (msg.wParam == Windows.VK_ESCAPE || msg.wParam == 'Q'))
             {
                 _ = Windows.DestroyWindow(hwnd);
             }

--- a/samples/ComputeSharp.SwapChain/Program.cs
+++ b/samples/ComputeSharp.SwapChain/Program.cs
@@ -35,28 +35,35 @@ class Program
 
     static void Main()
     {
-        Console.WriteLine("Available samples:");
-        Console.WriteLine();
-
-        for (int i = 0; i < Samples.Length; i++)
-        {
-            Console.WriteLine($"{i}: {Samples[i].GetType().GenericTypeArguments[0].Name}");
-        }
-
-        Console.WriteLine();
-
         int index;
 
         do
         {
-            Console.Write("Enter the index of the sample to run: ");
-        }
-        while (!int.TryParse(Console.ReadLine(), out index));
+            Console.WriteLine("Available samples:");
+            Console.WriteLine();
 
-        Console.WriteLine();
-        Console.WriteLine($"Starting {Samples[index].GetType().GenericTypeArguments[0].Name}...");
+            for (int i = 0; i < Samples.Length; i++)
+            {
+                Console.WriteLine($"{i}: {Samples[i].GetType().GenericTypeArguments[0].Name}");
+            }
 
-        Win32ApplicationRunner.Run(Samples[index]);
+            Console.WriteLine($"{Samples.Length}+: Exit (Use Escape, 'Q', or Alt+F4 to exit a sample once chosen.)");
+            Console.WriteLine();            
+
+            do
+            {
+                Console.Write("Enter the index of the sample to run: ");
+            }
+            while (!int.TryParse(Console.ReadLine(), out index));
+
+            if (index < Samples.Length)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Starting {Samples[index].GetType().GenericTypeArguments[0].Name}...");
+
+                Win32ApplicationRunner.Run(Samples[index]);
+            }
+        } while (index < Samples.Length);
     }
 
     /// <summary>

--- a/samples/ComputeSharp.SwapChain/Program.cs
+++ b/samples/ComputeSharp.SwapChain/Program.cs
@@ -39,6 +39,7 @@ class Program
 
         do
         {
+            Console.Clear();
             Console.WriteLine("Available samples:");
             Console.WriteLine();
 
@@ -47,7 +48,7 @@ class Program
                 Console.WriteLine($"{i}: {Samples[i].GetType().GenericTypeArguments[0].Name}");
             }
 
-            Console.WriteLine($"{Samples.Length}+: Exit (Use Escape, 'Q', or Alt+F4 to exit a sample once chosen.)");
+            Console.WriteLine($"{Samples.Length}+: Exit (Use Escape, 'Q', or Alt + F4 to exit a sample once chosen)");
             Console.WriteLine();            
 
             do
@@ -63,7 +64,8 @@ class Program
 
                 Win32ApplicationRunner.Run(Samples[index]);
             }
-        } while (index >= 0 && index < Samples.Length);
+        }
+        while (index >= 0 && index < Samples.Length);
     }
 
     /// <summary>

--- a/samples/ComputeSharp.SwapChain/Program.cs
+++ b/samples/ComputeSharp.SwapChain/Program.cs
@@ -56,14 +56,14 @@ class Program
             }
             while (!int.TryParse(Console.ReadLine(), out index));
 
-            if (index < Samples.Length)
+            if (index >= 0 && index < Samples.Length)
             {
                 Console.WriteLine();
                 Console.WriteLine($"Starting {Samples[index].GetType().GenericTypeArguments[0].Name}...");
 
                 Win32ApplicationRunner.Run(Samples[index]);
             }
-        } while (index < Samples.Length);
+        } while (index >= 0 && index < Samples.Length);
     }
 
     /// <summary>


### PR DESCRIPTION
Couple of small QoL updates to the Win32 sample:

1) Can also hit Escape or 'Q' to close the shader window in addition to using Alt+F4.
2) Main program runs in a loop so that another sample can be chosen without having to respawn the process.

This also fixes a bug where if you entered an invalid index integer for the sample the program would crash, now it just exits.