### PR TITLE
Add vertical sync option

### DIFF
--- a/samples/ComputeSharp.SwapChain.Core.Shared/Constants/Event.cs
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/Constants/Event.cs
@@ -5,6 +5,7 @@
 /// </summary>
 public static class Event
 {
+    public const string IsVerticalSyncEnabledChanged = "[SETTINGS] IsVerticalSyncEnabled";
     public const string IsDynamicResolutionEnabledChanged = "[SETTINGS] IsDynamicResolutionEnabled";
     public const string SelectedResolutionScaleChanged = "[SETTINGS] SelectedResolutionScale";
     public const string SelectedComputeShaderChanged = "[SETTINGS] SelectedComputeShader";

--- a/samples/ComputeSharp.SwapChain.Core.Shared/ViewModels/MainViewModel.cs
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/ViewModels/MainViewModel.cs
@@ -35,6 +35,7 @@ public sealed class MainViewModel : ObservableObject
         Guard.IsNotNull(analyticsService, nameof(analyticsService));
 
         this.analyticsService = analyticsService;
+        this.isVerticalSyncEnabled = true;
         this.isDynamicResolutionEnabled = true;
         this.selectedResolutionScale = 100;
         this.selectedComputeShader = ComputeShaderOptions[0];
@@ -48,6 +49,23 @@ public sealed class MainViewModel : ObservableObject
     /// Gets the available resolution scaling options (as percentage values).
     /// </summary>
     public IList<int> ResolutionScaleOptions { get; } = new[] { 25, 50, 75, 100 };
+
+    private bool isVerticalSyncEnabled;
+
+    /// <summary>
+    /// Gets or sets whether the vertical sync is enabled.
+    /// </summary>
+    public bool IsVerticalSyncEnabled
+    {
+        get => this.isVerticalSyncEnabled;
+        set
+        {
+            if (SetProperty(ref this.isVerticalSyncEnabled, value))
+            {
+                this.analyticsService.Log(Event.IsVerticalSyncEnabledChanged, (nameof(value), value));
+            }
+        }
+    }
 
     private bool isDynamicResolutionEnabled;
 

--- a/samples/ComputeSharp.SwapChain.Uwp/App.xaml
+++ b/samples/ComputeSharp.SwapChain.Uwp/App.xaml
@@ -1,4 +1,8 @@
 ﻿<Application
     x:Class="ComputeSharp.SwapChain.Uwp.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+    </Application.Resources>
+</Application>

--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -208,10 +208,10 @@
       <Version>7.1.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Analytics">
-      <Version>4.4.0</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AppCenter.Crashes">
-      <Version>4.4.0</Version>
+      <Version>4.5.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>6.0.0</Version>
@@ -224,6 +224,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Media">
       <Version>7.1.2</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.UI.Xaml">
+      <Version>2.7.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.Uwp/Views/MainView.xaml
+++ b/samples/ComputeSharp.SwapChain.Uwp/Views/MainView.xaml
@@ -154,6 +154,7 @@
             Grid.Row="1"
             IsDynamicResolutionEnabled="{x:Bind ViewModel.IsDynamicResolutionEnabled, Mode=OneWay}"
             IsPaused="{x:Bind ViewModel.IsRenderingPaused, Mode=OneWay}"
+            IsVerticalSyncEnabled="{x:Bind ViewModel.IsVerticalSyncEnabled, Mode=OneWay}"
             RenderingFailed="MainShaderPanel_RenderingFailed"
             ResolutionScale="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToScale(ViewModel.SelectedResolutionScale), Mode=OneWay}"
             ShaderRunner="{x:Bind ViewModel.SelectedComputeShader.ShaderRunner, Mode=OneWay}" />
@@ -192,6 +193,7 @@
                 <SymbolIcon Symbol="Setting" />
                 <Button.Flyout>
                     <MenuFlyout>
+                        <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsVerticalSyncEnabled, Mode=TwoWay}" Text="Vertical sync" />
                         <ToggleMenuFlyoutItem IsChecked="{x:Bind ViewModel.IsDynamicResolutionEnabled, Mode=TwoWay}" Text="Dynamic resolution" />
                         <MenuFlyoutSeparator />
                         <ToggleMenuFlyoutItem

--- a/samples/ComputeSharp.SwapChain.WinUI/Views/MainWindow.xaml
+++ b/samples/ComputeSharp.SwapChain.WinUI/Views/MainWindow.xaml
@@ -150,6 +150,7 @@
         <computesharp:AnimatedComputeShaderPanel
             x:Name="ShaderPanel"
             Grid.Row="1"
+            IsVerticalSyncEnabled="{x:Bind ViewModel.IsVerticalSyncEnabled, Mode=OneWay}"
             IsDynamicResolutionEnabled="{x:Bind ViewModel.IsDynamicResolutionEnabled, Mode=OneWay}"
             IsPaused="{x:Bind ViewModel.IsRenderingPaused, Mode=OneWay}"
             ResolutionScale="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToScale(ViewModel.SelectedResolutionScale), Mode=OneWay}"

--- a/src/ComputeSharp.UI/Controls/AnimatedComputeShaderPanel.Properties.cs
+++ b/src/ComputeSharp.UI/Controls/AnimatedComputeShaderPanel.Properties.cs
@@ -136,6 +136,34 @@ partial class AnimatedComputeShaderPanel
     }
 
     /// <summary>
+    /// Gets or sets whether vertical sync is enabled.
+    /// <para>The default value for this property is <see langword="true"/>.</para>
+    /// </summary>
+    public bool IsVerticalSyncEnabled
+    {
+        get => (bool)GetValue(IsVerticalSyncEnabledProperty);
+        set => SetValue(IsVerticalSyncEnabledProperty, value);
+    }
+
+    /// <summary>
+    /// The <see cref="DependencyProperty"/> backing <see cref="IsVerticalSyncEnabled"/>.
+    /// </summary>
+    public static readonly DependencyProperty IsVerticalSyncEnabledProperty = DependencyProperty.Register(
+        nameof(IsVerticalSyncEnabled),
+        typeof(bool),
+        typeof(AnimatedComputeShaderPanel),
+        new PropertyMetadata(true, OnIsVerticalSyncEnabledPropertyChanged));
+
+    /// <inheritdoc cref="DependencyPropertyChangedCallback"/>
+    private static void OnIsVerticalSyncEnabledPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var @this = (AnimatedComputeShaderPanel)d;
+        var isVerticalSyncEnabled = (bool)e.NewValue;
+
+        @this.swapChainManager.QueueVerticalSyncModeChange(isVerticalSyncEnabled);
+    }
+
+    /// <summary>
     /// Gets or sets whether or not the rendering is paused.
     /// </summary>
     public bool IsPaused

--- a/src/ComputeSharp.UI/Controls/AnimatedComputeShaderPanel.cs
+++ b/src/ComputeSharp.UI/Controls/AnimatedComputeShaderPanel.cs
@@ -50,6 +50,7 @@ public sealed partial class AnimatedComputeShaderPanel : SwapChainPanel
         this.swapChainManager.QueueCompositionScaleChange(CompositionScaleX, CompositionScaleY);
         this.swapChainManager.QueueResolutionScaleChange(ResolutionScale);
         this.swapChainManager.QueueDynamicResolutionModeChange(IsDynamicResolutionEnabled);
+        this.swapChainManager.QueueVerticalSyncModeChange(IsVerticalSyncEnabled);
 
         if (!IsPaused &&
             ShaderRunner is IShaderRunner shaderRunner)

--- a/src/ComputeSharp.UI/Controls/ComputeShaderPanel.Properties.cs
+++ b/src/ComputeSharp.UI/Controls/ComputeShaderPanel.Properties.cs
@@ -169,4 +169,32 @@ partial class ComputeShaderPanel
 
         @this.swapChainManager.QueueDynamicResolutionModeChange(isDynamicResolutionEnabled);
     }
+
+    /// <summary>
+    /// Gets or sets whether vertical sync is enabled.
+    /// <para>The default value for this property is <see langword="true"/>.</para>
+    /// </summary>
+    public bool IsVerticalSyncEnabled
+    {
+        get => (bool)GetValue(IsVerticalSyncEnabledProperty);
+        set => SetValue(IsVerticalSyncEnabledProperty, value);
+    }
+
+    /// <summary>
+    /// The <see cref="DependencyProperty"/> backing <see cref="IsVerticalSyncEnabled"/>.
+    /// </summary>
+    public static readonly DependencyProperty IsVerticalSyncEnabledProperty = DependencyProperty.Register(
+        nameof(IsVerticalSyncEnabled),
+        typeof(bool),
+        typeof(ComputeShaderPanel),
+        new PropertyMetadata(true, OnIsVerticalSyncEnabledPropertyChanged));
+
+    /// <inheritdoc cref="DependencyPropertyChangedCallback"/>
+    private static void OnIsVerticalSyncEnabledPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        var @this = (ComputeShaderPanel)d;
+        var isVerticalSyncEnabled = (bool)e.NewValue;
+
+        @this.swapChainManager.QueueVerticalSyncModeChange(isVerticalSyncEnabled);
+    }
 }

--- a/src/ComputeSharp.UI/Controls/ComputeShaderPanel.cs
+++ b/src/ComputeSharp.UI/Controls/ComputeShaderPanel.cs
@@ -50,6 +50,7 @@ public sealed partial class ComputeShaderPanel : SwapChainPanel
         this.swapChainManager.QueueCompositionScaleChange(CompositionScaleX, CompositionScaleY);
         this.swapChainManager.QueueResolutionScaleChange(ResolutionScale);
         this.swapChainManager.QueueDynamicResolutionModeChange(IsDynamicResolutionEnabled);
+        this.swapChainManager.QueueVerticalSyncModeChange(IsVerticalSyncEnabled);
 
         if (FrameRequestQueue is IFrameRequestQueue frameRequestQueue &&
             ShaderRunner is IShaderRunner shaderRunner)

--- a/src/ComputeSharp.UI/Helpers/DynamicResolutionManager.cs
+++ b/src/ComputeSharp.UI/Helpers/DynamicResolutionManager.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-#if !WINDOWS_UWP
-using System.Runtime.InteropServices;
-#endif
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 #if WINDOWS_UWP
@@ -82,14 +80,7 @@ internal unsafe ref struct DynamicResolutionManager
         manager.lowerFrameTimeThresholdInTicks = lowerFrameTimeThresholdInTicks;
         manager.slidingFrameTimeWindowSum = targetFrameTimeInTicks * SlidingFrameTimeWindowLength;
 
-#if WINDOWS_UWP
-        fixed (long* p = &manager.frameTimesInTicks[0])
-        {
-            new Span<long>(p, SlidingFrameTimeWindowLength).Fill(targetFrameTimeInTicks);
-        }
-#else
-        MemoryMarshal.CreateSpan(ref manager.frameTimesInTicks[0], SlidingFrameTimeWindowLength).Fill(targetFrameTimeInTicks);
-#endif
+        new Span<long>(Unsafe.AsPointer(ref manager.frameTimesInTicks[0]), SlidingFrameTimeWindowLength).Fill(targetFrameTimeInTicks);
     }
 
     /// <summary>

--- a/src/ComputeSharp.UI/Helpers/DynamicResolutionManager.cs
+++ b/src/ComputeSharp.UI/Helpers/DynamicResolutionManager.cs
@@ -31,17 +31,17 @@ internal unsafe ref struct DynamicResolutionManager
     /// <summary>
     /// The target frame time in ticks.
     /// </summary>
-    private long targetFrameTimeInTicks;
+    private readonly long targetFrameTimeInTicks;
 
     /// <summary>
     /// The upper frame time threshold in ticks.
     /// </summary>
-    private long upperFrameTimeThresholdInTicks;
+    private readonly long upperFrameTimeThresholdInTicks;
 
     /// <summary>
     /// The lower frame time threshold in ticks.
     /// </summary>
-    private long lowerFrameTimeThresholdInTicks;
+    private readonly long lowerFrameTimeThresholdInTicks;
 
     /// <summary>
     /// The window of registered frame times for previous frames.
@@ -67,20 +67,19 @@ internal unsafe ref struct DynamicResolutionManager
     /// Initializes a new <see cref="DynamicResolutionManager"/> instance.
     /// </summary>
     /// <param name="targetFramerate">The target framerate to use.</param>
-    /// <param name="manager">The resulting <see cref="DynamicResolutionManager"/> instance.</param>
-    public static void Create(int targetFramerate, out DynamicResolutionManager manager)
+    public DynamicResolutionManager(int targetFramerate)
     {
         long targetFrameTimeInTicks = TimeSpan.FromSeconds(1).Ticks / targetFramerate;
         long upperFrameTimeThresholdInTicks = TimeSpan.FromSeconds(1).Ticks / (targetFramerate - 2);
         long lowerFrameTimeThresholdInTicks = TimeSpan.FromSeconds(1).Ticks / (targetFramerate + 2);
 
-        manager.frameTimeOffset = 0;
-        manager.targetFrameTimeInTicks = targetFrameTimeInTicks;
-        manager.upperFrameTimeThresholdInTicks = upperFrameTimeThresholdInTicks;
-        manager.lowerFrameTimeThresholdInTicks = lowerFrameTimeThresholdInTicks;
-        manager.slidingFrameTimeWindowSum = targetFrameTimeInTicks * SlidingFrameTimeWindowLength;
+        this.frameTimeOffset = 0;
+        this.targetFrameTimeInTicks = targetFrameTimeInTicks;
+        this.upperFrameTimeThresholdInTicks = upperFrameTimeThresholdInTicks;
+        this.lowerFrameTimeThresholdInTicks = lowerFrameTimeThresholdInTicks;
+        this.slidingFrameTimeWindowSum = targetFrameTimeInTicks * SlidingFrameTimeWindowLength;
 
-        new Span<long>(Unsafe.AsPointer(ref manager.frameTimesInTicks[0]), SlidingFrameTimeWindowLength).Fill(targetFrameTimeInTicks);
+        new Span<long>(Unsafe.AsPointer(ref this.frameTimesInTicks[0]), SlidingFrameTimeWindowLength).Fill(targetFrameTimeInTicks);
     }
 
     /// <summary>

--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.Rendering.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.Rendering.cs
@@ -171,10 +171,14 @@ partial class SwapChainManager<TOwner>
                 RenderLoop();
             }
 
+            this.renderStopwatch?.Stop();
+
             OnRenderingStopped();
         }
         catch (Exception e)
         {
+            this.renderStopwatch?.Stop();
+
             OnRenderingFailed(e);
         }
         finally
@@ -223,8 +227,6 @@ partial class SwapChainManager<TOwner>
                 OnPresent();
             }
         }
-
-        renderStopwatch.Stop();
     }
 
     /// <summary>
@@ -275,8 +277,6 @@ partial class SwapChainManager<TOwner>
                 }
             }
         }
-
-        renderStopwatch.Stop();
     }
 
     /// <summary>

--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.Rendering.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.Rendering.cs
@@ -98,6 +98,17 @@ partial class SwapChainManager<TOwner>
     }
 
     /// <summary>
+    /// Queues a change in the vertical sync mode.
+    /// </summary>
+    /// <param name="isVerticalSyncEnabled">Whether or not to use vertical sync.</param>
+    public void QueueVerticalSyncModeChange(bool isVerticalSyncEnabled)
+    {
+        ThrowIfDisposed();
+
+        this.syncInterval = isVerticalSyncEnabled ? 1u : 0u;
+    }
+
+    /// <summary>
     /// Queues a resize operation.
     /// </summary>
     /// <param name="width">The width of the render resolution.</param>

--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.Rendering.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.Rendering.cs
@@ -230,6 +230,7 @@ partial class SwapChainManager<TOwner>
         // resuming after a pause correctly renders the first frame at the right time.        
         if (OnUpdate(renderStopwatch.Elapsed, parameter))
         {
+            OnWaitForPresent();
             OnPresent();
         }
 
@@ -247,6 +248,7 @@ partial class SwapChainManager<TOwner>
             
             if (OnUpdate(renderStopwatch.Elapsed, parameter))
             {
+                OnWaitForPresent();
                 OnPresent();
             }
         }
@@ -272,6 +274,7 @@ partial class SwapChainManager<TOwner>
 
         if (OnUpdate(renderStopwatch.Elapsed, parameter))
         {
+            OnWaitForPresent();
             OnPresent();
         }
 
@@ -290,6 +293,18 @@ partial class SwapChainManager<TOwner>
 
             if (OnUpdate(renderStopwatch.Elapsed, parameter))
             {
+                frameStopwatch.Stop();
+
+                // The time spent waiting for present isn't included in the frame time, as when v-sync is
+                // enabled it corresponds to the time spent waiting for the v-blank. If it was included,
+                // then the actual framerate would never exceed the target one, meaning that if dynamic
+                // resolution is enabled, the resolution scale could only keep decreasing without ever
+                // being able to be increased again, as the framerate would never exceed the target.
+                // Simply not counting the time spent waiting for that works around the issue.
+                OnWaitForPresent();
+
+                frameStopwatch.Start();
+
                 OnPresent();
 
                 // Evaluate the dynamic resolution frame time step
@@ -360,6 +375,11 @@ partial class SwapChainManager<TOwner>
     {
         return this.shaderRunner!.TryExecute(this.texture!, time, parameter);
     }
+
+    /// <summary>
+    /// Waits for the panel to be ready to present a new frame for the current application.
+    /// </summary>
+    private unsafe partial void OnWaitForPresent();
 
     /// <summary>
     /// Presents the last rendered frame for the current application.

--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.Rendering.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.Rendering.cs
@@ -261,19 +261,7 @@ partial class SwapChainManager<TOwner>
         Stopwatch renderStopwatch = this.renderStopwatch ??= new();
         Stopwatch frameStopwatch = new();
         CancellationToken cancellationToken = this.renderCancellationTokenSource!.Token;
-
-        DynamicResolutionManager frameTimeWatcher;
-
-        if (this.syncInterval == 0u)
-        {
-            DynamicResolutionManager.Create(60, out frameTimeWatcher);
-        }
-        else
-        {
-            // If v-sync is enabled, we target slightly below 60fps, in order to account for the
-            // actual framerate being capped due to waiting for the v-blank at each present.
-            DynamicResolutionManager.Create(55, out frameTimeWatcher);
-        }
+        DynamicResolutionManager frameTimeWatcher = new(60);
 
         if (!OnFrameRequest(out object? parameter, cancellationToken))
         {

--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
@@ -390,11 +390,14 @@ internal sealed unsafe partial class SwapChainManager<TOwner> : NativeObject
     }
 
     /// <inheritdoc/>
+    private unsafe partial void OnWaitForPresent()
+    {
+        _ = Win32.WaitForSingleObjectEx(frameLatencyWaitableObject, Win32.INFINITE, true);
+    }
+
+    /// <inheritdoc/>
     private unsafe partial void OnPresent()
     {
-        // Wait for the swap chain to be ready for presenting
-        _ = Win32.WaitForSingleObjectEx(frameLatencyWaitableObject, Win32.INFINITE, true);
-
         using ComPtr<ID3D12Resource> d3D12Resource = default;
 
         // Get the underlying ID3D12Resource pointer for the texture

--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
@@ -176,6 +176,11 @@ internal sealed unsafe partial class SwapChainManager<TOwner> : NativeObject
     private volatile bool isDynamicResolutionEnabled;
 
     /// <summary>
+    /// The flags to enable or disable vertical sync.
+    /// </summary>
+    private volatile uint syncInterval;
+
+    /// <summary>
     /// The <see cref="Stopwatch"/> instance tracking time since the first rendered frame.
     /// </summary>
     private volatile Stopwatch? renderStopwatch;
@@ -388,7 +393,7 @@ internal sealed unsafe partial class SwapChainManager<TOwner> : NativeObject
     private unsafe partial void OnPresent()
     {
         // Wait for the swap chain to be ready for presenting
-        _ = Win32.WaitForSingleObjectEx(frameLatencyWaitableObject, 1000, true);
+        _ = Win32.WaitForSingleObjectEx(frameLatencyWaitableObject, Win32.INFINITE, true);
 
         using ComPtr<ID3D12Resource> d3D12Resource = default;
 
@@ -455,7 +460,7 @@ internal sealed unsafe partial class SwapChainManager<TOwner> : NativeObject
         this.d3D12CommandQueue.Get()->Signal(this.d3D12Fence.Get(), updatedFenceValue).Assert();
 
         // Present the new frame
-        this.dxgiSwapChain3.Get()->Present(0, 0).Assert();
+        this.dxgiSwapChain3.Get()->Present(SyncInterval: this.syncInterval, 0).Assert();
 
         if (updatedFenceValue > this.d3D12Fence.Get()->GetCompletedValue())
         {


### PR DESCRIPTION
This PR adds an option to enable v-sync in the compute shader panels.
It also fixes a bug where the render timer wasn't stopped in case of a crash.