### PR TITLE
IGraphicsResource interface

### DIFF
--- a/samples/ComputeSharp.SwapChain.Core.Shared/Shaders/Runners/ContouredLayersRunner.cs
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/Shaders/Runners/ContouredLayersRunner.cs
@@ -25,14 +25,17 @@ public sealed class ContouredLayersRunner : IShaderRunner
     /// <inheritdoc/>
     public bool TryExecute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter)
     {
-        if (this.texture is null)
+        if (this.texture is null ||
+            this.texture.GraphicsDevice != texture.GraphicsDevice)
         {
             string filename = Path.Combine(Package.Current.InstalledLocation.Path, "Assets", "Textures", "RustyMetal.png");
 
-            this.texture = GraphicsDevice.Default.LoadReadOnlyTexture2D<Rgba32, Float4>(filename);
+            this.texture?.Dispose();
+
+            this.texture = texture.GraphicsDevice.LoadReadOnlyTexture2D<Rgba32, Float4>(filename);
         }
 
-        GraphicsDevice.Default.ForEach(texture, new ContouredLayers((float)timespan.TotalSeconds, this.texture));
+        texture.GraphicsDevice.ForEach(texture, new ContouredLayers((float)timespan.TotalSeconds, this.texture));
 
         return true;
     }

--- a/src/ComputeSharp.UI/ShaderRunner{T}.cs
+++ b/src/ComputeSharp.UI/ShaderRunner{T}.cs
@@ -61,11 +61,11 @@ public sealed class ShaderRunner<T> : IShaderRunner
     {
         if (this.shaderFactory is Func<TimeSpan, T> shaderFactory)
         {
-            GraphicsDevice.Default.ForEach(texture, this.shaderFactory(time));
+            texture.GraphicsDevice.ForEach(texture, this.shaderFactory(time));
         }
         else
         {
-            GraphicsDevice.Default.ForEach(texture, this.statefulShaderFactory!(time, parameter));
+            texture.GraphicsDevice.ForEach(texture, this.statefulShaderFactory!(time, parameter));
         }
 
         return true;

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
@@ -24,7 +24,7 @@ namespace ComputeSharp.Resources;
 /// A <see langword="class"/> representing a typed buffer stored on GPU memory.
 /// </summary>
 /// <typeparam name="T">The type of items stored on the buffer.</typeparam>
-public unsafe abstract class Buffer<T> : NativeObject
+public unsafe abstract class Buffer<T> : NativeObject, IGraphicsResource
     where T : unmanaged
 {
 #if NET6_0_OR_GREATER
@@ -122,9 +122,7 @@ public unsafe abstract class Buffer<T> : NativeObject
         this.d3D12Resource.Get()->SetName(this);
     }
 
-    /// <summary>
-    /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> associated with the current instance.
-    /// </summary>
+    /// <inheritdoc/>
     public GraphicsDevice GraphicsDevice { get; }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
@@ -24,7 +24,7 @@ namespace ComputeSharp.Resources;
 /// A <see langword="class"/> representing a typed 2D texture stored on GPU memory.
 /// </summary>
 /// <typeparam name="T">The type of items stored on the texture.</typeparam>
-public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper.IGraphicsResource
+public unsafe abstract class Texture2D<T> : NativeObject, IGraphicsResource, GraphicsResourceHelper.IGraphicsResource
     where T : unmanaged
 {
 #if NET6_0_OR_GREATER
@@ -132,9 +132,7 @@ public unsafe abstract class Texture2D<T> : NativeObject, GraphicsResourceHelper
         this.d3D12Resource.Get()->SetName(this);
     }
 
-    /// <summary>
-    /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> associated with the current instance.
-    /// </summary>
+    /// <inheritdoc/>
     public GraphicsDevice GraphicsDevice { get; }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
@@ -24,7 +24,7 @@ namespace ComputeSharp.Resources;
 /// A <see langword="class"/> representing a typed 3D texture stored on GPU memory.
 /// </summary>
 /// <typeparam name="T">The type of items stored on the texture.</typeparam>
-public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper.IGraphicsResource
+public unsafe abstract class Texture3D<T> : NativeObject, IGraphicsResource, GraphicsResourceHelper.IGraphicsResource
     where T : unmanaged
 {
 #if NET6_0_OR_GREATER
@@ -137,9 +137,7 @@ public unsafe abstract class Texture3D<T> : NativeObject, GraphicsResourceHelper
         this.d3D12Resource.Get()->SetName(this);
     }
 
-    /// <summary>
-    /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> associated with the current instance.
-    /// </summary>
+    /// <inheritdoc/>
     public GraphicsDevice GraphicsDevice { get; }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferBuffer{T}.cs
@@ -15,7 +15,7 @@ namespace ComputeSharp.Resources;
 /// A <see langword="class"/> representing a typed buffer stored on CPU memory, that can be used to transfer data to/from the GPU.
 /// </summary>
 /// <typeparam name="T">The type of items stored on the buffer.</typeparam>
-public abstract unsafe class TransferBuffer<T> : NativeObject, IMemoryOwner<T>
+public abstract unsafe class TransferBuffer<T> : NativeObject, IGraphicsResource, IMemoryOwner<T>
     where T : unmanaged
 {
 #if NET6_0_OR_GREATER
@@ -68,9 +68,7 @@ public abstract unsafe class TransferBuffer<T> : NativeObject, IMemoryOwner<T>
         this.d3D12Resource.Get()->SetName(this);
     }
 
-    /// <summary>
-    /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> associated with the current instance.
-    /// </summary>
+    /// <inheritdoc/>
     public GraphicsDevice GraphicsDevice { get; }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture2D{T}.cs
@@ -15,7 +15,7 @@ namespace ComputeSharp.Resources;
 /// A <see langword="class"/> representing a typed 2D texture stored on on CPU memory, that can be used to transfer data to/from the GPU.
 /// </summary>
 /// <typeparam name="T">The type of items stored on the texture.</typeparam>
-public unsafe abstract class TransferTexture2D<T> : NativeObject
+public unsafe abstract class TransferTexture2D<T> : NativeObject, IGraphicsResource
     where T : unmanaged
 {
 #if NET6_0_OR_GREATER
@@ -84,9 +84,7 @@ public unsafe abstract class TransferTexture2D<T> : NativeObject
         this.d3D12Resource.Get()->SetName(this);
     }
 
-    /// <summary>
-    /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> associated with the current instance.
-    /// </summary>
+    /// <inheritdoc/>
     public GraphicsDevice GraphicsDevice { get; }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture3D{T}.cs
@@ -15,7 +15,7 @@ namespace ComputeSharp.Resources;
 /// A <see langword="class"/> representing a typed 3D texture stored on on CPU memory, that can be used to transfer data to/from the GPU.
 /// </summary>
 /// <typeparam name="T">The type of items stored on the texture.</typeparam>
-public unsafe abstract class TransferTexture3D<T> : NativeObject
+public unsafe abstract class TransferTexture3D<T> : NativeObject, IGraphicsResource
     where T : unmanaged
 {
 #if NET6_0_OR_GREATER
@@ -87,9 +87,7 @@ public unsafe abstract class TransferTexture3D<T> : NativeObject
         this.d3D12Resource.Get()->SetName(this);
     }
 
-    /// <summary>
-    /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> associated with the current instance.
-    /// </summary>
+    /// <inheritdoc/>
     public GraphicsDevice GraphicsDevice { get; }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IGraphicsResource.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IGraphicsResource.cs
@@ -1,0 +1,12 @@
+﻿namespace ComputeSharp;
+
+/// <summary>
+/// An interface representing a graphics resource associated to a given <see cref="GraphicsDevice"/> instance.
+/// </summary>
+public interface IGraphicsResource
+{
+    /// <summary>
+    /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> instance associated with the current resource.
+    /// </summary>
+    GraphicsDevice GraphicsDevice { get; }
+}

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture2D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture2D{TPixel}.cs
@@ -5,7 +5,7 @@
 /// This interface can only be used to wrap <see cref="ReadOnlyTexture2D{T, TPixel}"/> instances.
 /// </summary>
 /// <typeparam name="TPixel">The type of normalized pixels used on the GPU side.</typeparam>
-public interface IReadOnlyTexture2D<TPixel>
+public interface IReadOnlyTexture2D<TPixel> : IGraphicsResource
     where TPixel : unmanaged
 {
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture3D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture3D{TPixel}.cs
@@ -5,7 +5,7 @@
 /// This interface can only be used to wrap <see cref="ReadOnlyTexture3D{T, TPixel}"/> instances.
 /// </summary>
 /// <typeparam name="TPixel">The type of normalized pixels used on the GPU side.</typeparam>
-public interface IReadOnlyTexture3D<TPixel>
+public interface IReadOnlyTexture3D<TPixel> : IGraphicsResource
     where TPixel : unmanaged
 {
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadWriteTexture2D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadWriteTexture2D{TPixel}.cs
@@ -5,7 +5,7 @@
 /// This interface can only be used to wrap <see cref="ReadWriteTexture2D{T, TPixel}"/> instances.
 /// </summary>
 /// <typeparam name="TPixel">The type of normalized pixels used on the GPU side.</typeparam>
-public interface IReadWriteTexture2D<TPixel>
+public interface IReadWriteTexture2D<TPixel> : IGraphicsResource
     where TPixel : unmanaged
 {
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadWriteTexture3D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadWriteTexture3D{TPixel}.cs
@@ -5,7 +5,7 @@
 /// This interface can only be used to wrap <see cref="ReadWriteTexture3D{T, TPixel}"/> instances.
 /// </summary>
 /// <typeparam name="TPixel">The type of normalized pixels used on the GPU side.</typeparam>
-public interface IReadWriteTexture3D<TPixel>
+public interface IReadWriteTexture3D<TPixel> : IGraphicsResource
     where TPixel : unmanaged
 {
     /// <summary>


### PR DESCRIPTION
### Description

This PR adds a public `IGraphicsResource` interface to all resource types.

### API breakdown

```csharp
namespace ComputeSharp;

/// <summary>
/// An interface representing a graphics resource associated to a given <see cref="GraphicsDevice"/> instance.
/// </summary>
public interface IGraphicsResource
{
    /// <summary>
    /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> instance associated with the current resource.
    /// </summary>
    GraphicsDevice GraphicsDevice { get; }
}
```