### PR TITLE
Enable sampling from non-uniform writeable textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ With the compute shader being like this:
 [AutoConstructor]
 public readonly partial struct GrayscaleEffect : IComputeShader
 {
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     // Other captured resources or values here...
 

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor{TPixel}.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor{TPixel}.cs
@@ -315,7 +315,7 @@ public sealed partial class HlslBokehBlurProcessor
         [AutoConstructor]
         internal partial struct VerticalConvolutionProcessor : IComputeShader
         {
-            public IReadWriteTexture2D<float4> source;
+            public IReadWriteNormalizedTexture2D<float4> source;
             public ReadWriteTexture2D<float4> reals;
             public ReadWriteTexture2D<float4> imaginaries;
             public ReadOnlyBuffer<Complex64> kernel;
@@ -392,7 +392,7 @@ public sealed partial class HlslBokehBlurProcessor
         [AutoConstructor]
         internal readonly partial struct GammaHighlightProcessor : IComputeShader
         {
-            public readonly IReadWriteTexture2D<float4> source;
+            public readonly IReadWriteNormalizedTexture2D<float4> source;
 
             /// <inheritdoc/>
             public void Execute()
@@ -417,7 +417,7 @@ public sealed partial class HlslBokehBlurProcessor
         internal readonly partial struct InverseGammaHighlightProcessor : IComputeShader
         {
             public readonly ReadWriteTexture2D<float4> source;
-            public readonly IReadWriteTexture2D<float4> target;
+            public readonly IReadWriteNormalizedTexture2D<float4> target;
 
             /// <inheritdoc/>
             public void Execute()

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor{TPixel}.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor{TPixel}.cs
@@ -121,8 +121,8 @@ public sealed partial class HlslGaussianBlurProcessor
         [AutoConstructor]
         internal readonly partial struct VerticalConvolutionProcessor : IComputeShader
         {
-            public readonly IReadWriteTexture2D<float4> source;
-            public readonly IReadWriteTexture2D<float4> target;
+            public readonly IReadWriteNormalizedTexture2D<float4> source;
+            public readonly IReadWriteNormalizedTexture2D<float4> target;
             public readonly ReadOnlyBuffer<float> kernel;
 
             /// <inheritdoc/>
@@ -153,8 +153,8 @@ public sealed partial class HlslGaussianBlurProcessor
         [AutoConstructor]
         internal readonly partial struct HorizontalConvolutionProcessor : IComputeShader
         {
-            public readonly IReadWriteTexture2D<float4> source;
-            public readonly IReadWriteTexture2D<float4> target;
+            public readonly IReadWriteNormalizedTexture2D<float4> source;
+            public readonly IReadWriteNormalizedTexture2D<float4> target;
             public readonly ReadOnlyBuffer<float> kernel;
 
             /// <inheritdoc/>

--- a/samples/ComputeSharp.SwapChain.Core.Shared/Shaders/Runners/ContouredLayersRunner.cs
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/Shaders/Runners/ContouredLayersRunner.cs
@@ -23,7 +23,7 @@ public sealed class ContouredLayersRunner : IShaderRunner
     private ReadOnlyTexture2D<Rgba32, Float4>? texture;
 
     /// <inheritdoc/>
-    public bool TryExecute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter)
+    public bool TryExecute(IReadWriteNormalizedTexture2D<Float4> texture, TimeSpan timespan, object? parameter)
     {
         if (this.texture is null ||
             this.texture.GraphicsDevice != texture.GraphicsDevice)

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ContouredLayers.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ContouredLayers.cs
@@ -19,7 +19,7 @@ internal readonly partial struct ContouredLayers : IPixelShader<float4>
     /// <summary>
     /// The background texture to sample.
     /// </summary>
-    public readonly IReadOnlyTexture2D<float4> texture;
+    public readonly IReadOnlyNormalizedTexture2D<float4> texture;
 
     // float3 to float hash.
     private static float Hash21(float2 p)

--- a/samples/ComputeSharp.SwapChain/Program.cs
+++ b/samples/ComputeSharp.SwapChain/Program.cs
@@ -12,7 +12,7 @@ class Program
     /// <summary>
     /// A texture for <c>\Textures\RustyMetal.png</c>.
     /// </summary>
-    private static readonly IReadOnlyTexture2D<float4> RustyMetal = LoadTexture();
+    private static readonly IReadOnlyNormalizedTexture2D<float4> RustyMetal = LoadTexture();
 
     /// <summary>
     /// The mapping of available samples to choose from.

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownMembers.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownMembers.cs
@@ -22,12 +22,16 @@ internal static class HlslKnownMembers
         [$"ComputeSharp.ReadOnlyTexture2D`2.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
         [$"ComputeSharp.ReadWriteTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
         [$"ComputeSharp.ReadWriteTexture2D`2.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
+        [$"ComputeSharp.IReadOnlyTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
+        [$"ComputeSharp.IReadWriteTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
         [$"ComputeSharp.IReadOnlyNormalizedTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
         [$"ComputeSharp.IReadWriteNormalizedTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
         [$"ComputeSharp.ReadOnlyTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
         [$"ComputeSharp.ReadOnlyTexture3D`2.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
         [$"ComputeSharp.ReadWriteTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
         [$"ComputeSharp.ReadWriteTexture3D`2.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
+        [$"ComputeSharp.IReadOnlyTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
+        [$"ComputeSharp.IReadWriteTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
         [$"ComputeSharp.IReadOnlyNormalizedTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
         [$"ComputeSharp.IReadWriteNormalizedTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3"
     };
@@ -39,10 +43,14 @@ internal static class HlslKnownMembers
     {
         [$"ComputeSharp.ReadOnlyTexture2D`2.this[{typeof(float).FullName}, {typeof(float).FullName}]"] = "float2",
         [$"ComputeSharp.ReadOnlyTexture2D`2.this[{typeof(Float2).FullName}]"] = null,
+        [$"ComputeSharp.IReadOnlyTexture2D`1.this[{typeof(float).FullName}, {typeof(float).FullName}]"] = "float2",
+        [$"ComputeSharp.IReadOnlyTexture2D`1.this[{typeof(Float2).FullName}]"] = null,
         [$"ComputeSharp.IReadOnlyNormalizedTexture2D`1.this[{typeof(float).FullName}, {typeof(float).FullName}]"] = "float2",
         [$"ComputeSharp.IReadOnlyNormalizedTexture2D`1.this[{typeof(Float2).FullName}]"] = null,
         [$"ComputeSharp.ReadOnlyTexture3D`2.this[{typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName}]"] = "float3",
         [$"ComputeSharp.ReadOnlyTexture3D`2.this[{typeof(Float3).FullName}]"] = null,
+        [$"ComputeSharp.IReadOnlyTexture3D`1.this[{typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName}]"] = "float3",
+        [$"ComputeSharp.IReadOnlyTexture3D`1.this[{typeof(Float3).FullName}]"] = null,
         [$"ComputeSharp.IReadOnlyNormalizedTexture3D`1.this[{typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName}]"] = "float3",
         [$"ComputeSharp.IReadOnlyNormalizedTexture3D`1.this[{typeof(Float3).FullName}]"] = null
     };
@@ -58,6 +66,11 @@ internal static class HlslKnownMembers
         ["ComputeSharp.Resources.Texture3D`1.Width"] = (3, 0),
         ["ComputeSharp.Resources.Texture3D`1.Height"] = (3, 1),
         ["ComputeSharp.Resources.Texture3D`1.Depth"] = (3, 2),
+        ["ComputeSharp.IReadOnlyTexture2D`1.Width"] = (2, 0),
+        ["ComputeSharp.IReadOnlyTexture2D`1.Height"] = (2, 1),
+        ["ComputeSharp.IReadOnlyTexture3D`1.Width"] = (3, 0),
+        ["ComputeSharp.IReadOnlyTexture3D`1.Height"] = (3, 1),
+        ["ComputeSharp.IReadOnlyTexture3D`1.Depth"] = (3, 2),
         ["ComputeSharp.IReadOnlyNormalizedTexture2D`1.Width"] = (2, 0),
         ["ComputeSharp.IReadOnlyNormalizedTexture2D`1.Height"] = (2, 1),
         ["ComputeSharp.IReadOnlyNormalizedTexture3D`1.Width"] = (3, 0),

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownMembers.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownMembers.cs
@@ -22,14 +22,14 @@ internal static class HlslKnownMembers
         [$"ComputeSharp.ReadOnlyTexture2D`2.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
         [$"ComputeSharp.ReadWriteTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
         [$"ComputeSharp.ReadWriteTexture2D`2.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
-        [$"ComputeSharp.IReadOnlyTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
-        [$"ComputeSharp.IReadWriteTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
+        [$"ComputeSharp.IReadOnlyNormalizedTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
+        [$"ComputeSharp.IReadWriteNormalizedTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
         [$"ComputeSharp.ReadOnlyTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
         [$"ComputeSharp.ReadOnlyTexture3D`2.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
         [$"ComputeSharp.ReadWriteTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
         [$"ComputeSharp.ReadWriteTexture3D`2.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
-        [$"ComputeSharp.IReadOnlyTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
-        [$"ComputeSharp.IReadWriteTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3"
+        [$"ComputeSharp.IReadOnlyNormalizedTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3",
+        [$"ComputeSharp.IReadWriteNormalizedTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3"
     };
 
     /// <summary>
@@ -39,12 +39,12 @@ internal static class HlslKnownMembers
     {
         [$"ComputeSharp.ReadOnlyTexture2D`2.this[{typeof(float).FullName}, {typeof(float).FullName}]"] = "float2",
         [$"ComputeSharp.ReadOnlyTexture2D`2.this[{typeof(Float2).FullName}]"] = null,
-        [$"ComputeSharp.IReadOnlyTexture2D`1.this[{typeof(float).FullName}, {typeof(float).FullName}]"] = "float2",
-        [$"ComputeSharp.IReadOnlyTexture2D`1.this[{typeof(Float2).FullName}]"] = null,
+        [$"ComputeSharp.IReadOnlyNormalizedTexture2D`1.this[{typeof(float).FullName}, {typeof(float).FullName}]"] = "float2",
+        [$"ComputeSharp.IReadOnlyNormalizedTexture2D`1.this[{typeof(Float2).FullName}]"] = null,
         [$"ComputeSharp.ReadOnlyTexture3D`2.this[{typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName}]"] = "float3",
         [$"ComputeSharp.ReadOnlyTexture3D`2.this[{typeof(Float3).FullName}]"] = null,
-        [$"ComputeSharp.IReadOnlyTexture3D`1.this[{typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName}]"] = "float3",
-        [$"ComputeSharp.IReadOnlyTexture3D`1.this[{typeof(Float3).FullName}]"] = null
+        [$"ComputeSharp.IReadOnlyNormalizedTexture3D`1.this[{typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName}]"] = "float3",
+        [$"ComputeSharp.IReadOnlyNormalizedTexture3D`1.this[{typeof(Float3).FullName}]"] = null
     };
 
     /// <summary>
@@ -58,16 +58,16 @@ internal static class HlslKnownMembers
         ["ComputeSharp.Resources.Texture3D`1.Width"] = (3, 0),
         ["ComputeSharp.Resources.Texture3D`1.Height"] = (3, 1),
         ["ComputeSharp.Resources.Texture3D`1.Depth"] = (3, 2),
-        ["ComputeSharp.IReadOnlyTexture2D`1.Width"] = (2, 0),
-        ["ComputeSharp.IReadOnlyTexture2D`1.Height"] = (2, 1),
-        ["ComputeSharp.IReadOnlyTexture3D`1.Width"] = (3, 0),
-        ["ComputeSharp.IReadOnlyTexture3D`1.Height"] = (3, 1),
-        ["ComputeSharp.IReadOnlyTexture3D`1.Depth"] = (3, 2),
-        ["ComputeSharp.IReadWriteTexture2D`1.Width"] = (2, 0),
-        ["ComputeSharp.IReadWriteTexture2D`1.Height"] = (2, 1),
-        ["ComputeSharp.IReadWriteTexture3D`1.Width"] = (3, 0),
-        ["ComputeSharp.IReadWriteTexture3D`1.Height"] = (3, 1),
-        ["ComputeSharp.IReadWriteTexture3D`1.Depth"] = (3, 2)
+        ["ComputeSharp.IReadOnlyNormalizedTexture2D`1.Width"] = (2, 0),
+        ["ComputeSharp.IReadOnlyNormalizedTexture2D`1.Height"] = (2, 1),
+        ["ComputeSharp.IReadOnlyNormalizedTexture3D`1.Width"] = (3, 0),
+        ["ComputeSharp.IReadOnlyNormalizedTexture3D`1.Height"] = (3, 1),
+        ["ComputeSharp.IReadOnlyNormalizedTexture3D`1.Depth"] = (3, 2),
+        ["ComputeSharp.IReadWriteNormalizedTexture2D`1.Width"] = (2, 0),
+        ["ComputeSharp.IReadWriteNormalizedTexture2D`1.Height"] = (2, 1),
+        ["ComputeSharp.IReadWriteNormalizedTexture3D`1.Width"] = (3, 0),
+        ["ComputeSharp.IReadWriteNormalizedTexture3D`1.Height"] = (3, 1),
+        ["ComputeSharp.IReadWriteNormalizedTexture3D`1.Depth"] = (3, 2)
     };
 
     /// <summary>

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
@@ -141,8 +141,8 @@ internal static class HlslKnownTypes
             "ComputeSharp.ReadOnlyTexture2D`2" or
             "ComputeSharp.ReadOnlyTexture3D`1" or
             "ComputeSharp.ReadOnlyTexture3D`2" or
-            "ComputeSharp.IReadOnlyTexture2D`1" or
-            "ComputeSharp.IReadOnlyTexture3D`1" => true,
+            "ComputeSharp.IReadOnlyNormalizedTexture2D`1" or
+            "ComputeSharp.IReadOnlyNormalizedTexture3D`1" => true,
             _ => false,
         };
     }
@@ -161,8 +161,8 @@ internal static class HlslKnownTypes
             "ComputeSharp.ReadWriteTexture2D`2" or
             "ComputeSharp.ReadWriteTexture3D`1" or
             "ComputeSharp.ReadWriteTexture3D`2" or
-            "ComputeSharp.IReadWriteTexture2D`1" or
-            "ComputeSharp.IReadWriteTexture3D`1" => true,
+            "ComputeSharp.IReadWriteNormalizedTexture2D`1" or
+            "ComputeSharp.IReadWriteNormalizedTexture3D`1" => true,
             _ => false,
         };
     }
@@ -187,10 +187,10 @@ internal static class HlslKnownTypes
             "ComputeSharp.ReadOnlyTexture3D`2" or
             "ComputeSharp.ReadWriteTexture3D`1" or
             "ComputeSharp.ReadWriteTexture3D`2" or
-            "ComputeSharp.IReadOnlyTexture2D`1" or
-            "ComputeSharp.IReadWriteTexture2D`1" or
-            "ComputeSharp.IReadOnlyTexture3D`1" or
-            "ComputeSharp.IReadWriteTexture3D`1" => true,
+            "ComputeSharp.IReadOnlyNormalizedTexture2D`1" or
+            "ComputeSharp.IReadWriteNormalizedTexture2D`1" or
+            "ComputeSharp.IReadOnlyNormalizedTexture3D`1" or
+            "ComputeSharp.IReadWriteNormalizedTexture3D`1" => true,
             _ => false,
         };
     }
@@ -294,10 +294,10 @@ internal static class HlslKnownTypes
                 "ComputeSharp.ReadOnlyTexture3D`2" => $"Texture3D<unorm {mappedElementType}>",
                 "ComputeSharp.ReadWriteTexture3D`1" => $"RWTexture3D<{mappedElementType}>",
                 "ComputeSharp.ReadWriteTexture3D`2" => $"RWTexture3D<unorm {mappedElementType}>",
-                "ComputeSharp.IReadOnlyTexture2D`1" => $"Texture2D<unorm {mappedElementType}>",
-                "ComputeSharp.IReadWriteTexture2D`1" => $"RWTexture2D<unorm {mappedElementType}>",
-                "ComputeSharp.IReadOnlyTexture3D`1" => $"Texture3D<unorm {mappedElementType}>",
-                "ComputeSharp.IReadWriteTexture3D`1" => $"RWTexture3D<unorm {mappedElementType}>",
+                "ComputeSharp.IReadOnlyNormalizedTexture2D`1" => $"Texture2D<unorm {mappedElementType}>",
+                "ComputeSharp.IReadWriteNormalizedTexture2D`1" => $"RWTexture2D<unorm {mappedElementType}>",
+                "ComputeSharp.IReadOnlyNormalizedTexture3D`1" => $"Texture3D<unorm {mappedElementType}>",
+                "ComputeSharp.IReadWriteNormalizedTexture3D`1" => $"RWTexture3D<unorm {mappedElementType}>",
                 _ => throw new ArgumentException()
             };
         }

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
@@ -141,6 +141,8 @@ internal static class HlslKnownTypes
             "ComputeSharp.ReadOnlyTexture2D`2" or
             "ComputeSharp.ReadOnlyTexture3D`1" or
             "ComputeSharp.ReadOnlyTexture3D`2" or
+            "ComputeSharp.IReadOnlyTexture2D`1" or
+            "ComputeSharp.IReadOnlyTexture3D`1" => true,
             "ComputeSharp.IReadOnlyNormalizedTexture2D`1" or
             "ComputeSharp.IReadOnlyNormalizedTexture3D`1" => true,
             _ => false,
@@ -187,6 +189,8 @@ internal static class HlslKnownTypes
             "ComputeSharp.ReadOnlyTexture3D`2" or
             "ComputeSharp.ReadWriteTexture3D`1" or
             "ComputeSharp.ReadWriteTexture3D`2" or
+            "ComputeSharp.IReadOnlyTexture2D`1" or
+            "ComputeSharp.IReadOnlyTexture3D`1" or
             "ComputeSharp.IReadOnlyNormalizedTexture2D`1" or
             "ComputeSharp.IReadWriteNormalizedTexture2D`1" or
             "ComputeSharp.IReadOnlyNormalizedTexture3D`1" or
@@ -294,6 +298,8 @@ internal static class HlslKnownTypes
                 "ComputeSharp.ReadOnlyTexture3D`2" => $"Texture3D<unorm {mappedElementType}>",
                 "ComputeSharp.ReadWriteTexture3D`1" => $"RWTexture3D<{mappedElementType}>",
                 "ComputeSharp.ReadWriteTexture3D`2" => $"RWTexture3D<unorm {mappedElementType}>",
+                "ComputeSharp.IReadOnlyTexture2D`1" => $"Texture2D<{mappedElementType}>",
+                "ComputeSharp.IReadOnlyTexture3D`1" => $"Texture3D<{mappedElementType}>",
                 "ComputeSharp.IReadOnlyNormalizedTexture2D`1" => $"Texture2D<unorm {mappedElementType}>",
                 "ComputeSharp.IReadWriteNormalizedTexture2D`1" => $"RWTexture2D<unorm {mappedElementType}>",
                 "ComputeSharp.IReadOnlyNormalizedTexture3D`1" => $"Texture3D<unorm {mappedElementType}>",

--- a/src/ComputeSharp.UI/IShaderRunner.cs
+++ b/src/ComputeSharp.UI/IShaderRunner.cs
@@ -22,5 +22,5 @@ public interface IShaderRunner
     /// Any exceptions thrown by the runner will result in <see cref="ComputeShaderPanel.RenderingFailed"/>
     /// or <see cref="AnimatedComputeShaderPanel.RenderingFailed"/> to be raised.
     /// </remarks>
-    bool TryExecute(IReadWriteTexture2D<Float4> texture, TimeSpan timespan, object? parameter);
+    bool TryExecute(IReadWriteNormalizedTexture2D<Float4> texture, TimeSpan timespan, object? parameter);
 }

--- a/src/ComputeSharp.UI/ShaderRunner{T}.cs
+++ b/src/ComputeSharp.UI/ShaderRunner{T}.cs
@@ -57,7 +57,7 @@ public sealed class ShaderRunner<T> : IShaderRunner
     }
 
     /// <inheritdoc/>
-    public bool TryExecute(IReadWriteTexture2D<Float4> texture, TimeSpan time, object? parameter)
+    public bool TryExecute(IReadWriteNormalizedTexture2D<Float4> texture, TimeSpan time, object? parameter)
     {
         if (this.shaderFactory is Func<TimeSpan, T> shaderFactory)
         {

--- a/src/ComputeSharp/Core/Dispatch/DispatchAxis.cs
+++ b/src/ComputeSharp/Core/Dispatch/DispatchAxis.cs
@@ -35,9 +35,9 @@ public enum DispatchAxis
     /// Indicates a shader dispatch along the X and Y axes.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, in T)"/>, <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteTexture2D{TPixel})"/>,
-    /// <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteTexture2D{TPixel}, in T)"/>, <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, in T)"/>,
-    /// <see cref="ComputeContextExtensions.ForEach{T, TPixel}(in ComputeContext, IReadWriteTexture2D{TPixel})"/> or <see cref="ComputeContextExtensions.ForEach{T, TPixel}(in ComputeContext, IReadWriteTexture2D{TPixel}, in T)"/>.
+    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, in T)"/>, <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel})"/>,
+    /// <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>, <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, in T)"/>,
+    /// <see cref="ComputeContextExtensions.ForEach{T, TPixel}(in ComputeContext, IReadWriteNormalizedTexture2D{TPixel})"/> or <see cref="ComputeContextExtensions.ForEach{T, TPixel}(in ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>.
     /// </remarks>
     XY,
 

--- a/src/ComputeSharp/Core/Imaging/Interfaces/IPixel{T,TPixel}.cs
+++ b/src/ComputeSharp/Core/Imaging/Interfaces/IPixel{T,TPixel}.cs
@@ -15,8 +15,8 @@ public interface IPixel<T, TPixel>
     /// <returns>The <typeparamref name="TPixel"/> representation for the current value.</returns>
     /// <remarks>
     /// This method is primarily meant to be used to support
-    /// <see cref="ComputeContextExtensions.Fill{TPixel}(in ComputeContext, IReadWriteTexture2D{TPixel}, TPixel)"/>
-    /// and <see cref="ComputeContextExtensions.Fill{TPixel}(in ComputeContext, IReadWriteTexture3D{TPixel}, TPixel)"/>.
+    /// <see cref="ComputeContextExtensions.Fill{TPixel}(in ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, TPixel)"/>
+    /// and <see cref="ComputeContextExtensions.Fill{TPixel}(in ComputeContext, IReadWriteNormalizedTexture3D{TPixel}, TPixel)"/>.
     /// </remarks>
     TPixel ToPixel();
 }

--- a/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Dispatching.cs
+++ b/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Dispatching.cs
@@ -75,7 +75,7 @@ public static partial class GraphicsDeviceExtensions
     /// <typeparam name="TPixel">The type of pixels being processed by the shader.</typeparam>
     /// <param name="device">The <see cref="GraphicsDevice"/> to use to run the shader.</param>
     /// <param name="texture">The target texture to apply the pixel shader to.</param>
-    public static void ForEach<T, TPixel>(this GraphicsDevice device, IReadWriteTexture2D<TPixel> texture)
+    public static void ForEach<T, TPixel>(this GraphicsDevice device, IReadWriteNormalizedTexture2D<TPixel> texture)
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {
@@ -90,7 +90,7 @@ public static partial class GraphicsDeviceExtensions
     /// <param name="device">The <see cref="GraphicsDevice"/> to use to run the shader.</param>
     /// <param name="texture">The target texture to apply the pixel shader to.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the pixel shader to run.</param>
-    public static void ForEach<T, TPixel>(this GraphicsDevice device, IReadWriteTexture2D<TPixel> texture, in T shader)
+    public static void ForEach<T, TPixel>(this GraphicsDevice device, IReadWriteNormalizedTexture2D<TPixel> texture, in T shader)
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {

--- a/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture2DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture2DExtensions.cs
@@ -1,0 +1,133 @@
+﻿using System;
+
+namespace ComputeSharp;
+
+/// <summary>
+/// A <see langword="class"/> that contains extension methods for the <see cref="ReadWriteTexture2D{T}"/> and <see cref="ReadWriteTexture2D{T, TPixel}"/> types.
+/// </summary>
+public static class ReadWriteTexture2DExtensions
+{
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture2D{T}"/> instance for the input resource.
+    /// </summary>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyTexture2D{T}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture2D{float}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyTexture2D<float> AsReadOnly(this ReadWriteTexture2D<float> texture)
+    {
+        return texture.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture2D{T}"/> instance for the input resource.
+    /// </summary>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyTexture2D{T}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture2D{Float2}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyTexture2D<Float2> AsReadOnly(this ReadWriteTexture2D<Float2> texture)
+    {
+        return texture.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture2D{T}"/> instance for the input resource.
+    /// </summary>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyTexture2D{T}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture2D{Float3}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyTexture2D<Float3> AsReadOnly(this ReadWriteTexture2D<Float3> texture)
+    {
+        return texture.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture2D{T}"/> instance for the input resource.
+    /// </summary>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyTexture2D{T}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture2D{Float4}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyTexture2D<Float4> AsReadOnly(this ReadWriteTexture2D<Float4> texture)
+    {
+        return texture.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance for the input resource.
+    /// </summary>
+    /// <typeparam name="T">The type of items to store in the texture.</typeparam>
+    /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T, TPixel}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture2D{T, TPixel}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyNormalizedTexture2D<TPixel> AsReadOnly<T, TPixel>(this ReadWriteTexture2D<T, TPixel> texture)
+        where T : unmanaged, IPixel<T, TPixel>
+        where TPixel : unmanaged
+    {
+        return texture.AsReadOnly();
+    }
+}

--- a/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture3DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture3DExtensions.cs
@@ -1,0 +1,133 @@
+﻿using System;
+
+namespace ComputeSharp;
+
+/// <summary>
+/// A <see langword="class"/> that contains extension methods for the <see cref="ReadWriteTexture3D{T}"/> and <see cref="ReadWriteTexture3D{T, TPixel}"/> types.
+/// </summary>
+public static class ReadWriteTexture3DExtensions
+{
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture3D{T}"/> instance for the input resource.
+    /// </summary>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyTexture3D{T}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture3D{float}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyTexture3D<float> AsReadOnly(this ReadWriteTexture3D<float> texture)
+    {
+        return texture.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture3D{T}"/> instance for the input resource.
+    /// </summary>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyTexture3D{T}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture3D{Float2}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyTexture3D<Float2> AsReadOnly(this ReadWriteTexture3D<Float2> texture)
+    {
+        return texture.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture3D{T}"/> instance for the input resource.
+    /// </summary>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyTexture3D{T}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture3D{Float3}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyTexture3D<Float3> AsReadOnly(this ReadWriteTexture3D<Float3> texture)
+    {
+        return texture.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture3D{T}"/> instance for the input resource.
+    /// </summary>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyTexture3D{T}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture3D{Float4}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyTexture3D<Float4> AsReadOnly(this ReadWriteTexture3D<Float4> texture)
+    {
+        return texture.AsReadOnly();
+    }
+
+    /// <summary>
+    /// Retrieves a wrapping <see cref="IReadOnlyNormalizedTexture3D{TPixel}"/> instance for the input resource.
+    /// </summary>
+    /// <typeparam name="T">The type of items to store in the texture.</typeparam>
+    /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T, TPixel}"/> instance to create a wrapper for.</param>
+    /// <returns>An <see cref="IReadOnlyNormalizedTexture3D{TPixel}"/> instance wrapping the current resource.</returns>
+    /// <remarks>
+    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
+    /// <para>
+    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
+    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture3D{T, TPixel}, ResourceState)"/>,
+    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
+    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
+    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
+    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
+    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    public static IReadOnlyNormalizedTexture3D<TPixel> AsReadOnly<T, TPixel>(this ReadWriteTexture3D<T, TPixel> texture)
+        where T : unmanaged, IPixel<T, TPixel>
+        where TPixel : unmanaged
+    {
+        return texture.AsReadOnly();
+    }
+}

--- a/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
@@ -112,11 +112,11 @@ public static class GraphicsResourceHelper
     /// Validates the given texture for usage with a specified device, and retrieves its GPU descriptor handle.
     /// </summary>
     /// <typeparam name="TPixel">The type of normalized values stored in the input texture.</typeparam>
-    /// <param name="texture">The input <see cref="IReadOnlyTexture2D{TPixel}"/> instance to check.</param>
+    /// <param name="texture">The input <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance to check.</param>
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the texture.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadOnlyTexture2D<TPixel> texture, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadOnlyNormalizedTexture2D<TPixel> texture, GraphicsDevice device)
         where TPixel : unmanaged
     {
         if (texture is IGraphicsResource resource)
@@ -133,11 +133,11 @@ public static class GraphicsResourceHelper
     /// Validates the given texture for usage with a specified device, and retrieves its GPU descriptor handle.
     /// </summary>
     /// <typeparam name="TPixel">The type of normalized values stored in the input texture.</typeparam>
-    /// <param name="texture">The input <see cref="IReadWriteTexture2D{TPixel}"/> instance to check.</param>
+    /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture2D{TPixel}"/> instance to check.</param>
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the texture.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadWriteTexture2D<TPixel> texture, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadWriteNormalizedTexture2D<TPixel> texture, GraphicsDevice device)
         where TPixel : unmanaged
     {
         if (texture is IGraphicsResource resource)
@@ -192,11 +192,11 @@ public static class GraphicsResourceHelper
     /// Validates the given texture for usage with a specified device, and retrieves its GPU descriptor handle.
     /// </summary>
     /// <typeparam name="TPixel">The type of normalized values stored in the input texture.</typeparam>
-    /// <param name="texture">The input <see cref="IReadOnlyTexture3D{TPixel}"/> instance to check.</param>
+    /// <param name="texture">The input <see cref="IReadOnlyNormalizedTexture3D{TPixel}"/> instance to check.</param>
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the texture.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadOnlyTexture3D<TPixel> texture, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadOnlyNormalizedTexture3D<TPixel> texture, GraphicsDevice device)
         where TPixel : unmanaged
     {
         if (texture is IGraphicsResource resource)
@@ -213,11 +213,11 @@ public static class GraphicsResourceHelper
     /// Validates the given texture for usage with a specified device, and retrieves its GPU descriptor handle.
     /// </summary>
     /// <typeparam name="TPixel">The type of normalized values stored in the input texture.</typeparam>
-    /// <param name="texture">The input <see cref="IReadWriteTexture3D{TPixel}"/> instance to check.</param>
+    /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture3D{TPixel}"/> instance to check.</param>
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
     /// <returns>The GPU descriptor handle for the texture.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadWriteTexture3D<TPixel> texture, GraphicsDevice device)
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadWriteNormalizedTexture3D<TPixel> texture, GraphicsDevice device)
         where TPixel : unmanaged
     {
         if (texture is IGraphicsResource resource)

--- a/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
@@ -111,6 +111,27 @@ public static class GraphicsResourceHelper
     /// <summary>
     /// Validates the given texture for usage with a specified device, and retrieves its GPU descriptor handle.
     /// </summary>
+    /// <typeparam name="T">The type of values stored in the input texture.</typeparam>
+    /// <param name="texture">The input <see cref="IReadOnlyTexture2D{T}"/> instance to check.</param>
+    /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
+    /// <returns>The GPU descriptor handle for the texture.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(IReadOnlyTexture2D<T> texture, GraphicsDevice device)
+        where T : unmanaged
+    {
+        if (texture is IGraphicsResource resource)
+        {
+            D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = resource.ValidateAndGetGpuDescriptorHandle(device);
+
+            return *(ulong*)&d3D12GpuDescriptorHandle;
+        }
+
+        return ThrowHelper.ThrowArgumentException<ulong>("The input texture is not a valid instance");
+    }
+
+    /// <summary>
+    /// Validates the given texture for usage with a specified device, and retrieves its GPU descriptor handle.
+    /// </summary>
     /// <typeparam name="TPixel">The type of normalized values stored in the input texture.</typeparam>
     /// <param name="texture">The input <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance to check.</param>
     /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
@@ -186,6 +207,27 @@ public static class GraphicsResourceHelper
         D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = texture.D3D12GpuDescriptorHandle;
 
         return *(ulong*)&d3D12GpuDescriptorHandle;
+    }
+
+    /// <summary>
+    /// Validates the given texture for usage with a specified device, and retrieves its GPU descriptor handle.
+    /// </summary>
+    /// <typeparam name="T">The type of values stored in the input texture.</typeparam>
+    /// <param name="texture">The input <see cref="IReadOnlyTexture3D{T}"/> instance to check.</param>
+    /// <param name="device">The target <see cref="GraphicsDevice"/> instance in use.</param>
+    /// <returns>The GPU descriptor handle for the texture.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(IReadOnlyTexture3D<T> texture, GraphicsDevice device)
+        where T : unmanaged
+    {
+        if (texture is IGraphicsResource resource)
+        {
+            D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = resource.ValidateAndGetGpuDescriptorHandle(device);
+
+            return *(ulong*)&d3D12GpuDescriptorHandle;
+        }
+
+        return ThrowHelper.ThrowArgumentException<ulong>("The input texture is not a valid instance");
     }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyNormalizedTexture2D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyNormalizedTexture2D{TPixel}.cs
@@ -5,7 +5,7 @@
 /// This interface can only be used to wrap <see cref="ReadOnlyTexture2D{T, TPixel}"/> instances.
 /// </summary>
 /// <typeparam name="TPixel">The type of normalized pixels used on the GPU side.</typeparam>
-public interface IReadOnlyTexture2D<TPixel> : IGraphicsResource
+public interface IReadOnlyNormalizedTexture2D<TPixel> : IGraphicsResource
     where TPixel : unmanaged
 {
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyNormalizedTexture3D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyNormalizedTexture3D{TPixel}.cs
@@ -5,7 +5,7 @@
 /// This interface can only be used to wrap <see cref="ReadOnlyTexture3D{T, TPixel}"/> instances.
 /// </summary>
 /// <typeparam name="TPixel">The type of normalized pixels used on the GPU side.</typeparam>
-public interface IReadOnlyTexture3D<TPixel> : IGraphicsResource
+public interface IReadOnlyNormalizedTexture3D<TPixel> : IGraphicsResource
     where TPixel : unmanaged
 {
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture2D{T}.cs
@@ -1,0 +1,50 @@
+﻿namespace ComputeSharp;
+
+/// <summary>
+/// An interface representing a typed readonly 2D texture containing raw data stored on GPU memory.
+/// This interface can only be used to wrap <see cref="ReadOnlyTexture2D{T}"/> instances.
+/// </summary>
+/// <typeparam name="T">The type of raw data used on the GPU side.</typeparam>
+public interface IReadOnlyTexture2D<T> : IGraphicsResource
+    where T : unmanaged
+{
+    /// <summary>
+    /// Gets the width of the current texture.
+    /// </summary>
+    int Width { get; }
+
+    /// <summary>
+    /// Gets the height of the current texture.
+    /// </summary>
+    int Height { get; }
+
+    /// <summary>
+    /// Gets a single <typeparamref name="T"/> value from the current readonly texture.
+    /// </summary>
+    /// <param name="x">The horizontal offset of the value to get.</param>
+    /// <param name="y">The vertical offset of the value to get.</param>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    ref readonly T this[int x, int y] { get; }
+
+    /// <summary>
+    /// Gets a single <typeparamref name="T"/> value from the current readonly texture.
+    /// </summary>
+    /// <param name="xy">The coordinates of the value to get.</param>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    ref readonly T this[Int2 xy] { get; }
+
+    /// <summary>
+    /// Gets a single <typeparamref name="T"/> value from the current readonly texture with linear sampling.
+    /// </summary>
+    /// <param name="u">The horizontal normalized offset of the value to get.</param>
+    /// <param name="v">The vertical normalized offset of the value to get.</param>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    ref readonly T this[float u, float v] { get; }
+
+    /// <summary>
+    /// Gets a single <typeparamref name="T"/> value from the current readonly texture with linear sampling.
+    /// </summary>
+    /// <param name="uv">The normalized coordinates of the value to get.</param>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    ref readonly T this[Float2 uv] { get; }
+}

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadOnlyTexture3D{T}.cs
@@ -1,0 +1,57 @@
+﻿namespace ComputeSharp;
+
+/// <summary>
+/// An interface representing a typed readonly 3D texture containing raw data stored on GPU memory.
+/// This interface can only be used to wrap <see cref="ReadOnlyTexture3D{T}"/> instances.
+/// </summary>
+/// <typeparam name="T">The type of raw data used on the GPU side.</typeparam>
+public interface IReadOnlyTexture3D<T> : IGraphicsResource
+    where T : unmanaged
+{
+    /// <summary>
+    /// Gets the width of the current texture.
+    /// </summary>
+    int Width { get; }
+
+    /// <summary>
+    /// Gets the height of the current texture.
+    /// </summary>
+    int Height { get; }
+
+    /// <summary>
+    /// Gets the depth of the current texture.
+    /// </summary>
+    int Depth { get; }
+
+    /// <summary>
+    /// Gets a single <typeparamref name="T"/> value from the current readonly texture.
+    /// </summary>
+    /// <param name="x">The horizontal offset of the value to get.</param>
+    /// <param name="y">The vertical offset of the value to get.</param>
+    /// <param name="z">The depthwise offset of the value to get.</param>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    ref readonly T this[int x, int y, int z] { get; }
+
+    /// <summary>
+    /// Gets a single <typeparamref name="T"/> value from the current readonly texture.
+    /// </summary>
+    /// <param name="xyz">The coordinates of the value to get.</param>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    ref readonly T this[Int3 xyz] { get; }
+
+    /// <summary>
+    /// Gets a single <typeparamref name="T"/> value from the current readonly texture with linear sampling.
+    /// </summary>
+    /// <param name="u">The horizontal normalized offset of the value to get.</param>
+    /// <param name="v">The vertical normalized offset of the value to get.</param>
+    /// <param name="w">The depthwise normalized offset of the value to get.</param>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    ref readonly T this[float u, float v, float w] { get; }
+
+    /// <summary>
+    /// Gets a single <typeparamref name="T"/> value from the current readonly texture with linear sampling.
+    /// </summary>
+    /// <param name="uvw">The normalized coordinates of the value to get.</param>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    ref readonly T this[Float3 uvw] { get; }
+}

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadWriteNormalizedTexture2D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadWriteNormalizedTexture2D{TPixel}.cs
@@ -2,10 +2,10 @@
 
 /// <summary>
 /// An interface representing a typed writeable 2D texture containing normalized pixel data stored on GPU memory.
-/// This interface can only be used to wrap <see cref="ReadWriteTexture3D{T, TPixel}"/> instances.
+/// This interface can only be used to wrap <see cref="ReadWriteTexture2D{T, TPixel}"/> instances.
 /// </summary>
 /// <typeparam name="TPixel">The type of normalized pixels used on the GPU side.</typeparam>
-public interface IReadWriteTexture3D<TPixel> : IGraphicsResource
+public interface IReadWriteNormalizedTexture2D<TPixel> : IGraphicsResource
     where TPixel : unmanaged
 {
     /// <summary>
@@ -19,23 +19,17 @@ public interface IReadWriteTexture3D<TPixel> : IGraphicsResource
     int Height { get; }
 
     /// <summary>
-    /// Gets the depth of the current texture.
-    /// </summary>
-    int Depth { get; }
-
-    /// <summary>
     /// Gets a single <typeparamref name="TPixel"/> value from the current writeable texture.
     /// </summary>
     /// <param name="x">The horizontal offset of the value to get.</param>
     /// <param name="y">The vertical offset of the value to get.</param>
-    /// <param name="z">The depthwise offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    ref TPixel this[int x, int y, int z] { get; }
+    ref TPixel this[int x, int y] { get; }
 
     /// <summary>
-    /// Gets a single <typeparamref name="TPixel"/> value from the current writeable texture.
+    /// Gets or sets a single <typeparamref name="TPixel"/> value from the current writeable texture.
     /// </summary>
-    /// <param name="xyz">The coordinates of the value to get.</param>
+    /// <param name="xy">The coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    ref TPixel this[Int3 xyz] { get; }
+    ref TPixel this[Int2 xy] { get; }
 }

--- a/src/ComputeSharp/Graphics/Resources/Interfaces/IReadWriteNormalizedTexture3D{TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Interfaces/IReadWriteNormalizedTexture3D{TPixel}.cs
@@ -2,10 +2,10 @@
 
 /// <summary>
 /// An interface representing a typed writeable 2D texture containing normalized pixel data stored on GPU memory.
-/// This interface can only be used to wrap <see cref="ReadWriteTexture2D{T, TPixel}"/> instances.
+/// This interface can only be used to wrap <see cref="ReadWriteTexture3D{T, TPixel}"/> instances.
 /// </summary>
 /// <typeparam name="TPixel">The type of normalized pixels used on the GPU side.</typeparam>
-public interface IReadWriteTexture2D<TPixel> : IGraphicsResource
+public interface IReadWriteNormalizedTexture3D<TPixel> : IGraphicsResource
     where TPixel : unmanaged
 {
     /// <summary>
@@ -19,17 +19,23 @@ public interface IReadWriteTexture2D<TPixel> : IGraphicsResource
     int Height { get; }
 
     /// <summary>
+    /// Gets the depth of the current texture.
+    /// </summary>
+    int Depth { get; }
+
+    /// <summary>
     /// Gets a single <typeparamref name="TPixel"/> value from the current writeable texture.
     /// </summary>
     /// <param name="x">The horizontal offset of the value to get.</param>
     /// <param name="y">The vertical offset of the value to get.</param>
+    /// <param name="z">The depthwise offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    ref TPixel this[int x, int y] { get; }
+    ref TPixel this[int x, int y, int z] { get; }
 
     /// <summary>
-    /// Gets or sets a single <typeparamref name="TPixel"/> value from the current writeable texture.
+    /// Gets a single <typeparamref name="TPixel"/> value from the current writeable texture.
     /// </summary>
-    /// <param name="xy">The coordinates of the value to get.</param>
+    /// <param name="xyz">The coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    ref TPixel this[Int2 xy] { get; }
+    ref TPixel this[Int3 xyz] { get; }
 }

--- a/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture2D{T,TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture2D{T,TPixel}.cs
@@ -14,7 +14,7 @@ namespace ComputeSharp;
 /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
 [DebuggerTypeProxy(typeof(Texture2DDebugView<>))]
 [DebuggerDisplay("{ToString(),raw}")]
-public sealed class ReadOnlyTexture2D<T, TPixel> : Texture2D<T>, IReadOnlyTexture2D<TPixel>
+public sealed class ReadOnlyTexture2D<T, TPixel> : Texture2D<T>, IReadOnlyNormalizedTexture2D<TPixel>
     where T : unmanaged, IPixel<T, TPixel>
     where TPixel : unmanaged
 {

--- a/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture3D{T,TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadOnlyTexture3D{T,TPixel}.cs
@@ -14,7 +14,7 @@ namespace ComputeSharp;
 /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
 [DebuggerTypeProxy(typeof(Texture3DDebugView<>))]
 [DebuggerDisplay("{ToString(),raw}")]
-public sealed class ReadOnlyTexture3D<T, TPixel> : Texture3D<T>, IReadOnlyTexture3D<TPixel>
+public sealed class ReadOnlyTexture3D<T, TPixel> : Texture3D<T>, IReadOnlyNormalizedTexture3D<TPixel>
     where T : unmanaged, IPixel<T, TPixel>
     where TPixel : unmanaged
 {

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T,TPixel}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T,TPixel}.ReadOnly.cs
@@ -22,9 +22,9 @@ partial class ReadWriteTexture2D<T, TPixel>
     private ReadOnly? readOnlyWrapper;
 
     /// <summary>
-    /// Retrieves a wrapping <see cref="IReadOnlyTexture2D{TPixel}"/> instance for the current resource.
+    /// Retrieves a wrapping <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance for the current resource.
     /// </summary>
-    /// <returns>An <see cref="IReadOnlyTexture2D{TPixel}"/> instance wrapping the current resource.</returns>
+    /// <returns>An <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance wrapping the current resource.</returns>
     /// <remarks>
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
@@ -39,7 +39,7 @@ partial class ReadWriteTexture2D<T, TPixel>
     /// </remarks>
     /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
-    public IReadOnlyTexture2D<TPixel> AsReadOnly()
+    public IReadOnlyNormalizedTexture2D<TPixel> AsReadOnly()
     {
         GraphicsDevice.ThrowIfDisposed();
 
@@ -76,7 +76,7 @@ partial class ReadWriteTexture2D<T, TPixel>
     /// <summary>
     /// A wrapper for a <see cref="ReadWriteTexture2D{T, TPixel}"/> resource that has been temporarily transitioned to readonly.
     /// </summary>
-    private sealed unsafe class ReadOnly : NativeObject, IReadOnlyTexture2D<TPixel>, GraphicsResourceHelper.IGraphicsResource
+    private sealed unsafe class ReadOnly : NativeObject, IReadOnlyNormalizedTexture2D<TPixel>, GraphicsResourceHelper.IGraphicsResource
     {
         /// <summary>
         /// The owning <see cref="ReadWriteTexture2D{T, TPixel}"/> instance being wrapped.

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T,TPixel}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T,TPixel}.ReadOnly.cs
@@ -21,25 +21,8 @@ partial class ReadWriteTexture2D<T, TPixel>
     /// </summary>
     private ReadOnly? readOnlyWrapper;
 
-    /// <summary>
-    /// Retrieves a wrapping <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance for the current resource.
-    /// </summary>
-    /// <returns>An <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance wrapping the current resource.</returns>
-    /// <remarks>
-    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
-    /// <para>
-    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture2D{T, TPixel}, ResourceState)"/>,
-    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, <see cref="AsReadOnly"/> can be used to get a readonly wrapper for
-    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
-    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
-    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
-    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
-    public IReadOnlyNormalizedTexture2D<TPixel> AsReadOnly()
+    /// <inheritdoc cref="ReadWriteTexture2DExtensions.AsReadOnly{T, TPixel}(ReadWriteTexture2D{T, TPixel})"/>
+    internal IReadOnlyNormalizedTexture2D<TPixel> AsReadOnly()
     {
         GraphicsDevice.ThrowIfDisposed();
 

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T,TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T,TPixel}.cs
@@ -14,7 +14,7 @@ namespace ComputeSharp;
 /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
 [DebuggerTypeProxy(typeof(Texture2DDebugView<>))]
 [DebuggerDisplay("{ToString(),raw}")]
-public sealed partial class ReadWriteTexture2D<T, TPixel> : Texture2D<T>, IReadWriteTexture2D<TPixel>
+public sealed partial class ReadWriteTexture2D<T, TPixel> : Texture2D<T>, IReadWriteNormalizedTexture2D<TPixel>
     where T : unmanaged, IPixel<T, TPixel>
     where TPixel : unmanaged
 {

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T}.ReadOnly.cs
@@ -21,24 +21,7 @@ partial class ReadWriteTexture2D<T>
     /// </summary>
     private ReadOnly? readOnlyWrapper;
 
-    /// <summary>
-    /// Retrieves a wrapping <see cref="IReadOnlyTexture2D{TPixel}"/> instance for the current resource.
-    /// </summary>
-    /// <returns>An <see cref="IReadOnlyTexture2D{TPixel}"/> instance wrapping the current resource.</returns>
-    /// <remarks>
-    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
-    /// <para>
-    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture2D{T, TPixel}, ResourceState)"/>,
-    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, <see cref="AsReadOnly"/> can be used to get a readonly wrapper for
-    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
-    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
-    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
-    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    /// <inheritdoc cref="ReadWriteTexture2DExtensions.AsReadOnly(ReadWriteTexture2D{float})"/>
     public IReadOnlyTexture2D<T> AsReadOnly()
     {
         GraphicsDevice.ThrowIfDisposed();

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T}.cs
@@ -13,7 +13,7 @@ namespace ComputeSharp;
 /// <typeparam name="T">The type of items stored on the texture.</typeparam>
 [DebuggerTypeProxy(typeof(Texture2DDebugView<>))]
 [DebuggerDisplay("{ToString(),raw}")]
-public sealed class ReadWriteTexture2D<T> : Texture2D<T>
+public sealed partial class ReadWriteTexture2D<T> : Texture2D<T>
     where T : unmanaged
 {
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T,TPixel}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T,TPixel}.ReadOnly.cs
@@ -21,24 +21,7 @@ partial class ReadWriteTexture3D<T, TPixel>
     /// </summary>
     private ReadOnly? readOnlyWrapper;
 
-    /// <summary>
-    /// Retrieves a wrapping <see cref="IReadOnlyNormalizedTexture3D{TPixel}"/> instance for the current resource.
-    /// </summary>
-    /// <returns>An <see cref="IReadOnlyNormalizedTexture3D{TPixel}"/> instance wrapping the current resource.</returns>
-    /// <remarks>
-    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
-    /// <para>
-    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture3D{T, TPixel}, ResourceState)"/>,
-    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, <see cref="AsReadOnly"/> can be used to get a readonly wrapper for
-    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
-    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
-    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
-    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    /// <inheritdoc cref="ReadWriteTexture3DExtensions.AsReadOnly{T, TPixel}(ReadWriteTexture3D{T, TPixel})"/>
     public IReadOnlyNormalizedTexture3D<TPixel> AsReadOnly()
     {
         GraphicsDevice.ThrowIfDisposed();

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T,TPixel}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T,TPixel}.ReadOnly.cs
@@ -22,9 +22,9 @@ partial class ReadWriteTexture3D<T, TPixel>
     private ReadOnly? readOnlyWrapper;
 
     /// <summary>
-    /// Retrieves a wrapping <see cref="IReadOnlyTexture3D{TPixel}"/> instance for the current resource.
+    /// Retrieves a wrapping <see cref="IReadOnlyNormalizedTexture3D{TPixel}"/> instance for the current resource.
     /// </summary>
-    /// <returns>An <see cref="IReadOnlyTexture3D{TPixel}"/> instance wrapping the current resource.</returns>
+    /// <returns>An <see cref="IReadOnlyNormalizedTexture3D{TPixel}"/> instance wrapping the current resource.</returns>
     /// <remarks>
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
@@ -39,7 +39,7 @@ partial class ReadWriteTexture3D<T, TPixel>
     /// </remarks>
     /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
-    public IReadOnlyTexture3D<TPixel> AsReadOnly()
+    public IReadOnlyNormalizedTexture3D<TPixel> AsReadOnly()
     {
         GraphicsDevice.ThrowIfDisposed();
 
@@ -73,7 +73,7 @@ partial class ReadWriteTexture3D<T, TPixel>
     /// <summary>
     /// A wrapper for a <see cref="ReadWriteTexture3D{T, TPixel}"/> resource that has been temporarily transitioned to readonly.
     /// </summary>
-    private sealed unsafe class ReadOnly : NativeObject, IReadOnlyTexture3D<TPixel>, GraphicsResourceHelper.IGraphicsResource
+    private sealed unsafe class ReadOnly : NativeObject, IReadOnlyNormalizedTexture3D<TPixel>, GraphicsResourceHelper.IGraphicsResource
     {
         /// <summary>
         /// The owning <see cref="ReadWriteTexture3D{T, TPixel}"/> instance being wrapped.

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T,TPixel}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T,TPixel}.cs
@@ -14,7 +14,7 @@ namespace ComputeSharp;
 /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
 [DebuggerTypeProxy(typeof(Texture3DDebugView<>))]
 [DebuggerDisplay("{ToString(),raw}")]
-public sealed partial class ReadWriteTexture3D<T, TPixel> : Texture3D<T>, IReadWriteTexture3D<TPixel>
+public sealed partial class ReadWriteTexture3D<T, TPixel> : Texture3D<T>, IReadWriteNormalizedTexture3D<TPixel>
     where T : unmanaged, IPixel<T, TPixel>
     where TPixel : unmanaged
 {

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T}.ReadOnly.cs
@@ -21,24 +21,7 @@ partial class ReadWriteTexture3D<T>
     /// </summary>
     private ReadOnly? readOnlyWrapper;
 
-    /// <summary>
-    /// Retrieves a wrapping <see cref="IReadOnlyTexture3D{TPixel}"/> instance for the current resource.
-    /// </summary>
-    /// <returns>An <see cref="IReadOnlyTexture3D{TPixel}"/> instance wrapping the current resource.</returns>
-    /// <remarks>
-    /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
-    /// <para>
-    /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture3D{T, TPixel}, ResourceState)"/>,
-    /// and specify <see cref="ResourceState.ReadOnly"/>. After that, <see cref="AsReadOnly"/> can be used to get a readonly wrapper for
-    /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
-    /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
-    /// Before the end of that list of operations, the texture also needs to be transitioned back to writeable state, using the same
-    /// API as before but specifying <see cref="ResourceState.ReadWrite"/>. Failing to do so results in undefined behavior.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
-    /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
+    /// <inheritdoc cref="ReadWriteTexture3DExtensions.AsReadOnly(ReadWriteTexture3D{float})"/>
     public IReadOnlyTexture3D<T> AsReadOnly()
     {
         GraphicsDevice.ThrowIfDisposed();

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T}.ReadOnly.cs
@@ -14,7 +14,7 @@ using static TerraFX.Interop.DirectX.D3D12_SRV_DIMENSION;
 namespace ComputeSharp;
 
 /// <inheritdoc/>
-partial class ReadWriteTexture2D<T, TPixel>
+partial class ReadWriteTexture3D<T>
 {
     /// <summary>
     /// The wrapping <see cref="ReadOnly"/> instance, if available.
@@ -22,14 +22,14 @@ partial class ReadWriteTexture2D<T, TPixel>
     private ReadOnly? readOnlyWrapper;
 
     /// <summary>
-    /// Retrieves a wrapping <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance for the current resource.
+    /// Retrieves a wrapping <see cref="IReadOnlyTexture3D{TPixel}"/> instance for the current resource.
     /// </summary>
-    /// <returns>An <see cref="IReadOnlyNormalizedTexture2D{TPixel}"/> instance wrapping the current resource.</returns>
+    /// <returns>An <see cref="IReadOnlyTexture3D{TPixel}"/> instance wrapping the current resource.</returns>
     /// <remarks>
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture2D{T, TPixel}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture3D{T, TPixel}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, <see cref="AsReadOnly"/> can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -39,7 +39,7 @@ partial class ReadWriteTexture2D<T, TPixel>
     /// </remarks>
     /// <exception cref="ObjectDisposedException">Thrown if the current instance or its associated device are disposed.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
-    public IReadOnlyNormalizedTexture2D<TPixel> AsReadOnly()
+    public IReadOnlyTexture3D<T> AsReadOnly()
     {
         GraphicsDevice.ThrowIfDisposed();
 
@@ -54,7 +54,7 @@ partial class ReadWriteTexture2D<T, TPixel>
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static ReadOnly InitializeWrapper(ReadWriteTexture2D<T, TPixel> texture)
+        static ReadOnly InitializeWrapper(ReadWriteTexture3D<T> texture)
         {
             return texture.readOnlyWrapper = new(texture);
         }
@@ -71,14 +71,14 @@ partial class ReadWriteTexture2D<T, TPixel>
     }
 
     /// <summary>
-    /// A wrapper for a <see cref="ReadWriteTexture2D{T, TPixel}"/> resource that has been temporarily transitioned to readonly.
+    /// A wrapper for a <see cref="ReadWriteTexture3D{T}"/> resource that has been temporarily transitioned to readonly.
     /// </summary>
-    private sealed unsafe class ReadOnly : NativeObject, IReadOnlyNormalizedTexture2D<TPixel>, GraphicsResourceHelper.IGraphicsResource
+    private sealed unsafe class ReadOnly : NativeObject, IReadOnlyTexture3D<T>, GraphicsResourceHelper.IGraphicsResource
     {
         /// <summary>
-        /// The owning <see cref="ReadWriteTexture2D{T, TPixel}"/> instance being wrapped.
+        /// The owning <see cref="ReadWriteTexture3D{T}"/> instance being wrapped.
         /// </summary>
-        private readonly ReadWriteTexture2D<T, TPixel> owner;
+        private readonly ReadWriteTexture3D<T> owner;
 
         /// <summary>
         /// The <see cref="ID3D12ResourceDescriptorHandles"/> instance for the current resource.
@@ -88,33 +88,36 @@ partial class ReadWriteTexture2D<T, TPixel>
         /// <summary>
         /// Creates a new <see cref="ReadOnly"/> instance with the specified parameters.
         /// </summary>
-        /// <param name="owner">The owning <see cref="ReadWriteTexture2D{T, TPixel}"/> instance to wrap.</param>
-        public ReadOnly(ReadWriteTexture2D<T, TPixel> owner)
+        /// <param name="owner">The owning <see cref="ReadWriteTexture3D{T}"/> instance to wrap.</param>
+        public ReadOnly(ReadWriteTexture3D<T> owner)
         {
             this.owner = owner;
 
             owner.GraphicsDevice.RentShaderResourceViewDescriptorHandles(out this.d3D12ResourceDescriptorHandles);
 
-            owner.GraphicsDevice.D3D12Device->CreateShaderResourceView(owner.D3D12Resource, DXGIFormatHelper.GetForType<T>(), D3D12_SRV_DIMENSION_TEXTURE2D, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandle);
+            owner.GraphicsDevice.D3D12Device->CreateShaderResourceView(owner.D3D12Resource, DXGIFormatHelper.GetForType<T>(), D3D12_SRV_DIMENSION_TEXTURE3D, this.d3D12ResourceDescriptorHandles.D3D12CpuDescriptorHandle);
         }
 
         /// <inheritdoc/>
-        public ref readonly TPixel this[int x, int y] => throw new InvalidExecutionContextException($"{typeof(ReadWriteTexture2D<T, TPixel>.ReadOnly)}[{typeof(int)}, {typeof(int)}]");
+        public ref readonly T this[int x, int y, int z] => throw new InvalidExecutionContextException($"{typeof(ReadWriteTexture3D<T>.ReadOnly)}[{typeof(int)}, {typeof(int)}, {typeof(int)}]");
 
         /// <inheritdoc/>
-        public ref readonly TPixel this[Int2 xy] => throw new InvalidExecutionContextException($"{typeof(ReadWriteTexture2D<T, TPixel>.ReadOnly)}[{typeof(Int2)}]");
+        public ref readonly T this[Int3 xyz] => throw new InvalidExecutionContextException($"{typeof(ReadWriteTexture3D<T>.ReadOnly)}[{typeof(Int3)}]");
 
         /// <inheritdoc/>
-        public ref readonly TPixel this[float u, float v] => throw new InvalidExecutionContextException($"{typeof(ReadWriteTexture2D<T, TPixel>.ReadOnly)}[{typeof(float)}, {typeof(float)}]");
+        public ref readonly T this[float u, float v, float w] => throw new InvalidExecutionContextException($"{typeof(ReadWriteTexture3D<T>.ReadOnly)}[{typeof(float)}, {typeof(float)}, {typeof(float)}]");
 
         /// <inheritdoc/>
-        public ref readonly TPixel this[Float2 uv] => throw new InvalidExecutionContextException($"{typeof(ReadWriteTexture2D<T, TPixel>.ReadOnly)}[{typeof(Float2)}]");
+        public ref readonly T this[Float3 uvw] => throw new InvalidExecutionContextException($"{typeof(ReadWriteTexture3D<T>.ReadOnly)}[{typeof(Float3)}]");
 
         /// <inheritdoc/>
         public int Width => this.owner.Width;
 
         /// <inheritdoc/>
         public int Height => this.owner.Height;
+
+        /// <inheritdoc/>
+        public int Depth => this.owner.Depth;
 
         /// <inheritdoc/>
         public GraphicsDevice GraphicsDevice => this.owner.GraphicsDevice;

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T}.cs
@@ -13,7 +13,7 @@ namespace ComputeSharp;
 /// <typeparam name="T">The type of items stored on the texture.</typeparam>
 [DebuggerTypeProxy(typeof(Texture3DDebugView<>))]
 [DebuggerDisplay("{ToString(),raw}")]
-public sealed class ReadWriteTexture3D<T> : Texture3D<T>
+public sealed partial class ReadWriteTexture3D<T> : Texture3D<T>
     where T : unmanaged
 {
     /// <summary>

--- a/src/ComputeSharp/Shaders/ComputeContext.cs
+++ b/src/ComputeSharp/Shaders/ComputeContext.cs
@@ -218,7 +218,7 @@ public struct ComputeContext : IDisposable, IAsyncDisposable
     /// <typeparam name="TPixel">The type of pixel to work on.</typeparam>
     /// <param name="texture">The target texture to invoke the pixel shader upon.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the pixel shader to run.</param>
-    internal readonly unsafe void Run<T, TPixel>(IReadWriteTexture2D<TPixel> texture, ref T shader)
+    internal readonly unsafe void Run<T, TPixel>(IReadWriteNormalizedTexture2D<TPixel> texture, ref T shader)
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {

--- a/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
@@ -81,8 +81,8 @@ public static class ComputeContextExtensions
     /// </summary>
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
-    /// <param name="texture">The input <see cref="IReadWriteTexture2D{TPixel}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteTexture2D<TPixel> texture)
+    /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture2D{TPixel}"/> instance to insert the barrier for.</param>
+    public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
         where TPixel : unmanaged
     {
         context.Barrier(((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetID3D12Resource(context.GraphicsDevice));
@@ -93,8 +93,8 @@ public static class ComputeContextExtensions
     /// </summary>
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
-    /// <param name="texture">The input <see cref="IReadWriteTexture3D{TPixel}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteTexture3D<TPixel> texture)
+    /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture3D{TPixel}"/> instance to insert the barrier for.</param>
+    public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture)
         where TPixel : unmanaged
     {
         context.Barrier(((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetID3D12Resource(context.GraphicsDevice));
@@ -179,8 +179,8 @@ public static class ComputeContextExtensions
     /// </summary>
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
-    /// <param name="texture">The input <see cref="IReadWriteTexture2D{TPixel}"/> instance to clear.</param>
-    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteTexture2D<TPixel> texture)
+    /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture2D{TPixel}"/> instance to clear.</param>
+    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
         where TPixel : unmanaged
     {
         var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
@@ -193,8 +193,8 @@ public static class ComputeContextExtensions
     /// </summary>
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
-    /// <param name="texture">The input <see cref="IReadWriteTexture3D{TPixel}"/> instance to clear.</param>
-    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteTexture3D<TPixel> texture)
+    /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture3D{TPixel}"/> instance to clear.</param>
+    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture)
         where TPixel : unmanaged
     {
         var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
@@ -241,9 +241,9 @@ public static class ComputeContextExtensions
     /// </summary>
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to fill the resource.</param>
-    /// <param name="texture">The input <see cref="IReadWriteTexture2D{TPixel}"/> instance to fill.</param>
+    /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture2D{TPixel}"/> instance to fill.</param>
     /// <param name="value">The value to use to fill <paramref name="texture"/>.</param>
-    public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteTexture2D<TPixel> texture, TPixel value)
+    public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture, TPixel value)
         where TPixel : unmanaged
     {
         var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
@@ -260,9 +260,9 @@ public static class ComputeContextExtensions
     /// </summary>
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to fill the resource.</param>
-    /// <param name="texture">The input <see cref="IReadWriteTexture3D{TPixel}"/> instance to fill.</param>
+    /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture3D{TPixel}"/> instance to fill.</param>
     /// <param name="value">The value to use to fill <paramref name="texture"/>.</param>
-    public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteTexture3D<TPixel> texture, TPixel value)
+    public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture, TPixel value)
         where TPixel : unmanaged
     {
         var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
@@ -341,7 +341,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels being processed by the shader.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to run the shader.</param>
     /// <param name="texture">The target texture to apply the pixel shader to.</param>
-    public static void ForEach<T, TPixel>(this in ComputeContext context, IReadWriteTexture2D<TPixel> texture)
+    public static void ForEach<T, TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {
@@ -356,7 +356,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to run the shader.</param>
     /// <param name="texture">The target texture to apply the pixel shader to.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the pixel shader to run.</param>
-    public static void ForEach<T, TPixel>(this in ComputeContext context, IReadWriteTexture2D<TPixel> texture, in T shader)
+    public static void ForEach<T, TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture, in T shader)
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {

--- a/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
@@ -366,6 +366,58 @@ public static class ComputeContextExtensions
     /// <summary>
     /// Transitions the state of a specific resource.
     /// </summary>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to transition.</param>
+    /// <param name="resourceState">The state to transition the input resource to.</param>
+    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<float> texture, ResourceState resourceState)
+    {
+        var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
+
+        context.Transition(d3D12Resource, states.Before, states.After);
+    }
+
+    /// <summary>
+    /// Transitions the state of a specific resource.
+    /// </summary>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to transition.</param>
+    /// <param name="resourceState">The state to transition the input resource to.</param>
+    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float2> texture, ResourceState resourceState)
+    {
+        var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
+
+        context.Transition(d3D12Resource, states.Before, states.After);
+    }
+
+    /// <summary>
+    /// Transitions the state of a specific resource.
+    /// </summary>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to transition.</param>
+    /// <param name="resourceState">The state to transition the input resource to.</param>
+    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float3> texture, ResourceState resourceState)
+    {
+        var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
+
+        context.Transition(d3D12Resource, states.Before, states.After);
+    }
+
+    /// <summary>
+    /// Transitions the state of a specific resource.
+    /// </summary>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to transition.</param>
+    /// <param name="resourceState">The state to transition the input resource to.</param>
+    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float4> texture, ResourceState resourceState)
+    {
+        var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
+
+        context.Transition(d3D12Resource, states.Before, states.After);
+    }
+
+    /// <summary>
+    /// Transitions the state of a specific resource.
+    /// </summary>
     /// <typeparam name="T">The type of items stored on the texture.</typeparam>
     /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
@@ -374,6 +426,58 @@ public static class ComputeContextExtensions
     public static unsafe void Transition<T, TPixel>(this in ComputeContext context, ReadWriteTexture2D<T, TPixel> texture, ResourceState resourceState)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
+    {
+        var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
+
+        context.Transition(d3D12Resource, states.Before, states.After);
+    }
+
+    /// <summary>
+    /// Transitions the state of a specific resource.
+    /// </summary>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to transition.</param>
+    /// <param name="resourceState">The state to transition the input resource to.</param>
+    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<float> texture, ResourceState resourceState)
+    {
+        var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
+
+        context.Transition(d3D12Resource, states.Before, states.After);
+    }
+
+    /// <summary>
+    /// Transitions the state of a specific resource.
+    /// </summary>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to transition.</param>
+    /// <param name="resourceState">The state to transition the input resource to.</param>
+    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float2> texture, ResourceState resourceState)
+    {
+        var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
+
+        context.Transition(d3D12Resource, states.Before, states.After);
+    }
+
+    /// <summary>
+    /// Transitions the state of a specific resource.
+    /// </summary>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to transition.</param>
+    /// <param name="resourceState">The state to transition the input resource to.</param>
+    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float3> texture, ResourceState resourceState)
+    {
+        var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
+
+        context.Transition(d3D12Resource, states.Before, states.After);
+    }
+
+    /// <summary>
+    /// Transitions the state of a specific resource.
+    /// </summary>
+    /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
+    /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to transition.</param>
+    /// <param name="resourceState">The state to transition the input resource to.</param>
+    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float4> texture, ResourceState resourceState)
     {
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 

--- a/src/ComputeSharp/Shaders/ShaderRunner{T}.cs
+++ b/src/ComputeSharp/Shaders/ShaderRunner{T}.cs
@@ -145,7 +145,7 @@ internal static class ShaderRunner<T>
     /// <param name="device">The <see cref="GraphicsDevice"/> to use to run the shader.</param>
     /// <param name="texture">The target texture to invoke the pixel shader upon.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the pixel shader to run.</param>
-    public static unsafe void Run<TPixel>(GraphicsDevice device, IReadWriteTexture2D<TPixel> texture, ref T shader)
+    public static unsafe void Run<TPixel>(GraphicsDevice device, IReadWriteNormalizedTexture2D<TPixel> texture, ref T shader)
         where TPixel : unmanaged
     {
         device.ThrowIfDisposed();

--- a/tests/ComputeSharp.Tests/ComputeContextTests.cs
+++ b/tests/ComputeSharp.Tests/ComputeContextTests.cs
@@ -898,13 +898,41 @@ public partial class ComputeContextTests
 
         using var sampled = Image.Load<ImageSharpRgba32>(Path.Combine(assetsPath, "CityAfter1024x1024Sampling.png"));
 
+        using ReadOnlyTexture2D<Rgba32, float4> source = device.Get().LoadReadOnlyTexture2D<Rgba32, float4>(Path.Combine(imagingPath, "city.jpg"));
+        using ReadWriteTexture2D<float4> sourceAsFloat4 = device.Get().AllocateReadWriteTexture2D<float4>(source.Width, source.Height);
+        using ReadWriteTexture2D<Rgba32, float4> destination = device.Get().AllocateReadWriteTexture2D<Rgba32, float4>(sampled.Width, sampled.Height);
+
+        using (var context = device.Get().CreateComputeContext())
+        {
+            context.For(source.Width, source.Height, new ConvertToNonNormalized2DShader(source, sourceAsFloat4));
+            context.Transition(sourceAsFloat4, ResourceState.ReadOnly);
+            context.ForEach(destination, new LinearSampling2DPixelShader(sourceAsFloat4.AsReadOnly()));
+            context.Transition(sourceAsFloat4, ResourceState.ReadWrite);
+        }
+
+        using var processed = destination.ToImage<Rgba32, ImageSharpRgba32>();
+
+        ImagingTests.TolerantImageComparer.AssertEqual(sampled, processed, 0.00000174f);
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public void Transition_ReadWriteTexture2D_Normalized(Device device)
+    {
+        _ = device.Get();
+
+        string imagingPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Imaging");
+        string assetsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Assets");
+
+        using var sampled = Image.Load<ImageSharpRgba32>(Path.Combine(assetsPath, "CityAfter1024x1024Sampling.png"));
+
         using ReadWriteTexture2D<Rgba32, float4> source = device.Get().LoadReadWriteTexture2D<Rgba32, float4>(Path.Combine(imagingPath, "city.jpg"));
         using ReadWriteTexture2D<Rgba32, float4> destination = device.Get().AllocateReadWriteTexture2D<Rgba32, float4>(sampled.Width, sampled.Height);
 
         using (var context = device.Get().CreateComputeContext())
         {
             context.Transition(source, ResourceState.ReadOnly);
-            context.ForEach(destination, new LinearSampling2DPixelShader(source.AsReadOnly()));
+            context.ForEach(destination, new LinearSamplingFromNormalized2DPixelShader(source.AsReadOnly()));
             context.Transition(source, ResourceState.ReadWrite);
         }
 
@@ -916,6 +944,58 @@ public partial class ComputeContextTests
     [CombinatorialTestMethod]
     [AllDevices]
     public void Transition_ReadWriteTexture3D(Device device)
+    {
+        _ = device.Get();
+
+        string assetsPath = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Assets");
+        string originalPath = Path.Combine(assetsPath, "CityWith1920x1280Resizing.png");
+        string sampledPath = Path.Combine(assetsPath, "CityAfter1024x1024Sampling.png");
+
+        var imageInfo = Image.Identify(originalPath);
+
+        using var sampled = Image.Load<ImageSharpRgba32>(Path.Combine(assetsPath, sampledPath));
+
+        using ReadWriteTexture3D<float4> sourceAsFloat4 = device.Get().AllocateReadWriteTexture3D<float4>(imageInfo.Width, imageInfo.Height, 3);
+
+        using (UploadTexture2D<Rgba32> upload2D = device.Get().LoadUploadTexture2D<Rgba32>(originalPath))
+        using (UploadTexture3D<float4> upload3D = device.Get().AllocateUploadTexture3D<float4>(upload2D.Width, upload2D.Height, 2))
+        {
+            for (int z = 0; z < upload3D.Depth; z++)
+            {
+                TextureView2D<float4> layer = upload3D.View.GetDepthView(z);
+
+                for (int y = 0; y < layer.Height; y++)
+                {
+                    for (int x = 0; x < layer.Width; x++)
+                    {
+                        layer[x, y] = upload2D.View[x, y].ToPixel();
+                    }
+                }
+            }
+
+            upload3D.CopyTo(sourceAsFloat4);
+        }
+
+        using ReadWriteTexture3D<Rgba32, float4> destination = device.Get().AllocateReadWriteTexture3D<Rgba32, float4>(sampled.Width, sampled.Height, 2);
+
+        using (var context = device.Get().CreateComputeContext())
+        {
+            context.Transition(sourceAsFloat4, ResourceState.ReadOnly);
+            context.For(destination.Width, destination.Height, destination.Depth, new LinearSampling3DComputeShader(sourceAsFloat4.AsReadOnly(), destination));
+            context.Transition(sourceAsFloat4, ResourceState.ReadWrite);
+        }
+
+        for (int z = 0; z < destination.Depth; z++)
+        {
+            using var processed = destination.ToImage<Rgba32, ImageSharpRgba32>(depth: z);
+
+            ImagingTests.TolerantImageComparer.AssertEqual(sampled, processed, 0.000012f);
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public void Transition_ReadWriteTexture3D_Normalized(Device device)
     {
         _ = device.Get();
 
@@ -945,7 +1025,7 @@ public partial class ComputeContextTests
         using (var context = device.Get().CreateComputeContext())
         {
             context.Transition(source, ResourceState.ReadOnly);
-            context.For(destination.Width, destination.Height, destination.Depth, new LinearSampling3DComputeShader(source.AsReadOnly(), destination));
+            context.For(destination.Width, destination.Height, destination.Depth, new LinearSamplingFromNormalized3DComputeShader(source.AsReadOnly(), destination));
             context.Transition(source, ResourceState.ReadWrite);
         }
 
@@ -959,7 +1039,7 @@ public partial class ComputeContextTests
 
     [CombinatorialTestMethod]
     [AllDevices]
-    public void TransitionAndWrites_ReadWriteTexture2D(Device device)
+    public void TransitionAndWrites_ReadWriteTexture2D_Normalized(Device device)
     {
         _ = device.Get();
 
@@ -975,7 +1055,7 @@ public partial class ComputeContextTests
         {
             context.For(source.Width, source.Height, new Dotted2DPixelShader(source));
             context.Transition(source, ResourceState.ReadOnly);
-            context.ForEach(destination, new LinearSampling2DPixelShader(source.AsReadOnly()));
+            context.ForEach(destination, new LinearSamplingFromNormalized2DPixelShader(source.AsReadOnly()));
             context.Transition(source, ResourceState.ReadWrite);
             context.Fill(source, new Rgba32(0xFF, 0x6A, 0x00, 0x00));
         }
@@ -994,7 +1074,7 @@ public partial class ComputeContextTests
 
     [CombinatorialTestMethod]
     [AllDevices]
-    public void TransitionAndWrites_ReadWriteTexture3D(Device device)
+    public void TransitionAndWrites_ReadWriteTexture3D_Normalized(Device device)
     {
         _ = device.Get();
 
@@ -1025,7 +1105,7 @@ public partial class ComputeContextTests
         {
             context.For(source.Width, source.Height, source.Depth, new Dotted3DPixelShader(source));
             context.Transition(source, ResourceState.ReadOnly);
-            context.For(destination.Width, destination.Height, destination.Depth, new LinearSampling3DComputeShader(source.AsReadOnly(), destination));
+            context.For(destination.Width, destination.Height, destination.Depth, new LinearSamplingFromNormalized3DComputeShader(source.AsReadOnly(), destination));
             context.Transition(source, ResourceState.ReadWrite);
             context.Fill(source, new Rgba32(0xFF, 0x6A, 0x00, 0x00));
         }
@@ -1203,7 +1283,7 @@ public partial class ComputeContextTests
     [AutoConstructor]
     internal readonly partial struct LinearSampling2DPixelShader : IPixelShader<float4>
     {
-        public readonly IReadOnlyNormalizedTexture2D<float4> source;
+        public readonly IReadOnlyTexture2D<float4> source;
 
         /// <inheritdoc/>
         public float4 Execute()
@@ -1214,6 +1294,31 @@ public partial class ComputeContextTests
 
     [AutoConstructor]
     internal readonly partial struct LinearSampling3DComputeShader : IComputeShader
+    {
+        public readonly IReadOnlyTexture3D<float4> source;
+        public readonly IReadWriteNormalizedTexture3D<float4> destination;
+
+        /// <inheritdoc/>
+        public void Execute()
+        {
+            destination[ThreadIds.XYZ] = source[ThreadIds.Normalized.XYZ];
+        }
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct LinearSamplingFromNormalized2DPixelShader : IPixelShader<float4>
+    {
+        public readonly IReadOnlyNormalizedTexture2D<float4> source;
+
+        /// <inheritdoc/>
+        public float4 Execute()
+        {
+            return source[ThreadIds.Normalized.XY];
+        }
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct LinearSamplingFromNormalized3DComputeShader : IComputeShader
     {
         public readonly IReadOnlyNormalizedTexture3D<float4> source;
         public readonly IReadWriteNormalizedTexture3D<float4> destination;
@@ -1278,6 +1383,19 @@ public partial class ComputeContextTests
                     source[ThreadIds.XYZ] = float4.Zero;
                 }
             }
+        }
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ConvertToNonNormalized2DShader : IComputeShader
+    {
+        public readonly IReadOnlyNormalizedTexture2D<float4> source;
+        public readonly ReadWriteTexture2D<float4> destination;
+
+        /// <inheritdoc/>
+        public void Execute()
+        {
+            destination[ThreadIds.XY] = source[ThreadIds.XY];
         }
     }
 }

--- a/tests/ComputeSharp.Tests/ComputeContextTests.cs
+++ b/tests/ComputeSharp.Tests/ComputeContextTests.cs
@@ -283,7 +283,7 @@ public partial class ComputeContextTests
 
             using (ComputeContext context = device.Get().CreateComputeContext())
             {
-                context.Clear((IReadWriteTexture2D<TPixel>)texture);
+                context.Clear((IReadWriteNormalizedTexture2D<TPixel>)texture);
             }
 
             texture.CopyTo(array);
@@ -325,7 +325,7 @@ public partial class ComputeContextTests
 
             using (ComputeContext context = device.Get().CreateComputeContext())
             {
-                context.Clear((IReadWriteTexture3D<TPixel>)texture);
+                context.Clear((IReadWriteNormalizedTexture3D<TPixel>)texture);
             }
 
             texture.CopyTo(array);
@@ -491,7 +491,7 @@ public partial class ComputeContextTests
 
             using (ComputeContext context = device.Get().CreateComputeContext())
             {
-                context.Fill((IReadWriteTexture2D<TPixel>)texture, color.ToPixel());
+                context.Fill((IReadWriteNormalizedTexture2D<TPixel>)texture, color.ToPixel());
             }
 
             T[,] result = texture.ToArray();
@@ -531,7 +531,7 @@ public partial class ComputeContextTests
 
             using (ComputeContext context = device.Get().CreateComputeContext())
             {
-                context.Fill((IReadWriteTexture3D<TPixel>)texture, color.ToPixel());
+                context.Fill((IReadWriteNormalizedTexture3D<TPixel>)texture, color.ToPixel());
             }
 
             T[,,] result = texture.ToArray();
@@ -1203,7 +1203,7 @@ public partial class ComputeContextTests
     [AutoConstructor]
     internal readonly partial struct LinearSampling2DPixelShader : IPixelShader<float4>
     {
-        public readonly IReadOnlyTexture2D<float4> source;
+        public readonly IReadOnlyNormalizedTexture2D<float4> source;
 
         /// <inheritdoc/>
         public float4 Execute()
@@ -1215,8 +1215,8 @@ public partial class ComputeContextTests
     [AutoConstructor]
     internal readonly partial struct LinearSampling3DComputeShader : IComputeShader
     {
-        public readonly IReadOnlyTexture3D<float4> source;
-        public readonly IReadWriteTexture3D<float4> destination;
+        public readonly IReadOnlyNormalizedTexture3D<float4> source;
+        public readonly IReadWriteNormalizedTexture3D<float4> destination;
 
         /// <inheritdoc/>
         public void Execute()
@@ -1228,7 +1228,7 @@ public partial class ComputeContextTests
     [AutoConstructor]
     internal readonly partial struct Dotted2DPixelShader : IComputeShader
     {
-        public readonly IReadWriteTexture2D<float4> source;
+        public readonly IReadWriteNormalizedTexture2D<float4> source;
 
         /// <inheritdoc/>
         public void Execute()
@@ -1256,7 +1256,7 @@ public partial class ComputeContextTests
     [AutoConstructor]
     internal readonly partial struct Dotted3DPixelShader : IComputeShader
     {
-        public readonly IReadWriteTexture3D<float4> source;
+        public readonly IReadWriteNormalizedTexture3D<float4> source;
 
         /// <inheritdoc/>
         public void Execute()

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ColorfulInfinity.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ColorfulInfinity.cs
@@ -12,7 +12,7 @@ internal readonly partial struct ColorfulInfinity : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ContouredLayers.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ContouredLayers.cs
@@ -11,7 +11,7 @@ internal readonly partial struct ContouredLayers : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> destination;
+    public readonly IReadWriteNormalizedTexture2D<float4> destination;
 
     /// <summary>
     /// The current time Hlsl.Since the start of the application.
@@ -21,7 +21,7 @@ internal readonly partial struct ContouredLayers : IComputeShader
     /// <summary>
     /// The sampling texture.
     /// </summary>
-    public readonly IReadOnlyTexture2D<float4> texture;
+    public readonly IReadOnlyNormalizedTexture2D<float4> texture;
 
     // float3 to float hash.
     private static float Hash21(float2 p)

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ExtrudedTruchetPattern.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ExtrudedTruchetPattern.cs
@@ -11,7 +11,7 @@ internal readonly partial struct ExtrudedTruchetPattern : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/FourColorGradient.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/FourColorGradient.cs
@@ -12,7 +12,7 @@ internal readonly partial struct FourColorGradient : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/FractalTiling.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/FractalTiling.cs
@@ -12,7 +12,7 @@ internal readonly partial struct FractalTiling : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/MengerJourney.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/MengerJourney.cs
@@ -11,7 +11,7 @@ internal readonly partial struct MengerJourney : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/Octagrams.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/Octagrams.cs
@@ -11,7 +11,7 @@ internal readonly partial struct Octagrams : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
@@ -12,7 +12,7 @@ internal readonly partial struct ProteanClouds : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time Hlsl.Since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/PyramidPattern.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/PyramidPattern.cs
@@ -12,7 +12,7 @@ internal readonly partial struct PyramidPattern : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time Hlsl.Since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/TriangleGridContouring.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/TriangleGridContouring.cs
@@ -11,7 +11,7 @@ internal readonly partial struct TriangleGridContouring : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time Hlsl.Since the start of the application.

--- a/tests/ComputeSharp.Tests/Shaders/Compute/TwoTiledTruchet.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/TwoTiledTruchet.cs
@@ -11,7 +11,7 @@ internal readonly partial struct TwoTiledTruchet : IComputeShader
     /// <summary>
     /// The target texture.
     /// </summary>
-    public readonly IReadWriteTexture2D<float4> texture;
+    public readonly IReadWriteNormalizedTexture2D<float4> texture;
 
     /// <summary>
     /// The current time since the start of the application.

--- a/tests/ComputeSharp.Tests/Texture2DTests.Pixels.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.Pixels.cs
@@ -74,8 +74,8 @@ public partial class Texture2DTests
     [AutoConstructor]
     public readonly partial struct SamplingComputeShader : IComputeShader
     {
-        public readonly IReadOnlyTexture2D<float4> source;
-        public readonly IReadWriteTexture2D<float4> destination;
+        public readonly IReadOnlyNormalizedTexture2D<float4> source;
+        public readonly IReadWriteNormalizedTexture2D<float4> destination;
 
         public void Execute()
         {
@@ -107,7 +107,7 @@ public partial class Texture2DTests
     [AutoConstructor]
     public readonly partial struct SamplingPixelShader : IPixelShader<float4>
     {
-        public readonly IReadOnlyTexture2D<float4> texture;
+        public readonly IReadOnlyNormalizedTexture2D<float4> texture;
 
         public float4 Execute()
         {
@@ -136,11 +136,11 @@ public partial class Texture2DTests
             {
                 context.Transition(texture, ResourceState.ReadOnly);
 
-                IReadOnlyTexture2D<TPixel> wrapper1 = texture.AsReadOnly();
+                IReadOnlyNormalizedTexture2D<TPixel> wrapper1 = texture.AsReadOnly();
 
                 Assert.IsNotNull(wrapper1);
 
-                IReadOnlyTexture2D<TPixel> wrapper2 = texture.AsReadOnly();
+                IReadOnlyNormalizedTexture2D<TPixel> wrapper2 = texture.AsReadOnly();
 
                 Assert.IsNotNull(wrapper2);
                 Assert.AreSame(wrapper1, wrapper2);

--- a/tests/ComputeSharp.Tests/Texture3DTests.Pixels.cs
+++ b/tests/ComputeSharp.Tests/Texture3DTests.Pixels.cs
@@ -69,11 +69,11 @@ public partial class Texture3DTests
             {
                 context.Transition(texture, ResourceState.ReadOnly);
 
-                IReadOnlyTexture3D<TPixel> wrapper1 = texture.AsReadOnly();
+                IReadOnlyNormalizedTexture3D<TPixel> wrapper1 = texture.AsReadOnly();
 
                 Assert.IsNotNull(wrapper1);
 
-                IReadOnlyTexture3D<TPixel> wrapper2 = texture.AsReadOnly();
+                IReadOnlyNormalizedTexture3D<TPixel> wrapper2 = texture.AsReadOnly();
 
                 Assert.IsNotNull(wrapper2);
                 Assert.AreSame(wrapper1, wrapper2);


### PR DESCRIPTION
This PR introduces an extension of the changes done in #196, to apply to non-uniform textures too.
Specifically, the same functionality is now available for `Texture2D<T>` and 3D of type `float`, `float2`, `float3` and `float4`.