### PR TITLE
Add IBufferWriter<byte> overloads to save/load textures

### DIFF
--- a/src/ComputeSharp/Graphics/Extensions/Interop/IWICStreamExtensions.IBufferWriter.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/IWICStreamExtensions.IBufferWriter.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.IO;
+using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Microsoft.Toolkit.Diagnostics;
 using TerraFX.Interop.Windows;
 using static TerraFX.Interop.Windows.E;
 using static TerraFX.Interop.Windows.IID;
@@ -21,76 +20,74 @@ using UnmanagedCallersOnlyAttribute = ComputeSharp.NetStandard.System.Runtime.In
 
 namespace ComputeSharp.Graphics.Extensions;
 
-/// <summary>
-/// A <see langword="class"/> with extensions for the <see cref="IWICStream"/> type.
-/// </summary>
-internal static unsafe class IWICStreamExtensions
+/// <inheritdoc/>
+internal static unsafe partial class IWICStreamExtensions
 {
     /// <summary>
-    /// Initializes an input <see cref="IWICStream"/> wrapping a given <see cref="Stream"/> instance.
+    /// Initializes an input <see cref="IWICStream"/> wrapping a given <see cref="IBufferWriter{T}"/> instance.
     /// </summary>
     /// <param name="stream">The target <see cref="IWICStream"/> object to initialize.</param>
-    /// <param name="source">The input <see cref="Stream"/> instance to wrap.</param>
+    /// <param name="destination">The input <see cref="IBufferWriter{T}"/> instance to wrap.</param>
     /// <returns>An <see cref="HRESULT"/> value indicating the operation result.</returns>
-    public static HRESULT InitializeFromStream(this ref IWICStream stream, Stream source)
+    public static HRESULT InitializeFromBufferWriter(this ref IWICStream stream, IBufferWriter<byte> destination)
     {
-        using ComPtr<IStreamWrapper> streamWrapper = default;
+        using ComPtr<IBufferWriterWrapper> streamWrapper = default;
 
-        IStreamWrapper.Create(source, streamWrapper.GetAddressOf());
+        IBufferWriterWrapper.Create(destination, streamWrapper.GetAddressOf());
 
         return stream.InitializeFromIStream((IStream*)streamWrapper.Get());
     }
 
     /// <summary>
-    /// A manual CCW implementation for an <see cref="IStream"/> object wrapping a <see cref="Stream"/> instance.
+    /// A manual CCW implementation for an <see cref="IStream"/> object wrapping an <see cref="IBufferWriter{T}"/> instance.
     /// </summary>
-    internal unsafe partial struct IStreamWrapper
+    internal unsafe partial struct IBufferWriterWrapper
 #if NET6_0_OR_GREATER
         : IUnknown.Interface
 #endif
     {
 #if !NET6_0_OR_GREATER
         /// <inheritdoc cref="QueryInterface"/>
-        private delegate int QueryInterfaceDelegate(IStreamWrapper* @this, Guid* riid, void** ppvObject);
+        private delegate int QueryInterfaceDelegate(IBufferWriterWrapper* @this, Guid* riid, void** ppvObject);
 
         /// <inheritdoc cref="AddRef"/>
-        private delegate uint AddRefDelegate(IStreamWrapper* @this);
+        private delegate uint AddRefDelegate(IBufferWriterWrapper* @this);
 
         /// <inheritdoc cref="Release"/>
-        private delegate uint ReleaseDelegate(IStreamWrapper* @this);
+        private delegate uint ReleaseDelegate(IBufferWriterWrapper* @this);
 
         /// <inheritdoc cref="Read"/>
-        private delegate HRESULT ReadDelegate(IStreamWrapper* @this, void* pv, uint cb, uint* pcbRead);
+        private delegate HRESULT ReadDelegate(IBufferWriterWrapper* @this, void* pv, uint cb, uint* pcbRead);
 
         /// <inheritdoc cref="Write"/>
-        private delegate HRESULT WriteDelegate(IStreamWrapper* @this, void* pv, uint cb, uint* pcbWritten);
+        private delegate HRESULT WriteDelegate(IBufferWriterWrapper* @this, void* pv, uint cb, uint* pcbWritten);
 
         /// <inheritdoc cref="Seek"/>
-        private delegate HRESULT SeekDelegate(IStreamWrapper* @this, LARGE_INTEGER dlibMove, uint dwOrigin, ULARGE_INTEGER* plibNewPosition);
+        private delegate HRESULT SeekDelegate(IBufferWriterWrapper* @this, LARGE_INTEGER dlibMove, uint dwOrigin, ULARGE_INTEGER* plibNewPosition);
 
         /// <inheritdoc cref="SetSize"/>
-        private delegate HRESULT SetSizeDelegate(IStreamWrapper* @this, ULARGE_INTEGER libNewSize);
+        private delegate HRESULT SetSizeDelegate(IBufferWriterWrapper* @this, ULARGE_INTEGER libNewSize);
 
         /// <inheritdoc cref="CopyTo"/>
-        private delegate HRESULT CopyToDelegate(IStreamWrapper* @this, IStream* pstm, ULARGE_INTEGER cb, ULARGE_INTEGER* pcbRead, ULARGE_INTEGER* pcbWritten);
+        private delegate HRESULT CopyToDelegate(IBufferWriterWrapper* @this, IStream* pstm, ULARGE_INTEGER cb, ULARGE_INTEGER* pcbRead, ULARGE_INTEGER* pcbWritten);
 
         /// <inheritdoc cref="Commit"/>
-        private delegate HRESULT CommitDelegate(IStreamWrapper* @this, uint grfCommitFlags);
+        private delegate HRESULT CommitDelegate(IBufferWriterWrapper* @this, uint grfCommitFlags);
 
         /// <inheritdoc cref="Revert"/>
-        private delegate HRESULT RevertDelegate(IStreamWrapper* @this);
+        private delegate HRESULT RevertDelegate(IBufferWriterWrapper* @this);
 
         /// <inheritdoc cref="LockRegion"/>
-        private delegate HRESULT LockRegionDelegate(IStreamWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType);
+        private delegate HRESULT LockRegionDelegate(IBufferWriterWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType);
 
         /// <inheritdoc cref="UnlockRegion"/>
-        private delegate HRESULT UnlockRegionDelegate(IStreamWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType);
+        private delegate HRESULT UnlockRegionDelegate(IBufferWriterWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType);
 
         /// <inheritdoc cref="Stat"/>
-        private delegate HRESULT StatDelegate(IStreamWrapper* @this, STATSTG* pstatstg, uint grfStatFlag);
+        private delegate HRESULT StatDelegate(IBufferWriterWrapper* @this, STATSTG* pstatstg, uint grfStatFlag);
 
         /// <inheritdoc cref="Clone"/>
-        private delegate HRESULT CloneDelegate(IStreamWrapper* @this, IStream** ppstm);
+        private delegate HRESULT CloneDelegate(IBufferWriterWrapper* @this, IStream** ppstm);
 
         /// <summary>
         /// A cached <see cref="QueryInterfaceDelegate"/> instance wrapping <see cref="QueryInterface"/>.
@@ -164,33 +161,33 @@ internal static unsafe class IWICStreamExtensions
 #endif
 
         /// <summary>
-        /// The shared vtable pointer for <see cref="IStreamWrapper"/> instances.
+        /// The shared vtable pointer for <see cref="IBufferWriterWrapper"/> instances.
         /// </summary>
         private static readonly void** Vtbl = InitVtbl();
 
         /// <summary>
-        /// Setups the vtable pointer for <see cref="IStreamWrapper"/>.
+        /// Setups the vtable pointer for <see cref="IBufferWriterWrapper"/>.
         /// </summary>
-        /// <returns>The initialized vtable pointer for <see cref="IStreamWrapper"/>.</returns>
+        /// <returns>The initialized vtable pointer for <see cref="IBufferWriterWrapper"/>.</returns>
         private static void** InitVtbl()
         {
-            void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IStreamWrapper), sizeof(void*) * 14);
+            void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IBufferWriterWrapper), sizeof(void*) * 14);
 
 #if NET6_0_OR_GREATER
-            lpVtbl[0] = (delegate* unmanaged<IStreamWrapper*, Guid*, void**, int>)&QueryInterface;
-            lpVtbl[1] = (delegate* unmanaged<IStreamWrapper*, uint>)&AddRef;
-            lpVtbl[2] = (delegate* unmanaged<IStreamWrapper*, uint>)&Release;
-            lpVtbl[3] = (delegate* unmanaged<IStreamWrapper*, void*, uint, uint*, HRESULT>)&Read;
-            lpVtbl[4] = (delegate* unmanaged<IStreamWrapper*, void*, uint, uint*, HRESULT>)&Write;
-            lpVtbl[5] = (delegate* unmanaged<IStreamWrapper*, LARGE_INTEGER, uint, ULARGE_INTEGER*, HRESULT>)&Seek;
-            lpVtbl[6] = (delegate* unmanaged<IStreamWrapper*, ULARGE_INTEGER, HRESULT>)&SetSize;
-            lpVtbl[7] = (delegate* unmanaged<IStreamWrapper*, IStream*, ULARGE_INTEGER, ULARGE_INTEGER*, ULARGE_INTEGER*, HRESULT>)&CopyTo;
-            lpVtbl[8] = (delegate* unmanaged<IStreamWrapper*, uint, HRESULT>)&Commit;
-            lpVtbl[9] = (delegate* unmanaged<IStreamWrapper*, HRESULT>)&Revert;
-            lpVtbl[10] = (delegate* unmanaged<IStreamWrapper*, ULARGE_INTEGER, ULARGE_INTEGER, uint, HRESULT>)&LockRegion;
-            lpVtbl[11] = (delegate* unmanaged<IStreamWrapper*, ULARGE_INTEGER, ULARGE_INTEGER, uint, HRESULT>)&UnlockRegion;
-            lpVtbl[12] = (delegate* unmanaged<IStreamWrapper*, STATSTG*, uint, HRESULT>)&Stat;
-            lpVtbl[13] = (delegate* unmanaged<IStreamWrapper*, IStream**, HRESULT>)&Clone;
+            lpVtbl[0] = (delegate* unmanaged<IBufferWriterWrapper*, Guid*, void**, int>)&QueryInterface;
+            lpVtbl[1] = (delegate* unmanaged<IBufferWriterWrapper*, uint>)&AddRef;
+            lpVtbl[2] = (delegate* unmanaged<IBufferWriterWrapper*, uint>)&Release;
+            lpVtbl[3] = (delegate* unmanaged<IBufferWriterWrapper*, void*, uint, uint*, HRESULT>)&Read;
+            lpVtbl[4] = (delegate* unmanaged<IBufferWriterWrapper*, void*, uint, uint*, HRESULT>)&Write;
+            lpVtbl[5] = (delegate* unmanaged<IBufferWriterWrapper*, LARGE_INTEGER, uint, ULARGE_INTEGER*, HRESULT>)&Seek;
+            lpVtbl[6] = (delegate* unmanaged<IBufferWriterWrapper*, ULARGE_INTEGER, HRESULT>)&SetSize;
+            lpVtbl[7] = (delegate* unmanaged<IBufferWriterWrapper*, IStream*, ULARGE_INTEGER, ULARGE_INTEGER*, ULARGE_INTEGER*, HRESULT>)&CopyTo;
+            lpVtbl[8] = (delegate* unmanaged<IBufferWriterWrapper*, uint, HRESULT>)&Commit;
+            lpVtbl[9] = (delegate* unmanaged<IBufferWriterWrapper*, HRESULT>)&Revert;
+            lpVtbl[10] = (delegate* unmanaged<IBufferWriterWrapper*, ULARGE_INTEGER, ULARGE_INTEGER, uint, HRESULT>)&LockRegion;
+            lpVtbl[11] = (delegate* unmanaged<IBufferWriterWrapper*, ULARGE_INTEGER, ULARGE_INTEGER, uint, HRESULT>)&UnlockRegion;
+            lpVtbl[12] = (delegate* unmanaged<IBufferWriterWrapper*, STATSTG*, uint, HRESULT>)&Stat;
+            lpVtbl[13] = (delegate* unmanaged<IBufferWriterWrapper*, IStream**, HRESULT>)&Clone;
 #else
             lpVtbl[0] = (void*)Marshal.GetFunctionPointerForDelegate(QueryInterfaceWrapper);
             lpVtbl[1] = (void*)Marshal.GetFunctionPointerForDelegate(AddRefWrapper);
@@ -222,59 +219,59 @@ internal static unsafe class IWICStreamExtensions
         public volatile int referenceCount;
 
         /// <summary>
-        /// The <see cref="GCHandle"/> to the captured <see cref="Stream"/>.
+        /// The <see cref="GCHandle"/> to the captured <see cref="IBufferWriter{T}"/>.
         /// </summary>
-        public GCHandle streamHandle;
+        public GCHandle writerHandle;
 
         /// <summary>
-        /// Creates and initializes a new <see cref="IStreamWrapper"/> instance.
+        /// Creates and initializes a new <see cref="IBufferWriterWrapper"/> instance.
         /// </summary>
-        /// <param name="stream">The input <see cref="Stream"/> instance to wrap.</param>
-        /// <param name="streamWrapper">The target <see cref="IStreamWrapper"/> instance to initialize.</param>
-        public static void Create(Stream stream, IStreamWrapper** streamWrapper)
+        /// <param name="writer">The input <see cref="IBufferWriter{T}"/> instance to wrap.</param>
+        /// <param name="streamWrapper">The target <see cref="IBufferWriterWrapper"/> instance to initialize.</param>
+        public static void Create(IBufferWriter<byte> writer, IBufferWriterWrapper** streamWrapper)
         {
-            IStreamWrapper* @this = (IStreamWrapper*)NativeMemory.Alloc((nuint)sizeof(IStreamWrapper));
+            IBufferWriterWrapper* @this = (IBufferWriterWrapper*)NativeMemory.Alloc((nuint)sizeof(IBufferWriterWrapper));
 
             @this->lpVtbl = Vtbl;
             @this->referenceCount = 1;
-            @this->streamHandle = GCHandle.Alloc(stream);
+            @this->writerHandle = GCHandle.Alloc(writer);
 
             *streamWrapper = @this;
         }
 
         /// <summary>
-        /// Gets the captured <see cref="Stream"/> instance.
+        /// Gets the captured <see cref="IBufferWriter{T}"/> instance.
         /// </summary>
-        /// <returns>The captured <see cref="Stream"/> instance</returns>
+        /// <returns>The captured <see cref="IBufferWriter{T}"/> instance</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private Stream GetStream()
+        private IBufferWriter<byte> GetWriter()
         {
-            return Unsafe.As<Stream>(this.streamHandle.Target!);
+            return Unsafe.As<IBufferWriter<byte>>(this.writerHandle.Target!);
         }
 
 #if NET6_0_OR_GREATER
         /// <inheritdoc/>
         public HRESULT QueryInterface(Guid* riid, void** ppvObject)
         {
-            return ((delegate* unmanaged<IStreamWrapper*, Guid*, void**, HRESULT>)lpVtbl[0])((IStreamWrapper*)Unsafe.AsPointer(ref this), riid, ppvObject);
+            return ((delegate* unmanaged<IBufferWriterWrapper*, Guid*, void**, HRESULT>)lpVtbl[0])((IBufferWriterWrapper*)Unsafe.AsPointer(ref this), riid, ppvObject);
         }
 
         /// <inheritdoc/>
         public uint AddRef()
         {
-            return ((delegate* unmanaged<IStreamWrapper*, uint>)lpVtbl[1])((IStreamWrapper*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged<IBufferWriterWrapper*, uint>)lpVtbl[1])((IBufferWriterWrapper*)Unsafe.AsPointer(ref this));
         }
 
         /// <inheritdoc/>
         public uint Release()
         {
-            return ((delegate* unmanaged<IStreamWrapper*, uint>)lpVtbl[2])((IStreamWrapper*)Unsafe.AsPointer(ref this));
+            return ((delegate* unmanaged<IBufferWriterWrapper*, uint>)lpVtbl[2])((IBufferWriterWrapper*)Unsafe.AsPointer(ref this));
         }
 #endif
 
         /// <inheritdoc cref="IStream.QueryInterface(Guid*, void**)"/>
         [UnmanagedCallersOnly]
-        private static int QueryInterface(IStreamWrapper* @this, Guid* riid, void** ppvObject)
+        private static int QueryInterface(IBufferWriterWrapper* @this, Guid* riid, void** ppvObject)
         {
             if (ppvObject is null)
             {
@@ -299,20 +296,20 @@ internal static unsafe class IWICStreamExtensions
 
         /// <inheritdoc cref="IStream.AddRef"/>
         [UnmanagedCallersOnly]
-        private static uint AddRef(IStreamWrapper* @this)
+        private static uint AddRef(IBufferWriterWrapper* @this)
         {
             return (uint)Interlocked.Increment(ref @this->referenceCount);
         }
 
         /// <inheritdoc cref="IStream.Release"/>
         [UnmanagedCallersOnly]
-        private static uint Release(IStreamWrapper* @this)
+        private static uint Release(IBufferWriterWrapper* @this)
         {
             uint referenceCount = (uint)Interlocked.Decrement(ref @this->referenceCount);
 
             if (referenceCount == 0)
             {
-                @this->streamHandle.Free();
+                @this->writerHandle.Free();
 
                 NativeMemory.Free(@this);
             }
@@ -322,55 +319,14 @@ internal static unsafe class IWICStreamExtensions
 
         /// <inheritdoc cref="IStream.Read(void*, uint, uint*)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT Read(IStreamWrapper* @this, void* pv, uint cb, uint* pcbRead)
+        private static HRESULT Read(IBufferWriterWrapper* @this, void* pv, uint cb, uint* pcbRead)
         {
-            if (pv == null)
-            {
-                return E_POINTER;
-            }
-
-            if (cb > int.MaxValue)
-            {
-                return E_INVALIDARG;
-            }
-
-            if (pcbRead != null)
-            {
-                *pcbRead = 0;
-            }
-
-            try
-            {
-                Span<byte> dst = new(pv, (int)cb);
-
-                while (dst.Length > 0)
-                {
-                    int bytesRead = @this->GetStream().Read(dst);
-
-                    if (bytesRead == 0)
-                    {
-                        return S_FALSE;
-                    }
-
-                    if (pcbRead != null)
-                    {
-                        *pcbRead += (uint)bytesRead;
-                    }
-
-                    dst = dst.Slice(bytesRead);
-                }
-
-                return S_OK;
-            }
-            catch (Exception ex)
-            {
-                return ex.HResult;
-            }
+            return STG_E_INVALIDFUNCTION;
         }
 
         /// <inheritdoc cref="IStream.Write(void*, uint, uint*)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT Write(IStreamWrapper* @this, void* pv, uint cb, uint* pcbWritten)
+        private static HRESULT Write(IBufferWriterWrapper* @this, void* pv, uint cb, uint* pcbWritten)
         {
             if (pv == null)
             {
@@ -389,7 +345,7 @@ internal static unsafe class IWICStreamExtensions
 
             try
             {
-                @this->GetStream().Write(new ReadOnlySpan<byte>(pv, (int)cb));
+                @this->GetWriter().Write(new ReadOnlySpan<byte>(pv, (int)cb));
 
                 if (pcbWritten != null)
                 {
@@ -406,110 +362,56 @@ internal static unsafe class IWICStreamExtensions
 
         /// <inheritdoc cref="IStream.Seek(LARGE_INTEGER, uint, ULARGE_INTEGER*)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT Seek(IStreamWrapper* @this, LARGE_INTEGER dlibMove, uint dwOrigin, ULARGE_INTEGER* plibNewPosition)
+        private static HRESULT Seek(IBufferWriterWrapper* @this, LARGE_INTEGER dlibMove, uint dwOrigin, ULARGE_INTEGER* plibNewPosition)
         {
-            SeekOrigin origin = (SeekOrigin)dwOrigin;
-
-            switch (origin)
-            {
-                case SeekOrigin.Begin:
-                case SeekOrigin.Current:
-                case SeekOrigin.End:
-                    break;
-                default:
-                    return E_INVALIDARG;
-            }
-
-            if (plibNewPosition != null)
-            {
-                *plibNewPosition = default;
-            }
-
-            try
-            {
-                long newPosition = @this->GetStream().Seek(dlibMove.QuadPart, origin);
-
-                if (plibNewPosition != null)
-                {
-                    plibNewPosition->QuadPart = (ulong)newPosition;
-                }
-
-                return S_OK;
-            }
-            catch (Exception ex)
-            {
-                return ex.HResult;
-            }
+            return STG_E_INVALIDFUNCTION;
         }
 
         /// <inheritdoc cref="IStream.SetSize(ULARGE_INTEGER)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT SetSize(IStreamWrapper* @this, ULARGE_INTEGER libNewSize)
+        private static HRESULT SetSize(IBufferWriterWrapper* @this, ULARGE_INTEGER libNewSize)
         {
-            if (libNewSize.QuadPart > long.MaxValue)
-            {
-                return E_INVALIDARG;
-            }
-
-            try
-            {
-                @this->GetStream().SetLength((long)libNewSize.QuadPart);
-
-                return S_OK;
-            }
-            catch (Exception ex)
-            {
-                return ex.HResult;
-            }
+            return STG_E_INVALIDFUNCTION;
         }
 
         /// <inheritdoc cref="IStream.CopyTo(IStream*, ULARGE_INTEGER, ULARGE_INTEGER*, ULARGE_INTEGER*)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT CopyTo(IStreamWrapper* @this, IStream* pstm, ULARGE_INTEGER cb, ULARGE_INTEGER* pcbRead, ULARGE_INTEGER* pcbWritten)
+        private static HRESULT CopyTo(IBufferWriterWrapper* @this, IStream* pstm, ULARGE_INTEGER cb, ULARGE_INTEGER* pcbRead, ULARGE_INTEGER* pcbWritten)
         {
             return E_NOTIMPL;
         }
 
         /// <inheritdoc cref="IStream.Commit(uint)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT Commit(IStreamWrapper* @this, uint grfCommitFlags)
+        private static HRESULT Commit(IBufferWriterWrapper* @this, uint grfCommitFlags)
         {
-            try
-            {
-                @this->GetStream().Flush();
-
-                return S_OK;
-            }
-            catch (Exception ex)
-            {
-                return ex.HResult;
-            }
+            return S_OK;
         }
 
         /// <inheritdoc cref="IStream.Revert"/>
         [UnmanagedCallersOnly]
-        private static HRESULT Revert(IStreamWrapper* @this)
+        private static HRESULT Revert(IBufferWriterWrapper* @this)
         {
             return STG_E_INVALIDFUNCTION;
         }
 
         /// <inheritdoc cref="IStream.LockRegion(ULARGE_INTEGER, ULARGE_INTEGER, uint)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT LockRegion(IStreamWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType)
+        private static HRESULT LockRegion(IBufferWriterWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType)
         {
             return STG_E_INVALIDFUNCTION;
         }
 
         /// <inheritdoc cref="IStream.UnlockRegion(ULARGE_INTEGER, ULARGE_INTEGER, uint)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT UnlockRegion(IStreamWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType)
+        private static HRESULT UnlockRegion(IBufferWriterWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType)
         {
             return STG_E_INVALIDFUNCTION;
         }
 
         /// <inheritdoc cref="IStream.Stat(STATSTG*, uint)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT Stat(IStreamWrapper* @this, STATSTG* pstatstg, uint grfStatFlag)
+        private static HRESULT Stat(IBufferWriterWrapper* @this, STATSTG* pstatstg, uint grfStatFlag)
         {
             if (pstatstg == null)
             {
@@ -527,57 +429,21 @@ internal static unsafe class IWICStreamExtensions
 
             try
             {
-                Stream stream = @this->GetStream();
-
-                if (!statFlag.HasFlag(STATFLAG_NONAME))
-                {
-                    if (stream is FileStream asFileStream)
-                    {
-                        pstatstg->pwcsName = (ushort*)Marshal.StringToCoTaskMemUni(asFileStream.Name);
-                    }
-                }
-
-                bool canRead = stream.CanRead;
-                bool canWrite = stream.CanWrite;
-
-                if (canRead && !canWrite)
-                {
-                    pstatstg->grfMode = STGM_READ;
-                }
-                else if (canRead && canWrite)
-                {
-                    pstatstg->grfMode = STGM_READWRITE;
-                }
-                else if (!canRead && canWrite)
-                {
-                    pstatstg->grfMode = STGM_WRITE;
-                }
-                else
-                {
-                    ThrowHelper.ThrowNotSupportedException();
-                }
-
+                pstatstg->grfMode = STGM_WRITE;
                 pstatstg->type = (uint)STGTY_STREAM;
-                pstatstg->cbSize.QuadPart = (ulong)stream.Length;
+                pstatstg->cbSize.QuadPart = ulong.MaxValue;
 
                 return S_OK;
             }
             catch (Exception ex)
             {
-                if (pstatstg->pwcsName != null)
-                {
-                    Marshal.FreeCoTaskMem((IntPtr)pstatstg->pwcsName);
-
-                    pstatstg->pwcsName = null;
-                }
-
                 return ex.HResult;
             }
         }
 
         /// <inheritdoc cref="IStream.Clone(IStream**)"/>
         [UnmanagedCallersOnly]
-        private static HRESULT Clone(IStreamWrapper* @this, IStream** ppstm)
+        private static HRESULT Clone(IBufferWriterWrapper* @this, IStream** ppstm)
         {
             return STG_E_INVALIDFUNCTION;
         }

--- a/src/ComputeSharp/Graphics/Extensions/Interop/IWICStreamExtensions.Stream.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/IWICStreamExtensions.Stream.cs
@@ -1,0 +1,585 @@
+﻿using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.Toolkit.Diagnostics;
+using TerraFX.Interop.Windows;
+using static TerraFX.Interop.Windows.E;
+using static TerraFX.Interop.Windows.IID;
+using static TerraFX.Interop.Windows.S;
+using static TerraFX.Interop.Windows.STATFLAG;
+using static TerraFX.Interop.Windows.STG;
+using static TerraFX.Interop.Windows.STGM;
+using static TerraFX.Interop.Windows.STGTY;
+#if NET6_0_OR_GREATER
+using RuntimeHelpers = System.Runtime.CompilerServices.RuntimeHelpers;
+#else
+using RuntimeHelpers = ComputeSharp.NetStandard.System.Runtime.CompilerServices.RuntimeHelpers;
+using UnmanagedCallersOnlyAttribute = ComputeSharp.NetStandard.System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute;
+#endif
+
+namespace ComputeSharp.Graphics.Extensions;
+
+/// <summary>
+/// A <see langword="class"/> with extensions for the <see cref="IWICStream"/> type.
+/// </summary>
+internal static unsafe partial class IWICStreamExtensions
+{
+    /// <summary>
+    /// Initializes an input <see cref="IWICStream"/> wrapping a given <see cref="Stream"/> instance.
+    /// </summary>
+    /// <param name="stream">The target <see cref="IWICStream"/> object to initialize.</param>
+    /// <param name="source">The input <see cref="Stream"/> instance to wrap.</param>
+    /// <returns>An <see cref="HRESULT"/> value indicating the operation result.</returns>
+    public static HRESULT InitializeFromStream(this ref IWICStream stream, Stream source)
+    {
+        using ComPtr<IStreamWrapper> streamWrapper = default;
+
+        IStreamWrapper.Create(source, streamWrapper.GetAddressOf());
+
+        return stream.InitializeFromIStream((IStream*)streamWrapper.Get());
+    }
+
+    /// <summary>
+    /// A manual CCW implementation for an <see cref="IStream"/> object wrapping a <see cref="Stream"/> instance.
+    /// </summary>
+    internal unsafe partial struct IStreamWrapper
+#if NET6_0_OR_GREATER
+        : IUnknown.Interface
+#endif
+    {
+#if !NET6_0_OR_GREATER
+        /// <inheritdoc cref="QueryInterface"/>
+        private delegate int QueryInterfaceDelegate(IStreamWrapper* @this, Guid* riid, void** ppvObject);
+
+        /// <inheritdoc cref="AddRef"/>
+        private delegate uint AddRefDelegate(IStreamWrapper* @this);
+
+        /// <inheritdoc cref="Release"/>
+        private delegate uint ReleaseDelegate(IStreamWrapper* @this);
+
+        /// <inheritdoc cref="Read"/>
+        private delegate HRESULT ReadDelegate(IStreamWrapper* @this, void* pv, uint cb, uint* pcbRead);
+
+        /// <inheritdoc cref="Write"/>
+        private delegate HRESULT WriteDelegate(IStreamWrapper* @this, void* pv, uint cb, uint* pcbWritten);
+
+        /// <inheritdoc cref="Seek"/>
+        private delegate HRESULT SeekDelegate(IStreamWrapper* @this, LARGE_INTEGER dlibMove, uint dwOrigin, ULARGE_INTEGER* plibNewPosition);
+
+        /// <inheritdoc cref="SetSize"/>
+        private delegate HRESULT SetSizeDelegate(IStreamWrapper* @this, ULARGE_INTEGER libNewSize);
+
+        /// <inheritdoc cref="CopyTo"/>
+        private delegate HRESULT CopyToDelegate(IStreamWrapper* @this, IStream* pstm, ULARGE_INTEGER cb, ULARGE_INTEGER* pcbRead, ULARGE_INTEGER* pcbWritten);
+
+        /// <inheritdoc cref="Commit"/>
+        private delegate HRESULT CommitDelegate(IStreamWrapper* @this, uint grfCommitFlags);
+
+        /// <inheritdoc cref="Revert"/>
+        private delegate HRESULT RevertDelegate(IStreamWrapper* @this);
+
+        /// <inheritdoc cref="LockRegion"/>
+        private delegate HRESULT LockRegionDelegate(IStreamWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType);
+
+        /// <inheritdoc cref="UnlockRegion"/>
+        private delegate HRESULT UnlockRegionDelegate(IStreamWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType);
+
+        /// <inheritdoc cref="Stat"/>
+        private delegate HRESULT StatDelegate(IStreamWrapper* @this, STATSTG* pstatstg, uint grfStatFlag);
+
+        /// <inheritdoc cref="Clone"/>
+        private delegate HRESULT CloneDelegate(IStreamWrapper* @this, IStream** ppstm);
+
+        /// <summary>
+        /// A cached <see cref="QueryInterfaceDelegate"/> instance wrapping <see cref="QueryInterface"/>.
+        /// </summary>
+        private static readonly QueryInterfaceDelegate QueryInterfaceWrapper = QueryInterface;
+
+        /// <summary>
+        /// A cached <see cref="AddRefDelegate"/> instance wrapping <see cref="AddRef"/>.
+        /// </summary>
+        private static readonly AddRefDelegate AddRefWrapper = AddRef;
+
+        /// <summary>
+        /// A cached <see cref="ReleaseDelegate"/> instance wrapping <see cref="Release"/>.
+        /// </summary>
+        private static readonly ReleaseDelegate ReleaseWrapper = Release;
+
+        /// <summary>
+        /// A cached <see cref="ReadDelegate"/> instance wrapping <see cref="Read"/>.
+        /// </summary>
+        private static readonly ReadDelegate ReadWrapper = Read;
+
+        /// <summary>
+        /// A cached <see cref="WriteDelegate"/> instance wrapping <see cref="Write"/>.
+        /// </summary>
+        private static readonly WriteDelegate WriteWrapper = Write;
+
+        /// <summary>
+        /// A cached <see cref="SeekDelegate"/> instance wrapping <see cref="Seek"/>.
+        /// </summary>
+        private static readonly SeekDelegate SeekWrapper = Seek;
+
+        /// <summary>
+        /// A cached <see cref="SetSizeDelegate"/> instance wrapping <see cref="SetSize"/>.
+        /// </summary>
+        private static readonly SetSizeDelegate SetSizeWrapper = SetSize;
+
+        /// <summary>
+        /// A cached <see cref="CopyToDelegate"/> instance wrapping <see cref="CopyTo"/>.
+        /// </summary>
+        private static readonly CopyToDelegate CopyToWrapper = CopyTo;
+
+        /// <summary>
+        /// A cached <see cref="CommitDelegate"/> instance wrapping <see cref="Commit"/>.
+        /// </summary>
+        private static readonly CommitDelegate CommitWrapper = Commit;
+
+        /// <summary>
+        /// A cached <see cref="RevertDelegate"/> instance wrapping <see cref="Revert"/>.
+        /// </summary>
+        private static readonly RevertDelegate RevertWrapper = Revert;
+
+        /// <summary>
+        /// A cached <see cref="LockRegionDelegate"/> instance wrapping <see cref="LockRegion"/>.
+        /// </summary>
+        private static readonly LockRegionDelegate LockRegionWrapper = LockRegion;
+
+        /// <summary>
+        /// A cached <see cref="UnlockRegionDelegate"/> instance wrapping <see cref="UnlockRegion"/>.
+        /// </summary>
+        private static readonly UnlockRegionDelegate UnlockRegionWrapper = UnlockRegion;
+
+        /// <summary>
+        /// A cached <see cref="StatDelegate"/> instance wrapping <see cref="Stat"/>.
+        /// </summary>
+        private static readonly StatDelegate StatWrapper = Stat;
+
+        /// <summary>
+        /// A cached <see cref="CloneDelegate"/> instance wrapping <see cref="Clone"/>.
+        /// </summary>
+        private static readonly CloneDelegate CloneWrapper = Clone;
+#endif
+
+        /// <summary>
+        /// The shared vtable pointer for <see cref="IStreamWrapper"/> instances.
+        /// </summary>
+        private static readonly void** Vtbl = InitVtbl();
+
+        /// <summary>
+        /// Setups the vtable pointer for <see cref="IStreamWrapper"/>.
+        /// </summary>
+        /// <returns>The initialized vtable pointer for <see cref="IStreamWrapper"/>.</returns>
+        private static void** InitVtbl()
+        {
+            void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(IStreamWrapper), sizeof(void*) * 14);
+
+#if NET6_0_OR_GREATER
+            lpVtbl[0] = (delegate* unmanaged<IStreamWrapper*, Guid*, void**, int>)&QueryInterface;
+            lpVtbl[1] = (delegate* unmanaged<IStreamWrapper*, uint>)&AddRef;
+            lpVtbl[2] = (delegate* unmanaged<IStreamWrapper*, uint>)&Release;
+            lpVtbl[3] = (delegate* unmanaged<IStreamWrapper*, void*, uint, uint*, HRESULT>)&Read;
+            lpVtbl[4] = (delegate* unmanaged<IStreamWrapper*, void*, uint, uint*, HRESULT>)&Write;
+            lpVtbl[5] = (delegate* unmanaged<IStreamWrapper*, LARGE_INTEGER, uint, ULARGE_INTEGER*, HRESULT>)&Seek;
+            lpVtbl[6] = (delegate* unmanaged<IStreamWrapper*, ULARGE_INTEGER, HRESULT>)&SetSize;
+            lpVtbl[7] = (delegate* unmanaged<IStreamWrapper*, IStream*, ULARGE_INTEGER, ULARGE_INTEGER*, ULARGE_INTEGER*, HRESULT>)&CopyTo;
+            lpVtbl[8] = (delegate* unmanaged<IStreamWrapper*, uint, HRESULT>)&Commit;
+            lpVtbl[9] = (delegate* unmanaged<IStreamWrapper*, HRESULT>)&Revert;
+            lpVtbl[10] = (delegate* unmanaged<IStreamWrapper*, ULARGE_INTEGER, ULARGE_INTEGER, uint, HRESULT>)&LockRegion;
+            lpVtbl[11] = (delegate* unmanaged<IStreamWrapper*, ULARGE_INTEGER, ULARGE_INTEGER, uint, HRESULT>)&UnlockRegion;
+            lpVtbl[12] = (delegate* unmanaged<IStreamWrapper*, STATSTG*, uint, HRESULT>)&Stat;
+            lpVtbl[13] = (delegate* unmanaged<IStreamWrapper*, IStream**, HRESULT>)&Clone;
+#else
+            lpVtbl[0] = (void*)Marshal.GetFunctionPointerForDelegate(QueryInterfaceWrapper);
+            lpVtbl[1] = (void*)Marshal.GetFunctionPointerForDelegate(AddRefWrapper);
+            lpVtbl[2] = (void*)Marshal.GetFunctionPointerForDelegate(ReleaseWrapper);
+            lpVtbl[3] = (void*)Marshal.GetFunctionPointerForDelegate(ReadWrapper);
+            lpVtbl[4] = (void*)Marshal.GetFunctionPointerForDelegate(WriteWrapper);
+            lpVtbl[5] = (void*)Marshal.GetFunctionPointerForDelegate(SeekWrapper);
+            lpVtbl[6] = (void*)Marshal.GetFunctionPointerForDelegate(SetSizeWrapper);
+            lpVtbl[7] = (void*)Marshal.GetFunctionPointerForDelegate(CopyToWrapper);
+            lpVtbl[8] = (void*)Marshal.GetFunctionPointerForDelegate(CommitWrapper);
+            lpVtbl[9] = (void*)Marshal.GetFunctionPointerForDelegate(RevertWrapper);
+            lpVtbl[10] = (void*)Marshal.GetFunctionPointerForDelegate(LockRegionWrapper);
+            lpVtbl[11] = (void*)Marshal.GetFunctionPointerForDelegate(UnlockRegionWrapper);
+            lpVtbl[12] = (void*)Marshal.GetFunctionPointerForDelegate(StatWrapper);
+            lpVtbl[13] = (void*)Marshal.GetFunctionPointerForDelegate(CloneWrapper);
+#endif
+
+            return lpVtbl;
+        }
+
+        /// <summary>
+        /// The vtable pointer for the current instance.
+        /// </summary>
+        public void** lpVtbl;
+
+        /// <summary>
+        /// The current reference count for the object (from <c>IUnknown</c>).
+        /// </summary>
+        public volatile int referenceCount;
+
+        /// <summary>
+        /// The <see cref="GCHandle"/> to the captured <see cref="Stream"/>.
+        /// </summary>
+        public GCHandle streamHandle;
+
+        /// <summary>
+        /// Creates and initializes a new <see cref="IStreamWrapper"/> instance.
+        /// </summary>
+        /// <param name="stream">The input <see cref="Stream"/> instance to wrap.</param>
+        /// <param name="streamWrapper">The target <see cref="IStreamWrapper"/> instance to initialize.</param>
+        public static void Create(Stream stream, IStreamWrapper** streamWrapper)
+        {
+            IStreamWrapper* @this = (IStreamWrapper*)NativeMemory.Alloc((nuint)sizeof(IStreamWrapper));
+
+            @this->lpVtbl = Vtbl;
+            @this->referenceCount = 1;
+            @this->streamHandle = GCHandle.Alloc(stream);
+
+            *streamWrapper = @this;
+        }
+
+        /// <summary>
+        /// Gets the captured <see cref="Stream"/> instance.
+        /// </summary>
+        /// <returns>The captured <see cref="Stream"/> instance</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Stream GetStream()
+        {
+            return Unsafe.As<Stream>(this.streamHandle.Target!);
+        }
+
+#if NET6_0_OR_GREATER
+        /// <inheritdoc/>
+        public HRESULT QueryInterface(Guid* riid, void** ppvObject)
+        {
+            return ((delegate* unmanaged<IStreamWrapper*, Guid*, void**, HRESULT>)lpVtbl[0])((IStreamWrapper*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        }
+
+        /// <inheritdoc/>
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged<IStreamWrapper*, uint>)lpVtbl[1])((IStreamWrapper*)Unsafe.AsPointer(ref this));
+        }
+
+        /// <inheritdoc/>
+        public uint Release()
+        {
+            return ((delegate* unmanaged<IStreamWrapper*, uint>)lpVtbl[2])((IStreamWrapper*)Unsafe.AsPointer(ref this));
+        }
+#endif
+
+        /// <inheritdoc cref="IStream.QueryInterface(Guid*, void**)"/>
+        [UnmanagedCallersOnly]
+        private static int QueryInterface(IStreamWrapper* @this, Guid* riid, void** ppvObject)
+        {
+            if (ppvObject is null)
+            {
+                return E_POINTER;
+            }
+
+            if (riid->Equals(IID_IUnknown) ||
+                riid->Equals(IID_ISequentialStream) ||
+                riid->Equals(IID_IStream))
+            {
+                _ = Interlocked.Increment(ref @this->referenceCount);
+
+                *ppvObject = @this;
+
+                return S_OK;
+            }
+
+            *ppvObject = null;
+
+            return E_NOINTERFACE;
+        }
+
+        /// <inheritdoc cref="IStream.AddRef"/>
+        [UnmanagedCallersOnly]
+        private static uint AddRef(IStreamWrapper* @this)
+        {
+            return (uint)Interlocked.Increment(ref @this->referenceCount);
+        }
+
+        /// <inheritdoc cref="IStream.Release"/>
+        [UnmanagedCallersOnly]
+        private static uint Release(IStreamWrapper* @this)
+        {
+            uint referenceCount = (uint)Interlocked.Decrement(ref @this->referenceCount);
+
+            if (referenceCount == 0)
+            {
+                @this->streamHandle.Free();
+
+                NativeMemory.Free(@this);
+            }
+
+            return referenceCount;
+        }
+
+        /// <inheritdoc cref="IStream.Read(void*, uint, uint*)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT Read(IStreamWrapper* @this, void* pv, uint cb, uint* pcbRead)
+        {
+            if (pv == null)
+            {
+                return E_POINTER;
+            }
+
+            if (cb > int.MaxValue)
+            {
+                return E_INVALIDARG;
+            }
+
+            if (pcbRead != null)
+            {
+                *pcbRead = 0;
+            }
+
+            try
+            {
+                Span<byte> dst = new(pv, (int)cb);
+
+                while (dst.Length > 0)
+                {
+                    int bytesRead = @this->GetStream().Read(dst);
+
+                    if (bytesRead == 0)
+                    {
+                        return S_FALSE;
+                    }
+
+                    if (pcbRead != null)
+                    {
+                        *pcbRead += (uint)bytesRead;
+                    }
+
+                    dst = dst.Slice(bytesRead);
+                }
+
+                return S_OK;
+            }
+            catch (Exception ex)
+            {
+                return ex.HResult;
+            }
+        }
+
+        /// <inheritdoc cref="IStream.Write(void*, uint, uint*)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT Write(IStreamWrapper* @this, void* pv, uint cb, uint* pcbWritten)
+        {
+            if (pv == null)
+            {
+                return E_POINTER;
+            }
+
+            if (cb > int.MaxValue)
+            {
+                return E_INVALIDARG;
+            }
+
+            if (pcbWritten != null)
+            {
+                *pcbWritten = 0;
+            }
+
+            try
+            {
+                @this->GetStream().Write(new ReadOnlySpan<byte>(pv, (int)cb));
+
+                if (pcbWritten != null)
+                {
+                    *pcbWritten = cb;
+                }
+
+                return S_OK;
+            }
+            catch (Exception ex)
+            {
+                return ex.HResult;
+            }
+        }
+
+        /// <inheritdoc cref="IStream.Seek(LARGE_INTEGER, uint, ULARGE_INTEGER*)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT Seek(IStreamWrapper* @this, LARGE_INTEGER dlibMove, uint dwOrigin, ULARGE_INTEGER* plibNewPosition)
+        {
+            SeekOrigin origin = (SeekOrigin)dwOrigin;
+
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                case SeekOrigin.Current:
+                case SeekOrigin.End:
+                    break;
+                default:
+                    return E_INVALIDARG;
+            }
+
+            if (plibNewPosition != null)
+            {
+                *plibNewPosition = default;
+            }
+
+            try
+            {
+                long newPosition = @this->GetStream().Seek(dlibMove.QuadPart, origin);
+
+                if (plibNewPosition != null)
+                {
+                    plibNewPosition->QuadPart = (ulong)newPosition;
+                }
+
+                return S_OK;
+            }
+            catch (Exception ex)
+            {
+                return ex.HResult;
+            }
+        }
+
+        /// <inheritdoc cref="IStream.SetSize(ULARGE_INTEGER)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT SetSize(IStreamWrapper* @this, ULARGE_INTEGER libNewSize)
+        {
+            if (libNewSize.QuadPart > long.MaxValue)
+            {
+                return E_INVALIDARG;
+            }
+
+            try
+            {
+                @this->GetStream().SetLength((long)libNewSize.QuadPart);
+
+                return S_OK;
+            }
+            catch (Exception ex)
+            {
+                return ex.HResult;
+            }
+        }
+
+        /// <inheritdoc cref="IStream.CopyTo(IStream*, ULARGE_INTEGER, ULARGE_INTEGER*, ULARGE_INTEGER*)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT CopyTo(IStreamWrapper* @this, IStream* pstm, ULARGE_INTEGER cb, ULARGE_INTEGER* pcbRead, ULARGE_INTEGER* pcbWritten)
+        {
+            return E_NOTIMPL;
+        }
+
+        /// <inheritdoc cref="IStream.Commit(uint)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT Commit(IStreamWrapper* @this, uint grfCommitFlags)
+        {
+            try
+            {
+                @this->GetStream().Flush();
+
+                return S_OK;
+            }
+            catch (Exception ex)
+            {
+                return ex.HResult;
+            }
+        }
+
+        /// <inheritdoc cref="IStream.Revert"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT Revert(IStreamWrapper* @this)
+        {
+            return STG_E_INVALIDFUNCTION;
+        }
+
+        /// <inheritdoc cref="IStream.LockRegion(ULARGE_INTEGER, ULARGE_INTEGER, uint)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT LockRegion(IStreamWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType)
+        {
+            return STG_E_INVALIDFUNCTION;
+        }
+
+        /// <inheritdoc cref="IStream.UnlockRegion(ULARGE_INTEGER, ULARGE_INTEGER, uint)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT UnlockRegion(IStreamWrapper* @this, ULARGE_INTEGER libOffset, ULARGE_INTEGER cb, uint dwLockType)
+        {
+            return STG_E_INVALIDFUNCTION;
+        }
+
+        /// <inheritdoc cref="IStream.Stat(STATSTG*, uint)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT Stat(IStreamWrapper* @this, STATSTG* pstatstg, uint grfStatFlag)
+        {
+            if (pstatstg == null)
+            {
+                return E_POINTER;
+            }
+
+            *pstatstg = default;
+
+            STATFLAG statFlag = (STATFLAG)grfStatFlag;
+
+            if ((statFlag & (STATFLAG_DEFAULT | STATFLAG_NONAME | STATFLAG_NOOPEN)) != statFlag)
+            {
+                return E_INVALIDARG;
+            }
+
+            try
+            {
+                Stream stream = @this->GetStream();
+
+                if (!statFlag.HasFlag(STATFLAG_NONAME))
+                {
+                    if (stream is FileStream asFileStream)
+                    {
+                        pstatstg->pwcsName = (ushort*)Marshal.StringToCoTaskMemUni(asFileStream.Name);
+                    }
+                }
+
+                bool canRead = stream.CanRead;
+                bool canWrite = stream.CanWrite;
+
+                if (canRead && !canWrite)
+                {
+                    pstatstg->grfMode = STGM_READ;
+                }
+                else if (canRead && canWrite)
+                {
+                    pstatstg->grfMode = STGM_READWRITE;
+                }
+                else if (!canRead && canWrite)
+                {
+                    pstatstg->grfMode = STGM_WRITE;
+                }
+                else
+                {
+                    ThrowHelper.ThrowNotSupportedException();
+                }
+
+                pstatstg->type = (uint)STGTY_STREAM;
+                pstatstg->cbSize.QuadPart = (ulong)stream.Length;
+
+                return S_OK;
+            }
+            catch (Exception ex)
+            {
+                if (pstatstg->pwcsName != null)
+                {
+                    Marshal.FreeCoTaskMem((IntPtr)pstatstg->pwcsName);
+
+                    pstatstg->pwcsName = null;
+                }
+
+                return ex.HResult;
+            }
+        }
+
+        /// <inheritdoc cref="IStream.Clone(IStream**)"/>
+        [UnmanagedCallersOnly]
+        private static HRESULT Clone(IStreamWrapper* @this, IStream** ppstm)
+        {
+            return STG_E_INVALIDFUNCTION;
+        }
+    }
+}

--- a/src/ComputeSharp/Graphics/Extensions/ReadBackTexture2DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadBackTexture2DExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.IO;
 using ComputeSharp.Graphics.Helpers;
 using ComputeSharp.Resources;
@@ -96,5 +97,20 @@ public static class ReadBackTexture2DExtensions
         Guard.IsNotNull(stream, nameof(stream));
 
         WICHelper.Instance.SaveTexture(texture.View, stream, format);
+    }
+
+    /// <summary>
+    /// Saves a texture to a specified buffer writer.
+    /// </summary>
+    /// <typeparam name="T">The type of items to store in the texture.</typeparam>
+    /// <param name="texture">The texture to save to an image.</param>
+    /// <param name="writer">The buffer writer to save the image to.</param>
+    /// <param name="format">The target image format to use.</param>
+    public static void Save<T>(this ReadBackTexture2D<T> texture, IBufferWriter<byte> writer, ImageFormat format)
+        where T : unmanaged
+    {
+        Guard.IsNotNull(writer, nameof(writer));
+
+        WICHelper.Instance.SaveTexture(texture.View, writer, format);
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/Texture2DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Texture2DExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Diagnostics.Contracts;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -583,5 +584,24 @@ public static class Texture2DExtensions
         texture.CopyTo(readback);
 
         WICHelper.Instance.SaveTexture(readback.View, stream, format);
+    }
+
+    /// <summary>
+    /// Saves a texture to a specified buffer writer.
+    /// </summary>
+    /// <typeparam name="T">The type of items to store in the texture.</typeparam>
+    /// <param name="texture">The texture to save to an image.</param>
+    /// <param name="writer">The buffer writer to save the image to.</param>
+    /// <param name="format">The target image format to use.</param>
+    public static void Save<T>(this Texture2D<T> texture, IBufferWriter<byte> writer, ImageFormat format)
+        where T : unmanaged
+    {
+        Guard.IsNotNull(writer, nameof(writer));
+
+        using ReadBackTexture2D<T> readback = texture.GraphicsDevice.AllocateReadBackTexture2D<T>(texture.Width, texture.Height);
+
+        texture.CopyTo(readback);
+
+        WICHelper.Instance.SaveTexture(readback.View, writer, format);
     }
 }


### PR DESCRIPTION
This PR adds an internal CCW wrapping an `IBufferWriter<byte>` that can be passed down to WIC APIs to load/save images.
There are also new overloads for all texture 2D types to save to an `IBufferWriter<byte>` instance.