### PR TITLE
Add CI run id to CI packages, make pipelines faster

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,10 @@ name: .NET
 
 on: [push, pull_request]
 
+env:
+  EXCLUDE_RUN_ID_FROM_PACKAGE: false
+  EXCLUDE_SUFFIX_FROM_VERSION: false
+
 jobs:
 
   # Build the whole ComputeSharp solution, in Debug

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -232,13 +232,13 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Create local NuGet feed
-      run: mkdir nuget_preview
+      run: mkdir artifacts
       shell: cmd
     - name: Download package artifacts
       uses: actions/download-artifact@v2
       with:
         name: nuget_preview
-        path: nuget_preview
+        path: artifacts
     - name: Build ComputeSharp.Sample.NuGet (.NET 6)
       run: dotnet build samples\ComputeSharp.Sample.NuGet\ComputeSharp.Sample.NuGet.csproj -c Release -f net6.0
       shell: cmd

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -48,6 +48,47 @@ jobs:
       run: msbuild -t:restore,build /p:Configuration=Release /p:Platform=x64
       shell: cmd
 
+  # Build the .msbuildproj projects and the UWP/WinUI projects to generate all the NuGet packages.
+  # This workflow also uploads the resulting packages as artifacts.
+  build-packages:
+    runs-on: windows-2022
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v2
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.3
+    - name: Setup .NET 6 SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+    - name: Build ComputeSharp.Core package
+      run: dotnet build src\ComputeSharp.Core.Package\ComputeSharp.Core.Package.msbuildproj -c Release
+      shell: cmd
+    - name: Build ComputeSharp package
+      run: dotnet build src\ComputeSharp.Package\ComputeSharp.Package.msbuildproj -c Release
+      shell: cmd
+    - name: Build ComputeSharp.Dynamic package
+      run: dotnet build src\ComputeSharp.Dynamic.Package\ComputeSharp.Dynamic.Package.msbuildproj -c Release
+      shell: cmd
+    - name: Build ComputeSharp.D2D1 package
+      run: dotnet build src\ComputeSharp.D2D1.Package\ComputeSharp.D2D1.Package.msbuildproj -c Release
+      shell: cmd
+    - name: Build ComputeSharp.Uwp package
+      run: msbuild src\ComputeSharp.Uwp\ComputeSharp.Uwp.csproj -t:restore,build,pack /p:Configuration=Release
+      shell: cmd
+    - name: Restore ComputeSharp.WinUI project
+      run: msbuild src\ComputeSharp.WinUI\ComputeSharp.WinUI.csproj -t:restore /p:Configuration=Release
+      shell: cmd
+    - name: Build ComputeSharp.WinUI package
+      run: msbuild src\ComputeSharp.WinUI\ComputeSharp.WinUI.csproj -t:pack /p:Configuration=Release
+      shell: cmd # Packing needs to be done separately and with no previous build target for it to work correctly
+    - name: Upload package artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: nuget_preview
+        path: artifacts\*.nupkg
+        if-no-files-found: error
+
   # Run all the DX12 unit tests referencing the ComputeSharp project directly
   run-dx12-tests:
     if: success()
@@ -176,52 +217,6 @@ jobs:
       run: dotnet build samples\ComputeSharp.SwapChain\ComputeSharp.SwapChain.csproj -c Release
       shell: cmd
 
-  # Build the .msbuildproj projects to generate the NuGet packages.
-  # This workflow also uploads the resulting packages as artifacts.
-  build-packages:
-    if: success()
-    needs: [build-solution-debug, build-solution-release]
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v2
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - name: Build ComputeSharp.Core package
-      run: dotnet build src\ComputeSharp.Core.Package\ComputeSharp.Core.Package.msbuildproj -c Release
-      shell: cmd
-    - name: Upload ComputeSharp.Core package artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ComputeSharp.Core.nupkg
-        path: src\ComputeSharp.Core.Package\bin\Release\*.nupkg
-    - name: Build ComputeSharp package
-      run: dotnet build src\ComputeSharp.Package\ComputeSharp.Package.msbuildproj -c Release
-      shell: cmd
-    - name: Upload ComputeSharp package artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ComputeSharp.nupkg
-        path: src\ComputeSharp.Package\bin\Release\*.nupkg
-    - name: Build ComputeSharp.Dynamic package
-      run: dotnet build src\ComputeSharp.Dynamic.Package\ComputeSharp.Dynamic.Package.msbuildproj -c Release
-      shell: cmd
-    - name: Upload ComputeSharp.Dynamic package artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ComputeSharp.Dynamic.nupkg
-        path: src\ComputeSharp.Dynamic.Package\bin\Release\*.nupkg
-    - name: Build ComputeSharp.D2D1 package
-      run: dotnet build src\ComputeSharp.D2D1.Package\ComputeSharp.D2D1.Package.msbuildproj -c Release
-      shell: cmd
-    - name: Upload ComputeSharp.D2D1 package artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ComputeSharp.D2D1.nupkg
-        path: src\ComputeSharp.D2D1.Package\bin\Release\*.nupkg
-
   # Download the NuGet packages generated in the previous job and use them
   # to build and run the sample project referencing them. This is used as
   # a test to ensure the NuGet packages work in a consuming project.
@@ -237,23 +232,13 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Create local NuGet feed
-      run: mkdir src\ComputeSharp.Package\bin\Release
+      run: mkdir nuget_preview
       shell: cmd
-    - name: Download ComputeSharp.Core package artifact
+    - name: Download package artifacts
       uses: actions/download-artifact@v2
       with:
-        name: ComputeSharp.Core.nupkg
-        path: src\ComputeSharp.Core.Package\bin\Release\ComputeSharp.Core.nupkg
-    - name: Download ComputeSharp package artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ComputeSharp.nupkg
-        path: src\ComputeSharp.Package\bin\Release\ComputeSharp.nupkg
-    - name: Download ComputeSharp.Dynamic package artifact
-      uses: actions/download-artifact@v2
-      with:
-        name: ComputeSharp.Dynamic.nupkg
-        path: src\ComputeSharp.Dynamic.Package\bin\Release\ComputeSharp.Dynamic.nupkg
+        name: nuget_preview
+        path: nuget_preview
     - name: Build ComputeSharp.Sample.NuGet (.NET 6)
       run: dotnet build samples\ComputeSharp.Sample.NuGet\ComputeSharp.Sample.NuGet.csproj -c Release -f net6.0
       shell: cmd
@@ -278,7 +263,7 @@ jobs:
   # regardless of whether the app is shipping with R2R, self-contained, etc.
   verify-package-native-libs:
     if: success()
-    needs: [verify-packages]
+    needs: [build-packages]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -290,54 +275,3 @@ jobs:
     - name: Run ComputeSharp.Tests.NativeLibrariesResolver
       run: dotnet test tests\ComputeSharp.Tests.NativeLibrariesResolver\ComputeSharp.Tests.NativeLibrariesResolver.csproj -v n -l "console;verbosity=detailed"
       shell: cmd
-
-  # Build the WinUI project again to generate a NuGet package from it.
-  # This workflow also uploads the resulting package as an artifact.
-  build-package-winui:
-    if: success()
-    needs: [verify-packages]
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v2
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.3
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - name: Build
-      run: msbuild src\ComputeSharp.WinUI\ComputeSharp.WinUI.csproj -t:restore /p:Configuration=Release
-      shell: cmd
-    - name: Build
-      run: msbuild src\ComputeSharp.WinUI\ComputeSharp.WinUI.csproj -t:pack /p:Configuration=Release
-      shell: cmd # Packing needs to be done separately and with no previous build target for it to work correctly
-    - name: Upload package artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ComputeSharp.WinUI.nupkg
-        path: src\ComputeSharp.WinUI\bin\Release\*.nupkg
-
-  # Build the UWP project again to generate a NuGet package from it.
-  # This workflow also uploads the resulting package as an artifact, like the WinUI one.
-  build-package-uwp:
-    if: success()
-    needs: [verify-packages]
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v2
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.3
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-    - name: Build
-      run: msbuild src\ComputeSharp.Uwp\ComputeSharp.Uwp.csproj -t:restore,build,pack /p:Configuration=Release
-      shell: cmd
-    - name: Upload package artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: ComputeSharp.Uwp.nupkg
-        path: src\ComputeSharp.Uwp\bin\Release\*.nupkg

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -155,7 +155,7 @@ jobs:
   # Run all the local samples to ensure they build and run with no errors
   run-dx12-samples:
     if: success()
-    needs: [run-dx12-tests]
+    needs: [build-solution-debug, build-solution-release]
     runs-on: windows-2022
     steps:
     - name: Git checkout

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -190,7 +190,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build ComputeSharp.Core package
-      run: dotnet build src\ComputeSharp.Core.Package\ComputeSharp.Core.Package.msbuildproj -c Release /p:ContinuousIntegrationBuild=True
+      run: dotnet build src\ComputeSharp.Core.Package\ComputeSharp.Core.Package.msbuildproj -c Release
       shell: cmd
     - name: Upload ComputeSharp.Core package artifact
       uses: actions/upload-artifact@v2
@@ -198,7 +198,7 @@ jobs:
         name: ComputeSharp.Core.nupkg
         path: src\ComputeSharp.Core.Package\bin\Release\*.nupkg
     - name: Build ComputeSharp package
-      run: dotnet build src\ComputeSharp.Package\ComputeSharp.Package.msbuildproj -c Release /p:ContinuousIntegrationBuild=True
+      run: dotnet build src\ComputeSharp.Package\ComputeSharp.Package.msbuildproj -c Release
       shell: cmd
     - name: Upload ComputeSharp package artifact
       uses: actions/upload-artifact@v2
@@ -206,7 +206,7 @@ jobs:
         name: ComputeSharp.nupkg
         path: src\ComputeSharp.Package\bin\Release\*.nupkg
     - name: Build ComputeSharp.Dynamic package
-      run: dotnet build src\ComputeSharp.Dynamic.Package\ComputeSharp.Dynamic.Package.msbuildproj -c Release /p:ContinuousIntegrationBuild=True
+      run: dotnet build src\ComputeSharp.Dynamic.Package\ComputeSharp.Dynamic.Package.msbuildproj -c Release
       shell: cmd
     - name: Upload ComputeSharp.Dynamic package artifact
       uses: actions/upload-artifact@v2
@@ -214,7 +214,7 @@ jobs:
         name: ComputeSharp.Dynamic.nupkg
         path: src\ComputeSharp.Dynamic.Package\bin\Release\*.nupkg
     - name: Build ComputeSharp.D2D1 package
-      run: dotnet build src\ComputeSharp.D2D1.Package\ComputeSharp.D2D1.Package.msbuildproj -c Release /p:ContinuousIntegrationBuild=True
+      run: dotnet build src\ComputeSharp.D2D1.Package\ComputeSharp.D2D1.Package.msbuildproj -c Release
       shell: cmd
     - name: Upload ComputeSharp.D2D1 package artifact
       uses: actions/upload-artifact@v2
@@ -307,10 +307,10 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build
-      run: msbuild src\ComputeSharp.WinUI\ComputeSharp.WinUI.csproj -t:restore /p:Configuration=Release /p:ContinuousIntegrationBuild=True
+      run: msbuild src\ComputeSharp.WinUI\ComputeSharp.WinUI.csproj -t:restore /p:Configuration=Release
       shell: cmd
     - name: Build
-      run: msbuild src\ComputeSharp.WinUI\ComputeSharp.WinUI.csproj -t:pack /p:Configuration=Release /p:ContinuousIntegrationBuild=True
+      run: msbuild src\ComputeSharp.WinUI\ComputeSharp.WinUI.csproj -t:pack /p:Configuration=Release
       shell: cmd # Packing needs to be done separately and with no previous build target for it to work correctly
     - name: Upload package artifact
       uses: actions/upload-artifact@v2
@@ -334,7 +334,7 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build
-      run: msbuild src\ComputeSharp.Uwp\ComputeSharp.Uwp.csproj -t:restore,build,pack /p:Configuration=Release /p:ContinuousIntegrationBuild=True
+      run: msbuild src\ComputeSharp.Uwp\ComputeSharp.Uwp.csproj -t:restore,build,pack /p:Configuration=Release
       shell: cmd
     - name: Upload package artifact
       uses: actions/upload-artifact@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,9 +12,18 @@
     <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts/</PackageOutputPath>
   </PropertyGroup>
 
+  <!--
+    The target version being built (this is referenced by all build steps).
+    This version will set the package version prefix and the assembly version.
+    As such, this needs to be changed before a new release as well.
+  -->
   <PropertyGroup>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <ComputeSharpPackageVersion>2.0.0</ComputeSharpPackageVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyVersion>$(ComputeSharpPackageVersion).0</AssemblyVersion>
+    <VersionPrefix>$(ComputeSharpPackageVersion)</VersionPrefix>
     <VersionSuffix Condition="'$(EXCLUDE_SUFFIX_FROM_VERSION)' != 'true'">alpha</VersionSuffix>
     <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">pr</VersionSuffix>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_RUN_ID)' != ''">true</ContinuousIntegrationBuild>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,11 @@
     <NoWarn>$(NoWarn);MSB3270</NoWarn>
   </PropertyGroup>
 
+  <!-- Centralized location for all generated artifacts -->
+  <PropertyGroup>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts/</PackageOutputPath>
+  </PropertyGroup>
+
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <VersionPrefix>2.0.0</VersionPrefix>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix Condition="'$(EXCLUDE_SUFFIX_FROM_VERSION)' != 'true'">alpha</VersionSuffix>
     <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">pr</VersionSuffix>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_RUN_ID)' != ''">true</ContinuousIntegrationBuild>
     <RepositoryUrl>https://github.com/Sergio0694/ComputeSharp/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,9 @@
 
   <PropertyGroup>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
-    <PackageVersion>2.0.0</PackageVersion>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix Condition="'$(EXCLUDE_SUFFIX_FROM_VERSION)' != 'true'">alpha</VersionSuffix>
+    <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">pr</VersionSuffix>
     <RepositoryUrl>https://github.com/Sergio0694/ComputeSharp/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,4 +24,9 @@
   <PropertyGroup Condition="'$(GITHUB_RUN_ID)' != ''">
     <PackageVersion Condition="'$(EXCLUDE_RUN_ID_FROM_PACKAGE)' != 'true'">$(Version).$(GITHUB_RUN_ID)</PackageVersion>
   </PropertyGroup>
+
+  <!-- Settings that are only set for non CI builds -->
+  <PropertyGroup Condition="'$(GITHUB_RUN_ID)' == ''">
+    <PackageVersion>$(Version)</PackageVersion>
+  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -13,9 +13,9 @@
     Manually set the version if null. This is copied from Microsoft.NET.DefaultAssemblyInfo.targets and is needed
     for cases where that target is not being automatically imported (which happens because MSBuild is used instead
     of dotnet build for some cases, due to the solution having some UWP and WinUI 3 projects, and non SDK-style too).
+    The lines setting the prefix have been omitted, as that is already handled in the root .props file.
   -->
   <PropertyGroup Condition=" '$(Version)' == '' ">
-    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">2.0.0</VersionPrefix>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
     <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+
+  <!--
+    Directory.Build.targets is automatically picked up and imported by
+    Microsoft.Common.targets. This file needs to exist, even if empty so that
+    files in the parent directory tree, with the same name, are not imported
+    instead. The import fairly late and most other props/targets will have been
+    imported beforehand. We also don't need to add ourselves to
+    MSBuildAllProjects, as that is done by the file that imports us.
+  -->
+
+  <!-- Settings that are only set for CI builds -->
+  <PropertyGroup Condition="'$(GITHUB_RUN_ID)' != ''">
+    <PackageVersion Condition="'$(EXCLUDE_RUN_ID_FROM_PACKAGE)' != 'true'">$(Version).$(GITHUB_RUN_ID)</PackageVersion>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,6 +9,17 @@
     MSBuildAllProjects, as that is done by the file that imports us.
   -->
 
+  <!--
+    Manually set the version if null. This is copied from Microsoft.NET.DefaultAssemblyInfo.targets and is needed
+    for cases where that target is not being automatically imported (which happens because MSBuild is used instead
+    of dotnet build for some cases, due to the solution having some UWP and WinUI 3 projects, and non SDK-style too).
+  -->
+  <PropertyGroup Condition=" '$(Version)' == '' ">
+    <VersionPrefix Condition=" '$(VersionPrefix)' == '' ">2.0.0</VersionPrefix>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
+  </PropertyGroup>
+
   <!-- Settings that are only set for CI builds -->
   <PropertyGroup Condition="'$(GITHUB_RUN_ID)' != ''">
     <PackageVersion Condition="'$(EXCLUDE_RUN_ID_FROM_PACKAGE)' != 'true'">$(Version).$(GITHUB_RUN_ID)</PackageVersion>

--- a/samples/ComputeSharp.Sample.NuGet/ComputeSharp.Sample.NuGet.csproj
+++ b/samples/ComputeSharp.Sample.NuGet/ComputeSharp.Sample.NuGet.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ComputeSharp.Core" Version="2.0.0" />
-    <PackageReference Include="ComputeSharp" Version="2.0.0" />
-    <PackageReference Include="ComputeSharp.Dynamic" Version="2.0.0" />
+    <PackageReference Include="ComputeSharp.Core" Version="$(PackageVersion)" />
+    <PackageReference Include="ComputeSharp" Version="$(PackageVersion)" />
+    <PackageReference Include="ComputeSharp.Dynamic" Version="$(PackageVersion)" />
   </ItemGroup>
 
   <Import Project="..\ComputeSharp.Sample.Shared\ComputeSharp.Sample.Shared.projitems" Label="Shared" />

--- a/samples/ComputeSharp.Sample.NuGet/nuget.config
+++ b/samples/ComputeSharp.Sample.NuGet/nuget.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget_preview" value="..\..\nuget_preview" />
+
+    <!-- This source is for the local NuGet packages, which are all generated in the centralized artifacts root folder -->
+    <add key="artifacts" value="..\..\artifacts" />
   </packageSources>
 </configuration>

--- a/samples/ComputeSharp.Sample.NuGet/nuget.config
+++ b/samples/ComputeSharp.Sample.NuGet/nuget.config
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="ComputeSharp-Core" value="..\..\src\ComputeSharp.Core.Package\bin\Release" />
-    <add key="ComputeSharp" value="..\..\src\ComputeSharp.Package\bin\Release" />
-    <add key="ComputeSharp-Dynamic" value="..\..\src\ComputeSharp.Dynamic.Package\bin\Release" />
+    <add key="nuget_preview" value="..\..\nuget_preview" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This PR adds the following changes:

- Add the CI run number to each generated package
- Upload all generated package artifacts in a single file
- Reorganize the CI workflow to be faster