### PR TITLE
Bugfix/shader misc

### DIFF
--- a/src/ComputeSharp.Dynamic/Shaders/Translation/__Internals/ShaderCompiler.cs
+++ b/src/ComputeSharp.Dynamic/Shaders/Translation/__Internals/ShaderCompiler.cs
@@ -16,15 +16,15 @@ public static class ShaderCompiler
     /// <summary>
     /// Compiles a new HLSL shader from the input source code.
     /// </summary>
-    /// <typeparam name="TLoadeer">The type of bytecode loader being used.</typeparam>
+    /// <typeparam name="TLoader">The type of bytecode loader being used.</typeparam>
     /// <typeparam name="T">The type of shader being dispatched.</typeparam>
-    /// <param name="loader">The <typeparamref name="TLoadeer"/> instance to use to load the bytecode.</param>
+    /// <param name="loader">The <typeparamref name="TLoader"/> instance to use to load the bytecode.</param>
     /// <param name="threadsX">The number of threads in each thread group for the X axis.</param>
     /// <param name="threadsY">The number of threads in each thread group for the Y axis.</param>
     /// <param name="threadsZ">The number of threads in each thread group for the Z axis.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the compute shader to run.</param>
-    public static unsafe void LoadDynamicBytecode<TLoadeer, T>(ref TLoadeer loader, int threadsX, int threadsY, int threadsZ, in T shader)
-        where TLoadeer : struct, IBytecodeLoader
+    public static unsafe void LoadDynamicBytecode<TLoader, T>(ref TLoader loader, int threadsX, int threadsY, int threadsZ, in T shader)
+        where TLoader : struct, IBytecodeLoader
         where T : struct, IShader
     {
         Unsafe.AsRef(in shader).BuildHlslString(out ArrayPoolStringBuilder builder, threadsX, threadsY, threadsZ);

--- a/src/ComputeSharp.SourceGenerators/SyntaxRewriters/ExecuteMethodRewriter.cs
+++ b/src/ComputeSharp.SourceGenerators/SyntaxRewriters/ExecuteMethodRewriter.cs
@@ -130,19 +130,24 @@ internal abstract class ExecuteMethodRewriter : CSharpSyntaxRewriter
         {
             var updatedNode = (ReturnStatementSyntax)base.VisitReturnStatement(node)!;
 
-            // __outputTexture[ThreadIds.xy] = <RETURN_EXPRESSION>;
+            // {
+            //     __outputTexture[ThreadIds.xy] = <RETURN_EXPRESSION>;
+            //     return;
+            // }
             return
-                ExpressionStatement(
-                    AssignmentExpression(
-                        SyntaxKind.SimpleAssignmentExpression,
-                        ElementAccessExpression(IdentifierName("__outputTexture"))
-                        .AddArgumentListArguments(
-                            Argument(
-                                MemberAccessExpression(
-                                    SyntaxKind.SimpleMemberAccessExpression,
-                                    IdentifierName("ThreadIds"),
-                                    IdentifierName("xy")))),
-                        updatedNode.Expression!));
+                Block(
+                    ExpressionStatement(
+                        AssignmentExpression(
+                            SyntaxKind.SimpleAssignmentExpression,
+                            ElementAccessExpression(IdentifierName("__outputTexture"))
+                            .AddArgumentListArguments(
+                                Argument(
+                                    MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("ThreadIds"),
+                                        IdentifierName("xy")))),
+                            updatedNode.Expression!)),
+                    ReturnStatement());
         }
 
         /// <inheritdoc/>

--- a/src/ComputeSharp/Core/Intrinsics/Hlsl.g.cs
+++ b/src/ComputeSharp/Core/Intrinsics/Hlsl.g.cs
@@ -12016,7 +12016,7 @@ public static partial class Hlsl
     /// <returns>The normalized <paramref name="x"/> parameter. If the length of the <paramref name="x"/> parameter is 0, the result is indefinite.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [HlslIntrinsicName("normalize")]
-    public static float Normalize(Float2 x) => default;
+    public static float Normalize(float x) => default;
 
     /// <summary>
     /// Normalizes the specified floating-point vector according to x / length(x).
@@ -12025,7 +12025,7 @@ public static partial class Hlsl
     /// <returns>The normalized <paramref name="x"/> parameter. If the length of the <paramref name="x"/> parameter is 0, the result is indefinite.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [HlslIntrinsicName("normalize")]
-    public static float Normalize(Float3 x) => default;
+    public static Float2 Normalize(Float2 x) => default;
 
     /// <summary>
     /// Normalizes the specified floating-point vector according to x / length(x).
@@ -12034,7 +12034,16 @@ public static partial class Hlsl
     /// <returns>The normalized <paramref name="x"/> parameter. If the length of the <paramref name="x"/> parameter is 0, the result is indefinite.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [HlslIntrinsicName("normalize")]
-    public static float Normalize(Float4 x) => default;
+    public static Float3 Normalize(Float3 x) => default;
+
+    /// <summary>
+    /// Normalizes the specified floating-point vector according to x / length(x).
+    /// </summary>
+    /// <param name="x">The specified floating-point vector.</param>
+    /// <returns>The normalized <paramref name="x"/> parameter. If the length of the <paramref name="x"/> parameter is 0, the result is indefinite.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    [HlslIntrinsicName("normalize")]
+    public static Float4 Normalize(Float4 x) => default;
 
     /// <summary>
     /// Returns the specified value raised to the specified power.

--- a/src/ComputeSharp/Core/Intrinsics/Hlsl.ttinclude
+++ b/src/ComputeSharp/Core/Intrinsics/Hlsl.ttinclude
@@ -1916,9 +1916,10 @@ var Intrinsics = new[]
         Returns = "The normalized {x} parameter. If the length of the {x} parameter is 0, the result is indefinite.",
         Overloads = new[]
         {
-            new { Return = "float", Params = new[] { "Float2" } },
-            new { Return = "float", Params = new[] { "Float3" } },
-            new { Return = "float", Params = new[] { "Float4" } }
+            new { Return = "float", Params = new[] { "float" } },
+            new { Return = "Float2", Params = new[] { "Float2" } },
+            new { Return = "Float3", Params = new[] { "Float3" } },
+            new { Return = "Float4", Params = new[] { "Float4" } }
         }
     },
     new

--- a/tests/ComputeSharp.Tests/IPixelShaderTests.cs
+++ b/tests/ComputeSharp.Tests/IPixelShaderTests.cs
@@ -1,0 +1,50 @@
+﻿using ComputeSharp.Tests.Attributes;
+using ComputeSharp.Tests.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.Tests;
+
+[TestClass]
+[TestCategory("IPixelShader")]
+public partial class IPixelShaderTests
+{
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public unsafe void PixelShader_EarlyReturn(Device device)
+    {
+        using ReadWriteTexture2D<Rgba32, float4> texture = device.Get().AllocateReadWriteTexture2D<Rgba32, float4>(128, 128);
+
+        device.Get().ForEach<EarlyReturnShader, float4>(texture);
+
+        Rgba32[,] result = texture.ToArray();
+
+        for (int i = 0; i < texture.Height; i++)
+        {
+            for (int j = 0; j < texture.Width; j++)
+            {
+                if (j % 2 == 0)
+                {
+                    Assert.AreEqual(result[i, j], new Rgba32(255, 0, 0, 0));
+                }
+                else
+                {
+                    Assert.AreEqual(result[i, j], new Rgba32(0, 255, 0, 0));
+                }
+            }
+        }
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct EarlyReturnShader : IPixelShader<float4>
+    {
+        public float4 Execute()
+        {
+            if (ThreadIds.X % 2 == 0)
+            {
+                return float4.UnitX;
+            }
+
+            return float4.UnitY;
+        }
+    }
+}


### PR DESCRIPTION
✅ Fix the `Hlsl.Normalize` intrinsic overloads and signatures
✅ Fix an HLSL codegen issue with pixel shaders with returns not at the end of `Execute`