### PR TITLE
Switch Marshal.AllocHGlobal to NativeMemory.Alloc

### DIFF
--- a/src/ComputeSharp.NetStandard/ComputeSharp.NetStandard.projitems
+++ b/src/ComputeSharp.NetStandard/ComputeSharp.NetStandard.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\SkipLocalsInitAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\InteropServices\MemoryMarshal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\InteropServices\NativeMemory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Versioning\OSPlatformAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Versioning\SupportedOSVersionAttribute.cs" />
   </ItemGroup>

--- a/src/ComputeSharp.NetStandard/System/Runtime/InteropServices/NativeMemory.cs
+++ b/src/ComputeSharp.NetStandard/System/Runtime/InteropServices/NativeMemory.cs
@@ -1,0 +1,35 @@
+﻿namespace System.Runtime.InteropServices;
+
+/// <summary>
+/// This class contains methods that are mainly used to manage native memory.
+/// </summary>
+internal static unsafe class NativeMemory
+{
+    /// <summary>
+    /// Allocates a block of memory of the specified size, in bytes.
+    /// </summary>
+    /// <param name="byteCount">The size, in bytes, of the block to allocate.</param>
+    /// <returns>A pointer to the allocated block of memory.</returns>
+    /// <exception cref="OutOfMemoryException">Thrown when allocating <paramref name="byteCount"/> of memory failed.</exception>
+    /// <remarks>
+    /// <para>This method allows <paramref name="byteCount" /> to be <c>0</c> and will return a valid pointer that should not be dereferenced and that should be passed to free to avoid memory leaks.</para>
+    /// <para>This method is a thin wrapper over the C <c>malloc</c> API.</para>
+    /// </remarks>
+    public static void* Alloc(nuint byteCount)
+    {
+        return (void*)Marshal.AllocHGlobal(checked((int)byteCount));
+    }
+
+    /// <summary>
+    /// Frees a block of memory.
+    /// </summary>
+    /// <param name="ptr">A pointer to the block of memory that should be freed.</param>
+    /// <remarks>
+    /// <para>This method does nothing if <paramref name="ptr" /> is <see langword="null"/>.</para>
+    /// <para>This method is a thin wrapper over the C <c>free</c> API.</para>
+    /// </remarks>
+    public static void Free(void* ptr)
+    {
+        Marshal.FreeHGlobal((IntPtr)ptr);
+    }
+}

--- a/src/ComputeSharp.NetStandard/System/Runtime/Versioning/SupportedOSVersionAttribute.cs
+++ b/src/ComputeSharp.NetStandard/System/Runtime/Versioning/SupportedOSVersionAttribute.cs
@@ -22,7 +22,6 @@
                 AttributeTargets.Struct,
                 AllowMultiple = true,
                 Inherited = false)]
-
 internal sealed class SupportedOSPlatformAttribute : OSPlatformAttribute
 {
     public SupportedOSPlatformAttribute(string platformName)

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.ID3D12InfoQueue.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.ID3D12InfoQueue.cs
@@ -41,18 +41,23 @@ internal static partial class DeviceHelper
                     nuint length;
                     queue.Get()->GetMessage(i, null, &length);
 
-                    D3D12_MESSAGE* message = (D3D12_MESSAGE*)Marshal.AllocHGlobal((nint)length);
+                    D3D12_MESSAGE* message = (D3D12_MESSAGE*)NativeMemory.Alloc(length);
 
-                    queue.Get()->GetMessage(i, message, &length);
+                    try
+                    {
+                        queue.Get()->GetMessage(i, message, &length);
 
-                    builder.Clear();
-                    builder.AppendLine($"[D3D12 message #{i} for \"{device}\" (HW: {device.IsHardwareAccelerated}, UMA: {device.IsCacheCoherentUMA})]");
-                    builder.AppendLine($"[Category]: {Enum.GetName(message->Category)}");
-                    builder.AppendLine($"[Severity]: {Enum.GetName(message->Severity)}");
-                    builder.AppendLine($"[ID]: {Enum.GetName(message->ID)}");
-                    builder.Append($"[Description]: \"{new string(message->pDescription)}\"");
-
-                    Marshal.FreeHGlobal((IntPtr)message);
+                        builder.Clear();
+                        builder.AppendLine($"[D3D12 message #{i} for \"{device}\" (HW: {device.IsHardwareAccelerated}, UMA: {device.IsCacheCoherentUMA})]");
+                        builder.AppendLine($"[Category]: {Enum.GetName(message->Category)}");
+                        builder.AppendLine($"[Severity]: {Enum.GetName(message->Severity)}");
+                        builder.AppendLine($"[ID]: {Enum.GetName(message->ID)}");
+                        builder.Append($"[Description]: \"{new string(message->pDescription)}\"");
+                    }
+                    finally
+                    {
+                        NativeMemory.Free(message);
+                    }
 
                     if (message->Severity is D3D12_MESSAGE_SEVERITY_ERROR or D3D12_MESSAGE_SEVERITY_CORRUPTION or D3D12_MESSAGE_SEVERITY_WARNING)
                     {

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
@@ -130,7 +130,7 @@ internal static partial class DeviceHelper
         /// <param name="dxgiFactory6">The resulting <see cref="IDXGIFactory6"/> instance.</param>
         public static void Create(IDXGIFactory4* dxgiFactory4, IDXGIFactory6** dxgiFactory6)
         {
-            IDXGIFactory4As6Backcompat* @this = (IDXGIFactory4As6Backcompat*)Marshal.AllocHGlobal(sizeof(IDXGIFactory4As6Backcompat));
+            IDXGIFactory4As6Backcompat* @this = (IDXGIFactory4As6Backcompat*)NativeMemory.Alloc((nuint)sizeof(IDXGIFactory4As6Backcompat));
 
             @this->lpVtbl = Vtbl;
             @this->dxgiFactory4 = dxgiFactory4;
@@ -156,7 +156,7 @@ internal static partial class DeviceHelper
         {
             @this->dxgiFactory4->Release();
 
-            Marshal.FreeHGlobal((IntPtr)@this);
+            NativeMemory.Free(@this);
 
             return 0;
         }


### PR DESCRIPTION
### Closes #155

- Switch `Marshal.AllocHGlobal` calls to `NativeMemory.Alloc` calls on .NET 6
- Add polyfills for .NET Standard 2.0