### PR TITLE
Remove UB from Unsafe.NullRef<T>() calls

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1InteropServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1InteropServices.cs
@@ -60,7 +60,9 @@ public static unsafe class D2D1InteropServices
     {
         D2D1ShaderBytecodeLoader bytecodeLoader = default;
 
-        Unsafe.NullRef<T>().LoadBytecode(ref bytecodeLoader, shaderProfile);
+        Unsafe.SkipInit(out T shader);
+
+        shader.LoadBytecode(ref bytecodeLoader, shaderProfile);
 
         using ComPtr<ID3DBlob> dynamicBytecode = bytecodeLoader.GetResultingShaderBytecode(out ReadOnlySpan<byte> precompiledBytecode);
 

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -23,11 +23,13 @@ public static class D2D1ReflectionServices
     public static unsafe D2D1ShaderInfo GetShaderInfo<T>()
         where T : struct, ID2D1PixelShader
     {
-        Unsafe.NullRef<T>().BuildHlslSource(out string hlslSource);
+        Unsafe.SkipInit(out T shader);
+
+        shader.BuildHlslSource(out string hlslSource);
 
         D2D1ShaderBytecodeLoader bytecodeLoader = default;
 
-        Unsafe.NullRef<T>().LoadBytecode(ref bytecodeLoader, D2D1ShaderProfile.PixelShader50);
+        shader.LoadBytecode(ref bytecodeLoader, D2D1ShaderProfile.PixelShader50);
 
         using ComPtr<ID3DBlob> dynamicBytecode = bytecodeLoader.GetResultingShaderBytecode(out ReadOnlySpan<byte> precompiledBytecode);
 

--- a/src/ComputeSharp/Shaders/Loading/PipelineDataLoader{T}.cs
+++ b/src/ComputeSharp/Shaders/Loading/PipelineDataLoader{T}.cs
@@ -89,7 +89,9 @@ internal static class PipelineDataLoader<T>
 
         ShaderDispatchMetadataLoader metadataLoader = new(device.D3D12Device);
 
-        Unsafe.NullRef<T>().LoadDispatchMetadata(ref metadataLoader, out *(IntPtr*)&d3D12RootSignature);
+        Unsafe.SkipInit(out T shader);
+
+        shader.LoadDispatchMetadata(ref metadataLoader, out *(IntPtr*)&d3D12RootSignature);
         
         using ComPtr<ID3D12PipelineState> d3D12PipelineState = device.D3D12Device->CreateComputePipelineState(d3D12RootSignature.Get(), shaderData.D3D12ShaderBytecode);
 


### PR DESCRIPTION
### Closes #243

### Description

This PR removes the `Unsafe.NullRef<T>()` uses that were technically UB.