### PR TITLE
Fix refresh rate detection on devices with no GPU outputs

### DIFF
--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
@@ -479,7 +479,15 @@ internal sealed unsafe partial class SwapChainManager<TOwner> : NativeObject
     /// <inheritdoc/>
     private unsafe partial void OnGetDynamicResolutionManager(out DynamicResolutionManager resolutionManager)
     {
-        int targetFramerate = GraphicsDevice.Default.DXGIAdapter->GetCompositionRefreshRate(DXGI_FORMAT.DXGI_FORMAT_R8G8B8A8_UNORM);
+        using ComPtr<IDXGIFactory4> dxgiFactory4 = default;
+
+        DeviceHelper.CreateDXGIFactory4(dxgiFactory4.GetAddressOf());
+
+        using ComPtr<IDXGIAdapter> dxgiAdapter = default;
+
+        dxgiFactory4.Get()->EnumAdapters(0, dxgiAdapter.GetAddressOf()).Assert();
+
+        int targetFramerate = dxgiAdapter.Get()->GetCompositionRefreshRate(DXGI_FORMAT.DXGI_FORMAT_R8G8B8A8_UNORM);
 
         resolutionManager = new DynamicResolutionManager(targetFramerate);
     }

--- a/src/ComputeSharp/Graphics/GraphicsDevice.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.cs
@@ -28,11 +28,6 @@ public sealed unsafe partial class GraphicsDevice : NativeObject
     private ComPtr<ID3D12Device> d3D12Device;
 
     /// <summary>
-    /// The <see cref="IDXGIAdapter"/> that <see cref="d3D12Device"/> was created from.
-    /// </summary>
-    private ComPtr<IDXGIAdapter> dxgiAdapter;
-
-    /// <summary>
     /// The <see cref="ID3D12CommandQueue"/> instance to use for compute operations.
     /// </summary>
     private ComPtr<ID3D12CommandQueue> d3D12ComputeCommandQueue;
@@ -98,7 +93,6 @@ public sealed unsafe partial class GraphicsDevice : NativeObject
     internal GraphicsDevice(ID3D12Device* d3D12Device, IDXGIAdapter* dxgiAdapter, DXGI_ADAPTER_DESC1* dxgiDescription1)
     {
         this.d3D12Device = new ComPtr<ID3D12Device>(d3D12Device);
-        this.dxgiAdapter = new ComPtr<IDXGIAdapter>(dxgiAdapter);
 
         this.d3D12ComputeCommandQueue = d3D12Device->CreateCommandQueue(D3D12_COMMAND_LIST_TYPE_COMPUTE);
         this.d3D12CopyCommandQueue = d3D12Device->CreateCommandQueue(D3D12_COMMAND_LIST_TYPE_COPY);
@@ -174,11 +168,6 @@ public sealed unsafe partial class GraphicsDevice : NativeObject
     /// Gets the underlying <see cref="ID3D12Device"/> wrapped by the current instance.
     /// </summary>
     internal ID3D12Device* D3D12Device => this.d3D12Device;
-
-    /// <summary>
-    /// Gets the underlying <see cref="IDXGIAdapter"/> wrapped by the current instance.
-    /// </summary>
-    internal IDXGIAdapter* DXGIAdapter => this.dxgiAdapter;
 
 #if NET6_0_OR_GREATER
     /// <summary>
@@ -363,7 +352,6 @@ public sealed unsafe partial class GraphicsDevice : NativeObject
         DeviceHelper.NotifyDisposedDevice(this);
 
         this.d3D12Device.Dispose();
-        this.dxgiAdapter.Dispose();
         this.d3D12ComputeCommandQueue.Dispose();
         this.d3D12CopyCommandQueue.Dispose();
         this.d3D12ComputeFence.Dispose();

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
@@ -28,6 +28,20 @@ internal static partial class DeviceHelper
 #endif
 
     /// <summary>
+    /// Creates a new <see cref="IDXGIFactory4"/> instance to be used to enumerate devices.
+    /// </summary>
+    /// <param name="dxgiFactory4">The resulting <see cref="IDXGIFactory4"/> instance.</param>
+    internal static unsafe void CreateDXGIFactory4(IDXGIFactory4** dxgiFactory4)
+    {
+        if (Configuration.IsDebugOutputEnabled)
+        {
+            EnableDebugMode();
+        }
+
+        DirectX.CreateDXGIFactory2(IDXGIFactoryCreationFlags, Windows.__uuidof<IDXGIFactory4>(), (void**)dxgiFactory4).Assert();
+    }
+
+    /// <summary>
     /// Creates a new <see cref="IDXGIFactory6"/> instance to be used to enumerate devices.
     /// </summary>
     /// <param name="dxgiFactory6">The resulting <see cref="IDXGIFactory6"/> instance.</param>


### PR DESCRIPTION
This PR fixes a crash when trying to get the refresh rate on devices where the GPU in use has no outputs.