### PR TITLE
Implement packaging for ComputeSharp.Dynamic

### DIFF
--- a/src/ComputeSharp.Dynamic.Package/ComputeSharp.Dynamic.Package.msbuildproj
+++ b/src/ComputeSharp.Dynamic.Package/ComputeSharp.Dynamic.Package.msbuildproj
@@ -16,7 +16,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ComputeSharp.Dynamic\ComputeSharp.Dynamic.csproj" />
-    <ProjectReference Include="..\ComputeSharp.Package\ComputeSharp.Package.msbuildproj">
+    <ProjectReference Include="..\ComputeSharp.Package\ComputeSharp.Package.msbuildproj" TargetFramework="net6.0">
+      <AdditionalProperties>PackageVersion=$(PackageVersion)</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="..\ComputeSharp.Package\ComputeSharp.Package.msbuildproj" TargetFramework="netstandard2.0">
       <AdditionalProperties>PackageVersion=$(PackageVersion)</AdditionalProperties>
     </ProjectReference>
   </ItemGroup>

--- a/src/ComputeSharp.Dynamic.Package/ComputeSharp.Dynamic.Package.msbuildproj
+++ b/src/ComputeSharp.Dynamic.Package/ComputeSharp.Dynamic.Package.msbuildproj
@@ -16,6 +16,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ComputeSharp.Dynamic\ComputeSharp.Dynamic.csproj" />
+    <ProjectReference Include="..\ComputeSharp.Package\ComputeSharp.Package.msbuildproj">
+      <AdditionalProperties>PackageVersion=$(PackageVersion)</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The idea is very simple: we take advantage of Nugetizer's behavior for ProjectReferences when packing:

 1) They become asset contributors when the referenced project does not specify PackageId.
 2) They become dependencies when the referenced project does specify PackageId.

So, all we have to do to get ComputeSharp to be a package dependency of ComputeSharp.Dynamic is reference the corresponding packaging project.

We also take care to specify the correct version via "AdditionalProperties".
