### PR TITLE
ShaderPanel improvements

### DIFF
--- a/samples/ComputeSharp.SwapChain.Core.Shared/Shaders/Runners/ContouredLayersRunner.cs
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/Shaders/Runners/ContouredLayersRunner.cs
@@ -23,7 +23,7 @@ public sealed class ContouredLayersRunner : IShaderRunner
     private ReadOnlyTexture2D<Rgba32, Float4>? texture;
 
     /// <inheritdoc/>
-    public void Execute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter)
+    public bool TryExecute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter)
     {
         if (this.texture is null)
         {
@@ -33,5 +33,7 @@ public sealed class ContouredLayersRunner : IShaderRunner
         }
 
         GraphicsDevice.Default.ForEach(texture, new ContouredLayers((float)timespan.TotalSeconds, this.texture));
+
+        return true;
     }
 }

--- a/src/ComputeSharp.UI/IShaderRunner.cs
+++ b/src/ComputeSharp.UI/IShaderRunner.cs
@@ -12,10 +12,11 @@ namespace ComputeSharp.WinUI;
 public interface IShaderRunner
 {
     /// <summary>
-    /// Renders a single frame to a texture.
+    /// Tries to render a single frame to a texture, optionally skipping the frame if needed.
     /// </summary>
     /// <param name="texture">The target texture to render the frame to.</param>
     /// <param name="timespan">The timespan for the current frame.</param>
     /// <param name="parameter">The input parameter for the frame being rendered.</param>
-    void Execute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter);
+    /// <returns>Whether or not to present the current frame. If <see langword="false"/>, the frame will be skipped.</returns>
+    bool TryExecute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter);
 }

--- a/src/ComputeSharp.UI/ShaderRunner{T}.cs
+++ b/src/ComputeSharp.UI/ShaderRunner{T}.cs
@@ -8,7 +8,8 @@ namespace ComputeSharp.WinUI;
 #endif
 
 /// <summary>
-/// An <see cref="IShaderRunner"/> implementation powered by a supplied shader type.
+/// A simple <see cref="IShaderRunner"/> implementation powered by a supplied shader type.
+/// All rendered frames produced by this type will always be presented.
 /// </summary>
 /// <typeparam name="T">The type of shader to use to render frames.</typeparam>
 public sealed class ShaderRunner<T> : IShaderRunner
@@ -56,7 +57,7 @@ public sealed class ShaderRunner<T> : IShaderRunner
     }
 
     /// <inheritdoc/>
-    public void Execute(IReadWriteTexture2D<Float4> texture, TimeSpan time, object? parameter)
+    public bool TryExecute(IReadWriteTexture2D<Float4> texture, TimeSpan time, object? parameter)
     {
         if (this.shaderFactory is Func<TimeSpan, T> shaderFactory)
         {
@@ -66,5 +67,7 @@ public sealed class ShaderRunner<T> : IShaderRunner
         {
             GraphicsDevice.Default.ForEach(texture, this.statefulShaderFactory!(time, parameter));
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
### Description

This PR introduces performance optimizations to the shader panel, and the new ability to skip presenting frames.
The performance optimization is the fact that unnecessary texture/backbuffer resizes will now be skipped.
Additionally, dynamic resolution no longer includes the time spent resizing backbuffers/textures, as those were one-offs.

### API breakdown

```diff
 public interface IShaderRunner
 {
-    void Execute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter);
+    bool TryExecute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter);
 }
```
