### PR TITLE
Fix ref returns of readonly types/interfaces

### DIFF
--- a/src/ComputeSharp/Graphics/Resources/ConstantBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ConstantBuffer{T}.cs
@@ -43,7 +43,7 @@ public sealed class ConstantBuffer<T> : Buffer<T>
     /// </summary>
     /// <param name="i">The index of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public T this[int i] => throw new InvalidExecutionContextException($"{typeof(ConstantBuffer<T>)}[{typeof(int)}]");
+    public ref readonly T this[int i] => throw new InvalidExecutionContextException($"{typeof(ConstantBuffer<T>)}[{typeof(int)}]");
 
     /// <summary>
     /// Gets the right padded size for <typeparamref name="T"/> elements to store in the current instance.

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture2D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture2D{TPixel}.cs
@@ -24,14 +24,14 @@ public interface IReadOnlyTexture2D<TPixel> : IGraphicsResource
     /// <param name="x">The horizontal offset of the value to get.</param>
     /// <param name="y">The vertical offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    TPixel this[int x, int y] { get; }
+    ref readonly TPixel this[int x, int y] { get; }
 
     /// <summary>
     /// Gets a single <typeparamref name="TPixel"/> value from the current readonly texture.
     /// </summary>
     /// <param name="xy">The coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    TPixel this[Int2 xy] { get; }
+    ref readonly TPixel this[Int2 xy] { get; }
 
     /// <summary>
     /// Gets a single <typeparamref name="TPixel"/> value from the current readonly texture with linear sampling.
@@ -39,12 +39,12 @@ public interface IReadOnlyTexture2D<TPixel> : IGraphicsResource
     /// <param name="u">The horizontal normalized offset of the value to get.</param>
     /// <param name="v">The vertical normalized offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    TPixel this[float u, float v] { get; }
+    ref readonly TPixel this[float u, float v] { get; }
 
     /// <summary>
     /// Gets a single <typeparamref name="TPixel"/> value from the current readonly texture with linear sampling.
     /// </summary>
     /// <param name="uv">The normalized coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    TPixel this[Float2 uv] { get; }
+    ref readonly TPixel this[Float2 uv] { get; }
 }

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture3D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture3D{TPixel}.cs
@@ -30,14 +30,14 @@ public interface IReadOnlyTexture3D<TPixel> : IGraphicsResource
     /// <param name="y">The vertical offset of the value to get.</param>
     /// <param name="z">The depthwise offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    TPixel this[int x, int y, int z] { get; }
+    ref readonly TPixel this[int x, int y, int z] { get; }
 
     /// <summary>
     /// Gets a single <typeparamref name="TPixel"/> value from the current readonly texture.
     /// </summary>
     /// <param name="xyz">The coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    TPixel this[Int3 xyz] { get; }
+    ref readonly TPixel this[Int3 xyz] { get; }
 
     /// <summary>
     /// Gets a single <typeparamref name="TPixel"/> value from the current readonly texture with linear sampling.
@@ -46,12 +46,12 @@ public interface IReadOnlyTexture3D<TPixel> : IGraphicsResource
     /// <param name="v">The vertical normalized offset of the value to get.</param>
     /// <param name="w">The depthwise normalized offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    TPixel this[float u, float v, float w] { get; }
+    ref readonly TPixel this[float u, float v, float w] { get; }
 
     /// <summary>
     /// Gets a single <typeparamref name="TPixel"/> value from the current readonly texture with linear sampling.
     /// </summary>
     /// <param name="uvw">The normalized coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    TPixel this[Float3 uvw] { get; }
+    ref readonly TPixel this[Float3 uvw] { get; }
 }

--- a/src/ComputeSharp/Graphics/Resources/ReadOnlyBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadOnlyBuffer{T}.cs
@@ -31,7 +31,7 @@ public sealed class ReadOnlyBuffer<T> : StructuredBuffer<T>
     /// </summary>
     /// <param name="i">The index of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public T this[int i] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyBuffer<T>)}[{typeof(int)}]");
+    public ref readonly T this[int i] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyBuffer<T>)}[{typeof(int)}]");
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture2D{T,TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture2D{T,TPixel}.cs
@@ -31,16 +31,16 @@ public sealed class ReadOnlyTexture2D<T, TPixel> : Texture2D<T>, IReadOnlyTextur
     }
 
     /// <inheritdoc/>
-    public TPixel this[int x, int y] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T, TPixel>)}[{typeof(int)}, {typeof(int)}]");
+    public ref readonly TPixel this[int x, int y] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T, TPixel>)}[{typeof(int)}, {typeof(int)}]");
 
     /// <inheritdoc/>
-    public TPixel this[Int2 xy] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T,TPixel>)}[{typeof(Int2)}]");
+    public ref readonly TPixel this[Int2 xy] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T,TPixel>)}[{typeof(Int2)}]");
 
     /// <inheritdoc/>
-    public TPixel this[float u, float v] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T, TPixel>)}[{typeof(float)}, {typeof(float)}]");
+    public ref readonly TPixel this[float u, float v] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T, TPixel>)}[{typeof(float)}, {typeof(float)}]");
 
     /// <inheritdoc/>
-    public TPixel this[Float2 uv] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T, TPixel>)}[{typeof(Float2)}]");
+    public ref readonly TPixel this[Float2 uv] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T, TPixel>)}[{typeof(Float2)}]");
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture2D{T}.cs
@@ -34,14 +34,14 @@ public sealed class ReadOnlyTexture2D<T> : Texture2D<T>
     /// <param name="x">The horizontal offset of the value to get.</param>
     /// <param name="y">The vertical offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public T this[int x, int y] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T>)}[{typeof(int)}, {typeof(int)}]");
+    public ref readonly T this[int x, int y] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T>)}[{typeof(int)}, {typeof(int)}]");
 
     /// <summary>
     /// Gets a single <typeparamref name="T"/> value from the current readonly texture.
     /// </summary>
     /// <param name="xy">The coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public T this[Int2 xy] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T>)}[{typeof(Int2)}]");
+    public ref readonly T this[Int2 xy] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture2D<T>)}[{typeof(Int2)}]");
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture3D{T,TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture3D{T,TPixel}.cs
@@ -32,16 +32,16 @@ public sealed class ReadOnlyTexture3D<T, TPixel> : Texture3D<T>, IReadOnlyTextur
     }
 
     /// <inheritdoc/>
-    public TPixel this[int x, int y, int z] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T, TPixel>)}[{typeof(int)}, {typeof(int)}, {typeof(int)}]");
+    public ref readonly TPixel this[int x, int y, int z] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T, TPixel>)}[{typeof(int)}, {typeof(int)}, {typeof(int)}]");
 
     /// <inheritdoc/>
-    public TPixel this[Int3 xyz] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T, TPixel>)}[{typeof(Int3)}]");
+    public ref readonly TPixel this[Int3 xyz] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T, TPixel>)}[{typeof(Int3)}]");
 
     /// <inheritdoc/>
-    public TPixel this[float u, float v, float w] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T, TPixel>)}[{typeof(float)}, {typeof(float)}, {typeof(float)}]");
+    public ref readonly TPixel this[float u, float v, float w] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T, TPixel>)}[{typeof(float)}, {typeof(float)}, {typeof(float)}]");
 
     /// <inheritdoc/>
-    public TPixel this[Float3 uvw] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T, TPixel>)}[{typeof(Float3)}]");
+    public ref readonly TPixel this[Float3 uvw] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T, TPixel>)}[{typeof(Float3)}]");
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture3D{T}.cs
@@ -36,14 +36,14 @@ public sealed class ReadOnlyTexture3D<T> : Texture3D<T>
     /// <param name="y">The vertical offset of the value to get.</param>
     /// <param name="z">The depthwise offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public T this[int x, int y, int z] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T>)}[{typeof(int)}, {typeof(int)}, {typeof(int)}]");
+    public ref readonly T this[int x, int y, int z] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T>)}[{typeof(int)}, {typeof(int)}, {typeof(int)}]");
 
     /// <summary>
     /// Gets a single <typeparamref name="T"/> value from the current readonly texture.
     /// </summary>
     /// <param name="xyz">The coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public T this[Int3 xyz] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T>)}[{typeof(Int3)}]");
+    public ref readonly T this[Int3 xyz] => throw new InvalidExecutionContextException($"{typeof(ReadOnlyTexture3D<T>)}[{typeof(Int3)}]");
 
     /// <inheritdoc/>
     public override string ToString()


### PR DESCRIPTION
This PR adds ref returns to all readonly resources and interfaces, for consistency.