### PR TITLE
Rename Gpu class to GraphicsDevice

### DIFF
--- a/samples/ComputeSharp.Benchmark/Blas/BlasBenchmark.cs
+++ b/samples/ComputeSharp.Benchmark/Blas/BlasBenchmark.cs
@@ -100,10 +100,10 @@ public class BlasBenchmark : IDisposable
         B = CreateRandomArray(P);
         Y = CreateRandomArray(C * N * P);
 
-        BufferX = Gpu.Default.AllocateReadOnlyBuffer(X);
-        BufferW = Gpu.Default.AllocateReadOnlyBuffer(W);
-        BufferB = Gpu.Default.AllocateReadOnlyBuffer(B);
-        BufferY = Gpu.Default.AllocateReadWriteBuffer(Y);
+        BufferX = GraphicsDevice.Default.AllocateReadOnlyBuffer(X);
+        BufferW = GraphicsDevice.Default.AllocateReadOnlyBuffer(W);
+        BufferB = GraphicsDevice.Default.AllocateReadOnlyBuffer(B);
+        BufferY = GraphicsDevice.Default.AllocateReadWriteBuffer(Y);
 
         Cpu();
         GpuWithNoTemporaryBuffers();
@@ -140,7 +140,7 @@ public class BlasBenchmark : IDisposable
     [Benchmark]
     public void GpuWithNoTemporaryBuffers()
     {
-        BlasHelpers.FullyConnectedForwardGpu(Gpu.Default, C, N, M, P, BufferX!, BufferW!, BufferB!, BufferY!);
+        BlasHelpers.FullyConnectedForwardGpu(GraphicsDevice.Default, C, N, M, P, BufferX!, BufferW!, BufferB!, BufferY!);
     }
 
     /// <summary>
@@ -149,12 +149,12 @@ public class BlasBenchmark : IDisposable
     [Benchmark]
     public void GpuWithTemporaryBuffers()
     {
-        using ReadOnlyBuffer<float> x = Gpu.Default.AllocateReadOnlyBuffer(X!);
-        using ReadOnlyBuffer<float> w = Gpu.Default.AllocateReadOnlyBuffer(W!);
-        using ReadOnlyBuffer<float> b = Gpu.Default.AllocateReadOnlyBuffer(B!);
-        using ReadWriteBuffer<float> y = Gpu.Default.AllocateReadWriteBuffer<float>(Y!.Length);
+        using ReadOnlyBuffer<float> x = GraphicsDevice.Default.AllocateReadOnlyBuffer(X!);
+        using ReadOnlyBuffer<float> w = GraphicsDevice.Default.AllocateReadOnlyBuffer(W!);
+        using ReadOnlyBuffer<float> b = GraphicsDevice.Default.AllocateReadOnlyBuffer(B!);
+        using ReadWriteBuffer<float> y = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(Y!.Length);
 
-        BlasHelpers.FullyConnectedForwardGpu(Gpu.Default, C, N, M, P, x, w, b, y);
+        BlasHelpers.FullyConnectedForwardGpu(GraphicsDevice.Default, C, N, M, P, x, w, b, y);
 
         y.CopyTo(Y);
     }

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.cs
@@ -26,7 +26,7 @@ public sealed partial class HlslBokehBlurProcessor : IImageProcessor
     /// Initializes a new instance of the <see cref="HlslBokehBlurProcessor"/> class.
     /// </summary>
     public HlslBokehBlurProcessor()
-        : this(Gpu.Default, DefaultRadius, DefaultComponents)
+        : this(GraphicsDevice.Default, DefaultRadius, DefaultComponents)
     {
     }
 
@@ -36,7 +36,7 @@ public sealed partial class HlslBokehBlurProcessor : IImageProcessor
     /// <param name="radius">The size of the area to sample.</param>
     /// <param name="components">The number of components to use to approximate the original 2D bokeh blur convolution kernel.</param>
     public HlslBokehBlurProcessor(int radius, int components)
-        : this(Gpu.Default, radius, components)
+        : this(GraphicsDevice.Default, radius, components)
     {
     }
 

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.cs
@@ -21,7 +21,7 @@ public sealed partial class HlslGaussianBlurProcessor : IImageProcessor
     /// Initializes a new instance of the <see cref="HlslGaussianBlurProcessor"/> class.
     /// </summary>
     public HlslGaussianBlurProcessor()
-        : this(Gpu.Default, DefaultSigma, 9)
+        : this(GraphicsDevice.Default, DefaultSigma, 9)
     {
     }
 
@@ -30,7 +30,7 @@ public sealed partial class HlslGaussianBlurProcessor : IImageProcessor
     /// </summary>
     /// <param name="radius">The radius value representing the size of the area to sample.</param>
     public HlslGaussianBlurProcessor(int radius)
-        : this(Gpu.Default, radius / 3F, radius)
+        : this(GraphicsDevice.Default, radius / 3F, radius)
     {
     }
 

--- a/samples/ComputeSharp.Sample.FSharp/Program.fs
+++ b/samples/ComputeSharp.Sample.FSharp/Program.fs
@@ -32,12 +32,12 @@ let main _ =
     let array = [| for i in 1 .. 100 -> (float32)i |]
 
     // Create the graphics buffer
-    use buffer = Gpu.Default.AllocateReadWriteBuffer(array)
+    use buffer = GraphicsDevice.Default.AllocateReadWriteBuffer(array)
 
     let shader = new MultiplyByTwo(buffer)
 
     // Run the shader (passed by reference)
-    Gpu.Default.For(100, &shader)
+    GraphicsDevice.Default.For(100, &shader)
 
     // Print the initial matrix
     printMatrix array 10 10 "BEFORE"

--- a/samples/ComputeSharp.Sample.Shared/Program.cs
+++ b/samples/ComputeSharp.Sample.Shared/Program.cs
@@ -11,10 +11,10 @@ partial class Program
         float[] array = Enumerable.Range(1, 100).Select(static i => (float)i).ToArray();
 
         // Create the graphics buffer
-        using ReadWriteBuffer<float> gpuBuffer = Gpu.Default.AllocateReadWriteBuffer(array);
+        using ReadWriteBuffer<float> gpuBuffer = GraphicsDevice.Default.AllocateReadWriteBuffer(array);
 
         // Run the shader
-        Gpu.Default.For(100, new MainKernel(gpuBuffer));
+        GraphicsDevice.Default.For(100, new MainKernel(gpuBuffer));
 
         // Print the initial matrix
         PrintMatrix(array, 10, 10, "BEFORE");

--- a/samples/ComputeSharp.SwapChain.Core.Shared/Shaders/Runners/ContouredLayersRunner.cs
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/Shaders/Runners/ContouredLayersRunner.cs
@@ -29,9 +29,9 @@ public sealed class ContouredLayersRunner : IShaderRunner
         {
             string filename = Path.Combine(Package.Current.InstalledLocation.Path, "Assets", "Textures", "RustyMetal.png");
 
-            this.texture = Gpu.Default.LoadReadOnlyTexture2D<Rgba32, Float4>(filename);
+            this.texture = GraphicsDevice.Default.LoadReadOnlyTexture2D<Rgba32, Float4>(filename);
         }
 
-        Gpu.Default.ForEach(texture, new ContouredLayers((float)timespan.TotalSeconds, this.texture));
+        GraphicsDevice.Default.ForEach(texture, new ContouredLayers((float)timespan.TotalSeconds, this.texture));
     }
 }

--- a/samples/ComputeSharp.SwapChain/Backend/SwapChainApplication{T}.cs
+++ b/samples/ComputeSharp.SwapChain/Backend/SwapChainApplication{T}.cs
@@ -90,7 +90,7 @@ internal sealed class SwapChainApplication<T> : Win32Application
         // Get the underlying ID3D12Device in use
         fixed (ID3D12Device** d3D12Device = this.d3D12Device)
         {
-            _ = InteropServices.TryGetID3D12Device(Gpu.Default, Windows.__uuidof<ID3D12Device>(), (void**)d3D12Device);
+            _ = InteropServices.TryGetID3D12Device(GraphicsDevice.Default, Windows.__uuidof<ID3D12Device>(), (void**)d3D12Device);
         }
 
         // Create the direct command queue to use
@@ -217,7 +217,7 @@ internal sealed class SwapChainApplication<T> : Win32Application
         D3D12_RESOURCE_DESC d3D12Resource0Description = this.d3D12Resource0.Get()->GetDesc();
 
         // Create the 2D texture to use to generate frames to display
-        this.texture = Gpu.Default.AllocateReadWriteTexture2D<Rgba32, float4>(
+        this.texture = GraphicsDevice.Default.AllocateReadWriteTexture2D<Rgba32, float4>(
             (int)d3D12Resource0Description.Width,
             (int)d3D12Resource0Description.Height);
     }
@@ -233,7 +233,7 @@ internal sealed class SwapChainApplication<T> : Win32Application
         }
 
         // Generate the new frame
-        Gpu.Default.ForEach(this.texture!, this.shaderFactory(time));
+        GraphicsDevice.Default.ForEach(this.texture!, this.shaderFactory(time));
 
         using ComPtr<ID3D12Resource> d3D12Resource = default;
 

--- a/samples/ComputeSharp.SwapChain/Program.cs
+++ b/samples/ComputeSharp.SwapChain/Program.cs
@@ -79,6 +79,6 @@ class Program
     {
         string filename = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Textures", $"{name}.png");
 
-        return Gpu.Default.LoadReadOnlyTexture2D<Rgba32, float4>(filename);
+        return GraphicsDevice.Default.LoadReadOnlyTexture2D<Rgba32, float4>(filename);
     }
 }

--- a/src/ComputeSharp.UI/Controls/ComputeShaderPanel.Rendering.cs
+++ b/src/ComputeSharp.UI/Controls/ComputeShaderPanel.Rendering.cs
@@ -171,7 +171,7 @@ public sealed partial class ComputeShaderPanel
         // Get the underlying ID3D12Device in use
         fixed (ID3D12Device** d3D12Device = this.d3D12Device)
         {
-            InteropServices.TryGetID3D12Device(Gpu.Default, Win32.__uuidof<ID3D12Device>(), (void**)d3D12Device).Assert();
+            InteropServices.TryGetID3D12Device(GraphicsDevice.Default, Win32.__uuidof<ID3D12Device>(), (void**)d3D12Device).Assert();
         }
 
         // Create the direct command queue to use
@@ -342,7 +342,7 @@ public sealed partial class ComputeShaderPanel
         D3D12_RESOURCE_DESC d3D12Resource0Description = this.d3D12Resource0.Get()->GetDesc();
 
         // Create the 2D texture to use to generate frames to display
-        this.texture = Gpu.Default.AllocateReadWriteTexture2D<Rgba32, Float4>(
+        this.texture = GraphicsDevice.Default.AllocateReadWriteTexture2D<Rgba32, Float4>(
             (int)d3D12Resource0Description.Width,
             (int)d3D12Resource0Description.Height);
     }

--- a/src/ComputeSharp.UI/ShaderRunner{T}.cs
+++ b/src/ComputeSharp.UI/ShaderRunner{T}.cs
@@ -40,6 +40,6 @@ public sealed class ShaderRunner<T> : IShaderRunner
     /// <inheritdoc/>
     public void Execute(IReadWriteTexture2D<Float4> texture, TimeSpan time)
     {
-        Gpu.Default.ForEach(texture, this.shaderFactory(time));
+        GraphicsDevice.Default.ForEach(texture, this.shaderFactory(time));
     }
 }

--- a/src/ComputeSharp/Graphics/GraphicsDevice.GetDevice.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.GetDevice.cs
@@ -5,10 +5,8 @@ using ComputeSharp.Graphics.Helpers;
 
 namespace ComputeSharp;
 
-/// <summary>
-/// A <see langword="class"/> that acts as an entry-point for all the library APIs, exposing the available GPU devices.
-/// </summary>
-public static class Gpu
+/// <inheritdoc/>
+partial class GraphicsDevice
 {
     /// <summary>
     /// Gets the default <see cref="GraphicsDevice"/> instance for the current machine.

--- a/src/ComputeSharp/Graphics/GraphicsDevice.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.cs
@@ -22,7 +22,7 @@ namespace ComputeSharp;
 /// A <see langword="class"/> that represents an <see cref="ID3D12Device"/> instance that can be used to run compute shaders.
 /// </summary>
 [DebuggerDisplay("{ToString(),raw}")]
-public sealed unsafe class GraphicsDevice : NativeObject
+public sealed unsafe partial class GraphicsDevice : NativeObject
 {
     /// <summary>
     /// The underlying <see cref="ID3D12Device"/> wrapped by the current instance.

--- a/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
@@ -23,11 +23,11 @@ public partial class ShaderDataLoaderTests
     [TestMethod]
     public unsafe void CapturedResource()
     {
-        using ReadWriteBuffer<float> buffer = Gpu.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> buffer = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
 
         DebugDispatchDataLoader dataLoader = DebugDispatchDataLoader.Create();
 
-        ((IShader)new CapturedResourceShader(buffer)).LoadDispatchData(ref dataLoader, Gpu.Default, 111, 222, 333);
+        ((IShader)new CapturedResourceShader(buffer)).LoadDispatchData(ref dataLoader, GraphicsDevice.Default, 111, 222, 333);
 
         Assert.AreEqual(3, dataLoader.Values.Length);
         Assert.AreEqual(1, dataLoader.Resources.Length);
@@ -55,12 +55,12 @@ public partial class ShaderDataLoaderTests
     [TestMethod]
     public unsafe void LoadMultipleResourcesAndPrimitives()
     {
-        using ReadWriteBuffer<float> buffer0 = Gpu.Default.AllocateReadWriteBuffer<float>(16);
-        using ReadWriteBuffer<float> buffer1 = Gpu.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> buffer0 = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> buffer1 = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
 
         DebugDispatchDataLoader dataLoader = DebugDispatchDataLoader.Create();
 
-        ((IShader)new MultipleResourcesAndPrimitivesShader(buffer0, buffer1, 1, 22, 77)).LoadDispatchData(ref dataLoader, Gpu.Default, 111, 222, 333);
+        ((IShader)new MultipleResourcesAndPrimitivesShader(buffer0, buffer1, 1, 22, 77)).LoadDispatchData(ref dataLoader, GraphicsDevice.Default, 111, 222, 333);
 
         Assert.AreEqual(6, dataLoader.Values.Length);
         Assert.AreEqual(2, dataLoader.Resources.Length);
@@ -94,12 +94,12 @@ public partial class ShaderDataLoaderTests
     [TestMethod]
     public unsafe void LoadScalarAndVectorTypes()
     {
-        using ReadWriteBuffer<float> buffer = Gpu.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> buffer = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
 
         DebugDispatchDataLoader dataLoader = DebugDispatchDataLoader.Create();
         ScalarAndVectorTypesShader shader = new(buffer, new(55, 44, 888), 22, 77, new(3.14, 6.28), 42, 9999);
 
-        ((IShader)shader).LoadDispatchData(ref dataLoader, Gpu.Default, 111, 222, 333);
+        ((IShader)shader).LoadDispatchData(ref dataLoader, GraphicsDevice.Default, 111, 222, 333);
 
         Assert.AreEqual(18, dataLoader.Values.Length);
         Assert.AreEqual(1, dataLoader.Resources.Length);
@@ -147,7 +147,7 @@ public partial class ShaderDataLoaderTests
     [TestMethod]
     public unsafe void LoadScalarVectorAndMatrixTypes()
     {
-        using ReadWriteBuffer<float> buffer = Gpu.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> buffer = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
 
         DebugDispatchDataLoader dataLoader = DebugDispatchDataLoader.Create();
         ScalarVectorAndMatrixTypesShader shader = new(
@@ -161,7 +161,7 @@ public partial class ShaderDataLoaderTests
             i2x2: new(11, 22, 33, 44),
             d: 9999);
 
-        ((IShader)shader).LoadDispatchData(ref dataLoader, Gpu.Default, 111, 222, 333);
+        ((IShader)shader).LoadDispatchData(ref dataLoader, GraphicsDevice.Default, 111, 222, 333);
 
         Assert.AreEqual(31, dataLoader.Values.Length);
         Assert.AreEqual(1, dataLoader.Resources.Length);
@@ -226,7 +226,7 @@ public partial class ShaderDataLoaderTests
     [TestMethod]
     public unsafe void LoadFlatCustomTypeShader()
     {
-        using ReadWriteBuffer<float> buffer = Gpu.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> buffer = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
 
         DebugDispatchDataLoader dataLoader = DebugDispatchDataLoader.Create();
         FlatCustomTypeShader shader = new(
@@ -241,7 +241,7 @@ public partial class ShaderDataLoaderTests
                 i2x2: new(11, 22, 33, 44),
                 d: 9999));
 
-        ((IShader)shader).LoadDispatchData(ref dataLoader, Gpu.Default, 111, 222, 333);
+        ((IShader)shader).LoadDispatchData(ref dataLoader, GraphicsDevice.Default, 111, 222, 333);
 
         Assert.AreEqual(31, dataLoader.Values.Length);
         Assert.AreEqual(1, dataLoader.Resources.Length);
@@ -318,7 +318,7 @@ public partial class ShaderDataLoaderTests
     [TestMethod]
     public unsafe void LoadNestedCustomTypes()
     {
-        using ReadWriteBuffer<float> buffer = Gpu.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> buffer = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
 
         DebugDispatchDataLoader dataLoader = DebugDispatchDataLoader.Create();
         NestedCustomTypesShader shader = new(
@@ -345,7 +345,7 @@ public partial class ShaderDataLoaderTests
                     a: 888888,
                     b: new(333.3f, 444.4f))));
 
-        ((IShader)shader).LoadDispatchData(ref dataLoader, Gpu.Default, 111, 222, 333);
+        ((IShader)shader).LoadDispatchData(ref dataLoader, GraphicsDevice.Default, 111, 222, 333);
 
         Assert.AreEqual(47, dataLoader.Values.Length);
         Assert.AreEqual(1, dataLoader.Resources.Length);
@@ -417,16 +417,16 @@ public partial class ShaderDataLoaderTests
     [TestMethod]
     public unsafe void AmbiguousNames()
     {
-        using ReadWriteBuffer<float> a = Gpu.Default.AllocateReadWriteBuffer<float>(16);
-        using ReadWriteBuffer<float> b = Gpu.Default.AllocateReadWriteBuffer<float>(16);
-        using ReadWriteBuffer<float> c = Gpu.Default.AllocateReadWriteBuffer<float>(16);
-        using ReadWriteBuffer<float> x = Gpu.Default.AllocateReadWriteBuffer<float>(16);
-        using ReadWriteBuffer<float> y = Gpu.Default.AllocateReadWriteBuffer<float>(16);
-        using ReadWriteBuffer<float> z = Gpu.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> a = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> b = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> c = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> x = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> y = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
+        using ReadWriteBuffer<float> z = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(16);
 
         DebugDispatchDataLoader dataLoader = DebugDispatchDataLoader.Create();
 
-        ((IShader)new AmbiguousNamesShader(a, b, c, x, y, z, 7777, 8888, 9999)).LoadDispatchData(ref dataLoader, Gpu.Default, 111, 222, 333);
+        ((IShader)new AmbiguousNamesShader(a, b, c, x, y, z, 7777, 8888, 9999)).LoadDispatchData(ref dataLoader, GraphicsDevice.Default, 111, 222, 333);
 
         Assert.AreEqual(6, dataLoader.Values.Length);
         Assert.AreEqual(6, dataLoader.Resources.Length);

--- a/tests/ComputeSharp.Tests.Internals/ShaderHashCodeTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/ShaderHashCodeTests.cs
@@ -25,7 +25,7 @@ public partial class ShaderHashCodeTests
     public void ShaderWithNoCapturedDelegates()
     {
         float value = 10;
-        using ReadWriteBuffer<float> buffer = Gpu.Default.AllocateReadWriteBuffer<float>(1);
+        using ReadWriteBuffer<float> buffer = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(1);
 
         Shader1 shader1 = new() { A = value, B = buffer };
 
@@ -58,7 +58,7 @@ public partial class ShaderHashCodeTests
     {
         Func<float, float> f = static x => x * x;
 
-        using ReadWriteBuffer<float> buffer = Gpu.Default.AllocateReadWriteBuffer<float>(1);
+        using ReadWriteBuffer<float> buffer = GraphicsDevice.Default.AllocateReadWriteBuffer<float>(1);
 
         Shader2 shader1 = new() { A = 1, B = buffer, F = f };
 

--- a/tests/ComputeSharp.Tests/BufferTests.cs
+++ b/tests/ComputeSharp.Tests/BufferTests.cs
@@ -132,8 +132,8 @@ public partial class BufferTests
     {
         GraphicsDevice? gpu = device switch
         {
-            Device.Discrete => Gpu.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
-            Device.Warp => Gpu.QueryDevices(info => !info.IsHardwareAccelerated).First(),
+            Device.Discrete => GraphicsDevice.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
+            Device.Warp => GraphicsDevice.QueryDevices(info => !info.IsHardwareAccelerated).First(),
             _ => throw new ArgumentException(nameof(device))
         };
 

--- a/tests/ComputeSharp.Tests/Extensions/DeviceExtensions.cs
+++ b/tests/ComputeSharp.Tests/Extensions/DeviceExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.Extensions;
 
 /// <summary>
-/// A helper class for testing <see cref="Gpu"/> APIs.
+/// A helper class for testing <see cref="GraphicsDevice"/> APIs.
 /// </summary>
 public static class DeviceExtensions
 {
@@ -19,8 +19,8 @@ public static class DeviceExtensions
     {
         GraphicsDevice? device = type switch
         {
-            Device.Discrete => Gpu.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
-            Device.Warp => Gpu.QueryDevices(info => !info.IsHardwareAccelerated).First(),
+            Device.Discrete => GraphicsDevice.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
+            Device.Warp => GraphicsDevice.QueryDevices(info => !info.IsHardwareAccelerated).First(),
             _ => ThrowHelper.ThrowArgumentException<GraphicsDevice>("Invalid device")
         };
 

--- a/tests/ComputeSharp.Tests/InitializationTests.cs
+++ b/tests/ComputeSharp.Tests/InitializationTests.cs
@@ -13,7 +13,7 @@ public partial class InitializationTests
     [TestMethod]
     public void IsSupported()
     {
-        Assert.IsTrue(Gpu.Default is not null);
+        Assert.IsTrue(GraphicsDevice.Default is not null);
     }
 
     [CombinatorialTestMethod]
@@ -31,11 +31,11 @@ public partial class InitializationTests
     [TestMethod]
     public void DisposeDefault()
     {
-        using var before = Gpu.Default.AllocateReadOnlyBuffer<float>(128);
+        using var before = GraphicsDevice.Default.AllocateReadOnlyBuffer<float>(128);
 
-        Gpu.Default.Dispose();
+        GraphicsDevice.Default.Dispose();
 
-        using var after = Gpu.Default.AllocateReadOnlyBuffer<float>(128);
+        using var after = GraphicsDevice.Default.AllocateReadOnlyBuffer<float>(128);
     }
 
     [TestMethod]
@@ -43,9 +43,9 @@ public partial class InitializationTests
     {
         int i = 0;
 
-        foreach (GraphicsDevice device in Gpu.EnumerateDevices())
+        foreach (GraphicsDevice device in GraphicsDevice.EnumerateDevices())
         {
-            if (i++ == 0) Assert.AreSame(Gpu.Default, device);
+            if (i++ == 0) Assert.AreSame(GraphicsDevice.Default, device);
 
             using ReadWriteBuffer<int> buffer = device.AllocateReadWriteBuffer<int>(128);
 
@@ -62,9 +62,9 @@ public partial class InitializationTests
     {
         int i = 0;
 
-        foreach (GraphicsDevice device in Gpu.QueryDevices(info => info.DedicatedMemorySize >= 1024))
+        foreach (GraphicsDevice device in GraphicsDevice.QueryDevices(info => info.DedicatedMemorySize >= 1024))
         {
-            if (i++ == 0) Assert.AreSame(Gpu.Default, device);
+            if (i++ == 0) Assert.AreSame(GraphicsDevice.Default, device);
 
             using ReadWriteBuffer<int> buffer = device.AllocateReadWriteBuffer<int>(128);
 

--- a/tests/ComputeSharp.Tests/Texture2DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.cs
@@ -94,8 +94,8 @@ public partial class Texture2DTests
     {
         GraphicsDevice? gpu = device switch
         {
-            Device.Discrete => Gpu.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
-            Device.Warp => Gpu.QueryDevices(info => !info.IsHardwareAccelerated).First(),
+            Device.Discrete => GraphicsDevice.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
+            Device.Warp => GraphicsDevice.QueryDevices(info => !info.IsHardwareAccelerated).First(),
             _ => throw new ArgumentException(nameof(device))
         };
 

--- a/tests/ComputeSharp.Tests/Texture3DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture3DTests.cs
@@ -113,8 +113,8 @@ public partial class Texture3DTests
     {
         GraphicsDevice? gpu = device switch
         {
-            Device.Discrete => Gpu.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
-            Device.Warp => Gpu.QueryDevices(info => !info.IsHardwareAccelerated).First(),
+            Device.Discrete => GraphicsDevice.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
+            Device.Warp => GraphicsDevice.QueryDevices(info => !info.IsHardwareAccelerated).First(),
             _ => throw new ArgumentException(nameof(device))
         };
 

--- a/tests/ComputeSharp.Tests/TransferBufferTests.cs
+++ b/tests/ComputeSharp.Tests/TransferBufferTests.cs
@@ -74,8 +74,8 @@ public partial class TransferBufferTests
     {
         GraphicsDevice? gpu = device switch
         {
-            Device.Discrete => Gpu.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
-            Device.Warp => Gpu.QueryDevices(info => !info.IsHardwareAccelerated).First(),
+            Device.Discrete => GraphicsDevice.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
+            Device.Warp => GraphicsDevice.QueryDevices(info => !info.IsHardwareAccelerated).First(),
             _ => throw new ArgumentException(nameof(device))
         };
 

--- a/tests/ComputeSharp.Tests/TransferTexture2DTests.cs
+++ b/tests/ComputeSharp.Tests/TransferTexture2DTests.cs
@@ -78,8 +78,8 @@ public partial class TransferTexture2DTests
     {
         GraphicsDevice? gpu = device switch
         {
-            Device.Discrete => Gpu.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
-            Device.Warp => Gpu.QueryDevices(info => !info.IsHardwareAccelerated).First(),
+            Device.Discrete => GraphicsDevice.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
+            Device.Warp => GraphicsDevice.QueryDevices(info => !info.IsHardwareAccelerated).First(),
             _ => throw new ArgumentException(nameof(device))
         };
 

--- a/tests/ComputeSharp.Tests/TransferTexture3DTests.cs
+++ b/tests/ComputeSharp.Tests/TransferTexture3DTests.cs
@@ -85,8 +85,8 @@ public partial class TransferTexture3DTests
     {
         GraphicsDevice? gpu = device switch
         {
-            Device.Discrete => Gpu.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
-            Device.Warp => Gpu.QueryDevices(info => !info.IsHardwareAccelerated).First(),
+            Device.Discrete => GraphicsDevice.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
+            Device.Warp => GraphicsDevice.QueryDevices(info => !info.IsHardwareAccelerated).First(),
             _ => throw new ArgumentException(nameof(device))
         };
 


### PR DESCRIPTION
This PR removes the `Gpu` class and moves the APIs into the `GraphicsDevice` type, which improves consistency and overall just makes more sense, given all those APIs were returning `GraphicsDevice` instances anyway.