### PR TITLE
Improve double precision support

### DIFF
--- a/src/ComputeSharp/Graphics/GraphicsDevice.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.cs
@@ -189,6 +189,20 @@ public sealed unsafe class GraphicsDevice : NativeObject
     internal bool IsCacheCoherentUMA { get; }
 
     /// <summary>
+    /// Checks whether the current device supports double precision floating point operations in shaders.
+    /// </summary>
+    /// <returns>Whether the current device supports double precision floating point operations in shaders.</returns>
+    [Pure]
+    public bool IsDoublePrecisionSupportAvailable()
+    {
+        ThrowIfDisposed();
+
+        var d3D12OptionsData = this.d3D12Device.Get()->CheckFeatureSupport<D3D12_FEATURE_DATA_D3D12_OPTIONS>(D3D12_FEATURE_D3D12_OPTIONS);
+
+        return d3D12OptionsData.DoublePrecisionFloatShaderOps;
+    }
+
+    /// <summary>
     /// Checks whether the current device supports the creation of
     /// <see cref="ReadOnlyTexture2D{T}"/> resources for a specified type <typeparamref name="T"/>.
     /// </summary>

--- a/src/ComputeSharp/Shaders/Interop/ReflectionServices.cs
+++ b/src/ComputeSharp/Shaders/Interop/ReflectionServices.cs
@@ -168,6 +168,7 @@ public static class ReflectionServices
         Unsafe.AsRef(shaderInfo.MovcInstructionCount) = d3D12ShaderReflection.Get()->GetMovcInstructionCount();
         Unsafe.AsRef(shaderInfo.MovInstructionCount) = d3D12ShaderReflection.Get()->GetMovInstructionCount();
         Unsafe.AsRef(shaderInfo.InterfaceSlotCount) = d3D12ShaderReflection.Get()->GetNumInterfaceSlots();
+        Unsafe.AsRef(shaderInfo.RequiresDoublePrecisionSupport) = (d3D12ShaderReflection.Get()->GetRequiresFlags() & (D3D.D3D_SHADER_REQUIRES_DOUBLES | D3D.D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS)) != 0;
 #endif
     }
 }

--- a/src/ComputeSharp/Shaders/Interop/ShaderInfo.cs
+++ b/src/ComputeSharp/Shaders/Interop/ShaderInfo.cs
@@ -124,4 +124,9 @@ public readonly struct ShaderInfo
     /// The number of interface slots used.
     /// </summary>
     public readonly uint InterfaceSlotCount;
+
+    /// <summary>
+    /// Indicates whether support for double precision floating point numbers is required.
+    /// </summary>
+    public readonly bool RequiresDoublePrecisionSupport;
 }

--- a/src/TerraFX.Interop.Windows/DirectX/um/d3d11shader/D3D.cs
+++ b/src/TerraFX.Interop.Windows/DirectX/um/d3d11shader/D3D.cs
@@ -1,0 +1,16 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/d3d11shader.h in the Windows SDK for Windows 10.0.20348.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.DirectX
+{
+    public static partial class D3D
+    {
+        [NativeTypeName("#define D3D_SHADER_REQUIRES_DOUBLES 0x00000001")]
+        public const int D3D_SHADER_REQUIRES_DOUBLES = 0x00000001;
+
+        [NativeTypeName("#define D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS 0x00000020")]
+        public const int D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS = 0x00000020;
+    }
+}

--- a/src/TerraFX.Interop.Windows/TerraFX.Interop.Windows.projitems
+++ b/src/TerraFX.Interop.Windows/TerraFX.Interop.Windows.projitems
@@ -53,6 +53,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\shared\dxgi\IDXGIOutput.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\shared\dxgi\IDXGISwapChain.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1\D2D1_FEATURE_LEVEL.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d3d11shader\D3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d3d11\D3D11.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d3d12sdklayers\D3D12_INFO_QUEUE_FILTER.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d3d12sdklayers\D3D12_INFO_QUEUE_FILTER_DESC.cs" />

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -193,6 +193,27 @@ namespace ComputeSharp.Tests
         {
             ReflectionServices.GetShaderInfo<LoopWithVarCounterShader>(out var info);
         }
+
+        [TestMethod]
+        public void DoublePrecisionSupport()
+        {
+            ReflectionServices.GetShaderInfo<DoublePrecisionSupportShader>(out var info);
+
+            Assert.IsTrue(info.RequiresDoublePrecisionSupport);
+        }
+
+        [AutoConstructor]
+        public readonly partial struct DoublePrecisionSupportShader : IComputeShader
+        {
+            public readonly ReadWriteBuffer<double> buffer;
+            public readonly double factor;
+
+            /// <inheritdoc/>
+            public void Execute()
+            {
+                buffer[ThreadIds.X] *= factor + 3.14;
+            }
+        }
     }
 }
 

--- a/tests/ComputeSharp.Tests/ShadersTests.cs
+++ b/tests/ComputeSharp.Tests/ShadersTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using ComputeSharp.Interop;
 using ComputeSharp.SwapChain.Shaders;
 using ComputeSharp.Tests.Attributes;
 using ComputeSharp.Tests.Extensions;
@@ -94,6 +95,10 @@ public class ShadersTests
     [Data(typeof(SwapChain.Shaders.Compute.ExtrudedTruchetPattern))]
     public void ExtrudedTruchetPattern(Device device, Type shaderType)
     {
+        ReflectionServices.GetShaderInfo<SwapChain.Shaders.Compute.ExtrudedTruchetPattern>(out var info);
+
+        Assert.IsFalse(info.RequiresDoublePrecisionSupport);
+
         RunAndCompareShader(device, shaderType, 0.00011f);
     }
 
@@ -156,6 +161,10 @@ public class ShadersTests
                 static void RunComputeShader<T>(ReadWriteTexture2D<Rgba32, float4> texture)
                     where T : struct, IComputeShader
                 {
+                    ReflectionServices.GetShaderInfo<T>(out var info);
+
+                    Assert.IsFalse(info.RequiresDoublePrecisionSupport);
+
                     texture.GraphicsDevice.For(texture.Width, texture.Height, (T)Activator.CreateInstance(typeof(T), texture, 0f)!);
                 }
 
@@ -221,6 +230,10 @@ public class ShadersTests
         {
             if (typeof(IComputeShader).IsAssignableFrom(shaderType))
             {
+                ReflectionServices.GetShaderInfo<TCompute>(out var info);
+
+                Assert.IsFalse(info.RequiresDoublePrecisionSupport);
+
                 Assert.AreEqual(typeof(TCompute), shaderType);
 
                 texture.GraphicsDevice.For(texture.Width, texture.Height, computeFactory(texture));


### PR DESCRIPTION
This PR includes the following changes:

- Add a new `GraphicsDevice.IsDoublePrecisionSupportAvailable()` API
- Add a new `RequiresDoublePrecisionSupport` property to `ShaderInfo`