### PR TITLE
Fix source generators when using some non-US locales

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.Syntax.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using ComputeSharp.__Internals;
 using ComputeSharp.D2D1.__Internals;
 using ComputeSharp.D2D1.SourceGenerators.Models;
@@ -111,7 +112,7 @@ partial class ID2D1ShaderGenerator
                                 MemberAccessExpression(
                                     SyntaxKind.SimpleMemberAccessExpression,
                                     IdentifierName("global::ComputeSharp.D2D1.D2D1ShaderProfile"),
-                                    IdentifierName(bytecodeInfo.ShaderProfile.GetValueOrDefault().ToString()))))),
+                                    IdentifierName(bytecodeInfo.ShaderProfile.GetValueOrDefault().ToString(CultureInfo.InvariantCulture)))))),
                     Block(
                         LocalDeclarationStatement(
                             VariableDeclaration(

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 #if !NET6_0_OR_GREATER
 using System.Runtime.InteropServices;
@@ -232,7 +233,7 @@ public static unsafe class D2D1PixelShaderEffect
         for (int i = 0; i < PixelShaderEffect.For<T>.NumberOfInputs; i++)
         {
             writer.WriteAsUtf8("<Input name='Source");
-            writer.WriteAsUtf8(i.ToString());
+            writer.WriteAsUtf8(i.ToString(CultureInfo.InvariantCulture));
             writer.WriteAsUtf8($"'/>");
         }
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
@@ -37,7 +37,7 @@ internal static partial class HlslKnownKeywords
         // HLSL primitive names
         foreach (var type in HlslKnownTypes.KnownVectorTypes.Concat(HlslKnownTypes.KnownMatrixTypes))
         {
-            knownKeywords.Add(type.Name.ToLower());
+            knownKeywords.Add(type.Name.ToLowerInvariant());
         }
 
         // HLSL intrinsics method names

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownProperties.cs
@@ -145,7 +145,7 @@ internal static partial class HlslKnownProperties
             from property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
             select (Type: type, Property: property))
         {
-            knownProperties.Add($"{item.Type.FullName}{Type.Delimiter}{item.Property.Name}", $"{item.Property.Name.ToLower()}");
+            knownProperties.Add($"{item.Type.FullName}{Type.Delimiter}{item.Property.Name}", $"{item.Property.Name.ToLowerInvariant()}");
         }
 
         // Load mappings for the matrix properties as well

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -79,13 +79,13 @@ internal static partial class HlslKnownTypes
         // Add all the vector types
         foreach (var type in KnownVectorTypes)
         {
-            knownTypes.Add(type.FullName, type.Name.ToLower());
+            knownTypes.Add(type.FullName, type.Name.ToLowerInvariant());
         }
 
         // Add all the matrix types
         foreach (var type in KnownMatrixTypes)
         {
-            knownTypes.Add(type.FullName, type.Name.ToLower());
+            knownTypes.Add(type.FullName, type.Name.ToLowerInvariant());
         }
 
         return knownTypes;

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Immutable;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -169,9 +170,9 @@ partial class IShaderGenerator
 
                 // Replace the actual thread num values
                 hlslSource = hlslSource
-                    .Replace("<THREADSX>", threadIds.X.ToString())
-                    .Replace("<THREADSY>", threadIds.Y.ToString())
-                    .Replace("<THREADSZ>", threadIds.Z.ToString());
+                    .Replace("<THREADSX>", threadIds.X.ToString(CultureInfo.InvariantCulture))
+                    .Replace("<THREADSY>", threadIds.Y.ToString(CultureInfo.InvariantCulture))
+                    .Replace("<THREADSZ>", threadIds.Z.ToString(CultureInfo.InvariantCulture));
 
                 // Compile the shader bytecode
                 using ComPtr<IDxcBlob> dxcBlobBytecode = ShaderCompiler.Instance.Compile(hlslSource.AsSpan());

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchMetadataMethod.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchMetadataMethod.Syntax.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Immutable;
+using System.Globalization;
 using ComputeSharp.__Internals;
 using ComputeSharp.SourceGenerators.Models;
 using Microsoft.CodeAnalysis.CSharp;
@@ -118,7 +119,7 @@ partial class IShaderGenerator
 
             // Serialized shader metadata
             statements.Add(ParseStatement($"global::System.Runtime.CompilerServices.Unsafe.WriteUnaligned<int>(ref global::System.Runtime.CompilerServices.Unsafe.Add(ref r0, 0), {metadataInfo.Root32BitConstantCount});"));
-            statements.Add(ParseStatement($"global::System.Runtime.CompilerServices.Unsafe.WriteUnaligned<bool>(ref global::System.Runtime.CompilerServices.Unsafe.Add(ref r0, 4), {metadataInfo.IsSamplerUsed.ToString().ToLowerInvariant()});"));
+            statements.Add(ParseStatement($"global::System.Runtime.CompilerServices.Unsafe.WriteUnaligned<bool>(ref global::System.Runtime.CompilerServices.Unsafe.Add(ref r0, 4), {metadataInfo.IsSamplerUsed.ToString(CultureInfo.InvariantCulture).ToLowerInvariant()});"));
 
 
             // Populate the sequence of resource descriptors

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownProperties.cs
@@ -98,7 +98,7 @@ partial class HlslKnownProperties
             }
             else
             {
-                knownProperties.Add($"{item.Type.FullName}{Type.Delimiter}{item.Property.Name}", $"{item.Type.Name}.{item.Property.Name.ToLower()}");
+                knownProperties.Add($"{item.Type.FullName}{Type.Delimiter}{item.Property.Name}", $"{item.Type.Name}.{item.Property.Name.ToLowerInvariant()}");
             }
         }
 
@@ -110,20 +110,20 @@ partial class HlslKnownProperties
             switch (property.Name)
             {
                 case string name when name.Length == 1:
-                    knownProperties.Add(key, $"{typeof(ThreadIds).Name}.{char.ToLower(name[0])} / (float)__{char.ToLower(name[0])}");
+                    knownProperties.Add(key, $"{typeof(ThreadIds).Name}.{char.ToLowerInvariant(name[0])} / (float)__{char.ToLowerInvariant(name[0])}");
                     break;
                 case string name when name.Length == 2:
                 {
-                    string numerator = $"float2({typeof(ThreadIds).Name}.{char.ToLower(name[0])}, {typeof(ThreadIds).Name}.{char.ToLower(name[1])})";
-                    string denominator = $"float2(__{char.ToLower(name[0])}, __{char.ToLower(name[1])})";
+                    string numerator = $"float2({typeof(ThreadIds).Name}.{char.ToLowerInvariant(name[0])}, {typeof(ThreadIds).Name}.{char.ToLowerInvariant(name[1])})";
+                    string denominator = $"float2(__{char.ToLowerInvariant(name[0])}, __{char.ToLowerInvariant(name[1])})";
 
                     knownProperties.Add(key, $"{numerator} / {denominator}");
                     break;
                 }
                 case string name when name.Length == 3:
                 {
-                    string numerator = $"float3({typeof(ThreadIds).Name}.{char.ToLower(name[0])}, {typeof(ThreadIds).Name}.{char.ToLower(name[1])}, {typeof(ThreadIds).Name}.{char.ToLower(name[2])})";
-                    string denominator = $"float3(__{char.ToLower(name[0])}, __{char.ToLower(name[1])}, __{char.ToLower(name[2])})";
+                    string numerator = $"float3({typeof(ThreadIds).Name}.{char.ToLowerInvariant(name[0])}, {typeof(ThreadIds).Name}.{char.ToLowerInvariant(name[1])}, {typeof(ThreadIds).Name}.{char.ToLowerInvariant(name[2])})";
+                    string denominator = $"float3(__{char.ToLowerInvariant(name[0])}, __{char.ToLowerInvariant(name[1])}, __{char.ToLowerInvariant(name[2])})";
 
                     knownProperties.Add(key, $"{numerator} / {denominator}");
                     break;
@@ -164,13 +164,13 @@ partial class HlslKnownProperties
                     knownProperties.Add(key, "__x * __y * __z");
                     break;
                 case string name when name.Length == 1:
-                    knownProperties.Add(key, $"__{char.ToLower(name[0])}");
+                    knownProperties.Add(key, $"__{char.ToLowerInvariant(name[0])}");
                     break;
                 case string name when name.Length == 2:
-                    knownProperties.Add(key, $"int2(__{char.ToLower(name[0])}, __{char.ToLower(name[1])})");
+                    knownProperties.Add(key, $"int2(__{char.ToLowerInvariant(name[0])}, __{char.ToLowerInvariant(name[1])})");
                     break;
                 case string name when name.Length == 3:
-                    knownProperties.Add(key, $"int3(__{char.ToLower(name[0])}, __{char.ToLower(name[1])}, __{char.ToLower(name[2])})");
+                    knownProperties.Add(key, $"int3(__{char.ToLowerInvariant(name[0])}, __{char.ToLowerInvariant(name[1])}, __{char.ToLowerInvariant(name[2])})");
                     break;
             }
         }


### PR DESCRIPTION
### Closes #238

This PR fixes the source generators using culture-aware in some formatting operations. This was causing invalid code to be produced when using some non-US locales (eg. Turkish), which would then fail to build for no apparent reason.