### PR TITLE
[EmbeddedBytecode] tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -83,17 +83,26 @@ jobs:
     - name: Run ComputeSharp.Tests (.NET 6)
       run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
       shell: cmd
+    - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET 6)
+      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f net6.0 /p:DisableShaderCompilationSupport=True -v n -l "console;verbosity=detailed"
+      shell: cmd
     - name: Run ComputeSharp.Tests.Internals (.NET 6)
       run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
       shell: cmd
     - name: Run ComputeSharp.Tests (.NET Core 3.1)
       run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -v n -l "console;verbosity=detailed"
       shell: cmd
+    - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET Core 3.1)
+      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 /p:DisableShaderCompilationSupport=True -v n -l "console;verbosity=detailed"
+      shell: cmd
     - name: Run ComputeSharp.Tests.Internals (.NET Core 3.1)
       run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -v n -l "console;verbosity=detailed"
       shell: cmd
     - name: Run ComputeSharp.Tests (.NET Framework 4.7.2)
       run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f net472 /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET Framework 4.7.2)
+      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f net472 /p:Platform=x64 /p:DisableShaderCompilationSupport=True -v n -l "console;verbosity=detailed"
       shell: cmd
     - name: Run ComputeSharp.Tests.Internals (.NET Framework 4.7.2)
       run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f net472 /p:Platform=x64 -v n -l "console;verbosity=detailed"

--- a/ComputeSharp.sln
+++ b/ComputeSharp.sln
@@ -68,6 +68,8 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ComputeSharp.SwapChain.Shad
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ComputeSharp.SwapChain.Core.Shared", "samples\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.shproj", "{751BB05B-563D-4B3A-94C6-15E2D79D35EA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComputeSharp.Tests.DisableDynamicCompilation", "tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj", "{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		samples\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.projitems*{0071701e-b9c5-4098-be5f-ef556c4553c6}*SharedItemsImports = 5
@@ -303,6 +305,18 @@ Global
 		{FBD388A5-7855-4408-98FF-E689F509DB5A}.Release|x64.ActiveCfg = Release|x64
 		{FBD388A5-7855-4408-98FF-E689F509DB5A}.Release|x64.Build.0 = Release|x64
 		{FBD388A5-7855-4408-98FF-E689F509DB5A}.Release|x64.Deploy.0 = Release|x64
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Debug|x64.Build.0 = Debug|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Release|ARM64.Build.0 = Release|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Release|x64.ActiveCfg = Release|Any CPU
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -325,6 +339,7 @@ Global
 		{FBD388A5-7855-4408-98FF-E689F509DB5A} = {0ED8F632-5E17-46BE-8CC3-B14A82D4AEB1}
 		{0800BD51-499D-44C2-9417-FD1F7FDFE9C4} = {0ED8F632-5E17-46BE-8CC3-B14A82D4AEB1}
 		{751BB05B-563D-4B3A-94C6-15E2D79D35EA} = {0ED8F632-5E17-46BE-8CC3-B14A82D4AEB1}
+		{4A8FCE22-851C-442A-8BC9-3EC3FD00B637} = {F8EFBB27-4EE2-4463-A75B-7EFDFB55D0F7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4664C5E3-0340-4E22-BCFD-98AAEDF5F2DC}

--- a/src/ComputeSharp/Shaders/ShaderRunner{T}.cs
+++ b/src/ComputeSharp/Shaders/ShaderRunner{T}.cs
@@ -228,7 +228,7 @@ internal static class ShaderRunner<T>
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static unsafe void LoadShader(int threadsX, int threadsY, int threadsZ, ref T shader, out ICachedShader shaderData)
     {
-        if (shader.TryGetBytecode(threadsX, threadsY, threadsZ, out ReadOnlySpan<byte> bytecode))
+        if (Unsafe.NullRef<T>().TryGetBytecode(threadsX, threadsY, threadsZ, out ReadOnlySpan<byte> bytecode))
         {
             shaderData = new ICachedShader.Embedded(bytecode);
         }

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -1,0 +1,52 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <Platforms>AnyCPU;x64;ARM64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ComputeSharp\ComputeSharp.csproj" />
+    <ProjectReference Include="..\..\src\ComputeSharp.SourceGenerators\ComputeSharp.SourceGenerators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+  <!-- Define DISABLE_RUNTIME_SHADER_COMPILATION_SUPPORT if requested -->
+  <PropertyGroup Condition="'$(DisableShaderCompilationSupport)' == 'true'">
+    <DefineConstants>$(DefineConstants);DISABLE_RUNTIME_SHADER_COMPILATION_SUPPORT</DefineConstants>
+  </PropertyGroup>
+
+  <!-- When the .NET Standard 2.0 version of ComputeSharp is resolved, the TerraFX APIs are internal, as they
+       are referenced from the shared project. The same reference is needed here to make all tests build fine. -->
+  <Import Condition="'$(TargetFramework)' != 'net6.0'" Project="..\..\src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems" />
+  <Import Condition="'$(TargetFramework)' != 'net6.0'" Project="..\..\src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems" />
+
+  <!-- Only when the local TerraFX is referenced, ignore warnings from there -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <NoWarn>$(NoWarn);CS0649</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ComputeSharp.Tests\Attributes\AdditionalDataAttribute.cs" Link="Attributes\AdditionalDataAttribute.cs" />
+    <Compile Include="..\ComputeSharp.Tests\Attributes\AdditionalResourceAttribute.cs" Link="Attributes\AdditionalResourceAttribute.cs" />
+    <Compile Include="..\ComputeSharp.Tests\Attributes\AllDevicesAttribute.cs" Link="Attributes\AllDevicesAttribute.cs" />
+    <Compile Include="..\ComputeSharp.Tests\Attributes\CombinatorialTestMethodAttribute.cs" Link="Attributes\CombinatorialTestMethodAttribute.cs" />
+    <Compile Include="..\ComputeSharp.Tests\Attributes\DataAttribute.cs" Link="Attributes\DataAttribute.cs" />
+    <Compile Include="..\ComputeSharp.Tests\Attributes\DeviceAttribute.cs" Link="Attributes\DeviceAttribute.cs" />
+    <Compile Include="..\ComputeSharp.Tests\Attributes\ResourceAttribute.cs" Link="Attributes\ResourceAttribute.cs" />
+    <Compile Include="..\ComputeSharp.Tests\Extensions\DeviceExtensions.cs" Link="Extensions\DeviceExtensions.cs" />
+    <Compile Include="..\ComputeSharp.Tests\Extensions\GraphicsDeviceExtensions.cs" Link="Extensions\GraphicsDeviceExtensions.cs" />
+  </ItemGroup>	
+
+</Project>

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/DispatchTests.cs
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/DispatchTests.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Linq;
+using ComputeSharp.Interop;
+using ComputeSharp.Tests.Attributes;
+using ComputeSharp.Tests.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.Tests.DisableDynamicCompilation;
+
+[TestClass]
+[TestCategory("Dispatch")]
+public partial class DispatchTests
+{
+    private static readonly bool IsDynamicCompilationDisabled =
+#if DISABLE_RUNTIME_SHADER_COMPILATION_SUPPORT
+        true;
+#else
+        false;
+#endif
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public void ComputeShader_Test_Ok(Device device)
+    {
+        if (!IsDynamicCompilationDisabled)
+        {
+            Assert.Inconclusive();
+        }
+
+        float[] array = Enumerable.Range(0, 128).Select(static i => (float)i).ToArray();
+
+        using ReadWriteBuffer<float> buffer = device.Get().AllocateReadWriteBuffer(array);
+
+        device.Get().For(128, 1, 1, 32, 1, 1, new ComputeShader(buffer, 2.0f));
+
+        float[] result = buffer.ToArray();
+
+        foreach (ref float value in array.AsSpan())
+        {
+            value *= 2.0f;
+        }
+
+        CollectionAssert.AreEqual(result, array);
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [ExpectedException(typeof(NotSupportedException))]
+    public void ComputeShader_Test_Fail(Device device)
+    {
+        if (!IsDynamicCompilationDisabled)
+        {
+            Assert.Inconclusive();
+        }
+
+        using ReadWriteBuffer<float> buffer = device.Get().AllocateReadWriteBuffer<float>(128);
+
+        device.Get().For(128, 1, 1, 64, 1, 1, new ComputeShader(buffer, 2.0f));
+    }
+
+    [AutoConstructor]
+    [EmbeddedBytecode(32, 1, 1)]
+    internal readonly partial struct ComputeShader : IComputeShader
+    {
+        public readonly ReadWriteBuffer<float> buffer;
+        public readonly float factor;
+
+        /// <inheritdoc/>
+        public void Execute()
+        {
+            buffer[ThreadIds.X] *= factor;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public void PixelShader_Test_Ok(Device device)
+    {
+        if (!IsDynamicCompilationDisabled)
+        {
+            Assert.Inconclusive();
+        }
+
+        using ReadWriteTexture2D<Rgba32, float4> texture = device.Get().AllocateReadWriteTexture2D<Rgba32, float4>(128, 128);
+
+        device.Get().ForEach(texture, new PixelShader(0.3f, 0.6f));
+
+        Rgba32[,] result = texture.ToArray();
+
+        for (int i = 0; i < texture.Height; i++)
+        {
+            for (int j = 0; j < texture.Width; j++)
+            {
+                byte r = (byte)(j / (float)texture.Width * 255f);
+                byte g = (byte)(i / (float)texture.Height * 255f);
+                const byte b = (byte)(0.3f * 255f);
+                const byte a = (byte)(0.6f * 255f);
+                Rgba32 pixel = result[i, j];
+
+                // Use a delta of 1 to account for small differences of precision when rounding. This test is just
+                // about validating the shader runs anyway, the actual accuracy is tested in other shader tests.
+                Assert.IsTrue(Math.Abs(r - pixel.R) <= 1);
+                Assert.IsTrue(Math.Abs(g - pixel.G) <= 1);
+                Assert.AreEqual(pixel.B, b);
+                Assert.AreEqual(pixel.A, a);
+            }
+        }
+    }
+
+    [AutoConstructor]
+    [EmbeddedBytecode(8, 8, 1)]
+    internal readonly partial struct PixelShader : IPixelShader<float4>
+    {
+        private readonly float b;
+        private readonly float a;
+
+        /// <inheritdoc/>
+        public float4 Execute()
+        {
+            return new(ThreadIds.Normalized.X, ThreadIds.Normalized.Y, b, a);
+        }
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(NotSupportedException))]
+    public void ReflectionService_ComputeShader()
+    {
+        if (!IsDynamicCompilationDisabled)
+        {
+            Assert.Inconclusive();
+        }
+
+        ReflectionServices.GetShaderInfo<ComputeShader>(out _);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(NotSupportedException))]
+    public void ReflectionService_PixelShader()
+    {
+        if (!IsDynamicCompilationDisabled)
+        {
+            Assert.Inconclusive();
+        }
+
+        ReflectionServices.GetShaderInfo<PixelShader, float4>(out _);
+    }
+}

--- a/tests/ComputeSharp.Tests.Internals/ShaderBytecodeTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/ShaderBytecodeTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.Tests.Internals;
+
+[TestClass]
+[TestCategory("ShaderBytecode")]
+public partial class ShaderBytecodeTests
+{
+    [TestMethod]
+    public void NonPrecompiledShader_Test()
+    {
+        Assert.IsFalse(((IComputeShader)default(NonPrecompiledShader)).TryGetBytecode(32, 1, 1, out ReadOnlySpan<byte> bytecode));
+        Assert.IsFalse(bytecode.Length > 0);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct NonPrecompiledShader : IComputeShader
+    {
+        public readonly ReadWriteBuffer<float> buffer;
+        public readonly float factor;
+
+        /// <inheritdoc/>
+        public void Execute()
+        {
+            buffer[ThreadIds.X] *= factor;
+        }
+    }
+
+    [TestMethod]
+    public void ComputeShader_Test()
+    {
+        Assert.IsTrue(((IComputeShader)default(ComputeShader)).TryGetBytecode(32, 1, 1, out ReadOnlySpan<byte> bytecode));
+        Assert.IsTrue(bytecode.Length > 0);
+
+        Assert.IsFalse(((IComputeShader)default(ComputeShader)).TryGetBytecode(64, 1, 1, out bytecode));
+        Assert.IsFalse(bytecode.Length > 0);
+    }
+
+    [AutoConstructor]
+    [EmbeddedBytecode(32, 1, 1)]
+    internal readonly partial struct ComputeShader : IComputeShader
+    {
+        public readonly ReadWriteBuffer<float> buffer;
+        public readonly float factor;
+
+        /// <inheritdoc/>
+        public void Execute()
+        {
+            buffer[ThreadIds.X] *= factor;
+        }
+    }
+
+    [TestMethod]
+    public void PixelShader_Test()
+    {
+        Assert.IsTrue(((IPixelShader<float4>)default(PixelShader)).TryGetBytecode(8, 8, 1, out ReadOnlySpan<byte> bytecode));
+        Assert.IsTrue(bytecode.Length > 0);
+
+        Assert.IsFalse(((IPixelShader<float4>)default(PixelShader)).TryGetBytecode(32, 1, 1, out bytecode));
+        Assert.IsFalse(bytecode.Length > 0);
+    }
+
+    [AutoConstructor]
+    [EmbeddedBytecode(8, 8, 1)]
+    internal readonly partial struct PixelShader : IPixelShader<float4>
+    {
+        public readonly ReadWriteTexture2D<float> buffer;
+        public readonly float factor;
+
+        /// <inheritdoc/>
+        public float4 Execute()
+        {
+            return buffer[ThreadIds.XY] * factor;
+        }
+    }
+}


### PR DESCRIPTION
Follow up to #171.
This PR adds internal unit tests and a separate test project for `DISABLE_RUNTIME_SHADER_COMPILATION_SUPPORT`.