### PR TITLE
Add diagnostics app context switch

### DIFF
--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Factory.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Factory.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-#if DEBUG
 using ComputeSharp.Graphics.Extensions;
-#endif
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 
@@ -15,12 +13,10 @@ internal static partial class DeviceHelper
     /// </summary>
     internal static readonly Dictionary<Luid, GraphicsDevice> DevicesCache = new();
 
-#if DEBUG
     /// <summary>
     /// The local map of <see cref="ID3D12InfoQueue"/> instances for the existing devices.
     /// </summary>
     private static readonly Dictionary<Luid, ComPtr<ID3D12InfoQueue>> D3D12InfoQueueMap = new();
-#endif
 
     /// <summary>
     /// Retrieves a <see cref="GraphicsDevice"/> instance for an <see cref="ID3D12Device"/> object.
@@ -41,9 +37,10 @@ internal static partial class DeviceHelper
 
                 DevicesCache.Add(luid, device);
 
-#if DEBUG
-                D3D12InfoQueueMap.Add(luid, d3D12Device->CreateInfoQueue());
-#endif
+                if (Configuration.IsDebugOutputEnabled)
+                {
+                    D3D12InfoQueueMap.Add(luid, d3D12Device->CreateInfoQueue());
+                }
             }
 
             return device;
@@ -60,11 +57,12 @@ internal static partial class DeviceHelper
         {
             DevicesCache.Remove(device.Luid);
 
-#if DEBUG
-            D3D12InfoQueueMap.Remove(device.Luid, out ComPtr<ID3D12InfoQueue> queue);
+            if (Configuration.IsDebugOutputEnabled)
+            {
+                D3D12InfoQueueMap.Remove(device.Luid, out ComPtr<ID3D12InfoQueue> queue);
 
-            queue.Dispose();
-#endif
+                queue.Dispose();
+            }
         }
     }
 }

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.ID3D12InfoQueue.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.ID3D12InfoQueue.cs
@@ -1,16 +1,13 @@
-﻿#if DEBUG
-
-#if NET6_0_OR_GREATER
-using System;
-#endif
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Toolkit.Diagnostics;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 using static TerraFX.Interop.DirectX.D3D12_MESSAGE_SEVERITY;
-#if !NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
+using Enum = System.Enum;
+#else
 using Enum = ComputeSharp.NetStandard.System.Enum;
 #endif
 
@@ -119,5 +116,3 @@ internal static partial class DeviceHelper
         return hasErrorsOrWarnings;
     }
 }
-
-#endif

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.ID3D12InfoQueue.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.ID3D12InfoQueue.cs
@@ -1,10 +1,14 @@
 ﻿#if DEBUG
 
+#if NET6_0_OR_GREATER
 using System;
+#endif
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.Toolkit.Diagnostics;
 using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 using static TerraFX.Interop.DirectX.D3D12_MESSAGE_SEVERITY;
 #if !NET6_0_OR_GREATER
 using Enum = ComputeSharp.NetStandard.System.Enum;
@@ -26,26 +30,26 @@ internal static partial class DeviceHelper
 
         lock (DevicesCache)
         {
-            int j = 0;
             StringBuilder builder = new(1024);
 
             foreach (var pair in D3D12InfoQueueMap)
             {
-                var device = DevicesCache[pair.Key];
-                var queue = pair.Value;
+                GraphicsDevice device = DevicesCache[pair.Key];
+                ID3D12InfoQueue* queue = pair.Value.Get();
 
-                ulong messages = queue.Get()->GetNumStoredMessagesAllowedByRetrievalFilter();
+                ulong messages = queue->GetNumStoredMessagesAllowedByRetrievalFilter();
 
                 for (ulong i = 0; i < messages; i++)
                 {
                     nuint length;
-                    queue.Get()->GetMessage(i, null, &length);
+
+                    queue->GetMessage(i, null, &length);
 
                     D3D12_MESSAGE* message = (D3D12_MESSAGE*)NativeMemory.Alloc(length);
 
                     try
                     {
-                        queue.Get()->GetMessage(i, message, &length);
+                        queue->GetMessage(i, message, &length);
 
                         builder.Clear();
                         builder.AppendLine($"[D3D12 message #{i} for \"{device}\" (HW: {device.IsHardwareAccelerated}, UMA: {device.IsCacheCoherentUMA})]");
@@ -72,13 +76,43 @@ internal static partial class DeviceHelper
                     }
                     else
                     {
-                        Console.WriteLine(text);
+                        Trace.WriteLine(text);
                     }
                 }
 
-                queue.Get()->ClearStoredMessages();
+                queue->ClearStoredMessages();
 
-                j++;
+                HRESULT result = device.D3D12Device->GetDeviceRemovedReason();
+
+                if (result != S.S_OK)
+                {
+                    string message = (int)result switch
+                    {
+                        DXGI.DXGI_ERROR_DEVICE_HUNG => nameof(DXGI.DXGI_ERROR_DEVICE_HUNG),
+                        DXGI.DXGI_ERROR_DEVICE_REMOVED => nameof(DXGI.DXGI_ERROR_DEVICE_REMOVED),
+                        DXGI.DXGI_ERROR_DEVICE_RESET => nameof(DXGI.DXGI_ERROR_DEVICE_RESET),
+                        DXGI.DXGI_ERROR_DRIVER_INTERNAL_ERROR => nameof(DXGI.DXGI_ERROR_DRIVER_INTERNAL_ERROR),
+                        DXGI.DXGI_ERROR_INVALID_CALL => nameof(DXGI.DXGI_ERROR_INVALID_CALL),
+                        _ => ThrowHelper.ThrowArgumentOutOfRangeException<string>("Invalid GetDeviceRemovedReason HRESULT.")
+                    };
+
+                    builder.Clear();
+                    builder.AppendLine($"[D3D12 device remove \"{device}\" (HW: {device.IsHardwareAccelerated}, UMA: {device.IsCacheCoherentUMA})]");
+                    builder.AppendLine($"[Reason]: {message}");
+
+                    hasErrorsOrWarnings = true;
+
+                    string text = builder.ToString();
+
+                    if (Debugger.IsAttached)
+                    {
+                        Debug.WriteLine(text);
+                    }
+                    else
+                    {
+                        Trace.WriteLine(text);
+                    }
+                }
             }
         }
 

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
@@ -20,11 +20,11 @@ internal static partial class DeviceHelper
     /// <summary>
     /// The creation flags for <see cref="IDXGIFactory"/> instances.
     /// </summary>
-    private const uint IDXGIFactoryCreationFlags =
+    private static readonly uint IDXGIFactoryCreationFlags =
 #if DEBUG
         DXGI.DXGI_CREATE_FACTORY_DEBUG;
 #else
-        0;
+        Configuration.IsDebugOutputEnabled ? (uint)DXGI.DXGI_CREATE_FACTORY_DEBUG : 0;
 #endif
 
     /// <summary>
@@ -35,9 +35,10 @@ internal static partial class DeviceHelper
     {
         using ComPtr<IDXGIFactory4> dxgiFactory4 = default;
 
-#if DEBUG
-        EnableDebugMode();
-#endif
+        if (Configuration.IsDebugOutputEnabled)
+        {
+            EnableDebugMode();
+        }
 
         DirectX.CreateDXGIFactory2(IDXGIFactoryCreationFlags, Windows.__uuidof<IDXGIFactory4>(), dxgiFactory4.GetVoidAddressOf()).Assert();
 
@@ -60,7 +61,6 @@ internal static partial class DeviceHelper
         return;
     }
 
-#if DEBUG
     /// <summary>
     /// Enables the debug layer for DirectX APIs.
     /// </summary>
@@ -79,7 +79,6 @@ internal static partial class DeviceHelper
             d3D12Debug1.Get()->SetEnableSynchronizedCommandQueueValidation(Windows.TRUE);
         }
     }
-#endif
 
     /// <summary>
     /// A custom <see cref="IDXGIFactory6"/> fallback implementation to use on systems with no support for it.

--- a/src/ComputeSharp/Properties/Configuration.cs
+++ b/src/ComputeSharp/Properties/Configuration.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+/// <summary>
+/// A container for all shared <see cref="AppContext"/> configuration switches for ComputeSharp.
+/// </summary>
+internal static class Configuration
+{
+    /// <summary>
+    /// The configuration property name for <see cref="IsDebugOutputEnabled"/>.
+    /// </summary>
+    private const string EnableDebugOutput = "COMPUTESHARP_ENABLE_DEBUG_OUTPUT";
+
+    /// <summary>
+    /// Indicates whether or not the debug output is enabled.
+    /// </summary>
+    public static readonly bool IsDebugOutputEnabled = GetConfigurationValue(EnableDebugOutput);
+
+    /// <summary>
+    /// Gets a configuration value for a specified property.
+    /// </summary>
+    /// <param name="propertyName">The property name to retrieve the value for.</param>
+    /// <returns>The value of the specified configuration setting.</returns>
+    private static bool GetConfigurationValue(string propertyName)
+    {
+        if (AppContext.TryGetSwitch(propertyName, out bool isEnabled))
+        {
+            return isEnabled;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
This PR adds the "COMPUTESHARP_ENABLE_DEBUG_OUTPUT" app context switch to enable debug diagnostics