### PR TITLE
Add ArgumentNullException validation for public params

### DIFF
--- a/src/ComputeSharp/Graphics/Extensions/BufferExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/BufferExtensions.cs
@@ -22,6 +22,8 @@ public static class BufferExtensions
     public static T[] ToArray<T>(this Buffer<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         return source.ToArray(0, source.Length);
     }
 
@@ -36,6 +38,7 @@ public static class BufferExtensions
     public static T[] ToArray<T>(this Buffer<T> source, int offset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
         Guard.IsGreaterThanOrEqualTo(count, 0, nameof(count));
 
         T[] data = GC.AllocateUninitializedArray<T>(count);
@@ -54,6 +57,9 @@ public static class BufferExtensions
     public static void CopyTo<T>(this Buffer<T> source, T[] destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(), 0);
     }
 
@@ -69,6 +75,9 @@ public static class BufferExtensions
     public static void CopyTo<T>(this Buffer<T> source, T[] destination, int sourceOffset, int destinationOffset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         Span<T> span = destination.AsSpan(destinationOffset, count);
 
         source.CopyTo(span, sourceOffset);
@@ -83,6 +92,8 @@ public static class BufferExtensions
     public static void CopyTo<T>(this Buffer<T> source, Span<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0);
     }
 
@@ -96,6 +107,8 @@ public static class BufferExtensions
     public static void CopyTo<T>(this Buffer<T> source, Span<T> destination, int sourceOffset)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(ref MemoryMarshal.GetReference(destination), sourceOffset, destination.Length);
     }
 
@@ -108,6 +121,9 @@ public static class BufferExtensions
     public static void CopyTo<T>(this Buffer<T> source, Buffer<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, 0, 0, source.Length);
     }
 
@@ -123,6 +139,9 @@ public static class BufferExtensions
     public static void CopyTo<T>(this Buffer<T> source, Buffer<T> destination, int sourceOffset, int destinationOffset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffset, destinationOffset, count);
     }
 
@@ -135,6 +154,9 @@ public static class BufferExtensions
     public static void CopyFrom<T>(this Buffer<T> destination, T[] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(), 0);
     }
 
@@ -150,6 +172,9 @@ public static class BufferExtensions
     public static void CopyFrom<T>(this Buffer<T> destination, T[] source, int sourceOffset, int destinationOffset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadOnlySpan<T> span = source.AsSpan(sourceOffset, count);
 
         destination.CopyFrom(span, destinationOffset);
@@ -164,6 +189,8 @@ public static class BufferExtensions
     public static void CopyFrom<T>(this Buffer<T> destination, ReadOnlySpan<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, 0);
     }
 
@@ -177,6 +204,8 @@ public static class BufferExtensions
     public static void CopyFrom<T>(this Buffer<T> destination, ReadOnlySpan<T> source, int destinationOffset)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(ref MemoryMarshal.GetReference(source), destinationOffset, source.Length);
     }
 
@@ -189,6 +218,9 @@ public static class BufferExtensions
     public static void CopyFrom<T>(this Buffer<T> destination, Buffer<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, source.Length);
     }
 
@@ -204,6 +236,9 @@ public static class BufferExtensions
     public static void CopyFrom<T>(this Buffer<T> destination, Buffer<T> source, int sourceOffset, int destinationOffset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffset, destinationOffset, count);
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Dispatching.cs
+++ b/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Dispatching.cs
@@ -1,4 +1,5 @@
 ﻿using ComputeSharp.Shaders;
+using Microsoft.Toolkit.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace ComputeSharp;
@@ -18,6 +19,8 @@ public static partial class GraphicsDeviceExtensions
     public static void For<T>(this GraphicsDevice device, int x, in T shader)
         where T : struct, IComputeShader
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ShaderRunner<T>.Run(device, x, 1, 1, ref Unsafe.AsRef(in shader));
     }
 
@@ -32,6 +35,8 @@ public static partial class GraphicsDeviceExtensions
     public static void For<T>(this GraphicsDevice device, int x, int y, in T shader)
         where T : struct, IComputeShader
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ShaderRunner<T>.Run(device, x, y, 1, ref Unsafe.AsRef(in shader));
     }
 
@@ -47,6 +52,8 @@ public static partial class GraphicsDeviceExtensions
     public static void For<T>(this GraphicsDevice device, int x, int y, int z, in T shader)
         where T : struct, IComputeShader
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ShaderRunner<T>.Run(device, x, y, z, ref Unsafe.AsRef(in shader));
     }
 
@@ -65,6 +72,8 @@ public static partial class GraphicsDeviceExtensions
     public static void For<T>(this GraphicsDevice device, int x, int y, int z, int threadsX, int threadsY, int threadsZ, in T shader)
         where T : struct, IComputeShader
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ShaderRunner<T>.Run(device, x, y, z, threadsX, threadsY, threadsZ, ref Unsafe.AsRef(in shader));
     }
 
@@ -79,6 +88,9 @@ public static partial class GraphicsDeviceExtensions
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(texture, nameof(texture));
+
         ShaderRunner<T>.Run(device, texture, ref Unsafe.AsRef(default(T)));
     }
 
@@ -94,6 +106,9 @@ public static partial class GraphicsDeviceExtensions
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(texture, nameof(texture));
+
         ShaderRunner<T>.Run(device, texture, ref Unsafe.AsRef(in shader));
     }
 
@@ -122,6 +137,8 @@ public static partial class GraphicsDeviceExtensions
     /// </remarks>
     public static ComputeContext CreateComputeContext(this GraphicsDevice device)
     {
+        Guard.IsNotNull(device, nameof(device));
+
         device.ThrowIfDisposed();
 
         return new(device);

--- a/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Resources.cs
+++ b/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Resources.cs
@@ -20,6 +20,8 @@ public static partial class GraphicsDeviceExtensions
     public static ConstantBuffer<T> AllocateConstantBuffer<T>(this GraphicsDevice device, int length, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, length, allocationMode);
     }
 
@@ -33,6 +35,9 @@ public static partial class GraphicsDeviceExtensions
     public static ConstantBuffer<T> AllocateConstantBuffer<T>(this GraphicsDevice device, T[] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateConstantBuffer<T>(source.AsSpan());
     }
 
@@ -46,6 +51,8 @@ public static partial class GraphicsDeviceExtensions
     public static ConstantBuffer<T> AllocateConstantBuffer<T>(this GraphicsDevice device, ReadOnlySpan<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ConstantBuffer<T> buffer = new(device, source.Length, AllocationMode.Default);
 
         buffer.CopyFrom(source);
@@ -63,6 +70,9 @@ public static partial class GraphicsDeviceExtensions
     public static ConstantBuffer<T> AllocateConstantBuffer<T>(this GraphicsDevice device, Buffer<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ConstantBuffer<T> constantBuffer = new(device, source.Length, AllocationMode.Default);
 
         constantBuffer.CopyFrom(source);
@@ -81,6 +91,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyBuffer<T> AllocateReadOnlyBuffer<T>(this GraphicsDevice device, int length, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, length, allocationMode);
     }
 
@@ -94,6 +106,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyBuffer<T> AllocateReadOnlyBuffer<T>(this GraphicsDevice device, T[] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyBuffer<T>(source.AsSpan());
     }
 
@@ -107,6 +122,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyBuffer<T> AllocateReadOnlyBuffer<T>(this GraphicsDevice device, ReadOnlySpan<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadOnlyBuffer<T> buffer = new(device, source.Length, AllocationMode.Default);
 
         buffer.CopyFrom(source);
@@ -124,6 +141,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyBuffer<T> AllocateReadOnlyBuffer<T>(this GraphicsDevice device, Buffer<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadOnlyBuffer<T> readWriteBuffer = new(device, source.Length, AllocationMode.Default);
 
         readWriteBuffer.CopyFrom(source);
@@ -143,6 +163,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture2D<T> AllocateReadOnlyTexture2D<T>(this GraphicsDevice device, int width, int height, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, allocationMode);
     }
 
@@ -158,6 +180,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture2D<T> AllocateReadOnlyTexture2D<T>(this GraphicsDevice device, T[] source, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyTexture2D<T>(source.AsSpan(), width, height);
     }
 
@@ -174,6 +199,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture2D<T> AllocateReadOnlyTexture2D<T>(this GraphicsDevice device, T[] source, int offset, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyTexture2D<T>(source.AsSpan(offset), width, height);
     }
 
@@ -187,6 +215,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture2D<T> AllocateReadOnlyTexture2D<T>(this GraphicsDevice device, T[,] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadOnlyTexture2D<T> texture = new(device, source.GetLength(1), source.GetLength(0), AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -206,6 +237,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture2D<T> AllocateReadOnlyTexture2D<T>(this GraphicsDevice device, ReadOnlySpan<T> source, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadOnlyTexture2D<T> texture = new(device, width, height, AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -227,6 +260,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, allocationMode);
     }
 
@@ -244,6 +279,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyTexture2D<T, TPixel>(source.AsSpan(), width, height);
     }
 
@@ -262,6 +300,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyTexture2D<T, TPixel>(source.AsSpan(offset), width, height);
     }
 
@@ -277,6 +318,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadOnlyTexture2D<T, TPixel> texture = new(device, source.GetLength(1), source.GetLength(0), AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -298,6 +342,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadOnlyTexture2D<T, TPixel> texture = new(device, width, height, AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -318,6 +364,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture3D<T> AllocateReadOnlyTexture3D<T>(this GraphicsDevice device, int width, int height, int depth, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, depth, allocationMode);
     }
 
@@ -334,6 +382,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture3D<T> AllocateReadOnlyTexture3D<T>(this GraphicsDevice device, T[] source, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyTexture3D<T>(source.AsSpan(), width, height, depth);
     }
 
@@ -351,6 +402,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture3D<T> AllocateReadOnlyTexture3D<T>(this GraphicsDevice device, T[] source, int offset, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyTexture3D<T>(source.AsSpan(offset), width, height, depth);
     }
 
@@ -368,6 +422,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture3D<T> AllocateReadOnlyTexture3D<T>(this GraphicsDevice device, T[,,] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadOnlyTexture3D<T> texture = new(device, source.GetLength(2), source.GetLength(1), source.GetLength(0), AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -388,6 +445,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadOnlyTexture3D<T> AllocateReadOnlyTexture3D<T>(this GraphicsDevice device, ReadOnlySpan<T> source, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadOnlyTexture3D<T> texture = new(device, width, height, depth, AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -410,6 +469,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, depth, allocationMode);
     }
 
@@ -428,6 +489,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyTexture3D<T, TPixel>(source.AsSpan(), width, height, depth);
     }
 
@@ -447,6 +511,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadOnlyTexture3D<T, TPixel>(source.AsSpan(offset), width, height, depth);
     }
 
@@ -466,6 +533,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadOnlyTexture3D<T, TPixel> texture = new(device, source.GetLength(2), source.GetLength(1), source.GetLength(0), AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -488,6 +558,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadOnlyTexture3D<T, TPixel> texture = new(device, width, height, depth, AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -506,6 +578,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteBuffer<T> AllocateReadWriteBuffer<T>(this GraphicsDevice device, int length, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, length, allocationMode);
     }
 
@@ -519,6 +593,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteBuffer<T> AllocateReadWriteBuffer<T>(this GraphicsDevice device, T[] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteBuffer<T>(source.AsSpan());
     }
 
@@ -532,6 +609,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteBuffer<T> AllocateReadWriteBuffer<T>(this GraphicsDevice device, ReadOnlySpan<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadWriteBuffer<T> buffer = new(device, source.Length, AllocationMode.Default);
 
         buffer.CopyFrom(source);
@@ -549,6 +628,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteBuffer<T> AllocateReadWriteBuffer<T>(this GraphicsDevice device, Buffer<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadWriteBuffer<T> readWriteBuffer = new(device, source.Length, AllocationMode.Default);
 
         readWriteBuffer.CopyFrom(source);
@@ -568,6 +650,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture2D<T> AllocateReadWriteTexture2D<T>(this GraphicsDevice device, int width, int height, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, allocationMode);
     }
 
@@ -583,6 +667,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture2D<T> AllocateReadWriteTexture2D<T>(this GraphicsDevice device, T[] source, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteTexture2D<T>(source.AsSpan(), width, height);
     }
 
@@ -599,6 +686,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture2D<T> AllocateReadWriteTexture2D<T>(this GraphicsDevice device, T[] source, int offset, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteTexture2D<T>(source.AsSpan(offset), width, height);
     }
 
@@ -612,6 +702,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture2D<T> AllocateReadWriteTexture2D<T>(this GraphicsDevice device, T[,] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadWriteTexture2D<T> texture = new(device, source.GetLength(1), source.GetLength(0), AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -631,6 +724,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture2D<T> AllocateReadWriteTexture2D<T>(this GraphicsDevice device, ReadOnlySpan<T> source, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadWriteTexture2D<T> texture = new(device, width, height, AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -652,6 +747,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, allocationMode);
     }
 
@@ -669,6 +766,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteTexture2D<T, TPixel>(source.AsSpan(), width, height);
     }
 
@@ -687,6 +787,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteTexture2D<T, TPixel>(source.AsSpan(offset), width, height);
     }
 
@@ -702,6 +805,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadWriteTexture2D<T, TPixel> texture = new(device, source.GetLength(1), source.GetLength(0), AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -723,6 +829,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadWriteTexture2D<T, TPixel> texture = new(device, width, height, AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -743,6 +851,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture3D<T> AllocateReadWriteTexture3D<T>(this GraphicsDevice device, int width, int height, int depth, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, depth, allocationMode);
     }
 
@@ -759,6 +869,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture3D<T> AllocateReadWriteTexture3D<T>(this GraphicsDevice device, T[] source, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteTexture3D<T>(source.AsSpan(), width, height, depth);
     }
 
@@ -776,6 +889,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture3D<T> AllocateReadWriteTexture3D<T>(this GraphicsDevice device, T[] source, int offset, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteTexture3D<T>(source.AsSpan(offset), width, height, depth);
     }
 
@@ -793,6 +909,9 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture3D<T> AllocateReadWriteTexture3D<T>(this GraphicsDevice device, T[,,] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadWriteTexture3D<T> texture = new(device, source.GetLength(2), source.GetLength(1), source.GetLength(0), AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -813,6 +932,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadWriteTexture3D<T> AllocateReadWriteTexture3D<T>(this GraphicsDevice device, ReadOnlySpan<T> source, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadWriteTexture3D<T> texture = new(device, width, height, depth, AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -835,6 +956,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, depth, allocationMode);
     }
 
@@ -853,6 +976,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteTexture3D<T, TPixel>(source.AsSpan(), width, height, depth);
     }
 
@@ -872,6 +998,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         return device.AllocateReadWriteTexture3D<T, TPixel>(source.AsSpan(offset), width, height, depth);
     }
 
@@ -891,6 +1020,9 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+        Guard.IsNotNull(source, nameof(source));
+
         ReadWriteTexture3D<T, TPixel> texture = new(device, source.GetLength(2), source.GetLength(1), source.GetLength(0), AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -913,6 +1045,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         ReadWriteTexture3D<T, TPixel> texture = new(device, width, height, depth, AllocationMode.Default);
 
         texture.CopyFrom(source);
@@ -931,6 +1065,8 @@ public static partial class GraphicsDeviceExtensions
     public static UploadBuffer<T> AllocateUploadBuffer<T>(this GraphicsDevice device, int length, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, length, allocationMode);
     }
 
@@ -946,6 +1082,8 @@ public static partial class GraphicsDeviceExtensions
     public static UploadTexture2D<T> AllocateUploadTexture2D<T>(this GraphicsDevice device, int width, int height, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, allocationMode);
     }
 
@@ -962,6 +1100,8 @@ public static partial class GraphicsDeviceExtensions
     public static UploadTexture3D<T> AllocateUploadTexture3D<T>(this GraphicsDevice device, int width, int height, int depth, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, depth, allocationMode);
     }
 
@@ -976,6 +1116,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadBackBuffer<T> AllocateReadBackBuffer<T>(this GraphicsDevice device, int length, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, length, allocationMode);
     }
 
@@ -991,6 +1133,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadBackTexture2D<T> AllocateReadBackTexture2D<T>(this GraphicsDevice device, int width, int height, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, allocationMode);
     }
 
@@ -1007,6 +1151,8 @@ public static partial class GraphicsDeviceExtensions
     public static ReadBackTexture3D<T> AllocateReadBackTexture3D<T>(this GraphicsDevice device, int width, int height, int depth, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return new(device, width, height, depth, allocationMode);
     }
 
@@ -1022,6 +1168,7 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
         Guard.IsNotNull(filename, nameof(filename));
 
         return device.LoadReadOnlyTexture2D<T, TPixel>(filename.AsSpan());
@@ -1039,6 +1186,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         using UploadTexture2D<T> upload = WICHelper.Instance.LoadTexture<T>(device, filename);
 
         ReadOnlyTexture2D<T, TPixel> texture = device.AllocateReadOnlyTexture2D<T, TPixel>(upload.Width, upload.Height);
@@ -1060,6 +1209,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         using UploadTexture2D<T> upload = WICHelper.Instance.LoadTexture<T>(device, span);
 
         ReadOnlyTexture2D<T, TPixel> texture = device.AllocateReadOnlyTexture2D<T, TPixel>(upload.Width, upload.Height);
@@ -1081,6 +1232,7 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
         Guard.IsNotNull(stream, nameof(stream));
 
         using UploadTexture2D<T> upload = WICHelper.Instance.LoadTexture<T>(device, stream);
@@ -1104,6 +1256,7 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
         Guard.IsNotNull(filename, nameof(filename));
 
         return device.LoadReadWriteTexture2D<T, TPixel>(filename.AsSpan());
@@ -1121,6 +1274,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         using UploadTexture2D<T> upload = WICHelper.Instance.LoadTexture<T>(device, filename);
 
         ReadWriteTexture2D<T, TPixel> texture = device.AllocateReadWriteTexture2D<T, TPixel>(upload.Width, upload.Height);
@@ -1142,6 +1297,8 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         using UploadTexture2D<T> upload = WICHelper.Instance.LoadTexture<T>(device, span);
 
         ReadWriteTexture2D<T, TPixel> texture = device.AllocateReadWriteTexture2D<T, TPixel>(upload.Width, upload.Height);
@@ -1163,6 +1320,7 @@ public static partial class GraphicsDeviceExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
         Guard.IsNotNull(stream, nameof(stream));
 
         using UploadTexture2D<T> upload = WICHelper.Instance.LoadTexture<T>(device, stream);
@@ -1184,6 +1342,7 @@ public static partial class GraphicsDeviceExtensions
     public static UploadTexture2D<T> LoadUploadTexture2D<T>(this GraphicsDevice device, string filename)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
         Guard.IsNotNull(filename, nameof(filename));
 
         return device.LoadUploadTexture2D<T>(filename.AsSpan());
@@ -1199,6 +1358,8 @@ public static partial class GraphicsDeviceExtensions
     public static UploadTexture2D<T> LoadUploadTexture2D<T>(this GraphicsDevice device, ReadOnlySpan<char> filename)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return WICHelper.Instance.LoadTexture<T>(device, filename);
     }
 
@@ -1212,6 +1373,8 @@ public static partial class GraphicsDeviceExtensions
     public static UploadTexture2D<T> LoadUploadTexture2D<T>(this GraphicsDevice device, ReadOnlySpan<byte> span)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
+
         return WICHelper.Instance.LoadTexture<T>(device, span);
     }
 
@@ -1225,6 +1388,7 @@ public static partial class GraphicsDeviceExtensions
     public static UploadTexture2D<T> LoadUploadTexture2D<T>(this GraphicsDevice device, Stream stream)
         where T : unmanaged
     {
+        Guard.IsNotNull(device, nameof(device));
         Guard.IsNotNull(stream, nameof(stream));
 
         return WICHelper.Instance.LoadTexture<T>(device, stream);

--- a/src/ComputeSharp/Graphics/Extensions/ReadBackBufferExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadBackBufferExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using ComputeSharp.Resources;
+using Microsoft.Toolkit.Diagnostics;
 
 namespace ComputeSharp;
 
@@ -16,6 +17,9 @@ public static class ReadBackBufferExtensions
     public static void CopyFrom<T>(this ReadBackBuffer<T> destination, StructuredBuffer<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, source.Length);
     }
 
@@ -31,6 +35,9 @@ public static class ReadBackBufferExtensions
     public static void CopyFrom<T>(this ReadBackBuffer<T> destination, StructuredBuffer<T> source, int sourceOffset, int destinationOffset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffset, destinationOffset, count);
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/ReadBackTexture2DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadBackTexture2DExtensions.cs
@@ -21,6 +21,9 @@ public static class ReadBackTexture2DExtensions
     public static void CopyFrom<T>(this ReadBackTexture2D<T> destination, Texture2D<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, 0, 0, source.Width, source.Height);
     }
 
@@ -37,6 +40,9 @@ public static class ReadBackTexture2DExtensions
     public static void CopyFrom<T>(this ReadBackTexture2D<T> destination, Texture2D<T> source, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, 0, 0, width, height);
     }
 
@@ -55,6 +61,9 @@ public static class ReadBackTexture2DExtensions
     public static void CopyFrom<T>(this ReadBackTexture2D<T> destination, Texture2D<T> source, int sourceOffsetX, int sourceOffsetY, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -67,6 +76,7 @@ public static class ReadBackTexture2DExtensions
     public static void Save<T>(this ReadBackTexture2D<T> texture, string filename)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
         Guard.IsNotNull(filename, nameof(filename));
 
         WICHelper.Instance.SaveTexture(texture.View, filename.AsSpan());
@@ -81,6 +91,8 @@ public static class ReadBackTexture2DExtensions
     public static void Save<T>(this ReadBackTexture2D<T> texture, ReadOnlySpan<char> filename)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         WICHelper.Instance.SaveTexture(texture.View, filename);
     }
 
@@ -94,6 +106,7 @@ public static class ReadBackTexture2DExtensions
     public static void Save<T>(this ReadBackTexture2D<T> texture, Stream stream, ImageFormat format)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
         Guard.IsNotNull(stream, nameof(stream));
 
         WICHelper.Instance.SaveTexture(texture.View, stream, format);
@@ -109,6 +122,7 @@ public static class ReadBackTexture2DExtensions
     public static void Save<T>(this ReadBackTexture2D<T> texture, IBufferWriter<byte> writer, ImageFormat format)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
         Guard.IsNotNull(writer, nameof(writer));
 
         WICHelper.Instance.SaveTexture(texture.View, writer, format);

--- a/src/ComputeSharp/Graphics/Extensions/ReadBackTexture3DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadBackTexture3DExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using ComputeSharp.Resources;
+using Microsoft.Toolkit.Diagnostics;
 
 namespace ComputeSharp;
 
@@ -16,6 +17,9 @@ public static class ReadBackTexture3DExtensions
     public static void CopyFrom<T>(this ReadBackTexture3D<T> destination, Texture3D<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, 0, 0, 0, 0, source.Width, source.Height, source.Depth);
     }
 
@@ -34,6 +38,9 @@ public static class ReadBackTexture3DExtensions
     public static void CopyFrom<T>(this ReadBackTexture3D<T> destination, Texture3D<T> source, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, sourceOffsetZ, 0, 0, 0, width, height, depth);
     }
 
@@ -55,6 +62,9 @@ public static class ReadBackTexture3DExtensions
     public static void CopyFrom<T>(this ReadBackTexture3D<T> destination, Texture3D<T> source, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, sourceOffsetZ, destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture2DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture2DExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Toolkit.Diagnostics;
 
 namespace ComputeSharp;
 
@@ -28,6 +29,8 @@ public static class ReadWriteTexture2DExtensions
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
     public static IReadOnlyTexture2D<float> AsReadOnly(this ReadWriteTexture2D<float> texture)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 
@@ -52,6 +55,8 @@ public static class ReadWriteTexture2DExtensions
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
     public static IReadOnlyTexture2D<Float2> AsReadOnly(this ReadWriteTexture2D<Float2> texture)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 
@@ -76,6 +81,8 @@ public static class ReadWriteTexture2DExtensions
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
     public static IReadOnlyTexture2D<Float3> AsReadOnly(this ReadWriteTexture2D<Float3> texture)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 
@@ -100,6 +107,8 @@ public static class ReadWriteTexture2DExtensions
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
     public static IReadOnlyTexture2D<Float4> AsReadOnly(this ReadWriteTexture2D<Float4> texture)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 
@@ -128,6 +137,8 @@ public static class ReadWriteTexture2DExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture3DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture3DExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Toolkit.Diagnostics;
 
 namespace ComputeSharp;
 
@@ -28,6 +29,8 @@ public static class ReadWriteTexture3DExtensions
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
     public static IReadOnlyTexture3D<float> AsReadOnly(this ReadWriteTexture3D<float> texture)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 
@@ -52,6 +55,8 @@ public static class ReadWriteTexture3DExtensions
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
     public static IReadOnlyTexture3D<Float2> AsReadOnly(this ReadWriteTexture3D<Float2> texture)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 
@@ -76,6 +81,8 @@ public static class ReadWriteTexture3DExtensions
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
     public static IReadOnlyTexture3D<Float3> AsReadOnly(this ReadWriteTexture3D<Float3> texture)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 
@@ -100,6 +107,8 @@ public static class ReadWriteTexture3DExtensions
     /// <exception cref="InvalidOperationException">Thrown if the current instance is not in a readonly state.</exception>
     public static IReadOnlyTexture3D<Float4> AsReadOnly(this ReadWriteTexture3D<Float4> texture)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 
@@ -128,6 +137,8 @@ public static class ReadWriteTexture3DExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         return texture.AsReadOnly();
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/StructuredBufferExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/StructuredBufferExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using ComputeSharp.Resources;
+using Microsoft.Toolkit.Diagnostics;
 
 namespace ComputeSharp;
 
@@ -16,6 +17,9 @@ public static class StructuredBufferExtensions
     public static void CopyTo<T>(this StructuredBuffer<T> source, ReadBackBuffer<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, 0, 0, source.Length);
     }
 
@@ -31,6 +35,9 @@ public static class StructuredBufferExtensions
     public static void CopyTo<T>(this StructuredBuffer<T> source, ReadBackBuffer<T> destination, int sourceOffset, int destinationOffset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffset, destinationOffset, count);
     }
 
@@ -43,6 +50,9 @@ public static class StructuredBufferExtensions
     public static void CopyFrom<T>(this StructuredBuffer<T> destination, UploadBuffer<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, source.Length);
     }
 
@@ -58,6 +68,9 @@ public static class StructuredBufferExtensions
     public static void CopyFrom<T>(this StructuredBuffer<T> destination, UploadBuffer<T> source, int sourceOffset, int destinationOffset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffset, destinationOffset, count);
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/Texture2DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Texture2DExtensions.cs
@@ -22,6 +22,8 @@ public static class Texture2DExtensions
     public static T[,] ToArray<T>(this Texture2D<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         T[,] data = new T[source.Height, source.Width];
 
         source.CopyTo(data);
@@ -42,6 +44,7 @@ public static class Texture2DExtensions
     public static unsafe T[,] ToArray<T>(this Texture2D<T> source, int x, int y, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
         Guard.IsGreaterThanOrEqualTo(width, 0, nameof(width));
         Guard.IsGreaterThanOrEqualTo(height, 0, nameof(height));
 
@@ -64,6 +67,8 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, T[,] destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
         Guard.IsEqualTo(destination.GetLength(0), source.Height, nameof(destination));
         Guard.IsEqualTo(destination.GetLength(1), source.Width, nameof(destination));
 
@@ -79,6 +84,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, T[] destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(), 0, 0, source.Width, source.Height);
     }
 
@@ -94,6 +102,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, T[] destination, Range x, Range y)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(), x, y);
     }
 #endif
@@ -111,6 +122,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, T[] destination, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(), sourceOffsetX, sourceOffsetY, width, height);
     }
 
@@ -124,6 +138,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, T[] destination, int destinationOffset)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(destinationOffset), 0, 0, source.Width, source.Height);
     }
 
@@ -140,6 +157,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, T[] destination, int destinationOffset, Range x, Range y)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(destinationOffset), x, y);
     }
 #endif
@@ -158,6 +178,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, T[] destination, int destinationOffset, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(destinationOffset), sourceOffsetX, sourceOffsetY, width, height);
     }
 
@@ -171,6 +194,8 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, Span<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, source.Width, source.Height);
     }
 
@@ -186,6 +211,8 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, Span<T> destination, Range x, Range y)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         var (offsetX, width) = x.GetOffsetAndLength(source.Width);
         var (offsetY, height) = y.GetOffsetAndLength(source.Height);
 
@@ -206,6 +233,8 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, Span<T> destination, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(ref MemoryMarshal.GetReference(destination), destination.Length, sourceOffsetX, sourceOffsetY, width, height);
     }
 
@@ -218,6 +247,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, Texture2D<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, 0, 0, 0, 0, source.Width, source.Height);
     }
 
@@ -234,6 +266,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, Texture2D<T> destination, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, 0, 0, width, height);
     }
 
@@ -252,6 +287,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, Texture2D<T> destination, int sourceOffsetX, int sourceOffsetY, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -264,6 +302,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, ReadBackTexture2D<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, 0, 0, 0, 0, source.Width, source.Height);
     }
 
@@ -280,6 +321,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, ReadBackTexture2D<T> destination, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, 0, 0, width, height);
     }
 
@@ -298,6 +342,9 @@ public static class Texture2DExtensions
     public static void CopyTo<T>(this Texture2D<T> source, ReadBackTexture2D<T> destination, int sourceOffsetX, int sourceOffsetY, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -310,6 +357,8 @@ public static class Texture2DExtensions
     public static unsafe void CopyFrom<T>(this Texture2D<T> destination, T[,] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
         Guard.IsEqualTo(source.GetLength(0), destination.Height, nameof(source));
         Guard.IsEqualTo(source.GetLength(1), destination.Width, nameof(source));
 
@@ -325,6 +374,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, T[] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(), 0, 0, destination.Width, destination.Height);
     }
 
@@ -340,6 +392,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, T[] source, Range x, Range y)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(), x, y);
     }
 #endif
@@ -357,6 +412,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, T[] source, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(), destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -373,6 +431,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, T[] source, int sourceOffset, Range x, Range y)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(sourceOffset), x, y);
     }
 #endif
@@ -391,6 +452,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, T[] source, int sourceOffset, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(sourceOffset), destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -404,6 +468,8 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, ReadOnlySpan<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, 0, 0, destination.Width, destination.Height);
     }
 
@@ -419,6 +485,8 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, ReadOnlySpan<T> source, Range x, Range y)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+
         var (offsetX, width) = x.GetOffsetAndLength(destination.Width);
         var (offsetY, height) = y.GetOffsetAndLength(destination.Height);
 
@@ -439,6 +507,8 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, ReadOnlySpan<T> source, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(ref MemoryMarshal.GetReference(source), source.Length, destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -451,6 +521,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, Texture2D<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source, 0, 0, 0, 0, source.Width, source.Height);
     }
 
@@ -467,6 +540,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, Texture2D<T> source, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, 0, 0, width, height);
     }
 
@@ -485,6 +561,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, Texture2D<T> source, int sourceOffsetX, int sourceOffsetY, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -497,6 +576,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, UploadTexture2D<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, 0, 0, source.Width, source.Height);
     }
 
@@ -513,6 +595,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, UploadTexture2D<T> source, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source, sourceOffsetX, sourceOffsetY, 0, 0, width, height);
     }
 
@@ -531,6 +616,9 @@ public static class Texture2DExtensions
     public static void CopyFrom<T>(this Texture2D<T> destination, UploadTexture2D<T> source, int sourceOffsetX, int sourceOffsetY, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source, sourceOffsetX, sourceOffsetY, destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -543,6 +631,7 @@ public static class Texture2DExtensions
     public static void Save<T>(this Texture2D<T> texture, string filename)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
         Guard.IsNotNull(filename, nameof(filename));
 
         texture.Save(filename.AsSpan());
@@ -557,6 +646,8 @@ public static class Texture2DExtensions
     public static void Save<T>(this Texture2D<T> texture, ReadOnlySpan<char> filename)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         using ReadBackTexture2D<T> readback = texture.GraphicsDevice.AllocateReadBackTexture2D<T>(texture.Width, texture.Height);
 
         texture.CopyTo(readback);
@@ -574,6 +665,7 @@ public static class Texture2DExtensions
     public static void Save<T>(this Texture2D<T> texture, Stream stream, ImageFormat format)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
         Guard.IsNotNull(stream, nameof(stream));
 
         using ReadBackTexture2D<T> readback = texture.GraphicsDevice.AllocateReadBackTexture2D<T>(texture.Width, texture.Height);
@@ -593,6 +685,7 @@ public static class Texture2DExtensions
     public static void Save<T>(this Texture2D<T> texture, IBufferWriter<byte> writer, ImageFormat format)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
         Guard.IsNotNull(writer, nameof(writer));
 
         using ReadBackTexture2D<T> readback = texture.GraphicsDevice.AllocateReadBackTexture2D<T>(texture.Width, texture.Height);

--- a/src/ComputeSharp/Graphics/Extensions/Texture3DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Texture3DExtensions.cs
@@ -24,6 +24,8 @@ public static class Texture3DExtensions
     public static T[,,] ToArray<T>(this Texture3D<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         T[,,] data = new T[source.Depth, source.Height, source.Width];
 
         source.CopyTo(data);
@@ -46,6 +48,7 @@ public static class Texture3DExtensions
     public static unsafe T[,,] ToArray<T>(this Texture3D<T> source, int x, int y, int z, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
         Guard.IsGreaterThanOrEqualTo(width, 0, nameof(width));
         Guard.IsGreaterThanOrEqualTo(height, 0, nameof(height));
         Guard.IsGreaterThanOrEqualTo(depth, 0, nameof(depth));
@@ -73,6 +76,8 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, T[,,] destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
         Guard.IsEqualTo(destination.GetLength(0), source.Depth, nameof(destination));
         Guard.IsEqualTo(destination.GetLength(1), source.Height, nameof(destination));
         Guard.IsEqualTo(destination.GetLength(2), source.Width, nameof(destination));
@@ -90,6 +95,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, T[] destination, int destinationOffset)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(destinationOffset), 0, 0, 0, source.Width, source.Height, source.Depth);
     }
 
@@ -107,6 +115,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, T[] destination, int destinationOffset, Range x, Range y, Range z)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(destinationOffset), x, y, z);
     }
 #endif
@@ -127,6 +138,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, T[] destination, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int destinationOffset, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination.AsSpan(destinationOffset), sourceOffsetX, sourceOffsetY, sourceOffsetZ, width, height, depth);
     }
 
@@ -139,6 +153,8 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, Span<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, 0, source.Width, source.Height, source.Depth);
     }
 
@@ -155,6 +171,8 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, Span<T> destination, Range x, Range y, Range z)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         var (offsetX, width) = x.GetOffsetAndLength(source.Width);
         var (offsetY, height) = y.GetOffsetAndLength(source.Height);
         var (offsetZ, depth) = z.GetOffsetAndLength(source.Depth);
@@ -178,6 +196,8 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, Span<T> destination, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(ref MemoryMarshal.GetReference(destination), destination.Length, sourceOffsetX, sourceOffsetY, sourceOffsetZ, width, height, depth);
     }
 
@@ -190,6 +210,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, Texture3D<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, 0, 0, 0, 0, 0, 0, source.Width, source.Height, source.Depth);
     }
 
@@ -208,6 +231,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, Texture3D<T> destination, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, sourceOffsetZ, 0, 0, 0, width, height, depth);
     }
 
@@ -229,6 +255,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, Texture3D<T> destination, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, sourceOffsetZ, destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 
@@ -241,6 +270,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, ReadBackTexture3D<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, 0, 0, 0, 0, 0, 0, source.Width, source.Height, source.Depth);
     }
 
@@ -259,6 +291,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, ReadBackTexture3D<T> destination, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, sourceOffsetZ, 0, 0, 0, width, height, depth);
     }
 
@@ -280,6 +315,9 @@ public static class Texture3DExtensions
     public static void CopyTo<T>(this Texture3D<T> source, ReadBackTexture3D<T> destination, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, sourceOffsetZ, destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 
@@ -296,6 +334,8 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, T[,,] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
         Guard.IsEqualTo(source.GetLength(0), destination.Depth, nameof(source));
         Guard.IsEqualTo(source.GetLength(1), destination.Height, nameof(source));
         Guard.IsEqualTo(source.GetLength(2), destination.Width, nameof(source));
@@ -312,6 +352,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, T[] source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(), 0, 0, 0, destination.Width, destination.Height, destination.Depth);
     }
 
@@ -328,6 +371,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, T[] source, Range x, Range y, Range z)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(), x, y, z);
     }
 #endif
@@ -347,6 +393,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, T[] source, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(), destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 
@@ -364,6 +413,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, T[] source, int sourceOffset, Range x, Range y, Range z)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(sourceOffset), x, y, z);
     }
 #endif
@@ -384,6 +436,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, T[] source, int sourceOffset, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source.AsSpan(sourceOffset), destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 
@@ -397,6 +452,8 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, ReadOnlySpan<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, 0, 0, 0, destination.Width, destination.Height, destination.Depth);
     }
 
@@ -413,6 +470,8 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, ReadOnlySpan<T> source, Range x, Range y, Range z)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+
         var (offsetX, width) = x.GetOffsetAndLength(destination.Width);
         var (offsetY, height) = y.GetOffsetAndLength(destination.Height);
         var (offsetZ, depth) = z.GetOffsetAndLength(destination.Depth);
@@ -436,6 +495,8 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, ReadOnlySpan<T> source, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(ref MemoryMarshal.GetReference(source), source.Length, destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 
@@ -448,6 +509,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, Texture3D<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, 0, 0, 0, 0, 0, 0, source.Width, source.Height, source.Depth);
     }
 
@@ -466,6 +530,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, Texture3D<T> source, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, sourceOffsetZ, 0, 0, 0, width, height, depth);
     }
 
@@ -487,6 +554,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, Texture3D<T> source, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         source.CopyTo(destination, sourceOffsetX, sourceOffsetY, sourceOffsetZ, destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 
@@ -499,6 +569,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, UploadTexture3D<T> source)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source, 0, 0, 0, 0, 0, 0, source.Width, source.Height, source.Depth);
     }
 
@@ -517,6 +590,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, UploadTexture3D<T> source, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source, sourceOffsetX, sourceOffsetY, sourceOffsetZ, 0, 0, 0, width, height, depth);
     }
 
@@ -538,6 +614,9 @@ public static class Texture3DExtensions
     public static void CopyFrom<T>(this Texture3D<T> destination, UploadTexture3D<T> source, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(destination, nameof(destination));
+        Guard.IsNotNull(source, nameof(source));
+
         destination.CopyFrom(source, sourceOffsetX, sourceOffsetY, sourceOffsetZ, destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/UploadBufferExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/UploadBufferExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using ComputeSharp.Resources;
+using Microsoft.Toolkit.Diagnostics;
 
 namespace ComputeSharp;
 
@@ -16,6 +17,9 @@ public static class UploadBufferExtensions
     public static void CopyTo<T>(this UploadBuffer<T> source, StructuredBuffer<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, 0, 0, source.Length);
     }
 
@@ -31,6 +35,9 @@ public static class UploadBufferExtensions
     public static void CopyTo<T>(this UploadBuffer<T> source, StructuredBuffer<T> destination, int sourceOffset, int destinationOffset, int count)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, sourceOffset, destinationOffset, count);
     }
 }

--- a/src/ComputeSharp/Graphics/Extensions/UploadTexture2DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/UploadTexture2DExtensions.cs
@@ -20,6 +20,9 @@ public static class UploadTexture2DExtensions
     public static void CopyTo<T>(this UploadTexture2D<T> source, Texture2D<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, 0, 0, 0, 0, source.Width, source.Height);
     }
 
@@ -36,6 +39,9 @@ public static class UploadTexture2DExtensions
     public static void CopyTo<T>(this UploadTexture2D<T> source, Texture2D<T> destination, int sourceOffsetX, int sourceOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, sourceOffsetX, sourceOffsetY, 0, 0, width, height);
     }
 
@@ -54,6 +60,9 @@ public static class UploadTexture2DExtensions
     public static void CopyTo<T>(this UploadTexture2D<T> source, Texture2D<T> destination, int sourceOffsetX, int sourceOffsetY, int destinationOffsetX, int destinationOffsetY, int width, int height)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, sourceOffsetX, sourceOffsetY, destinationOffsetX, destinationOffsetY, width, height);
     }
 
@@ -66,6 +75,7 @@ public static class UploadTexture2DExtensions
     public static void Load<T>(this UploadTexture2D<T> texture, string filename)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
         Guard.IsNotNull(filename, nameof(filename));
 
         texture. Load(filename.AsSpan());
@@ -80,6 +90,8 @@ public static class UploadTexture2DExtensions
     public static void Load<T>(this UploadTexture2D<T> texture, ReadOnlySpan<char> filename)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         WICHelper.Instance.LoadTexture(texture.View, filename);
     }
 
@@ -93,6 +105,8 @@ public static class UploadTexture2DExtensions
     public static void Load<T>(this UploadTexture2D<T> texture, ReadOnlySpan<byte> span)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         WICHelper.Instance.LoadTexture(texture.View, span);
     }
 
@@ -105,6 +119,7 @@ public static class UploadTexture2DExtensions
     public static void Load<T>(this UploadTexture2D<T> texture, Stream stream)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
         Guard.IsNotNull(stream, nameof(stream));
 
         WICHelper.Instance.LoadTexture(texture.View, stream);

--- a/src/ComputeSharp/Graphics/Extensions/UploadTexture3DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/UploadTexture3DExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using ComputeSharp.Resources;
+using Microsoft.Toolkit.Diagnostics;
 
 namespace ComputeSharp;
 
@@ -16,6 +17,9 @@ public static class UploadTexture3DExtensions
     public static void CopyTo<T>(this UploadTexture3D<T> source, Texture3D<T> destination)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, 0, 0, 0, 0, 0, 0, source.Width, source.Height, source.Depth);
     }
 
@@ -34,6 +38,9 @@ public static class UploadTexture3DExtensions
     public static void CopyTo<T>(this UploadTexture3D<T> source, Texture3D<T> destination, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, sourceOffsetX, sourceOffsetY, sourceOffsetZ, 0, 0, 0, width, height, depth);
     }
 
@@ -55,6 +62,9 @@ public static class UploadTexture3DExtensions
     public static void CopyTo<T>(this UploadTexture3D<T> source, Texture3D<T> destination, int sourceOffsetX, int sourceOffsetY, int sourceOffsetZ, int destinationOffsetX, int destinationOffsetY, int destinationOffsetZ, int width, int height, int depth)
         where T : unmanaged
     {
+        Guard.IsNotNull(source, nameof(source));
+        Guard.IsNotNull(destination, nameof(destination));
+
         destination.CopyFrom(source, sourceOffsetX, sourceOffsetY, sourceOffsetZ, destinationOffsetX, destinationOffsetY, destinationOffsetZ, width, height, depth);
     }
 }

--- a/src/ComputeSharp/Graphics/GraphicsDevice.GetDevice.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.GetDevice.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using ComputeSharp.Graphics.Helpers;
+using Microsoft.Toolkit.Diagnostics;
 
 namespace ComputeSharp;
 
@@ -46,6 +47,8 @@ partial class GraphicsDevice
     /// </remarks>
     public static IEnumerable<GraphicsDevice> QueryDevices(Predicate<GraphicsDeviceInfo> predicate)
     {
+        Guard.IsNotNull(predicate, nameof(predicate));
+
         return new DeviceHelper.DeviceQuery(predicate);
     }
 }

--- a/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/__Internals/GraphicsResourceHelper.cs
@@ -62,6 +62,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(Buffer<T> buffer, GraphicsDevice device)
         where T : unmanaged
     {
+        Guard.IsNotNull(buffer, nameof(buffer));
+
         buffer.ThrowIfDisposed();
         buffer.ThrowIfDeviceMismatch(device);
 
@@ -81,6 +83,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(ReadOnlyTexture2D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         texture.ThrowIfDisposed();
         texture.ThrowIfDeviceMismatch(device);
 
@@ -100,6 +104,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(ReadWriteTexture2D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         texture.ThrowIfDisposed();
         texture.ThrowIfDeviceMismatch(device);
 
@@ -119,6 +125,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(IReadOnlyTexture2D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         if (texture is IGraphicsResource resource)
         {
             D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = resource.ValidateAndGetGpuDescriptorHandle(device);
@@ -140,6 +148,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadOnlyNormalizedTexture2D<TPixel> texture, GraphicsDevice device)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         if (texture is IGraphicsResource resource)
         {
             D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = resource.ValidateAndGetGpuDescriptorHandle(device);
@@ -161,6 +171,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadWriteNormalizedTexture2D<TPixel> texture, GraphicsDevice device)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         if (texture is IGraphicsResource resource)
         {
             D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = resource.ValidateAndGetGpuDescriptorHandle(device);
@@ -182,6 +194,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(ReadOnlyTexture3D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         texture.ThrowIfDisposed();
         texture.ThrowIfDeviceMismatch(device);
 
@@ -201,6 +215,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(ReadWriteTexture3D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         texture.ThrowIfDisposed();
         texture.ThrowIfDeviceMismatch(device);
 
@@ -220,6 +236,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<T>(IReadOnlyTexture3D<T> texture, GraphicsDevice device)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         if (texture is IGraphicsResource resource)
         {
             D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = resource.ValidateAndGetGpuDescriptorHandle(device);
@@ -241,6 +259,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadOnlyNormalizedTexture3D<TPixel> texture, GraphicsDevice device)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         if (texture is IGraphicsResource resource)
         {
             D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = resource.ValidateAndGetGpuDescriptorHandle(device);
@@ -262,6 +282,8 @@ public static class GraphicsResourceHelper
     public static unsafe ulong ValidateAndGetGpuDescriptorHandle<TPixel>(IReadWriteNormalizedTexture3D<TPixel> texture, GraphicsDevice device)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         if (texture is IGraphicsResource resource)
         {
             D3D12_GPU_DESCRIPTOR_HANDLE d3D12GpuDescriptorHandle = resource.ValidateAndGetGpuDescriptorHandle(device);

--- a/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 using ComputeSharp.__Internals;
 using ComputeSharp.Graphics.Helpers;
+using Microsoft.Toolkit.Diagnostics;
 using TerraFX.Interop.DirectX;
 
 #pragma warning disable CS0618
@@ -21,6 +22,8 @@ public static class ComputeContextExtensions
     public static unsafe void Barrier<T>(this in ComputeContext context, ReadWriteBuffer<T> buffer)
         where T : unmanaged
     {
+        Guard.IsNotNull(buffer, nameof(buffer));
+
         context.Barrier(buffer.ValidateAndGetID3D12Resource(context.GraphicsDevice));
     }
 
@@ -33,6 +36,8 @@ public static class ComputeContextExtensions
     public static unsafe void Barrier<T>(this in ComputeContext context, ReadWriteTexture2D<T> texture)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         context.Barrier(texture.ValidateAndGetID3D12Resource(context.GraphicsDevice));
     }
 
@@ -45,6 +50,8 @@ public static class ComputeContextExtensions
     public static unsafe void Barrier<T>(this in ComputeContext context, ReadWriteTexture3D<T> texture)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         context.Barrier(texture.ValidateAndGetID3D12Resource(context.GraphicsDevice));
     }
 
@@ -59,6 +66,8 @@ public static class ComputeContextExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         context.Barrier(texture.ValidateAndGetID3D12Resource(context.GraphicsDevice));
     }
 
@@ -73,6 +82,8 @@ public static class ComputeContextExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         context.Barrier(texture.ValidateAndGetID3D12Resource(context.GraphicsDevice));
     }
 
@@ -85,6 +96,8 @@ public static class ComputeContextExtensions
     public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         context.Barrier(((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetID3D12Resource(context.GraphicsDevice));
     }
 
@@ -97,6 +110,8 @@ public static class ComputeContextExtensions
     public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         context.Barrier(((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetID3D12Resource(context.GraphicsDevice));
     }
 
@@ -109,6 +124,8 @@ public static class ComputeContextExtensions
     public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteBuffer<T> buffer)
         where T : unmanaged
     {
+        Guard.IsNotNull(buffer, nameof(buffer));
+
         var handles = buffer.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice);
 
         context.Clear(buffer.D3D12Resource, handles.Gpu, handles.Cpu, isNormalized: false);
@@ -123,6 +140,8 @@ public static class ComputeContextExtensions
     public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture2D<T> texture)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out bool isNormalized);
 
         context.Clear(texture.D3D12Resource, handles.Gpu, handles.Cpu, isNormalized);
@@ -137,6 +156,8 @@ public static class ComputeContextExtensions
     public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture3D<T> texture)
         where T : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out bool isNormalized);
 
         context.Clear(texture.D3D12Resource, handles.Gpu, handles.Cpu, isNormalized);
@@ -153,6 +174,8 @@ public static class ComputeContextExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
 
         context.Clear(texture.D3D12Resource, handles.Gpu, handles.Cpu, true);
@@ -169,6 +192,8 @@ public static class ComputeContextExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
 
         context.Clear(texture.D3D12Resource, handles.Gpu, handles.Cpu, true);
@@ -183,6 +208,8 @@ public static class ComputeContextExtensions
     public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
 
         context.Clear(((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetID3D12Resource(context.GraphicsDevice), handles.Gpu, handles.Cpu, true);
@@ -197,6 +224,8 @@ public static class ComputeContextExtensions
     public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
 
         context.Clear(((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetID3D12Resource(context.GraphicsDevice), handles.Gpu, handles.Cpu, true);
@@ -214,6 +243,8 @@ public static class ComputeContextExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
 
         context.Fill(texture.D3D12Resource, handles.Gpu, handles.Cpu, DXGIFormatHelper.ExtendToNormalizedValue(value.ToPixel()));
@@ -231,6 +262,8 @@ public static class ComputeContextExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = texture.ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
 
         context.Fill(texture.D3D12Resource, handles.Gpu, handles.Cpu, DXGIFormatHelper.ExtendToNormalizedValue(value.ToPixel()));
@@ -246,6 +279,8 @@ public static class ComputeContextExtensions
     public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture, TPixel value)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
 
         context.Fill(
@@ -265,6 +300,8 @@ public static class ComputeContextExtensions
     public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture, TPixel value)
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var handles = ((GraphicsResourceHelper.IGraphicsResource)texture).ValidateAndGetGpuAndCpuDescriptorHandlesForClear(context.GraphicsDevice, out _);
 
         context.Fill(
@@ -345,6 +382,8 @@ public static class ComputeContextExtensions
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         context.Run(texture, ref Unsafe.AsRef(default(T)));
     }
 
@@ -360,6 +399,8 @@ public static class ComputeContextExtensions
         where T : struct, IPixelShader<TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         context.Run(texture, ref Unsafe.AsRef(in shader));
     }
 
@@ -371,6 +412,8 @@ public static class ComputeContextExtensions
     /// <param name="resourceState">The state to transition the input resource to.</param>
     public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<float> texture, ResourceState resourceState)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -384,6 +427,8 @@ public static class ComputeContextExtensions
     /// <param name="resourceState">The state to transition the input resource to.</param>
     public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float2> texture, ResourceState resourceState)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -397,6 +442,8 @@ public static class ComputeContextExtensions
     /// <param name="resourceState">The state to transition the input resource to.</param>
     public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float3> texture, ResourceState resourceState)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -410,6 +457,8 @@ public static class ComputeContextExtensions
     /// <param name="resourceState">The state to transition the input resource to.</param>
     public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float4> texture, ResourceState resourceState)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -427,6 +476,8 @@ public static class ComputeContextExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -440,6 +491,8 @@ public static class ComputeContextExtensions
     /// <param name="resourceState">The state to transition the input resource to.</param>
     public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<float> texture, ResourceState resourceState)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -453,6 +506,8 @@ public static class ComputeContextExtensions
     /// <param name="resourceState">The state to transition the input resource to.</param>
     public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float2> texture, ResourceState resourceState)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -466,6 +521,8 @@ public static class ComputeContextExtensions
     /// <param name="resourceState">The state to transition the input resource to.</param>
     public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float3> texture, ResourceState resourceState)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -479,6 +536,8 @@ public static class ComputeContextExtensions
     /// <param name="resourceState">The state to transition the input resource to.</param>
     public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float4> texture, ResourceState resourceState)
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);
@@ -496,6 +555,8 @@ public static class ComputeContextExtensions
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
+        Guard.IsNotNull(texture, nameof(texture));
+
         var states = texture.ValidateAndGetID3D12ResourceAndTransitionStates(context.GraphicsDevice, resourceState, out ID3D12Resource* d3D12Resource);
 
         context.Transition(d3D12Resource, states.Before, states.After);


### PR DESCRIPTION
This PR adds valdation for all public non-nullable reference type parameters.
With this change, all APIs will immediately throw an `ArgumentNullException` when called.
This follows the recommended guidelines for public API design and nullable reference types.