### PR TITLE
Add missing HLSL operators

### DIFF
--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="bool2"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
@@ -6,6 +6,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -405,6 +406,25 @@ public unsafe partial struct Bool2
     /// Negates a <see cref="Bool2"/> value.
     /// </summary>
     /// <param name="xy">The <see cref="Bool2"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xy"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2 operator !(Bool2 xy) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator ==(Bool2 left, Bool2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator !=(Bool2 left, Bool2 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="bool3"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
@@ -6,6 +6,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -1486,6 +1487,25 @@ public unsafe partial struct Bool3
     /// Negates a <see cref="Bool3"/> value.
     /// </summary>
     /// <param name="xyz">The <see cref="Bool3"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xyz"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3 operator !(Bool3 xyz) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator ==(Bool3 left, Bool3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator !=(Bool3 left, Bool3 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="bool4"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
@@ -6,6 +6,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -4127,6 +4128,25 @@ public unsafe partial struct Bool4
     /// Negates a <see cref="Bool4"/> value.
     /// </summary>
     /// <param name="xyzw">The <see cref="Bool4"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xyzw"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4 operator !(Bool4 xyzw) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator ==(Bool4 left, Bool4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator !=(Bool4 left, Bool4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
@@ -5,6 +5,8 @@ using RuntimeHelpers = ComputeSharp.Core.NetStandard.System.Runtime.CompilerServ
 using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServices.MemoryMarshal;
 #endif
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 /// <inheritdoc cref="Bool1x1"/>
@@ -86,6 +88,24 @@ public unsafe partial struct Bool1x1
     /// <param name="matrix">The <see cref="Bool1x1"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool1x1 operator !(Bool1x1 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool1x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator ==(Bool1x1 left, Bool1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool1x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator !=(Bool1x1 left, Bool1x1 right) => default;
 }
 
 /// <inheritdoc cref="Bool1x2"/>
@@ -178,6 +198,24 @@ public unsafe partial struct Bool1x2
     /// <param name="matrix">The <see cref="Bool1x2"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool1x2 operator !(Bool1x2 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool1x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator ==(Bool1x2 left, Bool1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool1x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator !=(Bool1x2 left, Bool1x2 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Bool2"/> value to a <see cref="Bool1x2"/> one.
@@ -287,6 +325,24 @@ public unsafe partial struct Bool1x3
     /// <param name="matrix">The <see cref="Bool1x3"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool1x3 operator !(Bool1x3 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool1x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator ==(Bool1x3 left, Bool1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool1x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator !=(Bool1x3 left, Bool1x3 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Bool3"/> value to a <see cref="Bool1x3"/> one.
@@ -409,6 +465,24 @@ public unsafe partial struct Bool1x4
     public static Bool1x4 operator !(Bool1x4 matrix) => default;
 
     /// <summary>
+    /// Compares two <see cref="Bool1x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator ==(Bool1x4 left, Bool1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool1x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator !=(Bool1x4 left, Bool1x4 right) => default;
+
+    /// <summary>
     /// Casts a <see cref="Bool4"/> value to a <see cref="Bool1x4"/> one.
     /// </summary>
     /// <param name="vector">The input <see cref="Bool4"/> value to cast.</param>
@@ -505,6 +579,24 @@ public unsafe partial struct Bool2x1
     /// <param name="matrix">The <see cref="Bool2x1"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x1 operator !(Bool2x1 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator ==(Bool2x1 left, Bool2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator !=(Bool2x1 left, Bool2x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Bool2x1"/> value to a <see cref="Bool2"/> one.
@@ -638,6 +730,24 @@ public unsafe partial struct Bool2x2
     /// <param name="matrix">The <see cref="Bool2x2"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x2 operator !(Bool2x2 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator ==(Bool2x2 left, Bool2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator !=(Bool2x2 left, Bool2x2 right) => default;
 }
 
 /// <inheritdoc cref="Bool2x3"/>
@@ -789,6 +899,24 @@ public unsafe partial struct Bool2x3
     /// <param name="matrix">The <see cref="Bool2x3"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x3 operator !(Bool2x3 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator ==(Bool2x3 left, Bool2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator !=(Bool2x3 left, Bool2x3 right) => default;
 }
 
 /// <inheritdoc cref="Bool2x4"/>
@@ -964,6 +1092,24 @@ public unsafe partial struct Bool2x4
     /// <param name="matrix">The <see cref="Bool2x4"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x4 operator !(Bool2x4 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator ==(Bool2x4 left, Bool2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool2x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator !=(Bool2x4 left, Bool2x4 right) => default;
 }
 
 /// <inheritdoc cref="Bool3x1"/>
@@ -1067,6 +1213,24 @@ public unsafe partial struct Bool3x1
     /// <param name="matrix">The <see cref="Bool3x1"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x1 operator !(Bool3x1 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator ==(Bool3x1 left, Bool3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator !=(Bool3x1 left, Bool3x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Bool3x1"/> value to a <see cref="Bool3"/> one.
@@ -1225,6 +1389,24 @@ public unsafe partial struct Bool3x2
     /// <param name="matrix">The <see cref="Bool3x2"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x2 operator !(Bool3x2 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator ==(Bool3x2 left, Bool3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator !=(Bool3x2 left, Bool3x2 right) => default;
 }
 
 /// <inheritdoc cref="Bool3x3"/>
@@ -1413,6 +1595,24 @@ public unsafe partial struct Bool3x3
     /// <param name="matrix">The <see cref="Bool3x3"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x3 operator !(Bool3x3 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator ==(Bool3x3 left, Bool3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator !=(Bool3x3 left, Bool3x3 right) => default;
 }
 
 /// <inheritdoc cref="Bool3x4"/>
@@ -1637,6 +1837,24 @@ public unsafe partial struct Bool3x4
     /// <param name="matrix">The <see cref="Bool3x4"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x4 operator !(Bool3x4 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator ==(Bool3x4 left, Bool3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool3x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator !=(Bool3x4 left, Bool3x4 right) => default;
 }
 
 /// <inheritdoc cref="Bool4x1"/>
@@ -1751,6 +1969,24 @@ public unsafe partial struct Bool4x1
     /// <param name="matrix">The <see cref="Bool4x1"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x1 operator !(Bool4x1 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator ==(Bool4x1 left, Bool4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator !=(Bool4x1 left, Bool4x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Bool4x1"/> value to a <see cref="Bool4"/> one.
@@ -1934,6 +2170,24 @@ public unsafe partial struct Bool4x2
     /// <param name="matrix">The <see cref="Bool4x2"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x2 operator !(Bool4x2 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator ==(Bool4x2 left, Bool4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator !=(Bool4x2 left, Bool4x2 right) => default;
 }
 
 /// <inheritdoc cref="Bool4x3"/>
@@ -2159,6 +2413,24 @@ public unsafe partial struct Bool4x3
     /// <param name="matrix">The <see cref="Bool4x3"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x3 operator !(Bool4x3 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator ==(Bool4x3 left, Bool4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator !=(Bool4x3 left, Bool4x3 right) => default;
 }
 
 /// <inheritdoc cref="Bool4x4"/>
@@ -2432,4 +2704,22 @@ public unsafe partial struct Bool4x4
     /// <param name="matrix">The <see cref="Bool4x4"/> value to negate.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x4 operator !(Bool4x4 matrix) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator ==(Bool4x4 left, Bool4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Bool4x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Bool4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Bool4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator !=(Bool4x4 left, Bool4x4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Double/Double2.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double2.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="double2"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Double/Double2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double2.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -437,6 +438,7 @@ public unsafe partial struct Double2
     /// Negates a <see cref="Double2"/> value.
     /// </summary>
     /// <param name="xy">The <see cref="Double2"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xy"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2 operator -(Double2 xy) => default;
 
@@ -445,6 +447,7 @@ public unsafe partial struct Double2
     /// </summary>
     /// <param name="left">The first <see cref="Double2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2 operator +(Double2 left, Double2 right) => default;
 
@@ -453,14 +456,25 @@ public unsafe partial struct Double2
     /// </summary>
     /// <param name="left">The first <see cref="Double2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2 operator /(Double2 left, Double2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double2 operator %(Double2 left, Double2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double2"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Double2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2 operator *(Double2 left, Double2 right) => default;
 
@@ -469,6 +483,61 @@ public unsafe partial struct Double2
     /// </summary>
     /// <param name="left">The first <see cref="Double2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2 operator -(Double2 left, Double2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator >(Double2 left, Double2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator >=(Double2 left, Double2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator <(Double2 left, Double2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator <=(Double2 left, Double2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator ==(Double2 left, Double2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator !=(Double2 left, Double2 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Double/Double3.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double3.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="double3"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Double/Double3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double3.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -1518,6 +1519,7 @@ public unsafe partial struct Double3
     /// Negates a <see cref="Double3"/> value.
     /// </summary>
     /// <param name="xyz">The <see cref="Double3"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xyz"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3 operator -(Double3 xyz) => default;
 
@@ -1526,6 +1528,7 @@ public unsafe partial struct Double3
     /// </summary>
     /// <param name="left">The first <see cref="Double3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3 operator +(Double3 left, Double3 right) => default;
 
@@ -1534,14 +1537,25 @@ public unsafe partial struct Double3
     /// </summary>
     /// <param name="left">The first <see cref="Double3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3 operator /(Double3 left, Double3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double3 operator %(Double3 left, Double3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double3"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Double3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3 operator *(Double3 left, Double3 right) => default;
 
@@ -1550,6 +1564,61 @@ public unsafe partial struct Double3
     /// </summary>
     /// <param name="left">The first <see cref="Double3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3 operator -(Double3 left, Double3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator >(Double3 left, Double3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator >=(Double3 left, Double3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator <(Double3 left, Double3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator <=(Double3 left, Double3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator ==(Double3 left, Double3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator !=(Double3 left, Double3 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Double/Double4.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double4.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="double4"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Double/Double4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double4.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -4159,6 +4160,7 @@ public unsafe partial struct Double4
     /// Negates a <see cref="Double4"/> value.
     /// </summary>
     /// <param name="xyzw">The <see cref="Double4"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xyzw"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4 operator -(Double4 xyzw) => default;
 
@@ -4167,6 +4169,7 @@ public unsafe partial struct Double4
     /// </summary>
     /// <param name="left">The first <see cref="Double4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4 operator +(Double4 left, Double4 right) => default;
 
@@ -4175,14 +4178,25 @@ public unsafe partial struct Double4
     /// </summary>
     /// <param name="left">The first <see cref="Double4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4 operator /(Double4 left, Double4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double4 operator %(Double4 left, Double4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double4"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Double4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4 operator *(Double4 left, Double4 right) => default;
 
@@ -4191,6 +4205,61 @@ public unsafe partial struct Double4
     /// </summary>
     /// <param name="left">The first <see cref="Double4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4 operator -(Double4 left, Double4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator >(Double4 left, Double4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator >=(Double4 left, Double4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator <(Double4 left, Double4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator <=(Double4 left, Double4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator ==(Double4 left, Double4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator !=(Double4 left, Double4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
@@ -5,6 +5,8 @@ using RuntimeHelpers = ComputeSharp.Core.NetStandard.System.Runtime.CompilerServ
 using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServices.MemoryMarshal;
 #endif
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 /// <inheritdoc cref="Double1x1"/>
@@ -92,6 +94,7 @@ public unsafe partial struct Double1x1
     /// </summary>
     /// <param name="left">The first <see cref="Double1x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double1x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x1 operator +(Double1x1 left, Double1x1 right) => default;
 
@@ -100,14 +103,25 @@ public unsafe partial struct Double1x1
     /// </summary>
     /// <param name="left">The first <see cref="Double1x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double1x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x1 operator /(Double1x1 left, Double1x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double1x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double1x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double1x1 operator %(Double1x1 left, Double1x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double1x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double1x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double1x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x1 operator *(Double1x1 left, Double1x1 right) => default;
 
@@ -116,8 +130,63 @@ public unsafe partial struct Double1x1
     /// </summary>
     /// <param name="left">The first <see cref="Double1x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double1x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x1 operator -(Double1x1 left, Double1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator >(Double1x1 left, Double1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator >=(Double1x1 left, Double1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator <(Double1x1 left, Double1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator <=(Double1x1 left, Double1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator ==(Double1x1 left, Double1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator !=(Double1x1 left, Double1x1 right) => default;
 }
 
 /// <inheritdoc cref="Double1x2"/>
@@ -216,6 +285,7 @@ public unsafe partial struct Double1x2
     /// </summary>
     /// <param name="left">The first <see cref="Double1x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double1x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x2 operator +(Double1x2 left, Double1x2 right) => default;
 
@@ -224,14 +294,25 @@ public unsafe partial struct Double1x2
     /// </summary>
     /// <param name="left">The first <see cref="Double1x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double1x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x2 operator /(Double1x2 left, Double1x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double1x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double1x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double1x2 operator %(Double1x2 left, Double1x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double1x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double1x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double1x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x2 operator *(Double1x2 left, Double1x2 right) => default;
 
@@ -240,8 +321,63 @@ public unsafe partial struct Double1x2
     /// </summary>
     /// <param name="left">The first <see cref="Double1x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double1x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x2 operator -(Double1x2 left, Double1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator >(Double1x2 left, Double1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator >=(Double1x2 left, Double1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator <(Double1x2 left, Double1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator <=(Double1x2 left, Double1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator ==(Double1x2 left, Double1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator !=(Double1x2 left, Double1x2 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Double2"/> value to a <see cref="Double1x2"/> one.
@@ -357,6 +493,7 @@ public unsafe partial struct Double1x3
     /// </summary>
     /// <param name="left">The first <see cref="Double1x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double1x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x3 operator +(Double1x3 left, Double1x3 right) => default;
 
@@ -365,14 +502,25 @@ public unsafe partial struct Double1x3
     /// </summary>
     /// <param name="left">The first <see cref="Double1x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double1x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x3 operator /(Double1x3 left, Double1x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double1x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double1x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double1x3 operator %(Double1x3 left, Double1x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double1x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double1x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double1x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x3 operator *(Double1x3 left, Double1x3 right) => default;
 
@@ -381,8 +529,63 @@ public unsafe partial struct Double1x3
     /// </summary>
     /// <param name="left">The first <see cref="Double1x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double1x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x3 operator -(Double1x3 left, Double1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator >(Double1x3 left, Double1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator >=(Double1x3 left, Double1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator <(Double1x3 left, Double1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator <=(Double1x3 left, Double1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator ==(Double1x3 left, Double1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator !=(Double1x3 left, Double1x3 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Double3"/> value to a <see cref="Double1x3"/> one.
@@ -509,6 +712,7 @@ public unsafe partial struct Double1x4
     /// </summary>
     /// <param name="left">The first <see cref="Double1x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double1x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x4 operator +(Double1x4 left, Double1x4 right) => default;
 
@@ -517,14 +721,25 @@ public unsafe partial struct Double1x4
     /// </summary>
     /// <param name="left">The first <see cref="Double1x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double1x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x4 operator /(Double1x4 left, Double1x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double1x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double1x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double1x4 operator %(Double1x4 left, Double1x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double1x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double1x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double1x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x4 operator *(Double1x4 left, Double1x4 right) => default;
 
@@ -533,8 +748,63 @@ public unsafe partial struct Double1x4
     /// </summary>
     /// <param name="left">The first <see cref="Double1x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double1x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double1x4 operator -(Double1x4 left, Double1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator >(Double1x4 left, Double1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator >=(Double1x4 left, Double1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator <(Double1x4 left, Double1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator <=(Double1x4 left, Double1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator ==(Double1x4 left, Double1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double1x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator !=(Double1x4 left, Double1x4 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Double4"/> value to a <see cref="Double1x4"/> one.
@@ -639,6 +909,7 @@ public unsafe partial struct Double2x1
     /// </summary>
     /// <param name="left">The first <see cref="Double2x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double2x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x1 operator +(Double2x1 left, Double2x1 right) => default;
 
@@ -647,14 +918,25 @@ public unsafe partial struct Double2x1
     /// </summary>
     /// <param name="left">The first <see cref="Double2x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double2x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x1 operator /(Double2x1 left, Double2x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double2x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double2x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double2x1 operator %(Double2x1 left, Double2x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double2x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double2x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double2x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x1 operator *(Double2x1 left, Double2x1 right) => default;
 
@@ -663,8 +945,63 @@ public unsafe partial struct Double2x1
     /// </summary>
     /// <param name="left">The first <see cref="Double2x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double2x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x1 operator -(Double2x1 left, Double2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator >(Double2x1 left, Double2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator >=(Double2x1 left, Double2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator <(Double2x1 left, Double2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator <=(Double2x1 left, Double2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator ==(Double2x1 left, Double2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator !=(Double2x1 left, Double2x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Double2x1"/> value to a <see cref="Double2"/> one.
@@ -804,6 +1141,7 @@ public unsafe partial struct Double2x2
     /// </summary>
     /// <param name="left">The first <see cref="Double2x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double2x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x2 operator +(Double2x2 left, Double2x2 right) => default;
 
@@ -812,14 +1150,25 @@ public unsafe partial struct Double2x2
     /// </summary>
     /// <param name="left">The first <see cref="Double2x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double2x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x2 operator /(Double2x2 left, Double2x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double2x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double2x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double2x2 operator %(Double2x2 left, Double2x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double2x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double2x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double2x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x2 operator *(Double2x2 left, Double2x2 right) => default;
 
@@ -828,8 +1177,63 @@ public unsafe partial struct Double2x2
     /// </summary>
     /// <param name="left">The first <see cref="Double2x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double2x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x2 operator -(Double2x2 left, Double2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator >(Double2x2 left, Double2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator >=(Double2x2 left, Double2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator <(Double2x2 left, Double2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator <=(Double2x2 left, Double2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator ==(Double2x2 left, Double2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator !=(Double2x2 left, Double2x2 right) => default;
 }
 
 /// <inheritdoc cref="Double2x3"/>
@@ -987,6 +1391,7 @@ public unsafe partial struct Double2x3
     /// </summary>
     /// <param name="left">The first <see cref="Double2x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double2x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x3 operator +(Double2x3 left, Double2x3 right) => default;
 
@@ -995,14 +1400,25 @@ public unsafe partial struct Double2x3
     /// </summary>
     /// <param name="left">The first <see cref="Double2x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double2x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x3 operator /(Double2x3 left, Double2x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double2x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double2x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double2x3 operator %(Double2x3 left, Double2x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double2x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double2x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double2x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x3 operator *(Double2x3 left, Double2x3 right) => default;
 
@@ -1011,8 +1427,63 @@ public unsafe partial struct Double2x3
     /// </summary>
     /// <param name="left">The first <see cref="Double2x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double2x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x3 operator -(Double2x3 left, Double2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator >(Double2x3 left, Double2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator >=(Double2x3 left, Double2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator <(Double2x3 left, Double2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator <=(Double2x3 left, Double2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator ==(Double2x3 left, Double2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator !=(Double2x3 left, Double2x3 right) => default;
 }
 
 /// <inheritdoc cref="Double2x4"/>
@@ -1194,6 +1665,7 @@ public unsafe partial struct Double2x4
     /// </summary>
     /// <param name="left">The first <see cref="Double2x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double2x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x4 operator +(Double2x4 left, Double2x4 right) => default;
 
@@ -1202,14 +1674,25 @@ public unsafe partial struct Double2x4
     /// </summary>
     /// <param name="left">The first <see cref="Double2x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double2x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x4 operator /(Double2x4 left, Double2x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double2x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double2x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double2x4 operator %(Double2x4 left, Double2x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double2x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double2x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double2x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x4 operator *(Double2x4 left, Double2x4 right) => default;
 
@@ -1218,8 +1701,63 @@ public unsafe partial struct Double2x4
     /// </summary>
     /// <param name="left">The first <see cref="Double2x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double2x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double2x4 operator -(Double2x4 left, Double2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator >(Double2x4 left, Double2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator >=(Double2x4 left, Double2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator <(Double2x4 left, Double2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator <=(Double2x4 left, Double2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator ==(Double2x4 left, Double2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double2x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator !=(Double2x4 left, Double2x4 right) => default;
 }
 
 /// <inheritdoc cref="Double3x1"/>
@@ -1329,6 +1867,7 @@ public unsafe partial struct Double3x1
     /// </summary>
     /// <param name="left">The first <see cref="Double3x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double3x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x1 operator +(Double3x1 left, Double3x1 right) => default;
 
@@ -1337,14 +1876,25 @@ public unsafe partial struct Double3x1
     /// </summary>
     /// <param name="left">The first <see cref="Double3x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double3x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x1 operator /(Double3x1 left, Double3x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double3x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double3x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double3x1 operator %(Double3x1 left, Double3x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double3x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double3x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double3x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x1 operator *(Double3x1 left, Double3x1 right) => default;
 
@@ -1353,8 +1903,63 @@ public unsafe partial struct Double3x1
     /// </summary>
     /// <param name="left">The first <see cref="Double3x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double3x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x1 operator -(Double3x1 left, Double3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator >(Double3x1 left, Double3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator >=(Double3x1 left, Double3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator <(Double3x1 left, Double3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator <=(Double3x1 left, Double3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator ==(Double3x1 left, Double3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator !=(Double3x1 left, Double3x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Double3x1"/> value to a <see cref="Double3"/> one.
@@ -1519,6 +2124,7 @@ public unsafe partial struct Double3x2
     /// </summary>
     /// <param name="left">The first <see cref="Double3x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double3x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x2 operator +(Double3x2 left, Double3x2 right) => default;
 
@@ -1527,14 +2133,25 @@ public unsafe partial struct Double3x2
     /// </summary>
     /// <param name="left">The first <see cref="Double3x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double3x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x2 operator /(Double3x2 left, Double3x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double3x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double3x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double3x2 operator %(Double3x2 left, Double3x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double3x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double3x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double3x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x2 operator *(Double3x2 left, Double3x2 right) => default;
 
@@ -1543,8 +2160,63 @@ public unsafe partial struct Double3x2
     /// </summary>
     /// <param name="left">The first <see cref="Double3x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double3x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x2 operator -(Double3x2 left, Double3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator >(Double3x2 left, Double3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator >=(Double3x2 left, Double3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator <(Double3x2 left, Double3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator <=(Double3x2 left, Double3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator ==(Double3x2 left, Double3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator !=(Double3x2 left, Double3x2 right) => default;
 }
 
 /// <inheritdoc cref="Double3x3"/>
@@ -1739,6 +2411,7 @@ public unsafe partial struct Double3x3
     /// </summary>
     /// <param name="left">The first <see cref="Double3x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double3x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x3 operator +(Double3x3 left, Double3x3 right) => default;
 
@@ -1747,14 +2420,25 @@ public unsafe partial struct Double3x3
     /// </summary>
     /// <param name="left">The first <see cref="Double3x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double3x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x3 operator /(Double3x3 left, Double3x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double3x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double3x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double3x3 operator %(Double3x3 left, Double3x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double3x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double3x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double3x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x3 operator *(Double3x3 left, Double3x3 right) => default;
 
@@ -1763,8 +2447,63 @@ public unsafe partial struct Double3x3
     /// </summary>
     /// <param name="left">The first <see cref="Double3x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double3x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x3 operator -(Double3x3 left, Double3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator >(Double3x3 left, Double3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator >=(Double3x3 left, Double3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator <(Double3x3 left, Double3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator <=(Double3x3 left, Double3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator ==(Double3x3 left, Double3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator !=(Double3x3 left, Double3x3 right) => default;
 }
 
 /// <inheritdoc cref="Double3x4"/>
@@ -1995,6 +2734,7 @@ public unsafe partial struct Double3x4
     /// </summary>
     /// <param name="left">The first <see cref="Double3x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double3x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x4 operator +(Double3x4 left, Double3x4 right) => default;
 
@@ -2003,14 +2743,25 @@ public unsafe partial struct Double3x4
     /// </summary>
     /// <param name="left">The first <see cref="Double3x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double3x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x4 operator /(Double3x4 left, Double3x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double3x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double3x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double3x4 operator %(Double3x4 left, Double3x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double3x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double3x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double3x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x4 operator *(Double3x4 left, Double3x4 right) => default;
 
@@ -2019,8 +2770,63 @@ public unsafe partial struct Double3x4
     /// </summary>
     /// <param name="left">The first <see cref="Double3x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double3x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double3x4 operator -(Double3x4 left, Double3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator >(Double3x4 left, Double3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator >=(Double3x4 left, Double3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator <(Double3x4 left, Double3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator <=(Double3x4 left, Double3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator ==(Double3x4 left, Double3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double3x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator !=(Double3x4 left, Double3x4 right) => default;
 }
 
 /// <inheritdoc cref="Double4x1"/>
@@ -2141,6 +2947,7 @@ public unsafe partial struct Double4x1
     /// </summary>
     /// <param name="left">The first <see cref="Double4x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double4x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x1 operator +(Double4x1 left, Double4x1 right) => default;
 
@@ -2149,14 +2956,25 @@ public unsafe partial struct Double4x1
     /// </summary>
     /// <param name="left">The first <see cref="Double4x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double4x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x1 operator /(Double4x1 left, Double4x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double4x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double4x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double4x1 operator %(Double4x1 left, Double4x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double4x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double4x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double4x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x1 operator *(Double4x1 left, Double4x1 right) => default;
 
@@ -2165,8 +2983,63 @@ public unsafe partial struct Double4x1
     /// </summary>
     /// <param name="left">The first <see cref="Double4x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double4x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x1 operator -(Double4x1 left, Double4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator >(Double4x1 left, Double4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator >=(Double4x1 left, Double4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator <(Double4x1 left, Double4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator <=(Double4x1 left, Double4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator ==(Double4x1 left, Double4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator !=(Double4x1 left, Double4x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Double4x1"/> value to a <see cref="Double4"/> one.
@@ -2356,6 +3229,7 @@ public unsafe partial struct Double4x2
     /// </summary>
     /// <param name="left">The first <see cref="Double4x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double4x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x2 operator +(Double4x2 left, Double4x2 right) => default;
 
@@ -2364,14 +3238,25 @@ public unsafe partial struct Double4x2
     /// </summary>
     /// <param name="left">The first <see cref="Double4x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double4x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x2 operator /(Double4x2 left, Double4x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double4x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double4x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double4x2 operator %(Double4x2 left, Double4x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double4x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double4x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double4x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x2 operator *(Double4x2 left, Double4x2 right) => default;
 
@@ -2380,8 +3265,63 @@ public unsafe partial struct Double4x2
     /// </summary>
     /// <param name="left">The first <see cref="Double4x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double4x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x2 operator -(Double4x2 left, Double4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator >(Double4x2 left, Double4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator >=(Double4x2 left, Double4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator <(Double4x2 left, Double4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator <=(Double4x2 left, Double4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator ==(Double4x2 left, Double4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator !=(Double4x2 left, Double4x2 right) => default;
 }
 
 /// <inheritdoc cref="Double4x3"/>
@@ -2613,6 +3553,7 @@ public unsafe partial struct Double4x3
     /// </summary>
     /// <param name="left">The first <see cref="Double4x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double4x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x3 operator +(Double4x3 left, Double4x3 right) => default;
 
@@ -2621,14 +3562,25 @@ public unsafe partial struct Double4x3
     /// </summary>
     /// <param name="left">The first <see cref="Double4x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double4x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x3 operator /(Double4x3 left, Double4x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double4x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double4x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double4x3 operator %(Double4x3 left, Double4x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double4x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double4x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double4x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x3 operator *(Double4x3 left, Double4x3 right) => default;
 
@@ -2637,8 +3589,63 @@ public unsafe partial struct Double4x3
     /// </summary>
     /// <param name="left">The first <see cref="Double4x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double4x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x3 operator -(Double4x3 left, Double4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator >(Double4x3 left, Double4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator >=(Double4x3 left, Double4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator <(Double4x3 left, Double4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator <=(Double4x3 left, Double4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator ==(Double4x3 left, Double4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator !=(Double4x3 left, Double4x3 right) => default;
 }
 
 /// <inheritdoc cref="Double4x4"/>
@@ -2918,6 +3925,7 @@ public unsafe partial struct Double4x4
     /// </summary>
     /// <param name="left">The first <see cref="Double4x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Double4x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x4 operator +(Double4x4 left, Double4x4 right) => default;
 
@@ -2926,14 +3934,25 @@ public unsafe partial struct Double4x4
     /// </summary>
     /// <param name="left">The first <see cref="Double4x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Double4x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x4 operator /(Double4x4 left, Double4x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Double4x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Double4x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Double4x4 operator %(Double4x4 left, Double4x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Double4x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Double4x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Double4x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x4 operator *(Double4x4 left, Double4x4 right) => default;
 
@@ -2942,6 +3961,61 @@ public unsafe partial struct Double4x4
     /// </summary>
     /// <param name="left">The first <see cref="Double4x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Double4x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Double4x4 operator -(Double4x4 left, Double4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator >(Double4x4 left, Double4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator >=(Double4x4 left, Double4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator <(Double4x4 left, Double4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator <=(Double4x4 left, Double4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator ==(Double4x4 left, Double4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Double4x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Double4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Double4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator !=(Double4x4 left, Double4x4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Float/Float2.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float2.cs
@@ -1,5 +1,7 @@
 ﻿using System.Numerics;
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 /// <summary>

--- a/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -437,6 +438,7 @@ public unsafe partial struct Float2
     /// Negates a <see cref="Float2"/> value.
     /// </summary>
     /// <param name="xy">The <see cref="Float2"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xy"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2 operator -(Float2 xy) => default;
 
@@ -445,6 +447,7 @@ public unsafe partial struct Float2
     /// </summary>
     /// <param name="left">The first <see cref="Float2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2 operator +(Float2 left, Float2 right) => default;
 
@@ -453,14 +456,25 @@ public unsafe partial struct Float2
     /// </summary>
     /// <param name="left">The first <see cref="Float2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2 operator /(Float2 left, Float2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float2 operator %(Float2 left, Float2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float2"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Float2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2 operator *(Float2 left, Float2 right) => default;
 
@@ -469,6 +483,61 @@ public unsafe partial struct Float2
     /// </summary>
     /// <param name="left">The first <see cref="Float2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2 operator -(Float2 left, Float2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator >(Float2 left, Float2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator >=(Float2 left, Float2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator <(Float2 left, Float2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator <=(Float2 left, Float2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator ==(Float2 left, Float2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator !=(Float2 left, Float2 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Float/Float3.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float3.cs
@@ -1,5 +1,7 @@
 ﻿using System.Numerics;
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 /// <summary>

--- a/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -1518,6 +1519,7 @@ public unsafe partial struct Float3
     /// Negates a <see cref="Float3"/> value.
     /// </summary>
     /// <param name="xyz">The <see cref="Float3"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xyz"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3 operator -(Float3 xyz) => default;
 
@@ -1526,6 +1528,7 @@ public unsafe partial struct Float3
     /// </summary>
     /// <param name="left">The first <see cref="Float3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3 operator +(Float3 left, Float3 right) => default;
 
@@ -1534,14 +1537,25 @@ public unsafe partial struct Float3
     /// </summary>
     /// <param name="left">The first <see cref="Float3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3 operator /(Float3 left, Float3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float3 operator %(Float3 left, Float3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float3"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Float3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3 operator *(Float3 left, Float3 right) => default;
 
@@ -1550,6 +1564,61 @@ public unsafe partial struct Float3
     /// </summary>
     /// <param name="left">The first <see cref="Float3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3 operator -(Float3 left, Float3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator >(Float3 left, Float3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator >=(Float3 left, Float3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator <(Float3 left, Float3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator <=(Float3 left, Float3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator ==(Float3 left, Float3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator !=(Float3 left, Float3 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Float/Float4.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float4.cs
@@ -1,5 +1,7 @@
 ﻿using System.Numerics;
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 /// <summary>

--- a/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -4159,6 +4160,7 @@ public unsafe partial struct Float4
     /// Negates a <see cref="Float4"/> value.
     /// </summary>
     /// <param name="xyzw">The <see cref="Float4"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xyzw"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4 operator -(Float4 xyzw) => default;
 
@@ -4167,6 +4169,7 @@ public unsafe partial struct Float4
     /// </summary>
     /// <param name="left">The first <see cref="Float4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4 operator +(Float4 left, Float4 right) => default;
 
@@ -4175,14 +4178,25 @@ public unsafe partial struct Float4
     /// </summary>
     /// <param name="left">The first <see cref="Float4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4 operator /(Float4 left, Float4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float4 operator %(Float4 left, Float4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float4"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Float4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4 operator *(Float4 left, Float4 right) => default;
 
@@ -4191,6 +4205,61 @@ public unsafe partial struct Float4
     /// </summary>
     /// <param name="left">The first <see cref="Float4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4 operator -(Float4 left, Float4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator >(Float4 left, Float4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator >=(Float4 left, Float4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator <(Float4 left, Float4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator <=(Float4 left, Float4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator ==(Float4 left, Float4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator !=(Float4 left, Float4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
@@ -5,6 +5,8 @@ using RuntimeHelpers = ComputeSharp.Core.NetStandard.System.Runtime.CompilerServ
 using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServices.MemoryMarshal;
 #endif
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 /// <inheritdoc cref="Float1x1"/>
@@ -92,6 +94,7 @@ public unsafe partial struct Float1x1
     /// </summary>
     /// <param name="left">The first <see cref="Float1x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float1x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x1 operator +(Float1x1 left, Float1x1 right) => default;
 
@@ -100,14 +103,25 @@ public unsafe partial struct Float1x1
     /// </summary>
     /// <param name="left">The first <see cref="Float1x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float1x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x1 operator /(Float1x1 left, Float1x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float1x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float1x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float1x1 operator %(Float1x1 left, Float1x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float1x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float1x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float1x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x1 operator *(Float1x1 left, Float1x1 right) => default;
 
@@ -116,8 +130,63 @@ public unsafe partial struct Float1x1
     /// </summary>
     /// <param name="left">The first <see cref="Float1x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float1x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x1 operator -(Float1x1 left, Float1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator >(Float1x1 left, Float1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator >=(Float1x1 left, Float1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator <(Float1x1 left, Float1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator <=(Float1x1 left, Float1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator ==(Float1x1 left, Float1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator !=(Float1x1 left, Float1x1 right) => default;
 }
 
 /// <inheritdoc cref="Float1x2"/>
@@ -216,6 +285,7 @@ public unsafe partial struct Float1x2
     /// </summary>
     /// <param name="left">The first <see cref="Float1x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float1x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x2 operator +(Float1x2 left, Float1x2 right) => default;
 
@@ -224,14 +294,25 @@ public unsafe partial struct Float1x2
     /// </summary>
     /// <param name="left">The first <see cref="Float1x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float1x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x2 operator /(Float1x2 left, Float1x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float1x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float1x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float1x2 operator %(Float1x2 left, Float1x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float1x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float1x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float1x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x2 operator *(Float1x2 left, Float1x2 right) => default;
 
@@ -240,8 +321,63 @@ public unsafe partial struct Float1x2
     /// </summary>
     /// <param name="left">The first <see cref="Float1x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float1x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x2 operator -(Float1x2 left, Float1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator >(Float1x2 left, Float1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator >=(Float1x2 left, Float1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator <(Float1x2 left, Float1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator <=(Float1x2 left, Float1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator ==(Float1x2 left, Float1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator !=(Float1x2 left, Float1x2 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Float2"/> value to a <see cref="Float1x2"/> one.
@@ -357,6 +493,7 @@ public unsafe partial struct Float1x3
     /// </summary>
     /// <param name="left">The first <see cref="Float1x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float1x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x3 operator +(Float1x3 left, Float1x3 right) => default;
 
@@ -365,14 +502,25 @@ public unsafe partial struct Float1x3
     /// </summary>
     /// <param name="left">The first <see cref="Float1x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float1x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x3 operator /(Float1x3 left, Float1x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float1x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float1x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float1x3 operator %(Float1x3 left, Float1x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float1x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float1x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float1x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x3 operator *(Float1x3 left, Float1x3 right) => default;
 
@@ -381,8 +529,63 @@ public unsafe partial struct Float1x3
     /// </summary>
     /// <param name="left">The first <see cref="Float1x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float1x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x3 operator -(Float1x3 left, Float1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator >(Float1x3 left, Float1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator >=(Float1x3 left, Float1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator <(Float1x3 left, Float1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator <=(Float1x3 left, Float1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator ==(Float1x3 left, Float1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator !=(Float1x3 left, Float1x3 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Float3"/> value to a <see cref="Float1x3"/> one.
@@ -509,6 +712,7 @@ public unsafe partial struct Float1x4
     /// </summary>
     /// <param name="left">The first <see cref="Float1x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float1x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x4 operator +(Float1x4 left, Float1x4 right) => default;
 
@@ -517,14 +721,25 @@ public unsafe partial struct Float1x4
     /// </summary>
     /// <param name="left">The first <see cref="Float1x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float1x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x4 operator /(Float1x4 left, Float1x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float1x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float1x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float1x4 operator %(Float1x4 left, Float1x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float1x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float1x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float1x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x4 operator *(Float1x4 left, Float1x4 right) => default;
 
@@ -533,8 +748,63 @@ public unsafe partial struct Float1x4
     /// </summary>
     /// <param name="left">The first <see cref="Float1x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float1x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float1x4 operator -(Float1x4 left, Float1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator >(Float1x4 left, Float1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator >=(Float1x4 left, Float1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator <(Float1x4 left, Float1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator <=(Float1x4 left, Float1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator ==(Float1x4 left, Float1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float1x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator !=(Float1x4 left, Float1x4 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Float4"/> value to a <see cref="Float1x4"/> one.
@@ -639,6 +909,7 @@ public unsafe partial struct Float2x1
     /// </summary>
     /// <param name="left">The first <see cref="Float2x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float2x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x1 operator +(Float2x1 left, Float2x1 right) => default;
 
@@ -647,14 +918,25 @@ public unsafe partial struct Float2x1
     /// </summary>
     /// <param name="left">The first <see cref="Float2x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float2x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x1 operator /(Float2x1 left, Float2x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float2x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float2x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float2x1 operator %(Float2x1 left, Float2x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float2x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float2x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float2x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x1 operator *(Float2x1 left, Float2x1 right) => default;
 
@@ -663,8 +945,63 @@ public unsafe partial struct Float2x1
     /// </summary>
     /// <param name="left">The first <see cref="Float2x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float2x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x1 operator -(Float2x1 left, Float2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator >(Float2x1 left, Float2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator >=(Float2x1 left, Float2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator <(Float2x1 left, Float2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator <=(Float2x1 left, Float2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator ==(Float2x1 left, Float2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator !=(Float2x1 left, Float2x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Float2x1"/> value to a <see cref="Float2"/> one.
@@ -804,6 +1141,7 @@ public unsafe partial struct Float2x2
     /// </summary>
     /// <param name="left">The first <see cref="Float2x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float2x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x2 operator +(Float2x2 left, Float2x2 right) => default;
 
@@ -812,14 +1150,25 @@ public unsafe partial struct Float2x2
     /// </summary>
     /// <param name="left">The first <see cref="Float2x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float2x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x2 operator /(Float2x2 left, Float2x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float2x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float2x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float2x2 operator %(Float2x2 left, Float2x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float2x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float2x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float2x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x2 operator *(Float2x2 left, Float2x2 right) => default;
 
@@ -828,8 +1177,63 @@ public unsafe partial struct Float2x2
     /// </summary>
     /// <param name="left">The first <see cref="Float2x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float2x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x2 operator -(Float2x2 left, Float2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator >(Float2x2 left, Float2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator >=(Float2x2 left, Float2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator <(Float2x2 left, Float2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator <=(Float2x2 left, Float2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator ==(Float2x2 left, Float2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator !=(Float2x2 left, Float2x2 right) => default;
 }
 
 /// <inheritdoc cref="Float2x3"/>
@@ -987,6 +1391,7 @@ public unsafe partial struct Float2x3
     /// </summary>
     /// <param name="left">The first <see cref="Float2x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float2x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x3 operator +(Float2x3 left, Float2x3 right) => default;
 
@@ -995,14 +1400,25 @@ public unsafe partial struct Float2x3
     /// </summary>
     /// <param name="left">The first <see cref="Float2x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float2x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x3 operator /(Float2x3 left, Float2x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float2x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float2x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float2x3 operator %(Float2x3 left, Float2x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float2x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float2x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float2x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x3 operator *(Float2x3 left, Float2x3 right) => default;
 
@@ -1011,8 +1427,63 @@ public unsafe partial struct Float2x3
     /// </summary>
     /// <param name="left">The first <see cref="Float2x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float2x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x3 operator -(Float2x3 left, Float2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator >(Float2x3 left, Float2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator >=(Float2x3 left, Float2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator <(Float2x3 left, Float2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator <=(Float2x3 left, Float2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator ==(Float2x3 left, Float2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator !=(Float2x3 left, Float2x3 right) => default;
 }
 
 /// <inheritdoc cref="Float2x4"/>
@@ -1194,6 +1665,7 @@ public unsafe partial struct Float2x4
     /// </summary>
     /// <param name="left">The first <see cref="Float2x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float2x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x4 operator +(Float2x4 left, Float2x4 right) => default;
 
@@ -1202,14 +1674,25 @@ public unsafe partial struct Float2x4
     /// </summary>
     /// <param name="left">The first <see cref="Float2x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float2x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x4 operator /(Float2x4 left, Float2x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float2x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float2x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float2x4 operator %(Float2x4 left, Float2x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float2x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float2x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float2x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x4 operator *(Float2x4 left, Float2x4 right) => default;
 
@@ -1218,8 +1701,63 @@ public unsafe partial struct Float2x4
     /// </summary>
     /// <param name="left">The first <see cref="Float2x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float2x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float2x4 operator -(Float2x4 left, Float2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator >(Float2x4 left, Float2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator >=(Float2x4 left, Float2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator <(Float2x4 left, Float2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator <=(Float2x4 left, Float2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator ==(Float2x4 left, Float2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float2x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator !=(Float2x4 left, Float2x4 right) => default;
 }
 
 /// <inheritdoc cref="Float3x1"/>
@@ -1329,6 +1867,7 @@ public unsafe partial struct Float3x1
     /// </summary>
     /// <param name="left">The first <see cref="Float3x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float3x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x1 operator +(Float3x1 left, Float3x1 right) => default;
 
@@ -1337,14 +1876,25 @@ public unsafe partial struct Float3x1
     /// </summary>
     /// <param name="left">The first <see cref="Float3x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float3x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x1 operator /(Float3x1 left, Float3x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float3x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float3x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float3x1 operator %(Float3x1 left, Float3x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float3x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float3x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float3x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x1 operator *(Float3x1 left, Float3x1 right) => default;
 
@@ -1353,8 +1903,63 @@ public unsafe partial struct Float3x1
     /// </summary>
     /// <param name="left">The first <see cref="Float3x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float3x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x1 operator -(Float3x1 left, Float3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator >(Float3x1 left, Float3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator >=(Float3x1 left, Float3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator <(Float3x1 left, Float3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator <=(Float3x1 left, Float3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator ==(Float3x1 left, Float3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator !=(Float3x1 left, Float3x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Float3x1"/> value to a <see cref="Float3"/> one.
@@ -1519,6 +2124,7 @@ public unsafe partial struct Float3x2
     /// </summary>
     /// <param name="left">The first <see cref="Float3x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float3x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x2 operator +(Float3x2 left, Float3x2 right) => default;
 
@@ -1527,14 +2133,25 @@ public unsafe partial struct Float3x2
     /// </summary>
     /// <param name="left">The first <see cref="Float3x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float3x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x2 operator /(Float3x2 left, Float3x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float3x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float3x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float3x2 operator %(Float3x2 left, Float3x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float3x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float3x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float3x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x2 operator *(Float3x2 left, Float3x2 right) => default;
 
@@ -1543,8 +2160,63 @@ public unsafe partial struct Float3x2
     /// </summary>
     /// <param name="left">The first <see cref="Float3x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float3x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x2 operator -(Float3x2 left, Float3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator >(Float3x2 left, Float3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator >=(Float3x2 left, Float3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator <(Float3x2 left, Float3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator <=(Float3x2 left, Float3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator ==(Float3x2 left, Float3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator !=(Float3x2 left, Float3x2 right) => default;
 }
 
 /// <inheritdoc cref="Float3x3"/>
@@ -1739,6 +2411,7 @@ public unsafe partial struct Float3x3
     /// </summary>
     /// <param name="left">The first <see cref="Float3x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float3x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x3 operator +(Float3x3 left, Float3x3 right) => default;
 
@@ -1747,14 +2420,25 @@ public unsafe partial struct Float3x3
     /// </summary>
     /// <param name="left">The first <see cref="Float3x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float3x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x3 operator /(Float3x3 left, Float3x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float3x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float3x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float3x3 operator %(Float3x3 left, Float3x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float3x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float3x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float3x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x3 operator *(Float3x3 left, Float3x3 right) => default;
 
@@ -1763,8 +2447,63 @@ public unsafe partial struct Float3x3
     /// </summary>
     /// <param name="left">The first <see cref="Float3x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float3x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x3 operator -(Float3x3 left, Float3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator >(Float3x3 left, Float3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator >=(Float3x3 left, Float3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator <(Float3x3 left, Float3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator <=(Float3x3 left, Float3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator ==(Float3x3 left, Float3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator !=(Float3x3 left, Float3x3 right) => default;
 }
 
 /// <inheritdoc cref="Float3x4"/>
@@ -1995,6 +2734,7 @@ public unsafe partial struct Float3x4
     /// </summary>
     /// <param name="left">The first <see cref="Float3x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float3x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x4 operator +(Float3x4 left, Float3x4 right) => default;
 
@@ -2003,14 +2743,25 @@ public unsafe partial struct Float3x4
     /// </summary>
     /// <param name="left">The first <see cref="Float3x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float3x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x4 operator /(Float3x4 left, Float3x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float3x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float3x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float3x4 operator %(Float3x4 left, Float3x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float3x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float3x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float3x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x4 operator *(Float3x4 left, Float3x4 right) => default;
 
@@ -2019,8 +2770,63 @@ public unsafe partial struct Float3x4
     /// </summary>
     /// <param name="left">The first <see cref="Float3x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float3x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float3x4 operator -(Float3x4 left, Float3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator >(Float3x4 left, Float3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator >=(Float3x4 left, Float3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator <(Float3x4 left, Float3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator <=(Float3x4 left, Float3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator ==(Float3x4 left, Float3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float3x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator !=(Float3x4 left, Float3x4 right) => default;
 }
 
 /// <inheritdoc cref="Float4x1"/>
@@ -2141,6 +2947,7 @@ public unsafe partial struct Float4x1
     /// </summary>
     /// <param name="left">The first <see cref="Float4x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float4x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x1 operator +(Float4x1 left, Float4x1 right) => default;
 
@@ -2149,14 +2956,25 @@ public unsafe partial struct Float4x1
     /// </summary>
     /// <param name="left">The first <see cref="Float4x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float4x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x1 operator /(Float4x1 left, Float4x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float4x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float4x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float4x1 operator %(Float4x1 left, Float4x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float4x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float4x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float4x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x1 operator *(Float4x1 left, Float4x1 right) => default;
 
@@ -2165,8 +2983,63 @@ public unsafe partial struct Float4x1
     /// </summary>
     /// <param name="left">The first <see cref="Float4x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float4x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x1 operator -(Float4x1 left, Float4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator >(Float4x1 left, Float4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator >=(Float4x1 left, Float4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator <(Float4x1 left, Float4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator <=(Float4x1 left, Float4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator ==(Float4x1 left, Float4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator !=(Float4x1 left, Float4x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Float4x1"/> value to a <see cref="Float4"/> one.
@@ -2356,6 +3229,7 @@ public unsafe partial struct Float4x2
     /// </summary>
     /// <param name="left">The first <see cref="Float4x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float4x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x2 operator +(Float4x2 left, Float4x2 right) => default;
 
@@ -2364,14 +3238,25 @@ public unsafe partial struct Float4x2
     /// </summary>
     /// <param name="left">The first <see cref="Float4x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float4x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x2 operator /(Float4x2 left, Float4x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float4x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float4x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float4x2 operator %(Float4x2 left, Float4x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float4x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float4x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float4x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x2 operator *(Float4x2 left, Float4x2 right) => default;
 
@@ -2380,8 +3265,63 @@ public unsafe partial struct Float4x2
     /// </summary>
     /// <param name="left">The first <see cref="Float4x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float4x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x2 operator -(Float4x2 left, Float4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator >(Float4x2 left, Float4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator >=(Float4x2 left, Float4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator <(Float4x2 left, Float4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator <=(Float4x2 left, Float4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator ==(Float4x2 left, Float4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator !=(Float4x2 left, Float4x2 right) => default;
 }
 
 /// <inheritdoc cref="Float4x3"/>
@@ -2613,6 +3553,7 @@ public unsafe partial struct Float4x3
     /// </summary>
     /// <param name="left">The first <see cref="Float4x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float4x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x3 operator +(Float4x3 left, Float4x3 right) => default;
 
@@ -2621,14 +3562,25 @@ public unsafe partial struct Float4x3
     /// </summary>
     /// <param name="left">The first <see cref="Float4x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float4x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x3 operator /(Float4x3 left, Float4x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float4x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float4x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float4x3 operator %(Float4x3 left, Float4x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float4x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float4x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float4x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x3 operator *(Float4x3 left, Float4x3 right) => default;
 
@@ -2637,8 +3589,63 @@ public unsafe partial struct Float4x3
     /// </summary>
     /// <param name="left">The first <see cref="Float4x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float4x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x3 operator -(Float4x3 left, Float4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator >(Float4x3 left, Float4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator >=(Float4x3 left, Float4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator <(Float4x3 left, Float4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator <=(Float4x3 left, Float4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator ==(Float4x3 left, Float4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator !=(Float4x3 left, Float4x3 right) => default;
 }
 
 /// <inheritdoc cref="Float4x4"/>
@@ -2918,6 +3925,7 @@ public unsafe partial struct Float4x4
     /// </summary>
     /// <param name="left">The first <see cref="Float4x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Float4x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x4 operator +(Float4x4 left, Float4x4 right) => default;
 
@@ -2926,14 +3934,25 @@ public unsafe partial struct Float4x4
     /// </summary>
     /// <param name="left">The first <see cref="Float4x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Float4x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x4 operator /(Float4x4 left, Float4x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Float4x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Float4x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Float4x4 operator %(Float4x4 left, Float4x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Float4x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Float4x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Float4x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x4 operator *(Float4x4 left, Float4x4 right) => default;
 
@@ -2942,6 +3961,61 @@ public unsafe partial struct Float4x4
     /// </summary>
     /// <param name="left">The first <see cref="Float4x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Float4x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Float4x4 operator -(Float4x4 left, Float4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator >(Float4x4 left, Float4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator >=(Float4x4 left, Float4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator <(Float4x4 left, Float4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator <=(Float4x4 left, Float4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator ==(Float4x4 left, Float4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Float4x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Float4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Float4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator !=(Float4x4 left, Float4x4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="int2"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -437,6 +438,7 @@ public unsafe partial struct Int2
     /// Negates a <see cref="Int2"/> value.
     /// </summary>
     /// <param name="xy">The <see cref="Int2"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xy"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2 operator -(Int2 xy) => default;
 
@@ -445,6 +447,7 @@ public unsafe partial struct Int2
     /// </summary>
     /// <param name="left">The first <see cref="Int2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2 operator +(Int2 left, Int2 right) => default;
 
@@ -453,14 +456,25 @@ public unsafe partial struct Int2
     /// </summary>
     /// <param name="left">The first <see cref="Int2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2 operator /(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator %(Int2 left, Int2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int2"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Int2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2 operator *(Int2 left, Int2 right) => default;
 
@@ -469,6 +483,61 @@ public unsafe partial struct Int2
     /// </summary>
     /// <param name="left">The first <see cref="Int2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2 operator -(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator >(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator >=(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator <(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator <=(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator ==(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator !=(Int2 left, Int2 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="int3"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -1518,6 +1519,7 @@ public unsafe partial struct Int3
     /// Negates a <see cref="Int3"/> value.
     /// </summary>
     /// <param name="xyz">The <see cref="Int3"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xyz"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3 operator -(Int3 xyz) => default;
 
@@ -1526,6 +1528,7 @@ public unsafe partial struct Int3
     /// </summary>
     /// <param name="left">The first <see cref="Int3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3 operator +(Int3 left, Int3 right) => default;
 
@@ -1534,14 +1537,25 @@ public unsafe partial struct Int3
     /// </summary>
     /// <param name="left">The first <see cref="Int3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3 operator /(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator %(Int3 left, Int3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int3"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Int3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3 operator *(Int3 left, Int3 right) => default;
 
@@ -1550,6 +1564,61 @@ public unsafe partial struct Int3
     /// </summary>
     /// <param name="left">The first <see cref="Int3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3 operator -(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator >(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator >=(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator <(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator <=(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator ==(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator !=(Int3 left, Int3 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="int4"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -4159,6 +4160,7 @@ public unsafe partial struct Int4
     /// Negates a <see cref="Int4"/> value.
     /// </summary>
     /// <param name="xyzw">The <see cref="Int4"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="xyzw"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4 operator -(Int4 xyzw) => default;
 
@@ -4167,6 +4169,7 @@ public unsafe partial struct Int4
     /// </summary>
     /// <param name="left">The first <see cref="Int4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4 operator +(Int4 left, Int4 right) => default;
 
@@ -4175,14 +4178,25 @@ public unsafe partial struct Int4
     /// </summary>
     /// <param name="left">The first <see cref="Int4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4 operator /(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator %(Int4 left, Int4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int4"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="Int4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4 operator *(Int4 left, Int4 right) => default;
 
@@ -4191,6 +4205,61 @@ public unsafe partial struct Int4
     /// </summary>
     /// <param name="left">The first <see cref="Int4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4 operator -(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator >(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator >=(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator <(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator <=(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator ==(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator !=(Int4 left, Int4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -5,6 +5,8 @@ using RuntimeHelpers = ComputeSharp.Core.NetStandard.System.Runtime.CompilerServ
 using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServices.MemoryMarshal;
 #endif
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 /// <inheritdoc cref="Int1x1"/>
@@ -92,6 +94,7 @@ public unsafe partial struct Int1x1
     /// </summary>
     /// <param name="left">The first <see cref="Int1x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int1x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x1 operator +(Int1x1 left, Int1x1 right) => default;
 
@@ -100,14 +103,25 @@ public unsafe partial struct Int1x1
     /// </summary>
     /// <param name="left">The first <see cref="Int1x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int1x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x1 operator /(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int1x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int1x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator %(Int1x1 left, Int1x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int1x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int1x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int1x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x1 operator *(Int1x1 left, Int1x1 right) => default;
 
@@ -116,8 +130,63 @@ public unsafe partial struct Int1x1
     /// </summary>
     /// <param name="left">The first <see cref="Int1x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int1x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x1 operator -(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator >(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator >=(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator <(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator <=(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator ==(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator !=(Int1x1 left, Int1x1 right) => default;
 }
 
 /// <inheritdoc cref="Int1x2"/>
@@ -216,6 +285,7 @@ public unsafe partial struct Int1x2
     /// </summary>
     /// <param name="left">The first <see cref="Int1x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int1x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x2 operator +(Int1x2 left, Int1x2 right) => default;
 
@@ -224,14 +294,25 @@ public unsafe partial struct Int1x2
     /// </summary>
     /// <param name="left">The first <see cref="Int1x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int1x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x2 operator /(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int1x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int1x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator %(Int1x2 left, Int1x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int1x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int1x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int1x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x2 operator *(Int1x2 left, Int1x2 right) => default;
 
@@ -240,8 +321,63 @@ public unsafe partial struct Int1x2
     /// </summary>
     /// <param name="left">The first <see cref="Int1x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int1x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x2 operator -(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator >(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator >=(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator <(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator <=(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator ==(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator !=(Int1x2 left, Int1x2 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Int2"/> value to a <see cref="Int1x2"/> one.
@@ -357,6 +493,7 @@ public unsafe partial struct Int1x3
     /// </summary>
     /// <param name="left">The first <see cref="Int1x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int1x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x3 operator +(Int1x3 left, Int1x3 right) => default;
 
@@ -365,14 +502,25 @@ public unsafe partial struct Int1x3
     /// </summary>
     /// <param name="left">The first <see cref="Int1x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int1x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x3 operator /(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int1x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int1x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator %(Int1x3 left, Int1x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int1x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int1x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int1x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x3 operator *(Int1x3 left, Int1x3 right) => default;
 
@@ -381,8 +529,63 @@ public unsafe partial struct Int1x3
     /// </summary>
     /// <param name="left">The first <see cref="Int1x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int1x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x3 operator -(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator >(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator >=(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator <(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator <=(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator ==(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator !=(Int1x3 left, Int1x3 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Int3"/> value to a <see cref="Int1x3"/> one.
@@ -509,6 +712,7 @@ public unsafe partial struct Int1x4
     /// </summary>
     /// <param name="left">The first <see cref="Int1x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int1x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x4 operator +(Int1x4 left, Int1x4 right) => default;
 
@@ -517,14 +721,25 @@ public unsafe partial struct Int1x4
     /// </summary>
     /// <param name="left">The first <see cref="Int1x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int1x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x4 operator /(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int1x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int1x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator %(Int1x4 left, Int1x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int1x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int1x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int1x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x4 operator *(Int1x4 left, Int1x4 right) => default;
 
@@ -533,8 +748,63 @@ public unsafe partial struct Int1x4
     /// </summary>
     /// <param name="left">The first <see cref="Int1x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int1x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x4 operator -(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator >(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator >=(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator <(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator <=(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator ==(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int1x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator !=(Int1x4 left, Int1x4 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Int4"/> value to a <see cref="Int1x4"/> one.
@@ -639,6 +909,7 @@ public unsafe partial struct Int2x1
     /// </summary>
     /// <param name="left">The first <see cref="Int2x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int2x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x1 operator +(Int2x1 left, Int2x1 right) => default;
 
@@ -647,14 +918,25 @@ public unsafe partial struct Int2x1
     /// </summary>
     /// <param name="left">The first <see cref="Int2x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int2x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x1 operator /(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int2x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int2x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator %(Int2x1 left, Int2x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int2x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int2x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int2x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x1 operator *(Int2x1 left, Int2x1 right) => default;
 
@@ -663,8 +945,63 @@ public unsafe partial struct Int2x1
     /// </summary>
     /// <param name="left">The first <see cref="Int2x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int2x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x1 operator -(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator >(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator >=(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator <(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator <=(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator ==(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator !=(Int2x1 left, Int2x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Int2x1"/> value to a <see cref="Int2"/> one.
@@ -804,6 +1141,7 @@ public unsafe partial struct Int2x2
     /// </summary>
     /// <param name="left">The first <see cref="Int2x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int2x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x2 operator +(Int2x2 left, Int2x2 right) => default;
 
@@ -812,14 +1150,25 @@ public unsafe partial struct Int2x2
     /// </summary>
     /// <param name="left">The first <see cref="Int2x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int2x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x2 operator /(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int2x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int2x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator %(Int2x2 left, Int2x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int2x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int2x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int2x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x2 operator *(Int2x2 left, Int2x2 right) => default;
 
@@ -828,8 +1177,63 @@ public unsafe partial struct Int2x2
     /// </summary>
     /// <param name="left">The first <see cref="Int2x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int2x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x2 operator -(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator >(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator >=(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator <(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator <=(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator ==(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator !=(Int2x2 left, Int2x2 right) => default;
 }
 
 /// <inheritdoc cref="Int2x3"/>
@@ -987,6 +1391,7 @@ public unsafe partial struct Int2x3
     /// </summary>
     /// <param name="left">The first <see cref="Int2x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int2x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x3 operator +(Int2x3 left, Int2x3 right) => default;
 
@@ -995,14 +1400,25 @@ public unsafe partial struct Int2x3
     /// </summary>
     /// <param name="left">The first <see cref="Int2x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int2x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x3 operator /(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int2x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int2x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator %(Int2x3 left, Int2x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int2x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int2x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int2x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x3 operator *(Int2x3 left, Int2x3 right) => default;
 
@@ -1011,8 +1427,63 @@ public unsafe partial struct Int2x3
     /// </summary>
     /// <param name="left">The first <see cref="Int2x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int2x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x3 operator -(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator >(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator >=(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator <(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator <=(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator ==(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator !=(Int2x3 left, Int2x3 right) => default;
 }
 
 /// <inheritdoc cref="Int2x4"/>
@@ -1194,6 +1665,7 @@ public unsafe partial struct Int2x4
     /// </summary>
     /// <param name="left">The first <see cref="Int2x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int2x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x4 operator +(Int2x4 left, Int2x4 right) => default;
 
@@ -1202,14 +1674,25 @@ public unsafe partial struct Int2x4
     /// </summary>
     /// <param name="left">The first <see cref="Int2x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int2x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x4 operator /(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int2x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int2x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator %(Int2x4 left, Int2x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int2x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int2x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int2x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x4 operator *(Int2x4 left, Int2x4 right) => default;
 
@@ -1218,8 +1701,63 @@ public unsafe partial struct Int2x4
     /// </summary>
     /// <param name="left">The first <see cref="Int2x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int2x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x4 operator -(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator >(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator >=(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator <(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator <=(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator ==(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int2x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator !=(Int2x4 left, Int2x4 right) => default;
 }
 
 /// <inheritdoc cref="Int3x1"/>
@@ -1329,6 +1867,7 @@ public unsafe partial struct Int3x1
     /// </summary>
     /// <param name="left">The first <see cref="Int3x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int3x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x1 operator +(Int3x1 left, Int3x1 right) => default;
 
@@ -1337,14 +1876,25 @@ public unsafe partial struct Int3x1
     /// </summary>
     /// <param name="left">The first <see cref="Int3x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int3x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x1 operator /(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int3x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int3x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator %(Int3x1 left, Int3x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int3x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int3x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int3x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x1 operator *(Int3x1 left, Int3x1 right) => default;
 
@@ -1353,8 +1903,63 @@ public unsafe partial struct Int3x1
     /// </summary>
     /// <param name="left">The first <see cref="Int3x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int3x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x1 operator -(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator >(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator >=(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator <(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator <=(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator ==(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator !=(Int3x1 left, Int3x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Int3x1"/> value to a <see cref="Int3"/> one.
@@ -1519,6 +2124,7 @@ public unsafe partial struct Int3x2
     /// </summary>
     /// <param name="left">The first <see cref="Int3x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int3x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x2 operator +(Int3x2 left, Int3x2 right) => default;
 
@@ -1527,14 +2133,25 @@ public unsafe partial struct Int3x2
     /// </summary>
     /// <param name="left">The first <see cref="Int3x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int3x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x2 operator /(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int3x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int3x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator %(Int3x2 left, Int3x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int3x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int3x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int3x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x2 operator *(Int3x2 left, Int3x2 right) => default;
 
@@ -1543,8 +2160,63 @@ public unsafe partial struct Int3x2
     /// </summary>
     /// <param name="left">The first <see cref="Int3x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int3x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x2 operator -(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator >(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator >=(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator <(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator <=(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator ==(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator !=(Int3x2 left, Int3x2 right) => default;
 }
 
 /// <inheritdoc cref="Int3x3"/>
@@ -1739,6 +2411,7 @@ public unsafe partial struct Int3x3
     /// </summary>
     /// <param name="left">The first <see cref="Int3x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int3x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x3 operator +(Int3x3 left, Int3x3 right) => default;
 
@@ -1747,14 +2420,25 @@ public unsafe partial struct Int3x3
     /// </summary>
     /// <param name="left">The first <see cref="Int3x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int3x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x3 operator /(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int3x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int3x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator %(Int3x3 left, Int3x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int3x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int3x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int3x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x3 operator *(Int3x3 left, Int3x3 right) => default;
 
@@ -1763,8 +2447,63 @@ public unsafe partial struct Int3x3
     /// </summary>
     /// <param name="left">The first <see cref="Int3x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int3x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x3 operator -(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator >(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator >=(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator <(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator <=(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator ==(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator !=(Int3x3 left, Int3x3 right) => default;
 }
 
 /// <inheritdoc cref="Int3x4"/>
@@ -1995,6 +2734,7 @@ public unsafe partial struct Int3x4
     /// </summary>
     /// <param name="left">The first <see cref="Int3x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int3x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x4 operator +(Int3x4 left, Int3x4 right) => default;
 
@@ -2003,14 +2743,25 @@ public unsafe partial struct Int3x4
     /// </summary>
     /// <param name="left">The first <see cref="Int3x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int3x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x4 operator /(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int3x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int3x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator %(Int3x4 left, Int3x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int3x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int3x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int3x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x4 operator *(Int3x4 left, Int3x4 right) => default;
 
@@ -2019,8 +2770,63 @@ public unsafe partial struct Int3x4
     /// </summary>
     /// <param name="left">The first <see cref="Int3x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int3x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x4 operator -(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator >(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator >=(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator <(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator <=(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator ==(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int3x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator !=(Int3x4 left, Int3x4 right) => default;
 }
 
 /// <inheritdoc cref="Int4x1"/>
@@ -2141,6 +2947,7 @@ public unsafe partial struct Int4x1
     /// </summary>
     /// <param name="left">The first <see cref="Int4x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int4x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x1 operator +(Int4x1 left, Int4x1 right) => default;
 
@@ -2149,14 +2956,25 @@ public unsafe partial struct Int4x1
     /// </summary>
     /// <param name="left">The first <see cref="Int4x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int4x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x1 operator /(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int4x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int4x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator %(Int4x1 left, Int4x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int4x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int4x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int4x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x1 operator *(Int4x1 left, Int4x1 right) => default;
 
@@ -2165,8 +2983,63 @@ public unsafe partial struct Int4x1
     /// </summary>
     /// <param name="left">The first <see cref="Int4x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int4x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x1 operator -(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator >(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator >=(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator <(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator <=(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator ==(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator !=(Int4x1 left, Int4x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="Int4x1"/> value to a <see cref="Int4"/> one.
@@ -2356,6 +3229,7 @@ public unsafe partial struct Int4x2
     /// </summary>
     /// <param name="left">The first <see cref="Int4x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int4x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x2 operator +(Int4x2 left, Int4x2 right) => default;
 
@@ -2364,14 +3238,25 @@ public unsafe partial struct Int4x2
     /// </summary>
     /// <param name="left">The first <see cref="Int4x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int4x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x2 operator /(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int4x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int4x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator %(Int4x2 left, Int4x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int4x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int4x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int4x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x2 operator *(Int4x2 left, Int4x2 right) => default;
 
@@ -2380,8 +3265,63 @@ public unsafe partial struct Int4x2
     /// </summary>
     /// <param name="left">The first <see cref="Int4x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int4x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x2 operator -(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator >(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator >=(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator <(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator <=(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator ==(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator !=(Int4x2 left, Int4x2 right) => default;
 }
 
 /// <inheritdoc cref="Int4x3"/>
@@ -2613,6 +3553,7 @@ public unsafe partial struct Int4x3
     /// </summary>
     /// <param name="left">The first <see cref="Int4x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int4x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x3 operator +(Int4x3 left, Int4x3 right) => default;
 
@@ -2621,14 +3562,25 @@ public unsafe partial struct Int4x3
     /// </summary>
     /// <param name="left">The first <see cref="Int4x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int4x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x3 operator /(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int4x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int4x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator %(Int4x3 left, Int4x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int4x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int4x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int4x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x3 operator *(Int4x3 left, Int4x3 right) => default;
 
@@ -2637,8 +3589,63 @@ public unsafe partial struct Int4x3
     /// </summary>
     /// <param name="left">The first <see cref="Int4x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int4x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x3 operator -(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator >(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator >=(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator <(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator <=(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator ==(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator !=(Int4x3 left, Int4x3 right) => default;
 }
 
 /// <inheritdoc cref="Int4x4"/>
@@ -2918,6 +3925,7 @@ public unsafe partial struct Int4x4
     /// </summary>
     /// <param name="left">The first <see cref="Int4x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="Int4x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x4 operator +(Int4x4 left, Int4x4 right) => default;
 
@@ -2926,14 +3934,25 @@ public unsafe partial struct Int4x4
     /// </summary>
     /// <param name="left">The first <see cref="Int4x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="Int4x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x4 operator /(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="Int4x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="Int4x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator %(Int4x4 left, Int4x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="Int4x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="Int4x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="Int4x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x4 operator *(Int4x4 left, Int4x4 right) => default;
 
@@ -2942,6 +3961,61 @@ public unsafe partial struct Int4x4
     /// </summary>
     /// <param name="left">The first <see cref="Int4x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="Int4x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x4 operator -(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator >(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator >=(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator <(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator <=(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator ==(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="Int4x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="Int4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="Int4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator !=(Int4x4 left, Int4x4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -17,6 +17,8 @@ using RuntimeHelpers = ComputeSharp.Core.NetStandard.System.Runtime.CompilerServ
 using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServices.MemoryMarshal;
 #endif
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 <#
@@ -221,6 +223,7 @@ public unsafe partial struct <#=fullTypeName#>
     /// </summary>
     /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to sum.</param>
     /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=fullTypeName#> operator +(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
 
@@ -229,14 +232,25 @@ public unsafe partial struct <#=fullTypeName#>
     /// </summary>
     /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to divide.</param>
     /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=fullTypeName#> operator /(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="<#=fullTypeName#>"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to divide.</param>
+    /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator %(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="<#=fullTypeName#>"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to multiply.</param>
     /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=fullTypeName#> operator *(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
 
@@ -245,11 +259,68 @@ public unsafe partial struct <#=fullTypeName#>
     /// </summary>
     /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to subtract.</param>
     /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=fullTypeName#> operator -(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=fullTypeName#>"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=rows#>x<#=columns#> operator >(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=fullTypeName#>"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=rows#>x<#=columns#> operator >=(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=fullTypeName#>"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=rows#>x<#=columns#> operator <(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=fullTypeName#>"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=rows#>x<#=columns#> operator <=(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
 <#
     }
 
+    WriteLine("");
+#>
+    /// <summary>
+    /// Compares two <see cref="<#=fullTypeName#>"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=rows#>x<#=columns#> operator ==(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=fullTypeName#>"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=fullTypeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=rows#>x<#=columns#> operator !=(<#=fullTypeName#> left, <#=fullTypeName#> right) => default;
+<#
     // Generate the casting operators for row/column vectors
     if (rows == 1 && columns > 1)
     {

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="uint2"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -438,6 +439,7 @@ public unsafe partial struct UInt2
     /// </summary>
     /// <param name="left">The first <see cref="UInt2"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2 operator +(UInt2 left, UInt2 right) => default;
 
@@ -446,14 +448,25 @@ public unsafe partial struct UInt2
     /// </summary>
     /// <param name="left">The first <see cref="UInt2"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2 operator /(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator %(UInt2 left, UInt2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt2"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="UInt2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2 operator *(UInt2 left, UInt2 right) => default;
 
@@ -462,6 +475,61 @@ public unsafe partial struct UInt2
     /// </summary>
     /// <param name="left">The first <see cref="UInt2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2 operator -(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator >(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator >=(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator <(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator <=(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator ==(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2 operator !=(UInt2 left, UInt2 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="uint3"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -1519,6 +1520,7 @@ public unsafe partial struct UInt3
     /// </summary>
     /// <param name="left">The first <see cref="UInt3"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3 operator +(UInt3 left, UInt3 right) => default;
 
@@ -1527,14 +1529,25 @@ public unsafe partial struct UInt3
     /// </summary>
     /// <param name="left">The first <see cref="UInt3"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3 operator /(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator %(UInt3 left, UInt3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt3"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="UInt3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3 operator *(UInt3 left, UInt3 right) => default;
 
@@ -1543,6 +1556,61 @@ public unsafe partial struct UInt3
     /// </summary>
     /// <param name="left">The first <see cref="UInt3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3 operator -(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator >(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator >=(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator <(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator <=(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator ==(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3 operator !=(UInt3 left, UInt3 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.cs
@@ -1,4 +1,6 @@
-﻿namespace ComputeSharp;
+﻿#pragma warning disable CS0660, CS0661
+
+namespace ComputeSharp;
 
 /// <summary>
 /// A <see langword="struct"/> that maps the <see langword="uint4"/> HLSL type.

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
@@ -8,6 +8,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -4160,6 +4161,7 @@ public unsafe partial struct UInt4
     /// </summary>
     /// <param name="left">The first <see cref="UInt4"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4 operator +(UInt4 left, UInt4 right) => default;
 
@@ -4168,14 +4170,25 @@ public unsafe partial struct UInt4
     /// </summary>
     /// <param name="left">The first <see cref="UInt4"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4 operator /(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator %(UInt4 left, UInt4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt4"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="UInt4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4 operator *(UInt4 left, UInt4 right) => default;
 
@@ -4184,6 +4197,61 @@ public unsafe partial struct UInt4
     /// </summary>
     /// <param name="left">The first <see cref="UInt4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4 operator -(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator >(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator >=(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator <(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator <=(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator ==(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4 operator !=(UInt4 left, UInt4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -5,6 +5,8 @@ using RuntimeHelpers = ComputeSharp.Core.NetStandard.System.Runtime.CompilerServ
 using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServices.MemoryMarshal;
 #endif
 
+#pragma warning disable CS0660, CS0661
+
 namespace ComputeSharp;
 
 /// <inheritdoc cref="UInt1x1"/>
@@ -85,6 +87,7 @@ public unsafe partial struct UInt1x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt1x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x1 operator +(UInt1x1 left, UInt1x1 right) => default;
 
@@ -93,14 +96,25 @@ public unsafe partial struct UInt1x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt1x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x1 operator /(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt1x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt1x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator %(UInt1x1 left, UInt1x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt1x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt1x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x1 operator *(UInt1x1 left, UInt1x1 right) => default;
 
@@ -109,8 +123,63 @@ public unsafe partial struct UInt1x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt1x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x1 operator -(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator >(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator >=(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator <(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator <=(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator ==(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x1 operator !=(UInt1x1 left, UInt1x1 right) => default;
 }
 
 /// <inheritdoc cref="UInt1x2"/>
@@ -202,6 +271,7 @@ public unsafe partial struct UInt1x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt1x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x2 operator +(UInt1x2 left, UInt1x2 right) => default;
 
@@ -210,14 +280,25 @@ public unsafe partial struct UInt1x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt1x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x2 operator /(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt1x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt1x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator %(UInt1x2 left, UInt1x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt1x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt1x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x2 operator *(UInt1x2 left, UInt1x2 right) => default;
 
@@ -226,8 +307,63 @@ public unsafe partial struct UInt1x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt1x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x2 operator -(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator >(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator >=(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator <(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator <=(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator ==(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x2 operator !=(UInt1x2 left, UInt1x2 right) => default;
 
     /// <summary>
     /// Casts a <see cref="UInt2"/> value to a <see cref="UInt1x2"/> one.
@@ -336,6 +472,7 @@ public unsafe partial struct UInt1x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt1x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x3 operator +(UInt1x3 left, UInt1x3 right) => default;
 
@@ -344,14 +481,25 @@ public unsafe partial struct UInt1x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt1x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x3 operator /(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt1x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt1x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator %(UInt1x3 left, UInt1x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt1x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt1x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x3 operator *(UInt1x3 left, UInt1x3 right) => default;
 
@@ -360,8 +508,63 @@ public unsafe partial struct UInt1x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt1x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x3 operator -(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator >(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator >=(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator <(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator <=(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator ==(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x3 operator !=(UInt1x3 left, UInt1x3 right) => default;
 
     /// <summary>
     /// Casts a <see cref="UInt3"/> value to a <see cref="UInt1x3"/> one.
@@ -481,6 +684,7 @@ public unsafe partial struct UInt1x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt1x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x4 operator +(UInt1x4 left, UInt1x4 right) => default;
 
@@ -489,14 +693,25 @@ public unsafe partial struct UInt1x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt1x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x4 operator /(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt1x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt1x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator %(UInt1x4 left, UInt1x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt1x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt1x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x4 operator *(UInt1x4 left, UInt1x4 right) => default;
 
@@ -505,8 +720,63 @@ public unsafe partial struct UInt1x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt1x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x4 operator -(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator >(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator >=(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator <(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator <=(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator ==(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt1x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt1x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt1x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool1x4 operator !=(UInt1x4 left, UInt1x4 right) => default;
 
     /// <summary>
     /// Casts a <see cref="UInt4"/> value to a <see cref="UInt1x4"/> one.
@@ -604,6 +874,7 @@ public unsafe partial struct UInt2x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt2x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x1 operator +(UInt2x1 left, UInt2x1 right) => default;
 
@@ -612,14 +883,25 @@ public unsafe partial struct UInt2x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt2x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x1 operator /(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt2x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt2x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator %(UInt2x1 left, UInt2x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt2x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt2x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x1 operator *(UInt2x1 left, UInt2x1 right) => default;
 
@@ -628,8 +910,63 @@ public unsafe partial struct UInt2x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt2x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x1 operator -(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator >(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator >=(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator <(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator <=(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator ==(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x1 operator !=(UInt2x1 left, UInt2x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="UInt2x1"/> value to a <see cref="UInt2"/> one.
@@ -762,6 +1099,7 @@ public unsafe partial struct UInt2x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt2x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x2 operator +(UInt2x2 left, UInt2x2 right) => default;
 
@@ -770,14 +1108,25 @@ public unsafe partial struct UInt2x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt2x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x2 operator /(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt2x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt2x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator %(UInt2x2 left, UInt2x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt2x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt2x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x2 operator *(UInt2x2 left, UInt2x2 right) => default;
 
@@ -786,8 +1135,63 @@ public unsafe partial struct UInt2x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt2x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x2 operator -(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator >(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator >=(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator <(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator <=(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator ==(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x2 operator !=(UInt2x2 left, UInt2x2 right) => default;
 }
 
 /// <inheritdoc cref="UInt2x3"/>
@@ -938,6 +1342,7 @@ public unsafe partial struct UInt2x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt2x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x3 operator +(UInt2x3 left, UInt2x3 right) => default;
 
@@ -946,14 +1351,25 @@ public unsafe partial struct UInt2x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt2x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x3 operator /(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt2x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt2x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator %(UInt2x3 left, UInt2x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt2x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt2x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x3 operator *(UInt2x3 left, UInt2x3 right) => default;
 
@@ -962,8 +1378,63 @@ public unsafe partial struct UInt2x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt2x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x3 operator -(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator >(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator >=(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator <(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator <=(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator ==(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x3 operator !=(UInt2x3 left, UInt2x3 right) => default;
 }
 
 /// <inheritdoc cref="UInt2x4"/>
@@ -1138,6 +1609,7 @@ public unsafe partial struct UInt2x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt2x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x4 operator +(UInt2x4 left, UInt2x4 right) => default;
 
@@ -1146,14 +1618,25 @@ public unsafe partial struct UInt2x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt2x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x4 operator /(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt2x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt2x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator %(UInt2x4 left, UInt2x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt2x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt2x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x4 operator *(UInt2x4 left, UInt2x4 right) => default;
 
@@ -1162,8 +1645,63 @@ public unsafe partial struct UInt2x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt2x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x4 operator -(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator >(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator >=(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator <(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator <=(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator ==(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt2x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt2x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt2x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool2x4 operator !=(UInt2x4 left, UInt2x4 right) => default;
 }
 
 /// <inheritdoc cref="UInt3x1"/>
@@ -1266,6 +1804,7 @@ public unsafe partial struct UInt3x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt3x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x1 operator +(UInt3x1 left, UInt3x1 right) => default;
 
@@ -1274,14 +1813,25 @@ public unsafe partial struct UInt3x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt3x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x1 operator /(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt3x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt3x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator %(UInt3x1 left, UInt3x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt3x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt3x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x1 operator *(UInt3x1 left, UInt3x1 right) => default;
 
@@ -1290,8 +1840,63 @@ public unsafe partial struct UInt3x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt3x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x1 operator -(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator >(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator >=(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator <(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator <=(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator ==(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x1 operator !=(UInt3x1 left, UInt3x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="UInt3x1"/> value to a <see cref="UInt3"/> one.
@@ -1449,6 +2054,7 @@ public unsafe partial struct UInt3x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt3x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x2 operator +(UInt3x2 left, UInt3x2 right) => default;
 
@@ -1457,14 +2063,25 @@ public unsafe partial struct UInt3x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt3x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x2 operator /(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt3x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt3x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator %(UInt3x2 left, UInt3x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt3x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt3x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x2 operator *(UInt3x2 left, UInt3x2 right) => default;
 
@@ -1473,8 +2090,63 @@ public unsafe partial struct UInt3x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt3x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x2 operator -(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator >(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator >=(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator <(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator <=(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator ==(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x2 operator !=(UInt3x2 left, UInt3x2 right) => default;
 }
 
 /// <inheritdoc cref="UInt3x3"/>
@@ -1662,6 +2334,7 @@ public unsafe partial struct UInt3x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt3x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x3 operator +(UInt3x3 left, UInt3x3 right) => default;
 
@@ -1670,14 +2343,25 @@ public unsafe partial struct UInt3x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt3x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x3 operator /(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt3x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt3x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator %(UInt3x3 left, UInt3x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt3x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt3x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x3 operator *(UInt3x3 left, UInt3x3 right) => default;
 
@@ -1686,8 +2370,63 @@ public unsafe partial struct UInt3x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt3x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x3 operator -(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator >(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator >=(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator <(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator <=(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator ==(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x3 operator !=(UInt3x3 left, UInt3x3 right) => default;
 }
 
 /// <inheritdoc cref="UInt3x4"/>
@@ -1911,6 +2650,7 @@ public unsafe partial struct UInt3x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt3x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x4 operator +(UInt3x4 left, UInt3x4 right) => default;
 
@@ -1919,14 +2659,25 @@ public unsafe partial struct UInt3x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt3x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x4 operator /(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt3x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt3x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator %(UInt3x4 left, UInt3x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt3x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt3x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x4 operator *(UInt3x4 left, UInt3x4 right) => default;
 
@@ -1935,8 +2686,63 @@ public unsafe partial struct UInt3x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt3x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x4 operator -(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator >(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator >=(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator <(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator <=(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator ==(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt3x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt3x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt3x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool3x4 operator !=(UInt3x4 left, UInt3x4 right) => default;
 }
 
 /// <inheritdoc cref="UInt4x1"/>
@@ -2050,6 +2856,7 @@ public unsafe partial struct UInt4x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x1"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt4x1"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x1 operator +(UInt4x1 left, UInt4x1 right) => default;
 
@@ -2058,14 +2865,25 @@ public unsafe partial struct UInt4x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x1"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt4x1"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x1 operator /(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt4x1"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x1"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt4x1"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator %(UInt4x1 left, UInt4x1 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt4x1"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x1"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt4x1"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x1 operator *(UInt4x1 left, UInt4x1 right) => default;
 
@@ -2074,8 +2892,63 @@ public unsafe partial struct UInt4x1
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x1"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt4x1"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x1 operator -(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x1"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator >(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x1"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator >=(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x1"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator <(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x1"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator <=(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x1"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator ==(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x1"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x1"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x1"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x1 operator !=(UInt4x1 left, UInt4x1 right) => default;
 
     /// <summary>
     /// Casts a <see cref="UInt4x1"/> value to a <see cref="UInt4"/> one.
@@ -2258,6 +3131,7 @@ public unsafe partial struct UInt4x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x2"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt4x2"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x2 operator +(UInt4x2 left, UInt4x2 right) => default;
 
@@ -2266,14 +3140,25 @@ public unsafe partial struct UInt4x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x2"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt4x2"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x2 operator /(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt4x2"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x2"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt4x2"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator %(UInt4x2 left, UInt4x2 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt4x2"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x2"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt4x2"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x2 operator *(UInt4x2 left, UInt4x2 right) => default;
 
@@ -2282,8 +3167,63 @@ public unsafe partial struct UInt4x2
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x2"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt4x2"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x2 operator -(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x2"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator >(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x2"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator >=(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x2"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator <(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x2"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator <=(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x2"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator ==(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x2"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x2"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x2"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x2 operator !=(UInt4x2 left, UInt4x2 right) => default;
 }
 
 /// <inheritdoc cref="UInt4x3"/>
@@ -2508,6 +3448,7 @@ public unsafe partial struct UInt4x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x3"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt4x3"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x3 operator +(UInt4x3 left, UInt4x3 right) => default;
 
@@ -2516,14 +3457,25 @@ public unsafe partial struct UInt4x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x3"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt4x3"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x3 operator /(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt4x3"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x3"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt4x3"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator %(UInt4x3 left, UInt4x3 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt4x3"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x3"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt4x3"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x3 operator *(UInt4x3 left, UInt4x3 right) => default;
 
@@ -2532,8 +3484,63 @@ public unsafe partial struct UInt4x3
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x3"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt4x3"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x3 operator -(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x3"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator >(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x3"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator >=(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x3"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator <(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x3"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator <=(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x3"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator ==(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x3"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x3"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x3"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x3 operator !=(UInt4x3 left, UInt4x3 right) => default;
 }
 
 /// <inheritdoc cref="UInt4x4"/>
@@ -2806,6 +3813,7 @@ public unsafe partial struct UInt4x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x4"/> value to sum.</param>
     /// <param name="right">The second <see cref="UInt4x4"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x4 operator +(UInt4x4 left, UInt4x4 right) => default;
 
@@ -2814,14 +3822,25 @@ public unsafe partial struct UInt4x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x4"/> value to divide.</param>
     /// <param name="right">The second <see cref="UInt4x4"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x4 operator /(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="UInt4x4"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x4"/> value to divide.</param>
+    /// <param name="right">The second <see cref="UInt4x4"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator %(UInt4x4 left, UInt4x4 right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="UInt4x4"/> values (elementwise product).
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x4"/> value to multiply.</param>
     /// <param name="right">The second <see cref="UInt4x4"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x4 operator *(UInt4x4 left, UInt4x4 right) => default;
 
@@ -2830,6 +3849,61 @@ public unsafe partial struct UInt4x4
     /// </summary>
     /// <param name="left">The first <see cref="UInt4x4"/> value to subtract.</param>
     /// <param name="right">The second <see cref="UInt4x4"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x4 operator -(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x4"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator >(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x4"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator >=(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x4"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator <(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x4"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator <=(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x4"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator ==(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="UInt4x4"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="UInt4x4"/> value to compare.</param>
+    /// <param name="right">The second <see cref="UInt4x4"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool4x4 operator !=(UInt4x4 left, UInt4x4 right) => default;
 }

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -66,6 +66,7 @@ using MemoryMarshal = ComputeSharp.Core.NetStandard.System.Runtime.InteropServic
 #endif
 
 #nullable enable
+#pragma warning disable CS0660, CS0661
 
 namespace ComputeSharp;
 
@@ -234,6 +235,7 @@ public unsafe partial struct <#=typeName#>
     /// Negates a <see cref="<#=typeName#>"/> value.
     /// </summary>
     /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="<#=argumentName#>"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=typeName#> operator <#=operatorName#>(<#=typeName#> <#=argumentName#>) => default;
 <#
@@ -249,6 +251,7 @@ public unsafe partial struct <#=typeName#>
     /// </summary>
     /// <param name="left">The first <see cref="<#=typeName#>"/> value to sum.</param>
     /// <param name="right">The second <see cref="<#=typeName#>"/> value to sum.</param>
+    /// <returns>The result of adding <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=typeName#> operator +(<#=typeName#> left, <#=typeName#> right) => default;
 
@@ -257,14 +260,25 @@ public unsafe partial struct <#=typeName#>
     /// </summary>
     /// <param name="left">The first <see cref="<#=typeName#>"/> value to divide.</param>
     /// <param name="right">The second <see cref="<#=typeName#>"/> value to divide.</param>
+    /// <returns>The result of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=typeName#> operator /(<#=typeName#> left, <#=typeName#> right) => default;
+
+    /// <summary>
+    /// Calculates the remainder of the division between two <see cref="<#=typeName#>"/> values.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=typeName#>"/> value to divide.</param>
+    /// <param name="right">The second <see cref="<#=typeName#>"/> value to divide.</param>
+    /// <returns>The remainder of dividing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator %(<#=typeName#> left, <#=typeName#> right) => default;
 
     /// <summary>
     /// Multiplies two <see cref="<#=typeName#>"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="<#=typeName#>"/> value to multiply.</param>
     /// <param name="right">The second <see cref="<#=typeName#>"/> value to multiply.</param>
+    /// <returns>The result of multiplying <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=typeName#> operator *(<#=typeName#> left, <#=typeName#> right) => default;
 
@@ -273,10 +287,68 @@ public unsafe partial struct <#=typeName#>
     /// </summary>
     /// <param name="left">The first <see cref="<#=typeName#>"/> value to subtract.</param>
     /// <param name="right">The second <see cref="<#=typeName#>"/> value to subtract.</param>
+    /// <returns>The result of subtracting <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=typeName#> operator -(<#=typeName#> left, <#=typeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=typeName#>"/> values to see if the first is greater than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=i#> operator >(<#=typeName#> left, <#=typeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=typeName#>"/> values to see if the first is greater than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=i#> operator >=(<#=typeName#> left, <#=typeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=typeName#>"/> values to see if the first is lower than the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=i#> operator <(<#=typeName#> left, <#=typeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=typeName#>"/> values to see if the first is lower than or equal to the second.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=i#> operator <=(<#=typeName#> left, <#=typeName#> right) => default;
 <#
     }
+
+    WriteLine("");
+#>
+    /// <summary>
+    /// Compares two <see cref="<#=typeName#>"/> values to see if they are equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=i#> operator ==(<#=typeName#> left, <#=typeName#> right) => default;
+
+    /// <summary>
+    /// Compares two <see cref="<#=typeName#>"/> values to see if they are not equal.
+    /// </summary>
+    /// <param name="left">The first <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <param name="right">The second <see cref="<#=typeName#>"/> value to compare.</param>
+    /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Bool<#=i#> operator !=(<#=typeName#> left, <#=typeName#> right) => default;
+<#
 #>
 }
 <#


### PR DESCRIPTION
### Closes #233

### Description

This PR adds the following operators to HLSL vector and matrix types:

- `%`
- `>`
- `>=`
- `<`
- `<=`
- `==`
- `!=`

Also adds missing `<returns>` XML docs to those same types.
