### PR TITLE
Try workaround extra diagnostic bug

### DIFF
--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -190,7 +190,7 @@ public sealed partial class IShaderGenerator
             }
             catch (HlslCompilationException e)
             {
-                diagnostic = new DiagnosticInfo(EmbeddedBytecodeFailedWithHlslCompilationException, e.Message);
+                diagnostic = new DiagnosticInfo(EmbeddedBytecodeFailedWithHlslCompilationException, e.Message.Replace("\n", "\n    ");
             }
 
             End:


### PR DESCRIPTION
@Sergio0694 I haven't tested this, and didn't dig into how build output is interpreted by VS/Roslyn. Just a quick idea to workaround the issue. Let me know if you can confirm whether this works or not.

Note that lines will still be trimmed, unfortunately, for build diagnostics. But I expect them to show for IntelliSense (live) diagnostics.

The only expected thing from this PR is for the nested diagnostic to not show separately.
An alternative (probably even better), is to replace new lines with a space. So we convert the multiline diagnostic into a single line and avoid all that.