### PR TITLE
Add ComputeContext.Clear APIs

### DIFF
--- a/src/ComputeSharp/Graphics/Commands/Interop/ID3D12DescriptorHandleAllocator.cs
+++ b/src/ComputeSharp/Graphics/Commands/Interop/ID3D12DescriptorHandleAllocator.cs
@@ -26,9 +26,14 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     private ComPtr<ID3D12DescriptorHeap> d3D12DescriptorHeap;
 
     /// <summary>
-    /// The array of <see cref="D3D12DescriptorHandlePair"/> items with the available descriptor handles.
+    /// The non shader visible <see cref="ID3D12DescriptorHeap"/> in use for the current <see cref="ID3D12DescriptorHandleAllocator"/> instance.
     /// </summary>
-    private readonly D3D12DescriptorHandlePair[] d3D12DescriptorHandlePairs;
+    private ComPtr<ID3D12DescriptorHeap> d3D12DescriptorHeapNonShaderVisible;
+
+    /// <summary>
+    /// The array of <see cref="D3D12DescriptorHandleBundle"/> items with the available descriptor handles.
+    /// </summary>
+    private readonly D3D12DescriptorHandleBundle[] d3D12DescriptorHandlePairs;
 
     /// <summary>
     /// The head index for the queue.
@@ -51,20 +56,23 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     /// <param name="device">The <see cref="ID3D12Device"/> instance to use.</param>
     public ID3D12DescriptorHandleAllocator(ID3D12Device* device)
     {
-        this.d3D12DescriptorHeap = device->CreateDescriptorHeap(DescriptorsPerHeap);
-        this.d3D12DescriptorHandlePairs = GC.AllocateUninitializedArray<D3D12DescriptorHandlePair>((int)DescriptorsPerHeap);
+        this.d3D12DescriptorHeap = device->CreateDescriptorHeap(DescriptorsPerHeap, isShaderVisible: true);
+        this.d3D12DescriptorHeapNonShaderVisible = device->CreateDescriptorHeap(DescriptorsPerHeap, isShaderVisible: false);
+        this.d3D12DescriptorHandlePairs = GC.AllocateUninitializedArray<D3D12DescriptorHandleBundle>((int)DescriptorsPerHeap);
         this.head = 0;
         this.tail = 0;
         this.size = (int)DescriptorsPerHeap;
 
         D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle = this.d3D12DescriptorHeap.Get()->GetCPUDescriptorHandleForHeapStart();
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible = this.d3D12DescriptorHeapNonShaderVisible.Get()->GetCPUDescriptorHandleForHeapStart();
         D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandleStart = this.d3D12DescriptorHeap.Get()->GetGPUDescriptorHandleForHeapStart();
         uint descriptorIncrementSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
         for (int i = 0; i < this.d3D12DescriptorHandlePairs.Length; i++)
         {
-            this.d3D12DescriptorHandlePairs[i] = new D3D12DescriptorHandlePair(
+            this.d3D12DescriptorHandlePairs[i] = new D3D12DescriptorHandleBundle(
                 in d3D12CpuDescriptorHandle,
+                in d3D12CpuDescriptorHandleNonShaderVisible,
                 in d3D12GpuDescriptorHandleStart,
                 i,
                 descriptorIncrementSize);
@@ -80,18 +88,21 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     /// Rents a new CPU and GPU handle pair to use in a memory buffer.
     /// </summary>
     /// <param name="d3D12CpuDescriptorHandle">The resulting <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
+    /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The resulting non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
     /// <param name="d3D12GpuDescriptorHandle">The resulting <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
     public void Rent(
         out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+        out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible,
         out D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
     {
         lock (this.d3D12DescriptorHandlePairs)
         {
             Guard.IsGreaterThan(this.size, 0, nameof(size));
 
-            ref readonly D3D12DescriptorHandlePair d3D12DescriptorHandlePair = ref this.d3D12DescriptorHandlePairs[this.head++];
+            ref readonly D3D12DescriptorHandleBundle d3D12DescriptorHandlePair = ref this.d3D12DescriptorHandlePairs[this.head++];
 
             d3D12CpuDescriptorHandle = d3D12DescriptorHandlePair.D3D12CpuDescriptorHandle;
+            d3D12CpuDescriptorHandleNonShaderVisible = d3D12DescriptorHandlePair.D3D12CpuDescriptorHandleNonShaderVisible;
             d3D12GpuDescriptorHandle = d3D12DescriptorHandlePair.D3D12GpuDescriptorhandle;
 
             if (this.head == DescriptorsPerHeap)
@@ -107,16 +118,18 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     /// Returns a CPU and GPU handle pair for later use.
     /// </summary>
     /// <param name="d3D12CpuDescriptorHandle">The returned <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
+    /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The returned non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
     /// <param name="d3D12GpuDescriptorHandle">The returned <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
     public void Return(
         D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible,
         D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
     {
         lock (this.d3D12DescriptorHandlePairs)
         {
             Guard.IsLessThan(this.size, DescriptorsPerHeap, nameof(size));
 
-            this.d3D12DescriptorHandlePairs[this.tail++] = new D3D12DescriptorHandlePair(d3D12CpuDescriptorHandle, d3D12GpuDescriptorHandle);
+            this.d3D12DescriptorHandlePairs[this.tail++] = new D3D12DescriptorHandleBundle(d3D12CpuDescriptorHandle, d3D12CpuDescriptorHandleNonShaderVisible, d3D12GpuDescriptorHandle);
 
             if (this.tail == DescriptorsPerHeap)
             {
@@ -134,9 +147,9 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     }
 
     /// <summary>
-    /// A type representing a pair of reusable descriptor handles.
+    /// A type representing a bundle of reusable descriptor handles.
     /// </summary>
-    private readonly struct D3D12DescriptorHandlePair
+    private readonly struct D3D12DescriptorHandleBundle
     {
         /// <summary>
         /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the current entry.
@@ -144,37 +157,48 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
         public readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle;
 
         /// <summary>
+        /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the current entry, non shader visible.
+        /// </summary>
+        public readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonShaderVisible;
+
+        /// <summary>
         /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the current entry.
         /// </summary>
         public readonly D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorhandle;
 
         /// <summary>
-        /// Creates a new <see cref="D3D12DescriptorHandlePair"/> instance with the given parameters.
+        /// Creates a new <see cref="D3D12DescriptorHandleBundle"/> instance with the given parameters.
         /// </summary>
         /// <param name="d3D12CpuDescriptorHandle">The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
+        /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The non shader visible <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
         /// <param name="d3D12GpuDescriptorHandle">The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
-        public D3D12DescriptorHandlePair(
+        public D3D12DescriptorHandleBundle(
             D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+            D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible,
             D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
         {
             D3D12CpuDescriptorHandle = d3D12CpuDescriptorHandle;
+            D3D12CpuDescriptorHandleNonShaderVisible = d3D12CpuDescriptorHandleNonShaderVisible;
             D3D12GpuDescriptorhandle = d3D12GpuDescriptorHandle;
         }
 
         /// <summary>
-        /// Creates a new <see cref="D3D12DescriptorHandlePair"/> instance with the given parameters.
+        /// Creates a new <see cref="D3D12DescriptorHandleBundle"/> instance with the given parameters.
         /// </summary>
         /// <param name="d3D12CpuDescriptorHandleStart">The base <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
+        /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The base non shader visible <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
         /// <param name="d3D12GpuDescriptorHandleStart">The base <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
         /// <param name="offset">The offset for the new pair of handles to compute.</param>
         /// <param name="descriptorIncrementSize">The increment size for each consecutive handles pair.</param>
-        public D3D12DescriptorHandlePair(
+        public D3D12DescriptorHandleBundle(
             in D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleStart,
+            in D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible,
             in D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandleStart,
             int offset,
             uint descriptorIncrementSize)
         {
             D3D12_CPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12CpuDescriptorHandle, in d3D12CpuDescriptorHandleStart, offset, descriptorIncrementSize);
+            D3D12_CPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12CpuDescriptorHandleNonShaderVisible, in d3D12CpuDescriptorHandleNonShaderVisible, offset, descriptorIncrementSize);
             D3D12_GPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12GpuDescriptorhandle, in d3D12GpuDescriptorHandleStart, offset, descriptorIncrementSize);
         }
     }

--- a/src/ComputeSharp/Graphics/Commands/Interop/ID3D12DescriptorHandleAllocator.cs
+++ b/src/ComputeSharp/Graphics/Commands/Interop/ID3D12DescriptorHandleAllocator.cs
@@ -31,9 +31,9 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     private ComPtr<ID3D12DescriptorHeap> d3D12DescriptorHeapNonShaderVisible;
 
     /// <summary>
-    /// The array of <see cref="D3D12DescriptorHandleBundle"/> items with the available descriptor handles.
+    /// The array of <see cref="ID3D12ResourceDescriptorHandles"/> items with the available descriptor handles.
     /// </summary>
-    private readonly D3D12DescriptorHandleBundle[] d3D12DescriptorHandlePairs;
+    private readonly ID3D12ResourceDescriptorHandles[] d3D12DescriptorHandlePairs;
 
     /// <summary>
     /// The head index for the queue.
@@ -58,24 +58,26 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     {
         this.d3D12DescriptorHeap = device->CreateDescriptorHeap(DescriptorsPerHeap, isShaderVisible: true);
         this.d3D12DescriptorHeapNonShaderVisible = device->CreateDescriptorHeap(DescriptorsPerHeap, isShaderVisible: false);
-        this.d3D12DescriptorHandlePairs = GC.AllocateUninitializedArray<D3D12DescriptorHandleBundle>((int)DescriptorsPerHeap);
+        this.d3D12DescriptorHandlePairs = GC.AllocateUninitializedArray<ID3D12ResourceDescriptorHandles>((int)DescriptorsPerHeap);
         this.head = 0;
         this.tail = 0;
         this.size = (int)DescriptorsPerHeap;
 
-        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle = this.d3D12DescriptorHeap.Get()->GetCPUDescriptorHandleForHeapStart();
-        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible = this.d3D12DescriptorHeapNonShaderVisible.Get()->GetCPUDescriptorHandleForHeapStart();
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleStart = this.d3D12DescriptorHeap.Get()->GetCPUDescriptorHandleForHeapStart();
         D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandleStart = this.d3D12DescriptorHeap.Get()->GetGPUDescriptorHandleForHeapStart();
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisibleStart = this.d3D12DescriptorHeapNonShaderVisible.Get()->GetCPUDescriptorHandleForHeapStart();
         uint descriptorIncrementSize = device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
 
         for (int i = 0; i < this.d3D12DescriptorHandlePairs.Length; i++)
         {
-            this.d3D12DescriptorHandlePairs[i] = new D3D12DescriptorHandleBundle(
-                in d3D12CpuDescriptorHandle,
-                in d3D12CpuDescriptorHandleNonShaderVisible,
-                in d3D12GpuDescriptorHandleStart,
-                i,
-                descriptorIncrementSize);
+            D3D12_CPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle, in d3D12CpuDescriptorHandleStart, i, descriptorIncrementSize);
+            D3D12_GPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle, in d3D12GpuDescriptorHandleStart, i, descriptorIncrementSize);
+            D3D12_CPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible, in d3D12CpuDescriptorHandleNonShaderVisibleStart, i, descriptorIncrementSize);
+
+            this.d3D12DescriptorHandlePairs[i] = new ID3D12ResourceDescriptorHandles(
+                d3D12CpuDescriptorHandle,
+                d3D12GpuDescriptorHandle,
+                d3D12CpuDescriptorHandleNonShaderVisible);
         }
     }
 
@@ -85,25 +87,16 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     public ID3D12DescriptorHeap* D3D12DescriptorHeap => this.d3D12DescriptorHeap;
 
     /// <summary>
-    /// Rents a new CPU and GPU handle pair to use in a memory buffer.
+    /// Rents a new bundle of CPU and GPU handles to use in a resource.
     /// </summary>
-    /// <param name="d3D12CpuDescriptorHandle">The resulting <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
-    /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The resulting non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
-    /// <param name="d3D12GpuDescriptorHandle">The resulting <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
-    public void Rent(
-        out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
-        out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible,
-        out D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
+    /// <param name="d3D12ResourceDescriptorHandles">The resulting <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
+    public void Rent(out ID3D12ResourceDescriptorHandles d3D12ResourceDescriptorHandles)
     {
         lock (this.d3D12DescriptorHandlePairs)
         {
             Guard.IsGreaterThan(this.size, 0, nameof(size));
 
-            ref readonly D3D12DescriptorHandleBundle d3D12DescriptorHandlePair = ref this.d3D12DescriptorHandlePairs[this.head++];
-
-            d3D12CpuDescriptorHandle = d3D12DescriptorHandlePair.D3D12CpuDescriptorHandle;
-            d3D12CpuDescriptorHandleNonShaderVisible = d3D12DescriptorHandlePair.D3D12CpuDescriptorHandleNonShaderVisible;
-            d3D12GpuDescriptorHandle = d3D12DescriptorHandlePair.D3D12GpuDescriptorhandle;
+            d3D12ResourceDescriptorHandles = this.d3D12DescriptorHandlePairs[this.head++];
 
             if (this.head == DescriptorsPerHeap)
             {
@@ -117,19 +110,14 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     /// <summary>
     /// Returns a CPU and GPU handle pair for later use.
     /// </summary>
-    /// <param name="d3D12CpuDescriptorHandle">The returned <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
-    /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The returned non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
-    /// <param name="d3D12GpuDescriptorHandle">The returned <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
-    public void Return(
-        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
-        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible,
-        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
+    /// <param name="d3D12ResourceDescriptorHandles">The returned <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value.</param>
+    public void Return(in ID3D12ResourceDescriptorHandles d3D12ResourceDescriptorHandles)
     {
         lock (this.d3D12DescriptorHandlePairs)
         {
             Guard.IsLessThan(this.size, DescriptorsPerHeap, nameof(size));
 
-            this.d3D12DescriptorHandlePairs[this.tail++] = new D3D12DescriptorHandleBundle(d3D12CpuDescriptorHandle, d3D12CpuDescriptorHandleNonShaderVisible, d3D12GpuDescriptorHandle);
+            this.d3D12DescriptorHandlePairs[this.tail++] = d3D12ResourceDescriptorHandles;
 
             if (this.tail == DescriptorsPerHeap)
             {
@@ -144,62 +132,5 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     public void Dispose()
     {
         this.d3D12DescriptorHeap.Dispose();
-    }
-
-    /// <summary>
-    /// A type representing a bundle of reusable descriptor handles.
-    /// </summary>
-    private readonly struct D3D12DescriptorHandleBundle
-    {
-        /// <summary>
-        /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the current entry.
-        /// </summary>
-        public readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle;
-
-        /// <summary>
-        /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the current entry, non shader visible.
-        /// </summary>
-        public readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonShaderVisible;
-
-        /// <summary>
-        /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the current entry.
-        /// </summary>
-        public readonly D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorhandle;
-
-        /// <summary>
-        /// Creates a new <see cref="D3D12DescriptorHandleBundle"/> instance with the given parameters.
-        /// </summary>
-        /// <param name="d3D12CpuDescriptorHandle">The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
-        /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The non shader visible <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
-        /// <param name="d3D12GpuDescriptorHandle">The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
-        public D3D12DescriptorHandleBundle(
-            D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
-            D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible,
-            D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
-        {
-            D3D12CpuDescriptorHandle = d3D12CpuDescriptorHandle;
-            D3D12CpuDescriptorHandleNonShaderVisible = d3D12CpuDescriptorHandleNonShaderVisible;
-            D3D12GpuDescriptorhandle = d3D12GpuDescriptorHandle;
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="D3D12DescriptorHandleBundle"/> instance with the given parameters.
-        /// </summary>
-        /// <param name="d3D12CpuDescriptorHandleStart">The base <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
-        /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The base non shader visible <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
-        /// <param name="d3D12GpuDescriptorHandleStart">The base <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value.</param>
-        /// <param name="offset">The offset for the new pair of handles to compute.</param>
-        /// <param name="descriptorIncrementSize">The increment size for each consecutive handles pair.</param>
-        public D3D12DescriptorHandleBundle(
-            in D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleStart,
-            in D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible,
-            in D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandleStart,
-            int offset,
-            uint descriptorIncrementSize)
-        {
-            D3D12_CPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12CpuDescriptorHandle, in d3D12CpuDescriptorHandleStart, offset, descriptorIncrementSize);
-            D3D12_CPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12CpuDescriptorHandleNonShaderVisible, in d3D12CpuDescriptorHandleNonShaderVisible, offset, descriptorIncrementSize);
-            D3D12_GPU_DESCRIPTOR_HANDLE.InitOffsetted(out D3D12GpuDescriptorhandle, in d3D12GpuDescriptorHandleStart, offset, descriptorIncrementSize);
-        }
     }
 }

--- a/src/ComputeSharp/Graphics/Commands/Interop/ID3D12ResourceDescriptorHandles.cs
+++ b/src/ComputeSharp/Graphics/Commands/Interop/ID3D12ResourceDescriptorHandles.cs
@@ -1,0 +1,40 @@
+﻿using TerraFX.Interop.DirectX;
+
+namespace ComputeSharp.Graphics.Commands.Interop;
+
+/// <summary>
+/// A type representing a bundle of reusable resource descriptor handles.
+/// </summary>
+internal readonly struct ID3D12ResourceDescriptorHandles
+{
+    /// <summary>
+    /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the current entry.
+    /// </summary>
+    public readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle;
+
+    /// <summary>
+    /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the current entry.
+    /// </summary>
+    public readonly D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle;
+
+    /// <summary>
+    /// The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value for the current entry, non shader visible.
+    /// </summary>
+    public readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonShaderVisible;
+
+    /// <summary>
+    /// Creates a new <see cref="ID3D12ResourceDescriptorHandles"/> instance with the given parameters.
+    /// </summary>
+    /// <param name="d3D12CpuDescriptorHandle">The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
+    /// <param name="d3D12GpuDescriptorHandle">The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
+    /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value to wrap.</param>
+    public ID3D12ResourceDescriptorHandles(
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle,
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible)
+    {
+        D3D12CpuDescriptorHandle = d3D12CpuDescriptorHandle;
+        D3D12GpuDescriptorHandle = d3D12GpuDescriptorHandle;
+        D3D12CpuDescriptorHandleNonShaderVisible = d3D12CpuDescriptorHandleNonShaderVisible;
+    }
+}

--- a/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
@@ -321,16 +321,17 @@ internal static unsafe class ID3D12DeviceExtensions
     /// </summary>
     /// <param name="d3D12Device">The target <see cref="ID3D12Device"/> to use to create the descriptor heap.</param>
     /// <param name="descriptorsCount">The number of descriptors to allocate.</param>
+    /// <param name="isShaderVisible">Whether or not the descriptor heap should be shader visible.</param>
     /// <returns>A pointer to the newly allocated <see cref="ID3D12DescriptorHeap"/> instance.</returns>
     /// <exception cref="Exception">Thrown when the creation of the command queue fails.</exception>
-    public static ComPtr<ID3D12DescriptorHeap> CreateDescriptorHeap(this ref ID3D12Device d3D12Device, uint descriptorsCount)
+    public static ComPtr<ID3D12DescriptorHeap> CreateDescriptorHeap(this ref ID3D12Device d3D12Device, uint descriptorsCount, bool isShaderVisible)
     {
         using ComPtr<ID3D12DescriptorHeap> d3D12DescriptorHeap = default;
 
         D3D12_DESCRIPTOR_HEAP_DESC d3D12DescriptorHeapDesc;
         d3D12DescriptorHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
         d3D12DescriptorHeapDesc.NumDescriptors = descriptorsCount;
-        d3D12DescriptorHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+        d3D12DescriptorHeapDesc.Flags = isShaderVisible ? D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE : D3D12_DESCRIPTOR_HEAP_FLAGS.D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
         d3D12DescriptorHeapDesc.NodeMask = 0;
 
         d3D12Device.CreateDescriptorHeap(

--- a/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
@@ -459,6 +459,37 @@ internal static unsafe class ID3D12DeviceExtensions
     }
 
     /// <summary>
+    /// Creates a view for a buffer that will need to be cleared.
+    /// </summary>
+    /// <param name="d3D12Device">The target <see cref="ID3D12Device"/> instance in use.</param>
+    /// <param name="d3D12Resource">The <see cref="ID3D12Resource"/> to create a view for.</param>
+    /// <param name="dxgiFormat">The <see cref="DXGI_FORMAT"/> value to use.</param>
+    /// <param name="bufferSize">The size of the target resource.</param>
+    /// <param name="d3D12CpuDescriptorHandle">The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.</param>
+    /// <param name="d3D12CpuDescriptorHandleNonShaderVisible">The non shader visible<see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.</param>
+    public static void CreateUnorderedAccessViewForClear(
+        this ref ID3D12Device d3D12Device,
+        ID3D12Resource* d3D12Resource,
+        DXGI_FORMAT dxgiFormat,
+        uint bufferSize,
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible)
+    {
+        D3D12_UNORDERED_ACCESS_VIEW_DESC d3D12UnorderedAccessViewDescription = default;
+        d3D12UnorderedAccessViewDescription.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+        d3D12UnorderedAccessViewDescription.Format = dxgiFormat;
+        d3D12UnorderedAccessViewDescription.Buffer.NumElements = bufferSize;
+
+        d3D12Device.CreateUnorderedAccessView(d3D12Resource, null, &d3D12UnorderedAccessViewDescription, d3D12CpuDescriptorHandleNonShaderVisible);
+
+        d3D12Device.CopyDescriptorsSimple(
+            NumDescriptors: 1,
+            DestDescriptorRangeStart: d3D12CpuDescriptorHandle,
+            SrcDescriptorRangeStart: d3D12CpuDescriptorHandleNonShaderVisible,
+            D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
+    }
+
+    /// <summary>
     /// Creates a new <see cref="ID3D12CommandAllocator"/> for a given device.
     /// </summary>
     /// <param name="d3D12Device">The target <see cref="ID3D12Device"/> to use to create the command allocator.</param>

--- a/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12GraphicsCommandListExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12GraphicsCommandListExtensions.cs
@@ -222,31 +222,19 @@ internal static unsafe class ID3D12GraphicsCommandListExtensions
     /// <summary>
     /// Clears a target UAV resource.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
     /// <param name="d3D12GraphicsCommandList">The <see cref="ID3D12GraphicsCommandList"/> instance in use.</param>
     /// <param name="d3D12Resource">The <see cref="ID3D12Resource"/> to clear.</param>
     /// <param name="d3D12GpuDescriptorHandle">The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the target resource.</param>
     /// <param name="d3D12CpuDescriptorHandle">The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value for the target resource.</param>
-    public static unsafe void ClearUnorderedAccessView<T>(
+    /// <param name="isNormalized">Indicates whether the target resource uses a normalized format.</param>
+    public static unsafe void ClearUnorderedAccessView(
         this ref ID3D12GraphicsCommandList d3D12GraphicsCommandList,
         ID3D12Resource* d3D12Resource,
         D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle,
-        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle)
-        where T : unmanaged
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+        bool isNormalized)
     {
-        if (typeof(T) == typeof(uint))
-        {
-            UInt4 values = default;
-
-            d3D12GraphicsCommandList.ClearUnorderedAccessViewUint(
-                ViewGPUHandleInCurrentHeap: d3D12GpuDescriptorHandle,
-                ViewCPUHandle: d3D12CpuDescriptorHandle,
-                pResource: d3D12Resource,
-                Values: (uint*)&values,
-                NumRects: 0,
-                pRects: null);
-        }
-        else if (typeof(T) == typeof(float))
+        if (isNormalized)
         {
             Float4 values = default;
 
@@ -260,7 +248,15 @@ internal static unsafe class ID3D12GraphicsCommandListExtensions
         }
         else
         {
-            ThrowHelper.ThrowArgumentException("Invalid clear type");
+            UInt4 values = default;
+
+            d3D12GraphicsCommandList.ClearUnorderedAccessViewUint(
+                ViewGPUHandleInCurrentHeap: d3D12GpuDescriptorHandle,
+                ViewCPUHandle: d3D12CpuDescriptorHandle,
+                pResource: d3D12Resource,
+                Values: (uint*)&values,
+                NumRects: 0,
+                pRects: null);
         }
     }
 

--- a/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12GraphicsCommandListExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12GraphicsCommandListExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
+using Microsoft.Toolkit.Diagnostics;
 using TerraFX.Interop.DirectX;
-using static TerraFX.Interop.DirectX.D3D12_RESOURCE_BARRIER_FLAGS;
-using static TerraFX.Interop.DirectX.D3D12_RESOURCE_BARRIER_TYPE;
 
 namespace ComputeSharp.Graphics.Extensions;
 
@@ -213,11 +212,56 @@ internal static unsafe class ID3D12GraphicsCommandListExtensions
     /// </summary>
     /// <param name="d3D12GraphicsCommandList">The <see cref="ID3D12GraphicsCommandList"/> instance in use.</param>
     /// <param name="d3D12Resource">The <see cref="ID3D12Resource"/> to insert the barrier for.</param>
-    public static void UAVBarrier(this ref ID3D12GraphicsCommandList d3D12GraphicsCommandList, ID3D12Resource* d3D12Resource)
+    public static void UnorderedAccessViewBarrier(this ref ID3D12GraphicsCommandList d3D12GraphicsCommandList, ID3D12Resource* d3D12Resource)
     {
         D3D12_RESOURCE_BARRIER d3D12ResourceBarrier = D3D12_RESOURCE_BARRIER.InitUAV(d3D12Resource);
 
         d3D12GraphicsCommandList.ResourceBarrier(1, &d3D12ResourceBarrier);
+    }
+
+    /// <summary>
+    /// Clears a target UAV resource.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="d3D12GraphicsCommandList">The <see cref="ID3D12GraphicsCommandList"/> instance in use.</param>
+    /// <param name="d3D12Resource">The <see cref="ID3D12Resource"/> to clear.</param>
+    /// <param name="d3D12GpuDescriptorHandle">The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the target resource.</param>
+    /// <param name="d3D12CpuDescriptorHandle">The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value for the target resource.</param>
+    public static unsafe void ClearUnorderedAccessView<T>(
+        this ref ID3D12GraphicsCommandList d3D12GraphicsCommandList,
+        ID3D12Resource* d3D12Resource,
+        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle,
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle)
+        where T : unmanaged
+    {
+        if (typeof(T) == typeof(uint))
+        {
+            UInt4 values = default;
+
+            d3D12GraphicsCommandList.ClearUnorderedAccessViewUint(
+                ViewGPUHandleInCurrentHeap: d3D12GpuDescriptorHandle,
+                ViewCPUHandle: d3D12CpuDescriptorHandle,
+                pResource: d3D12Resource,
+                Values: (uint*)&values,
+                NumRects: 0,
+                pRects: null);
+        }
+        else if (typeof(T) == typeof(float))
+        {
+            Float4 values = default;
+
+            d3D12GraphicsCommandList.ClearUnorderedAccessViewFloat(
+                ViewGPUHandleInCurrentHeap: d3D12GpuDescriptorHandle,
+                ViewCPUHandle: d3D12CpuDescriptorHandle,
+                pResource: d3D12Resource,
+                Values: (float*)&values,
+                NumRects: 0,
+                pRects: null);
+        }
+        else
+        {
+            ThrowHelper.ThrowArgumentException("Invalid clear type");
+        }
     }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/GraphicsDevice.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.cs
@@ -284,22 +284,16 @@ public sealed unsafe partial class GraphicsDevice : NativeObject
 
     /// <inheritdoc cref="ID3D12DescriptorHandleAllocator.Rent"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void RentShaderResourceViewDescriptorHandles(
-        out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
-        out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonGpuVisible,
-        out D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
+    internal void RentShaderResourceViewDescriptorHandles(out ID3D12ResourceDescriptorHandles d3D12ResourceDescriptorHandles)
     {
-        this.shaderResourceViewDescriptorAllocator.Rent(out d3D12CpuDescriptorHandle, out d3D12CpuDescriptorHandleNonGpuVisible, out d3D12GpuDescriptorHandle);
+        this.shaderResourceViewDescriptorAllocator.Rent(out d3D12ResourceDescriptorHandles);
     }
 
     /// <inheritdoc cref="ID3D12DescriptorHandleAllocator.Return"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal void ReturnShaderResourceViewDescriptorHandles(
-        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
-        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonGpuVisible,
-        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
+    internal void ReturnShaderResourceViewDescriptorHandles(in ID3D12ResourceDescriptorHandles d3D12ResourceDescriptorHandles)
     {
-        this.shaderResourceViewDescriptorAllocator.Return(d3D12CpuDescriptorHandle, d3D12CpuDescriptorHandleNonGpuVisible, d3D12GpuDescriptorHandle);
+        this.shaderResourceViewDescriptorAllocator.Return(in d3D12ResourceDescriptorHandles);
     }
 
     /// <inheritdoc cref="ID3D12CommandListPool.Rent"/>

--- a/src/ComputeSharp/Graphics/GraphicsDevice.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.cs
@@ -286,18 +286,20 @@ public sealed unsafe partial class GraphicsDevice : NativeObject
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void RentShaderResourceViewDescriptorHandles(
         out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+        out D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonGpuVisible,
         out D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
     {
-        this.shaderResourceViewDescriptorAllocator.Rent(out d3D12CpuDescriptorHandle, out d3D12GpuDescriptorHandle);
+        this.shaderResourceViewDescriptorAllocator.Rent(out d3D12CpuDescriptorHandle, out d3D12CpuDescriptorHandleNonGpuVisible, out d3D12GpuDescriptorHandle);
     }
 
     /// <inheritdoc cref="ID3D12DescriptorHandleAllocator.Return"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void ReturnShaderResourceViewDescriptorHandles(
         D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonGpuVisible,
         D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle)
     {
-        this.shaderResourceViewDescriptorAllocator.Return(d3D12CpuDescriptorHandle, d3D12GpuDescriptorHandle);
+        this.shaderResourceViewDescriptorAllocator.Return(d3D12CpuDescriptorHandle, d3D12CpuDescriptorHandleNonGpuVisible, d3D12GpuDescriptorHandle);
     }
 
     /// <inheritdoc cref="ID3D12CommandListPool.Rent"/>

--- a/src/ComputeSharp/Graphics/Helpers/DXGIFormatHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DXGIFormatHelper.cs
@@ -45,4 +45,47 @@ internal static class DXGIFormatHelper
         else if (typeof(T) == typeof(Rg32)) return DXGI_FORMAT_R16G16_UNORM;
         else return ThrowHelper.ThrowArgumentException<DXGI_FORMAT>("Invalid texture type");
     }
+
+    /// <summary>
+    /// Gets whether or not the input type corresponds to a normalized format.
+    /// </summary>
+    /// <typeparam name="T">The input type argument to check.</typeparam>
+    /// <returns>TWhether or not the input type corresponds to a normalized format..</returns>
+    /// <exception cref="System.ArgumentException">Thrown when the input type <typeparamref name="T"/> is not supported.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsNormalizedType<T>()
+        where T : unmanaged
+    {
+        if (typeof(T) == typeof(int) ||
+            typeof(T) == typeof(Int2) ||
+            typeof(T) == typeof(Int3) ||
+            typeof(T) == typeof(Int4) ||
+            typeof(T) == typeof(uint) ||
+            typeof(T) == typeof(UInt2) ||
+            typeof(T) == typeof(UInt3) ||
+            typeof(T) == typeof(UInt4) ||
+            typeof(T) == typeof(float) ||
+            typeof(T) == typeof(Float2) ||
+            typeof(T) == typeof(Float3) ||
+            typeof(T) == typeof(Float4) ||
+            typeof(T) == typeof(Vector2) ||
+            typeof(T) == typeof(Vector3) ||
+            typeof(T) == typeof(Vector4))
+        {
+            return false;
+        }
+
+        if (typeof(T) == typeof(Bgra32) ||
+            typeof(T) == typeof(Rgba32) ||
+            typeof(T) == typeof(Rgba64) ||
+            typeof(T) == typeof(R8) ||
+            typeof(T) == typeof(R16) ||
+            typeof(T) == typeof(Rg16) ||
+            typeof(T) == typeof(Rg32))
+        {
+            return true;
+        }
+        
+        return ThrowHelper.ThrowArgumentException<bool>("Invalid texture type");
+    }
 }

--- a/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
@@ -27,6 +27,13 @@ public static class GraphicsResourceHelper
         D3D12_GPU_DESCRIPTOR_HANDLE ValidateAndGetGpuDescriptorHandle(GraphicsDevice device);
 
         /// <summary>
+        /// Validates the given resource for usage with a specified device, and retrieves its GPU and CPU descriptor handles.
+        /// </summary>
+        /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
+        /// <returns>The GPU and CPU descriptor handles for the resource.</returns> 
+        (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device);
+
+        /// <summary>
         /// Validates the given resource for usage with a specified device, and retrieves the underlying <see cref="ID3D12Resource"/> object.
         /// </summary>
         /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
@@ -42,13 +49,15 @@ public static class GraphicsResourceHelper
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the buffer.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ulong ValidateAndGetGpuDescriptorHandle<T>(Buffer<T> buffer, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(Buffer<T> buffer, GraphicsDevice device)
         where T : unmanaged
     {
         buffer.ThrowIfDisposed();
         buffer.ThrowIfDeviceMismatch(device);
 
-        return Unsafe.As<D3D12_GPU_DESCRIPTOR_HANDLE, ulong>(ref Unsafe.AsRef(in buffer.D3D12GpuDescriptorHandle));
+        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = buffer.D3D12GpuDescriptorHandle;
+
+        return *(ulong*)&d3D12GpuDescriptorHandle;
     }
 
     /// <summary>
@@ -59,13 +68,15 @@ public static class GraphicsResourceHelper
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the texture.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ulong ValidateAndGetGpuDescriptorHandle<T>(ReadOnlyTexture2D<T> texture, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(ReadOnlyTexture2D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
         texture.ThrowIfDisposed();
         texture.ThrowIfDeviceMismatch(device);
 
-        return Unsafe.As<D3D12_GPU_DESCRIPTOR_HANDLE, ulong>(ref Unsafe.AsRef(in texture.D3D12GpuDescriptorHandle));
+        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = texture.D3D12GpuDescriptorHandle;
+
+        return *(ulong*)&d3D12GpuDescriptorHandle;
     }
 
     /// <summary>
@@ -76,13 +87,15 @@ public static class GraphicsResourceHelper
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the texture.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ulong ValidateAndGetGpuDescriptorHandle<T>(ReadWriteTexture2D<T> texture, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(ReadWriteTexture2D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
         texture.ThrowIfDisposed();
         texture.ThrowIfDeviceMismatch(device);
 
-        return Unsafe.As<D3D12_GPU_DESCRIPTOR_HANDLE, ulong>(ref Unsafe.AsRef(in texture.D3D12GpuDescriptorHandle));
+        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = texture.D3D12GpuDescriptorHandle;
+
+        return *(ulong*)&d3D12GpuDescriptorHandle;
     }
 
     /// <summary>
@@ -135,13 +148,15 @@ public static class GraphicsResourceHelper
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the texture.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ulong ValidateAndGetGpuDescriptorHandle<T>(ReadOnlyTexture3D<T> texture, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(ReadOnlyTexture3D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
         texture.ThrowIfDisposed();
         texture.ThrowIfDeviceMismatch(device);
 
-        return Unsafe.As<D3D12_GPU_DESCRIPTOR_HANDLE, ulong>(ref Unsafe.AsRef(in texture.D3D12GpuDescriptorHandle));
+        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = texture.D3D12GpuDescriptorHandle;
+
+        return *(ulong*)&d3D12GpuDescriptorHandle;
     }
 
     /// <summary>
@@ -152,13 +167,15 @@ public static class GraphicsResourceHelper
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the texture.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ulong ValidateAndGetGpuDescriptorHandle<T>(ReadWriteTexture3D<T> texture, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(ReadWriteTexture3D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
         texture.ThrowIfDisposed();
         texture.ThrowIfDeviceMismatch(device);
 
-        return Unsafe.As<D3D12_GPU_DESCRIPTOR_HANDLE, ulong>(ref Unsafe.AsRef(in texture.D3D12GpuDescriptorHandle));
+        D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = texture.D3D12GpuDescriptorHandle;
+
+        return *(ulong*)&d3D12GpuDescriptorHandle;
     }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
@@ -27,11 +27,12 @@ public static class GraphicsResourceHelper
         D3D12_GPU_DESCRIPTOR_HANDLE ValidateAndGetGpuDescriptorHandle(GraphicsDevice device);
 
         /// <summary>
-        /// Validates the given resource for usage with a specified device, and retrieves its GPU and CPU descriptor handles.
+        /// Validates the given resource for usage with a specified device, and retrieves its GPU and CPU descriptor handles for a clear operation.
         /// </summary>
         /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
+        /// <param name="isNormalized">Indicates whether the current resource uses a normalized format.</param>
         /// <returns>The GPU and CPU descriptor handles for the resource.</returns> 
-        (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device);
+        (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice device, out bool isNormalized);
 
         /// <summary>
         /// Validates the given resource for usage with a specified device, and retrieves the underlying <see cref="ID3D12Resource"/> object.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
@@ -10,6 +10,7 @@ using Microsoft.Toolkit.Diagnostics;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 using static TerraFX.Interop.DirectX.D3D12_FEATURE;
+using static TerraFX.Interop.DirectX.DXGI_FORMAT;
 using ResourceType = ComputeSharp.Graphics.Resources.Enums.ResourceType;
 #if NET6_0_OR_GREATER
 using MemoryMarshal = System.Runtime.InteropServices.MemoryMarshal;
@@ -42,6 +43,11 @@ public unsafe abstract class Buffer<T> : NativeObject
     /// The <see cref="ID3D12ResourceDescriptorHandles"/> instance for the current resource.
     /// </summary>
     private readonly ID3D12ResourceDescriptorHandles d3D12ResourceDescriptorHandles;
+
+    /// <summary>
+    /// The <see cref="ID3D12ResourceDescriptorHandles"/> instance for the current resource, when a typed UAV is needed.
+    /// </summary>
+    private readonly ID3D12ResourceDescriptorHandles d3D12ResourceDescriptorHandlesForTypedUnorderedAccessView;
 
     /// <summary>
     /// The size in bytes of the current buffer (this value is never negative).
@@ -92,6 +98,7 @@ public unsafe abstract class Buffer<T> : NativeObject
 
         device.RegisterAllocatedResource();
         device.RentShaderResourceViewDescriptorHandles(out this.d3D12ResourceDescriptorHandles);
+        device.RentShaderResourceViewDescriptorHandles(out this.d3D12ResourceDescriptorHandlesForTypedUnorderedAccessView);
 
         switch (resourceType)
         {
@@ -103,7 +110,12 @@ public unsafe abstract class Buffer<T> : NativeObject
                 break;
             case ResourceType.ReadWrite:
                 device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), (uint)length, elementSizeInBytes, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandle);
-                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), (uint)length, elementSizeInBytes, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandleNonShaderVisible);
+                device.D3D12Device->CreateUnorderedAccessViewForClear(
+                    this.d3D12Resource.Get(),
+                    DXGI_FORMAT_R32_UINT,
+                    (uint)(usableSizeInBytes / sizeof(uint)),
+                    this.d3D12ResourceDescriptorHandlesForTypedUnorderedAccessView.D3D12CpuDescriptorHandle,
+                    this.d3D12ResourceDescriptorHandlesForTypedUnorderedAccessView.D3D12CpuDescriptorHandleNonShaderVisible);
                 break;
         }
 
@@ -201,6 +213,7 @@ public unsafe abstract class Buffer<T> : NativeObject
         {
             device.UnregisterAllocatedResource();
             device.ReturnShaderResourceViewDescriptorHandles(in this.d3D12ResourceDescriptorHandles);
+            device.ReturnShaderResourceViewDescriptorHandles(in this.d3D12ResourceDescriptorHandlesForTypedUnorderedAccessView);
         }
     }
 
@@ -222,7 +235,9 @@ public unsafe abstract class Buffer<T> : NativeObject
         ThrowIfDisposed();
         ThrowIfDeviceMismatch(device);
 
-        return (this.d3D12ResourceDescriptorHandles.D3D12GpuDescriptorHandle, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandleNonShaderVisible);
+        return (
+            this.d3D12ResourceDescriptorHandlesForTypedUnorderedAccessView.D3D12GpuDescriptorHandle,
+            this.d3D12ResourceDescriptorHandlesForTypedUnorderedAccessView.D3D12CpuDescriptorHandleNonShaderVisible);
     }
 
     /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
@@ -156,7 +156,7 @@ public unsafe abstract class Buffer<T> : NativeObject
     /// <summary>
     /// Gets the non shader visible <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonGpuVisible => this.d3D12CpuDescriptorHandleNonShaderVisible;
+    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonShaderVisible => this.d3D12CpuDescriptorHandleNonShaderVisible;
 
     /// <summary>
     /// Reads the contents of the specified range from the current <see cref="Buffer{T}"/> instance and writes them into a target memory area.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
@@ -40,12 +40,12 @@ public unsafe abstract class Buffer<T> : NativeObject
     /// <summary>
     /// The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    private readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle;
+    private readonly D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle;
 
     /// <summary>
     /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    internal readonly D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle;
+    private readonly D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle;
 
     /// <summary>
     /// The size in bytes of the current buffer (this value is never negative).
@@ -95,18 +95,18 @@ public unsafe abstract class Buffer<T> : NativeObject
 #endif
 
         device.RegisterAllocatedResource();
-        device.RentShaderResourceViewDescriptorHandles(out D3D12CpuDescriptorHandle, out D3D12GpuDescriptorHandle);
+        device.RentShaderResourceViewDescriptorHandles(out this.d3D12CpuDescriptorHandle, out this.d3D12GpuDescriptorHandle);
 
         switch (resourceType)
         {
             case ResourceType.Constant:
-                device.D3D12Device->CreateConstantBufferView(this.d3D12Resource.Get(), effectiveSizeInBytes, D3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateConstantBufferView(this.d3D12Resource.Get(), effectiveSizeInBytes, this.d3D12CpuDescriptorHandle);
                 break;
             case ResourceType.ReadOnly:
-                device.D3D12Device->CreateShaderResourceView(this.d3D12Resource.Get(), (uint)length, elementSizeInBytes, D3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateShaderResourceView(this.d3D12Resource.Get(), (uint)length, elementSizeInBytes, this.d3D12CpuDescriptorHandle);
                 break;
             case ResourceType.ReadWrite:
-                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), (uint)length, elementSizeInBytes, D3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), (uint)length, elementSizeInBytes, this.d3D12CpuDescriptorHandle);
                 break;
         }
 
@@ -136,6 +136,16 @@ public unsafe abstract class Buffer<T> : NativeObject
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
     internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+
+    /// <summary>
+    /// Gets the <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// </summary>
+    internal D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle => this.d3D12GpuDescriptorHandle;
+
+    /// <summary>
+    /// Gets the <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// </summary>
+    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle => this.d3D12CpuDescriptorHandle;
 
     /// <summary>
     /// Reads the contents of the specified range from the current <see cref="Buffer{T}"/> instance and writes them into a target memory area.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/StructuredBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/StructuredBuffer{T}.cs
@@ -305,6 +305,15 @@ public abstract class StructuredBuffer<T> : Buffer<T>
         }
     }
 
+    /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice)"/>
+    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    {
+        ThrowIfDisposed();
+        ThrowIfDeviceMismatch(device);
+
+        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandle);
+    }
+
     /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>
     internal unsafe ID3D12Resource* ValidateAndGetID3D12Resource(GraphicsDevice device)
     {

--- a/src/ComputeSharp/Graphics/Resources/Abstract/StructuredBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/StructuredBuffer{T}.cs
@@ -311,7 +311,7 @@ public abstract class StructuredBuffer<T> : Buffer<T>
         ThrowIfDisposed();
         ThrowIfDeviceMismatch(device);
 
-        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandle);
+        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandleNonGpuVisible);
     }
 
     /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/StructuredBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/StructuredBuffer{T}.cs
@@ -305,13 +305,13 @@ public abstract class StructuredBuffer<T> : Buffer<T>
         }
     }
 
-    /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice)"/>
-    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice, out bool)"/>
+    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice device)
     {
         ThrowIfDisposed();
         ThrowIfDeviceMismatch(device);
 
-        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandleNonGpuVisible);
+        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandleNonShaderVisible);
     }
 
     /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/StructuredBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/StructuredBuffer{T}.cs
@@ -304,22 +304,4 @@ public abstract class StructuredBuffer<T> : Buffer<T>
             copyCommandList.ExecuteAndWaitForCompletion();
         }
     }
-
-    /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice, out bool)"/>
-    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice device)
-    {
-        ThrowIfDisposed();
-        ThrowIfDeviceMismatch(device);
-
-        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandleNonShaderVisible);
-    }
-
-    /// <inheritdoc cref="__Internals.GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>
-    internal unsafe ID3D12Resource* ValidateAndGetID3D12Resource(GraphicsDevice device)
-    {
-        ThrowIfDisposed();
-        ThrowIfDeviceMismatch(device);
-
-        return D3D12Resource;
-    }
 }

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
@@ -174,7 +174,7 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
     /// <summary>
     /// Gets the non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonGpuVisible => this.d3D12CpuDescriptorHandleNonShaderVisible;
+    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonShaderVisible => this.d3D12CpuDescriptorHandleNonShaderVisible;
 
     /// <summary>
     /// Reads the contents of the specified range from the current <see cref="Texture2D{T}"/> instance and writes them into a target memory area.
@@ -573,13 +573,15 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
         }
     }
 
-    /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice)"/>
-    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice, out bool)"/>
+    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice device, out bool isNormalized)
     {
         ThrowIfDisposed();
         ThrowIfDeviceMismatch(device);
 
-        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandleNonGpuVisible);
+        isNormalized = DXGIFormatHelper.IsNormalizedType<T>();
+
+        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandleNonShaderVisible);
     }
 
     /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>
@@ -601,9 +603,9 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
     }
 
     /// <inheritdoc/>
-    (D3D12_GPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE) GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    (D3D12_GPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE) GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice device, out bool isNormalized)
     {
-        return ValidateAndGetGpuAndCpuDescriptorHandles(device);
+        return ValidateAndGetGpuAndCpuDescriptorHandlesForClear(device, out isNormalized);
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
@@ -2,6 +2,7 @@
 using ComputeSharp.__Internals;
 using ComputeSharp.Exceptions;
 using ComputeSharp.Graphics.Commands;
+using ComputeSharp.Graphics.Commands.Interop;
 using ComputeSharp.Graphics.Extensions;
 using ComputeSharp.Graphics.Helpers;
 using ComputeSharp.Graphics.Resources.Interop;
@@ -39,19 +40,9 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
     private ComPtr<ID3D12Resource> d3D12Resource;
 
     /// <summary>
-    /// The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// The <see cref="ID3D12ResourceDescriptorHandles"/> instance for the current resource.
     /// </summary>
-    private readonly D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle;
-
-    /// <summary>
-    /// The non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
-    /// </summary>
-    private readonly D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible;
-
-    /// <summary>
-    /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
-    /// </summary>
-    private readonly D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle;
+    private readonly ID3D12ResourceDescriptorHandles d3D12ResourceDescriptorHandles;
 
     /// <summary>
     /// The default <see cref="D3D12_RESOURCE_STATES"/> value for the current resource.
@@ -125,16 +116,16 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
             out _);
 
         device.RegisterAllocatedResource();
-        device.RentShaderResourceViewDescriptorHandles(out this.d3D12CpuDescriptorHandle, out this.d3D12CpuDescriptorHandleNonShaderVisible, out this.d3D12GpuDescriptorHandle);
+        device.RentShaderResourceViewDescriptorHandles(out this.d3D12ResourceDescriptorHandles);
 
         switch (resourceType)
         {
             case ResourceType.ReadOnly:
-                device.D3D12Device->CreateShaderResourceView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_SRV_DIMENSION_TEXTURE2D, this.d3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateShaderResourceView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_SRV_DIMENSION_TEXTURE2D, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandle);
                 break;
             case ResourceType.ReadWrite:
-                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE2D, this.d3D12CpuDescriptorHandle);
-                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE2D, this.d3D12CpuDescriptorHandleNonShaderVisible);
+                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE2D, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE2D, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandleNonShaderVisible);
                 break;
         }
 
@@ -164,17 +155,7 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
     /// <summary>
     /// Gets the <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    internal D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle => this.d3D12GpuDescriptorHandle;
-
-    /// <summary>
-    /// Gets the <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
-    /// </summary>
-    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle => this.d3D12CpuDescriptorHandle;
-
-    /// <summary>
-    /// Gets the non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
-    /// </summary>
-    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonShaderVisible => this.d3D12CpuDescriptorHandleNonShaderVisible;
+    internal D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle => this.d3D12ResourceDescriptorHandles.D3D12GpuDescriptorHandle;
 
     /// <summary>
     /// Reads the contents of the specified range from the current <see cref="Texture2D{T}"/> instance and writes them into a target memory area.
@@ -557,7 +538,7 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
         if (GraphicsDevice is GraphicsDevice device)
         {
             device.UnregisterAllocatedResource();
-            device.ReturnShaderResourceViewDescriptorHandles(D3D12CpuDescriptorHandle, this.d3D12CpuDescriptorHandleNonShaderVisible, D3D12GpuDescriptorHandle);
+            device.ReturnShaderResourceViewDescriptorHandles(in this.d3D12ResourceDescriptorHandles);
         }
     }
 
@@ -581,7 +562,7 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
 
         isNormalized = DXGIFormatHelper.IsNormalizedType<T>();
 
-        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandleNonShaderVisible);
+        return (this.d3D12ResourceDescriptorHandles.D3D12GpuDescriptorHandle, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandleNonShaderVisible);
     }
 
     /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
@@ -41,12 +41,12 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
     /// <summary>
     /// The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    private readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle;
+    private readonly D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle;
 
     /// <summary>
     /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    internal readonly D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle;
+    private readonly D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle;
 
     /// <summary>
     /// The default <see cref="D3D12_RESOURCE_STATES"/> value for the current resource.
@@ -120,15 +120,15 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
             out _);
 
         device.RegisterAllocatedResource();
-        device.RentShaderResourceViewDescriptorHandles(out D3D12CpuDescriptorHandle, out D3D12GpuDescriptorHandle);
+        device.RentShaderResourceViewDescriptorHandles(out this.d3D12CpuDescriptorHandle, out this.d3D12GpuDescriptorHandle);
 
         switch (resourceType)
         {
             case ResourceType.ReadOnly:
-                device.D3D12Device->CreateShaderResourceView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_SRV_DIMENSION_TEXTURE2D, D3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateShaderResourceView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_SRV_DIMENSION_TEXTURE2D, this.d3D12CpuDescriptorHandle);
                 break;
             case ResourceType.ReadWrite:
-                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE2D, D3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE2D, this.d3D12CpuDescriptorHandle);
                 break;
         }
 
@@ -154,6 +154,16 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
     internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+
+    /// <summary>
+    /// Gets the <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// </summary>
+    internal D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle => this.d3D12GpuDescriptorHandle;
+
+    /// <summary>
+    /// Gets the <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// </summary>
+    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle => this.d3D12CpuDescriptorHandle;
 
     /// <summary>
     /// Reads the contents of the specified range from the current <see cref="Texture2D{T}"/> instance and writes them into a target memory area.
@@ -552,6 +562,15 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
         }
     }
 
+    /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice)"/>
+    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    {
+        ThrowIfDisposed();
+        ThrowIfDeviceMismatch(device);
+
+        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandle);
+    }
+
     /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>
     internal ID3D12Resource* ValidateAndGetID3D12Resource(GraphicsDevice device)
     {
@@ -568,6 +587,12 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
         ThrowIfDeviceMismatch(device);
 
         return D3D12GpuDescriptorHandle;
+    }
+
+    /// <inheritdoc/>
+    (D3D12_GPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE) GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    {
+        return ValidateAndGetGpuAndCpuDescriptorHandles(device);
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
@@ -41,12 +41,12 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
     /// <summary>
     /// The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    private readonly D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle;
+    private readonly D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle;
 
     /// <summary>
     /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
-    internal readonly D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle;
+    private readonly D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle;
 
     /// <summary>
     /// The default <see cref="D3D12_RESOURCE_STATES"/> value for the current resource.
@@ -125,15 +125,15 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
             out _);
 
         device.RegisterAllocatedResource();
-        device.RentShaderResourceViewDescriptorHandles(out D3D12CpuDescriptorHandle, out D3D12GpuDescriptorHandle);
+        device.RentShaderResourceViewDescriptorHandles(out this.d3D12CpuDescriptorHandle, out this.d3D12GpuDescriptorHandle);
 
         switch (resourceType)
         {
             case ResourceType.ReadOnly:
-                device.D3D12Device->CreateShaderResourceView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_SRV_DIMENSION_TEXTURE3D, D3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateShaderResourceView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_SRV_DIMENSION_TEXTURE3D, this.d3D12CpuDescriptorHandle);
                 break;
             case ResourceType.ReadWrite:
-                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE3D, D3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE3D, this.d3D12CpuDescriptorHandle);
                 break;
         }
 
@@ -164,6 +164,16 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
     internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+
+    /// <summary>
+    /// Gets the <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// </summary>
+    internal D3D12_GPU_DESCRIPTOR_HANDLE D3D12GpuDescriptorHandle => this.d3D12GpuDescriptorHandle;
+
+    /// <summary>
+    /// Gets the <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// </summary>
+    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle => this.d3D12CpuDescriptorHandle;
 
     /// <summary>
     /// Reads the contents of the specified range from the current <see cref="Texture3D{T}"/> instance and writes them into a target memory area.
@@ -605,6 +615,15 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
         }
     }
 
+    /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice)"/>
+    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    {
+        ThrowIfDisposed();
+        ThrowIfDeviceMismatch(device);
+
+        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandle);
+    }
+
     /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>
     internal ID3D12Resource* ValidateAndGetID3D12Resource(GraphicsDevice device)
     {
@@ -621,6 +640,12 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
         ThrowIfDeviceMismatch(device);
 
         return D3D12GpuDescriptorHandle;
+    }
+
+    /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice)"/>
+    (D3D12_GPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE) GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    {
+        return ValidateAndGetGpuAndCpuDescriptorHandles(device);
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
@@ -182,6 +182,11 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
     internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandle => this.d3D12CpuDescriptorHandle;
 
     /// <summary>
+    /// Gets the non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// </summary>
+    internal D3D12_CPU_DESCRIPTOR_HANDLE D3D12CpuDescriptorHandleNonShaderVisible => this.d3D12CpuDescriptorHandleNonShaderVisible;
+
+    /// <summary>
     /// Reads the contents of the specified range from the current <see cref="Texture3D{T}"/> instance and writes them into a target memory area.
     /// </summary>
     /// <param name="destination">The target memory area to write data to.</param>
@@ -621,13 +626,15 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
         }
     }
 
-    /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice)"/>
-    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice, out bool)"/>
+    internal (D3D12_GPU_DESCRIPTOR_HANDLE Gpu, D3D12_CPU_DESCRIPTOR_HANDLE Cpu) ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice device, out bool isNormalized)
     {
         ThrowIfDisposed();
         ThrowIfDeviceMismatch(device);
 
-        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandle);
+        isNormalized = DXGIFormatHelper.IsNormalizedType<T>();
+
+        return (D3D12GpuDescriptorHandle, D3D12CpuDescriptorHandleNonShaderVisible);
     }
 
     /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetID3D12Resource(GraphicsDevice)"/>
@@ -648,10 +655,10 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
         return D3D12GpuDescriptorHandle;
     }
 
-    /// <inheritdoc cref="GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice)"/>
-    (D3D12_GPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE) GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandles(GraphicsDevice device)
+    /// <inheritdoc/>
+    (D3D12_GPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE) GraphicsResourceHelper.IGraphicsResource.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(GraphicsDevice device, out bool isNormalized)
     {
-        return ValidateAndGetGpuAndCpuDescriptorHandles(device);
+        return ValidateAndGetGpuAndCpuDescriptorHandlesForClear(device, out isNormalized);
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
@@ -44,6 +44,11 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
     private readonly D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle;
 
     /// <summary>
+    /// The non shader visible <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
+    /// </summary>
+    private readonly D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandleNonShaderVisible;
+
+    /// <summary>
     /// The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.
     /// </summary>
     private readonly D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle;
@@ -125,7 +130,7 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
             out _);
 
         device.RegisterAllocatedResource();
-        device.RentShaderResourceViewDescriptorHandles(out this.d3D12CpuDescriptorHandle, out this.d3D12GpuDescriptorHandle);
+        device.RentShaderResourceViewDescriptorHandles(out this.d3D12CpuDescriptorHandle, out this.d3D12CpuDescriptorHandleNonShaderVisible, out this.d3D12GpuDescriptorHandle);
 
         switch (resourceType)
         {
@@ -134,6 +139,7 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
                 break;
             case ResourceType.ReadWrite:
                 device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE3D, this.d3D12CpuDescriptorHandle);
+                device.D3D12Device->CreateUnorderedAccessView(this.d3D12Resource.Get(), DXGIFormatHelper.GetForType<T>(), D3D12_UAV_DIMENSION_TEXTURE3D, this.d3D12CpuDescriptorHandleNonShaderVisible);
                 break;
         }
 
@@ -599,7 +605,7 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
         if (GraphicsDevice is GraphicsDevice device)
         {
             device.UnregisterAllocatedResource();
-            device.ReturnShaderResourceViewDescriptorHandles(D3D12CpuDescriptorHandle, D3D12GpuDescriptorHandle);
+            device.ReturnShaderResourceViewDescriptorHandles(D3D12CpuDescriptorHandle, this.d3D12CpuDescriptorHandleNonShaderVisible, D3D12GpuDescriptorHandle);
         }
     }
 

--- a/src/ComputeSharp/Shaders/ComputeContext.cs
+++ b/src/ComputeSharp/Shaders/ComputeContext.cs
@@ -40,7 +40,15 @@ public ref struct ComputeContext
     /// <summary>
     /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> associated with the current instance.
     /// </summary>
-    public GraphicsDevice GraphicsDevice => this.device;
+    public GraphicsDevice GraphicsDevice
+    {
+        get
+        {
+            ThrowInvalidOperationExceptionIfDeviceIsNull();
+
+            return this.device;
+        }
+    }
 
     /// <summary>
     /// Clears a specific resource.
@@ -48,17 +56,18 @@ public ref struct ComputeContext
     /// <param name="d3D12Resource">The <see cref="ID3D12Resource"/> to clear.</param>
     /// <param name="d3D12GpuDescriptorHandle">The <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> value for the target resource.</param>
     /// <param name="d3D12CpuDescriptorHandle">The <see cref="D3D12_CPU_DESCRIPTOR_HANDLE"/> value for the target resource.</param>
-    internal readonly unsafe void Clear<T>(
+    /// <param name="isNormalized">Indicates whether the target resource uses a normalized format.</param>
+    internal readonly unsafe void Clear(
         ID3D12Resource* d3D12Resource,
         D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle,
-        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle)
-        where T : unmanaged
+        D3D12_CPU_DESCRIPTOR_HANDLE d3D12CpuDescriptorHandle,
+        bool isNormalized)
     {
         ThrowInvalidOperationExceptionIfDeviceIsNull();
 
         ref CommandList commandList = ref GetCommandList(in this, null);
 
-        commandList.D3D12GraphicsCommandList->ClearUnorderedAccessView<T>(d3D12Resource, d3D12GpuDescriptorHandle, d3D12CpuDescriptorHandle);
+        commandList.D3D12GraphicsCommandList->ClearUnorderedAccessView(d3D12Resource, d3D12GpuDescriptorHandle, d3D12CpuDescriptorHandle, isNormalized);
     }
 
     /// <summary>

--- a/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
@@ -107,9 +107,9 @@ public static partial class ComputeContextExtensions
     public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteBuffer<T> buffer)
         where T : unmanaged
     {
-        var handles = buffer.ValidateAndGetGpuAndCpuDescriptorHandles(context.GraphicsDevice);
+        var handles = buffer.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice);
 
-        context.Clear<uint>(buffer.D3D12Resource, handles.Gpu, handles.Cpu);
+        context.Clear(buffer.D3D12Resource, handles.Gpu, handles.Cpu, isNormalized: false);
     }
 
     /// <summary>
@@ -121,7 +121,9 @@ public static partial class ComputeContextExtensions
     public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture2D<T> texture)
         where T : unmanaged
     {
-        throw new System.NotImplementedException();
+        var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out bool isNormalized);
+
+        context.Clear(texture.D3D12Resource, handles.Gpu, handles.Cpu, isNormalized);
     }
 
     /// <summary>
@@ -133,7 +135,9 @@ public static partial class ComputeContextExtensions
     public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture3D<T> texture)
         where T : unmanaged
     {
-        throw new System.NotImplementedException();
+        var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out bool isNormalized);
+
+        context.Clear(texture.D3D12Resource, handles.Gpu, handles.Cpu, isNormalized);
     }
 
     /// <summary>
@@ -147,7 +151,9 @@ public static partial class ComputeContextExtensions
         where T : unmanaged, IUnorm<TPixel>
         where TPixel : unmanaged
     {
-        throw new System.NotImplementedException();
+        var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out bool isNormalized);
+
+        context.Clear(texture.D3D12Resource, handles.Gpu, handles.Cpu, isNormalized);
     }
 
     /// <summary>
@@ -161,7 +167,9 @@ public static partial class ComputeContextExtensions
         where T : unmanaged, IUnorm<TPixel>
         where TPixel : unmanaged
     {
-        throw new System.NotImplementedException();
+        var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out bool isNormalized);
+
+        context.Clear(texture.D3D12Resource, handles.Gpu, handles.Cpu, isNormalized);
     }
 
     /// <summary>
@@ -173,7 +181,9 @@ public static partial class ComputeContextExtensions
     public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteTexture2D<TPixel> texture)
         where TPixel : unmanaged
     {
-        throw new System.NotImplementedException();
+        var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out bool isNormalized);
+
+        context.Clear(((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetID3D12Resource(context.GraphicsDevice), handles.Gpu, handles.Cpu, isNormalized);
     }
 
     /// <summary>
@@ -185,7 +195,9 @@ public static partial class ComputeContextExtensions
     public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteTexture3D<TPixel> texture)
         where TPixel : unmanaged
     {
-        throw new System.NotImplementedException();
+        var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out bool isNormalized);
+
+        context.Clear(((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetID3D12Resource(context.GraphicsDevice), handles.Gpu, handles.Cpu, isNormalized);
     }
 
     /// <summary>

--- a/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
@@ -99,6 +99,96 @@ public static partial class ComputeContextExtensions
     }
 
     /// <summary>
+    /// Clears a specific resource.
+    /// </summary>
+    /// <typeparam name="T">The type of items stored on the buffer.</typeparam>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
+    /// <param name="buffer">The input <see cref="ReadWriteBuffer{T}"/> instance to clear.</param>
+    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteBuffer<T> buffer)
+        where T : unmanaged
+    {
+        var handles = buffer.ValidateAndGetGpuAndCpuDescriptorHandles(context.GraphicsDevice);
+
+        context.Clear<uint>(buffer.D3D12Resource, handles.Gpu, handles.Cpu);
+    }
+
+    /// <summary>
+    /// Clears a specific resource, with a specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of items stored on the texture.</typeparam>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to clear.</param>
+    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture2D<T> texture)
+        where T : unmanaged
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <summary>
+    /// Clears a specific resource, with a specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of items stored on the texture.</typeparam>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteBuffer{T}"/> instance to clear.</param>
+    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture3D<T> texture)
+        where T : unmanaged
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <summary>
+    /// Clears a specific resource, with a specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of items stored on the texture.</typeparam>
+    /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T,TPixel}"/> instance to clear.</param>
+    public static unsafe void Clear<T, TPixel>(this in ComputeContext context, ReadWriteTexture2D<T, TPixel> texture)
+        where T : unmanaged, IUnorm<TPixel>
+        where TPixel : unmanaged
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <summary>
+    /// Clears a specific resource, with a specified value.
+    /// </summary>
+    /// <typeparam name="T">The type of items stored on the texture.</typeparam>
+    /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T,TPixel}"/> instance to clear.</param>
+    public static unsafe void Clear<T, TPixel>(this in ComputeContext context, ReadWriteTexture3D<T, TPixel> texture)
+        where T : unmanaged, IUnorm<TPixel>
+        where TPixel : unmanaged
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <summary>
+    /// Clears a specific resource, with a specified value.
+    /// </summary>
+    /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
+    /// <param name="texture">The input <see cref="IReadWriteTexture2D{TPixel}"/> instance to clear.</param>
+    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteTexture2D<TPixel> texture)
+        where TPixel : unmanaged
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <summary>
+    /// Clears a specific resource, with a specified value.
+    /// </summary>
+    /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
+    /// <param name="texture">The input <see cref="IReadWriteTexture3D{TPixel}"/> instance to clear.</param>
+    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteTexture3D<TPixel> texture)
+        where TPixel : unmanaged
+    {
+        throw new System.NotImplementedException();
+    }
+
+    /// <summary>
     /// Runs the input shader on a target <see cref="ComputeContext"/> instance, with the specified parameters.
     /// </summary>
     /// <typeparam name="T">The type of compute shader to run.</typeparam>

--- a/src/TerraFX.Interop.Windows/DirectX/um/d3d12/ID3D12GraphicsCommandList.cs
+++ b/src/TerraFX.Interop.Windows/DirectX/um/d3d12/ID3D12GraphicsCommandList.cs
@@ -298,5 +298,19 @@ namespace TerraFX.Interop.DirectX
         {
             ((delegate* unmanaged[Stdcall]<ID3D12GraphicsCommandList*, uint, ulong, void>)(lpVtbl[42]))((ID3D12GraphicsCommandList*)Unsafe.AsPointer(ref this), RootParameterIndex, BufferLocation);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [VtblIndex(49)]
+        public void ClearUnorderedAccessViewUint(D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap, D3D12_CPU_DESCRIPTOR_HANDLE ViewCPUHandle, ID3D12Resource* pResource, [NativeTypeName("const UINT [4]")] uint* Values, uint NumRects, [NativeTypeName("const D3D12_RECT *")] void* pRects)
+        {
+            ((delegate* unmanaged[Stdcall]<ID3D12GraphicsCommandList*, D3D12_GPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE, ID3D12Resource*, uint*, uint, void*, void>)(lpVtbl[49]))((ID3D12GraphicsCommandList*)Unsafe.AsPointer(ref this), ViewGPUHandleInCurrentHeap, ViewCPUHandle, pResource, Values, NumRects, pRects);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [VtblIndex(50)]
+        public void ClearUnorderedAccessViewFloat(D3D12_GPU_DESCRIPTOR_HANDLE ViewGPUHandleInCurrentHeap, D3D12_CPU_DESCRIPTOR_HANDLE ViewCPUHandle, ID3D12Resource* pResource, [NativeTypeName("const FLOAT [4]")] float* Values, uint NumRects, [NativeTypeName("const D3D12_RECT *")] void* pRects)
+        {
+            ((delegate* unmanaged[Stdcall]<ID3D12GraphicsCommandList*, D3D12_GPU_DESCRIPTOR_HANDLE, D3D12_CPU_DESCRIPTOR_HANDLE, ID3D12Resource*, float*, uint, void*, void>)(lpVtbl[50]))((ID3D12GraphicsCommandList*)Unsafe.AsPointer(ref this), ViewGPUHandleInCurrentHeap, ViewCPUHandle, pResource, Values, NumRects, pRects);
+        }
     }
 }

--- a/tests/ComputeSharp.Tests/ComputeContextTests.cs
+++ b/tests/ComputeSharp.Tests/ComputeContextTests.cs
@@ -2,6 +2,8 @@
 using System.Linq;
 using ComputeSharp.Tests.Attributes;
 using ComputeSharp.Tests.Extensions;
+using ComputeSharp.Tests.Helpers;
+using Microsoft.Toolkit.HighPerformance;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ComputeSharp.Tests;
@@ -10,6 +12,112 @@ namespace ComputeSharp.Tests;
 [TestCategory("ComputeContext")]
 public partial class ComputeContextTests
 {
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(typeof(int))]
+    [Data(typeof(Int2))]
+    [Data(typeof(Int3))]
+    [Data(typeof(Int4))]
+    [Data(typeof(uint))]
+    [Data(typeof(UInt2))]
+    [Data(typeof(UInt3))]
+    [Data(typeof(UInt4))]
+    [Data(typeof(float))]
+    [Data(typeof(Float2))]
+    [Data(typeof(Float3))]
+    [Data(typeof(Float4))]
+    [Data(typeof(Bgra32))]
+    [Data(typeof(Rgba32))]
+    [Data(typeof(Rgba64))]
+    [Data(typeof(R8))]
+    [Data(typeof(R16))]
+    [Data(typeof(Rg16))]
+    [Data(typeof(Rg32))]
+    public void Clear_ReadWriteTexture2D(Device device, Type type)
+    {
+        static void Test<T>(Device device)
+            where T : unmanaged
+        {
+            if (!device.Get().IsReadWriteTexture2DSupportedForType<T>())
+            {
+                Assert.Inconclusive();
+            }
+
+            T[] array = new T[128 * 128];
+
+            new Random().NextBytes(array.AsSpan().AsBytes());
+
+            using ReadWriteTexture2D<T> texture = device.Get().AllocateReadWriteTexture2D<T>(array, 128, 128);
+
+            using (ComputeContext context = device.Get().CreateComputeContext())
+            {
+                context.Clear(texture);
+            }
+
+            texture.CopyTo(array);
+
+            foreach (byte value in array.AsSpan().AsBytes())
+            {
+                Assert.AreEqual(value, 0);
+            }
+        }
+
+        TestHelper.Run(Test<int>, type, device);
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(typeof(int))]
+    [Data(typeof(Int2))]
+    [Data(typeof(Int3))]
+    [Data(typeof(Int4))]
+    [Data(typeof(uint))]
+    [Data(typeof(UInt2))]
+    [Data(typeof(UInt3))]
+    [Data(typeof(UInt4))]
+    [Data(typeof(float))]
+    [Data(typeof(Float2))]
+    [Data(typeof(Float3))]
+    [Data(typeof(Float4))]
+    [Data(typeof(Bgra32))]
+    [Data(typeof(Rgba32))]
+    [Data(typeof(Rgba64))]
+    [Data(typeof(R8))]
+    [Data(typeof(R16))]
+    [Data(typeof(Rg16))]
+    [Data(typeof(Rg32))]
+    public void Clear_ReadWriteTexture3D(Device device, Type type)
+    {
+        static void Test<T>(Device device)
+            where T : unmanaged
+        {
+            if (!device.Get().IsReadWriteTexture3DSupportedForType<T>())
+            {
+                Assert.Inconclusive();
+            }
+
+            T[] array = new T[128 * 128 * 3];
+
+            new Random().NextBytes(array.AsSpan().AsBytes());
+
+            using ReadWriteTexture3D<T> texture = device.Get().AllocateReadWriteTexture3D<T>(array, 128, 128, 3);
+
+            using (ComputeContext context = device.Get().CreateComputeContext())
+            {
+                context.Clear(texture);
+            }
+
+            texture.CopyTo(array);
+
+            foreach (byte value in array.AsSpan().AsBytes())
+            {
+                Assert.AreEqual(value, 0);
+            }
+        }
+
+        TestHelper.Run(Test<int>, type, device);
+    }
+
     [CombinatorialTestMethod]
     [AllDevices]
     public void For_Batched(Device device)
@@ -108,7 +216,7 @@ public partial class ComputeContextTests
 
     [CombinatorialTestMethod]
     [AllDevices]
-    [ExpectedException(typeof(InvalidOperationException))]
+    [ExpectedException(typeof(InvalidOperationException), AllowDerivedTypes = false)]
     public void Barrier_WithoutPreviousDispatches_ThrowsException(Device device)
     {
         using ReadWriteBuffer<int> buffer = device.Get().AllocateReadWriteBuffer<int>(64);
@@ -123,7 +231,7 @@ public partial class ComputeContextTests
 
     [CombinatorialTestMethod]
     [AllDevices]
-    [ExpectedException(typeof(InvalidOperationException))]
+    [ExpectedException(typeof(InvalidOperationException), AllowDerivedTypes = false)]
     public void DefaultContext_Barrier_ThrowsException(Device device)
     {
         using ReadWriteBuffer<int> buffer = device.Get().AllocateReadWriteBuffer<int>(64);
@@ -135,8 +243,22 @@ public partial class ComputeContextTests
         Assert.Fail();
     }
 
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [ExpectedException(typeof(InvalidOperationException), AllowDerivedTypes = false)]
+    public void DefaultContext_Clear_ThrowsException(Device device)
+    {
+        using ReadWriteBuffer<int> buffer = device.Get().AllocateReadWriteBuffer<int>(64);
+
+        using ComputeContext context = default;
+
+        context.Clear(buffer);
+
+        Assert.Fail();
+    }
+
     [TestMethod]
-    [ExpectedException(typeof(InvalidOperationException))]
+    [ExpectedException(typeof(InvalidOperationException), AllowDerivedTypes = false)]
     public void DefaultContext_For_ThrowsException()
     {
         using ComputeContext context = default;
@@ -148,7 +270,7 @@ public partial class ComputeContextTests
 
     [CombinatorialTestMethod]
     [AllDevices]
-    [ExpectedException(typeof(InvalidOperationException))]
+    [ExpectedException(typeof(InvalidOperationException), AllowDerivedTypes = false)]
     public void DefaultContext_ForEach_ThrowsException(Device device)
     {
         using ReadWriteTexture2D<Rgba32, float4> texture = device.Get().AllocateReadWriteTexture2D<Rgba32, float4>(128, 128);
@@ -161,7 +283,7 @@ public partial class ComputeContextTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidOperationException))]
+    [ExpectedException(typeof(InvalidOperationException), AllowDerivedTypes = false)]
     public void DefaultContext_Dispose_ThrowsException()
     {
         using ComputeContext context = default;

--- a/tests/ComputeSharp.Tests/ComputeContextTests.cs
+++ b/tests/ComputeSharp.Tests/ComputeContextTests.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Linq;
+using ComputeSharp.__Internals;
 using ComputeSharp.Tests.Attributes;
 using ComputeSharp.Tests.Extensions;
 using ComputeSharp.Tests.Helpers;
 using Microsoft.Toolkit.HighPerformance;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#pragma warning disable CS0618
 
 namespace ComputeSharp.Tests;
 
@@ -116,6 +119,174 @@ public partial class ComputeContextTests
         }
 
         TestHelper.Run(Test<int>, type, device);
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(typeof(Bgra32), typeof(Float4))]
+    [Data(typeof(Rgba32), typeof(Float4))]
+    [Data(typeof(Rgba64), typeof(Float4))]
+    [Data(typeof(R8), typeof(float))]
+    [Data(typeof(R16), typeof(float))]
+    [Data(typeof(Rg16), typeof(Float2))]
+    [Data(typeof(Rg32), typeof(Float2))]
+    public void Clear_ReadWriteTexture2D_WithPixel(Device device, Type cpuType, Type gpuType)
+    {
+        static void Test<T, TPixel>(Device device)
+            where T : unmanaged, IUnorm<TPixel>
+            where TPixel : unmanaged
+        {
+            if (!device.Get().IsReadWriteTexture2DSupportedForType<T>())
+            {
+                Assert.Inconclusive();
+            }
+
+            T[] array = new T[128 * 128];
+
+            new Random().NextBytes(array.AsSpan().AsBytes());
+
+            using ReadWriteTexture2D<T, TPixel> texture = device.Get().AllocateReadWriteTexture2D<T, TPixel>(array, 128, 128);
+
+            using (ComputeContext context = device.Get().CreateComputeContext())
+            {
+                context.Clear(texture);
+            }
+
+            texture.CopyTo(array);
+
+            foreach (byte value in array.AsSpan().AsBytes())
+            {
+                Assert.AreEqual(value, 0);
+            }
+        }
+
+        TestHelper.Run(Test<Bgra32, Float4>, cpuType, gpuType, device);
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(typeof(Bgra32), typeof(Float4))]
+    [Data(typeof(Rgba32), typeof(Float4))]
+    [Data(typeof(Rgba64), typeof(Float4))]
+    [Data(typeof(R8), typeof(float))]
+    [Data(typeof(R16), typeof(float))]
+    [Data(typeof(Rg16), typeof(Float2))]
+    [Data(typeof(Rg32), typeof(Float2))]
+    public void Clear_ReadWriteTexture3D_WithPixel(Device device, Type cpuType, Type gpuType)
+    {
+        static void Test<T, TPixel>(Device device)
+            where T : unmanaged, IUnorm<TPixel>
+            where TPixel : unmanaged
+        {
+            if (!device.Get().IsReadWriteTexture2DSupportedForType<T>())
+            {
+                Assert.Inconclusive();
+            }
+
+            T[] array = new T[128 * 128 * 3];
+
+            new Random().NextBytes(array.AsSpan().AsBytes());
+
+            using ReadWriteTexture3D<T, TPixel> texture = device.Get().AllocateReadWriteTexture3D<T, TPixel>(array, 128, 128, 3);
+
+            using (ComputeContext context = device.Get().CreateComputeContext())
+            {
+                context.Clear(texture);
+            }
+
+            texture.CopyTo(array);
+
+            foreach (byte value in array.AsSpan().AsBytes())
+            {
+                Assert.AreEqual(value, 0);
+            }
+        }
+
+        TestHelper.Run(Test<Bgra32, Float4>, cpuType, gpuType, device);
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(typeof(Bgra32), typeof(Float4))]
+    [Data(typeof(Rgba32), typeof(Float4))]
+    [Data(typeof(Rgba64), typeof(Float4))]
+    [Data(typeof(R8), typeof(float))]
+    [Data(typeof(R16), typeof(float))]
+    [Data(typeof(Rg16), typeof(Float2))]
+    [Data(typeof(Rg32), typeof(Float2))]
+    public void Clear_ReadWriteTexture2D_WithPixel_AsNormalizedTexture(Device device, Type cpuType, Type gpuType)
+    {
+        static void Test<T, TPixel>(Device device)
+            where T : unmanaged, IUnorm<TPixel>
+            where TPixel : unmanaged
+        {
+            if (!device.Get().IsReadWriteTexture2DSupportedForType<T>())
+            {
+                Assert.Inconclusive();
+            }
+
+            T[] array = new T[128 * 128];
+
+            new Random().NextBytes(array.AsSpan().AsBytes());
+
+            using ReadWriteTexture2D<T, TPixel> texture = device.Get().AllocateReadWriteTexture2D<T, TPixel>(array, 128, 128);
+
+            using (ComputeContext context = device.Get().CreateComputeContext())
+            {
+                context.Clear((IReadWriteTexture2D<TPixel>)texture);
+            }
+
+            texture.CopyTo(array);
+
+            foreach (byte value in array.AsSpan().AsBytes())
+            {
+                Assert.AreEqual(value, 0);
+            }
+        }
+
+        TestHelper.Run(Test<Bgra32, Float4>, cpuType, gpuType, device);
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(typeof(Bgra32), typeof(Float4))]
+    [Data(typeof(Rgba32), typeof(Float4))]
+    [Data(typeof(Rgba64), typeof(Float4))]
+    [Data(typeof(R8), typeof(float))]
+    [Data(typeof(R16), typeof(float))]
+    [Data(typeof(Rg16), typeof(Float2))]
+    [Data(typeof(Rg32), typeof(Float2))]
+    public void Clear_ReadWriteTexture3D_WithPixel_AsNormalizedTexture(Device device, Type cpuType, Type gpuType)
+    {
+        static void Test<T, TPixel>(Device device)
+            where T : unmanaged, IUnorm<TPixel>
+            where TPixel : unmanaged
+        {
+            if (!device.Get().IsReadWriteTexture2DSupportedForType<T>())
+            {
+                Assert.Inconclusive();
+            }
+
+            T[] array = new T[128 * 128 * 3];
+
+            new Random().NextBytes(array.AsSpan().AsBytes());
+
+            using ReadWriteTexture3D<T, TPixel> texture = device.Get().AllocateReadWriteTexture3D<T, TPixel>(array, 128, 128, 3);
+
+            using (ComputeContext context = device.Get().CreateComputeContext())
+            {
+                context.Clear((IReadWriteTexture3D<TPixel>)texture);
+            }
+
+            texture.CopyTo(array);
+
+            foreach (byte value in array.AsSpan().AsBytes())
+            {
+                Assert.AreEqual(value, 0);
+            }
+        }
+
+        TestHelper.Run(Test<Bgra32, Float4>, cpuType, gpuType, device);
     }
 
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ComputeContextTests.cs
+++ b/tests/ComputeSharp.Tests/ComputeContextTests.cs
@@ -36,6 +36,54 @@ public partial class ComputeContextTests
     [Data(typeof(R16))]
     [Data(typeof(Rg16))]
     [Data(typeof(Rg32))]
+    public void Clear_ReadWriteBuffer(Device device, Type type)
+    {
+        static void Test<T>(Device device)
+            where T : unmanaged
+        {
+            T[] array = new T[128];
+
+            new Random().NextBytes(array.AsSpan().AsBytes());
+
+            using ReadWriteBuffer<T> texture = device.Get().AllocateReadWriteBuffer<T>(array);
+
+            using (ComputeContext context = device.Get().CreateComputeContext())
+            {
+                context.Clear(texture);
+            }
+
+            texture.CopyTo(array);
+
+            foreach (byte value in array.AsSpan().AsBytes())
+            {
+                Assert.AreEqual(value, 0);
+            }
+        }
+
+        TestHelper.Run(Test<int>, type, device);
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(typeof(int))]
+    [Data(typeof(Int2))]
+    [Data(typeof(Int3))]
+    [Data(typeof(Int4))]
+    [Data(typeof(uint))]
+    [Data(typeof(UInt2))]
+    [Data(typeof(UInt3))]
+    [Data(typeof(UInt4))]
+    [Data(typeof(float))]
+    [Data(typeof(Float2))]
+    [Data(typeof(Float3))]
+    [Data(typeof(Float4))]
+    [Data(typeof(Bgra32))]
+    [Data(typeof(Rgba32))]
+    [Data(typeof(Rgba64))]
+    [Data(typeof(R8))]
+    [Data(typeof(R16))]
+    [Data(typeof(Rg16))]
+    [Data(typeof(Rg32))]
     public void Clear_ReadWriteTexture2D(Device device, Type type)
     {
         static void Test<T>(Device device)

--- a/tests/ComputeSharp.Tests/Helpers/TestHelper.cs
+++ b/tests/ComputeSharp.Tests/Helpers/TestHelper.cs
@@ -31,4 +31,28 @@ public static class TestHelper
             throw e.InnerException;
         }
     }
+
+    /// <summary>
+    /// Runs a generic test methods with the specified arguments.
+    /// </summary>
+    /// <param name="delegate">A <see cref="Delegate"/> instance wrapping the target method.</param>
+    /// <param name="type1">The first type argument to use to invoke <paramref name="delegate"/>.</param>
+    /// <param name="type2">The second type argument to use to invoke <paramref name="delegate"/>.</param>
+    /// <param name="arguments">The arguments to use to invoke <paramref name="delegate"/>.</param>
+    public static void Run(Delegate @delegate, Type type1, Type type2, params object[] arguments)
+    {
+        if (@delegate.Method is not { IsStatic: true, IsGenericMethod: true })
+        {
+            Assert.Fail("The input delegate must point to a generic static method");
+        }
+
+        try
+        {
+            @delegate.Method.GetGenericMethodDefinition().MakeGenericMethod(type1, type2).Invoke(null, arguments);
+        }
+        catch (TargetInvocationException e) when (e.InnerException is not null)
+        {
+            throw e.InnerException;
+        }
+    }
 }

--- a/tests/ComputeSharp.Tests/Helpers/TestHelper.cs
+++ b/tests/ComputeSharp.Tests/Helpers/TestHelper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.Tests.Helpers;
+
+/// <summary>
+/// A helper class for test methods.
+/// </summary>
+public static class TestHelper
+{
+    /// <summary>
+    /// Runs a generic test methods with the specified arguments.
+    /// </summary>
+    /// <param name="delegate">A <see cref="Delegate"/> instance wrapping the target method.</param>
+    /// <param name="type">The type argument to use to invoke <paramref name="delegate"/>.</param>
+    /// <param name="arguments">The arguments to use to invoke <paramref name="delegate"/>.</param>
+    public static void Run(Delegate @delegate, Type type, params object[] arguments)
+    {
+        if (@delegate.Method is not { IsStatic: true, IsGenericMethod: true })
+        {
+            Assert.Fail("The input delegate must point to a generic static method");
+        }
+
+        try
+        {
+            @delegate.Method.GetGenericMethodDefinition().MakeGenericMethod(type).Invoke(null, arguments);
+        }
+        catch (TargetInvocationException e) when (e.InnerException is not null)
+        {
+            throw e.InnerException;
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR adds the new `ComputeContext.Clear` APIs to clear writeable resources.

### API breakdown

```csharp
namespace ComputeSharp;

public static partial class ComputeContextExtensions
{
    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteBuffer<T> buffer) where T : unmanaged;
    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture2D<T> texture) where T : unmanaged;
    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture3D<T> texture) where T : unmanaged;
    public static unsafe void Clear<T, TPixel>(this in ComputeContext context, ReadWriteTexture2D<T, TPixel> texture) where T : unmanaged, IUnorm<TPixel> where TPixel : unmanaged;
    public static unsafe void Clear<T, TPixel>(this in ComputeContext context, ReadWriteTexture3D<T, TPixel> texture) where T : unmanaged, IUnorm<TPixel> where TPixel : unmanaged;
    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteTexture2D<TPixel> texture) where TPixel : unmanaged;
    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteTexture3D<TPixel> texture) where TPixel : unmanaged;
}
```