### PR TITLE
Add D2D1InteropServices.GetPixelShaderInputCount<T>() API

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetInputCountMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetInputCountMethod.Syntax.cs
@@ -1,0 +1,38 @@
+﻿using ComputeSharp.D2D1.__Internals;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <summary>
+    /// A helper with all logic to generate the <c>GetInputCount</c> method.
+    /// </summary>
+    partial class GetInputCount
+    {
+        /// <summary>
+        /// Creates a <see cref="MethodDeclarationSyntax"/> instance for the <c>GetInputCount</c> method.
+        /// </summary>
+        /// <param name="inputCount">The number of inputs for the shader.</param>
+        /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the <c>GetInputCount</c> method.</returns>
+        public static MethodDeclarationSyntax GetSyntax(int inputCount)
+        {
+            // This code produces a method declaration as follows:
+            //
+            // readonly uint global::ComputeSharp.D2D1.__Internals.ID2D1Shader.GetInputCount()
+            // {
+            //     return <INPUT_COUNT>;
+            // }
+            return
+                MethodDeclaration(PredefinedType(Token(SyntaxKind.UIntKeyword)), Identifier("GetInputCount"))
+                .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IdentifierName($"global::ComputeSharp.D2D1.__Internals.{nameof(ID2D1Shader)}")))
+                .AddModifiers(Token(SyntaxKind.ReadOnlyKeyword))
+                .WithBody(Block(ReturnStatement(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(inputCount)))));
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
@@ -20,6 +20,14 @@ public interface ID2D1Shader
     void InitializeFromDispatchData(ReadOnlySpan<byte> data);
 
     /// <summary>
+    /// Gets the number of inputs for the current shader.
+    /// </summary>
+    /// <returns>The number of inputs for the current shader.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This method is not intended to be used directly by user code")]
+    uint GetInputCount();
+
+    /// <summary>
     /// Loads the dispatch data for the shader.
     /// </summary>
     /// <typeparam name="TLoader">The type of data loader being used.</typeparam>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1InteropServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1InteropServices.cs
@@ -80,6 +80,19 @@ public static unsafe class D2D1InteropServices
     }
 
     /// <summary>
+    /// Gets the number of inputs from an input D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the input count for.</typeparam>
+    /// <returns>The number of inputs for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static uint GetPixelShaderInputCount<T>()
+        where T : unmanaged, ID2D1PixelShader
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.GetInputCount();
+    }
+
+    /// <summary>
     /// Gets the constant buffer from an input D2D1 pixel shader.
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to retrieve info for.</typeparam>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.For{T}.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.For{T}.cs
@@ -89,7 +89,7 @@ internal unsafe partial struct PixelShaderEffect
                 {
                     // Load all shader properties
                     Guid guid = typeof(T).GUID;
-                    int inputCount = ((D2DInputCountAttribute[])typeof(T).GetCustomAttributes(typeof(D2DInputCountAttribute), false))[0].Count;
+                    int inputCount = (int)D2D1InteropServices.GetPixelShaderInputCount<T>();
                     ReadOnlyMemory<byte> buffer = D2D1InteropServices.LoadShaderBytecode<T>();
                     byte* typeAssociatedMemory = (byte*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(For<T>), buffer.Length);
 

--- a/tests/ComputeSharp.D2D1.Tests/D2D1InteropServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1InteropServicesTests.cs
@@ -1,0 +1,18 @@
+﻿using ComputeSharp.D2D1.Interop;
+using ComputeSharp.D2D1.Tests.Effects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.D2D1.Tests;
+
+[TestClass]
+[TestCategory("D2D1InteropServices")]
+public class D2D1InteropServicesTests
+{
+    [TestMethod]
+    public unsafe void GetInputCount()
+    {
+        Assert.AreEqual(D2D1InteropServices.GetPixelShaderInputCount<InvertEffect>(), 1u);
+        Assert.AreEqual(D2D1InteropServices.GetPixelShaderInputCount<PixelateEffect.Shader>(), 1u);
+        Assert.AreEqual(D2D1InteropServices.GetPixelShaderInputCount<ZonePlateEffect>(), 0u);
+    }
+}


### PR DESCRIPTION
### Description

This PR adds the `D2D1InteropServices.GetPixelShaderInputCount<T>()` API, and also removes the reflection usage from the pixel shader effect implementation that was used to try to get the shader input attribute at runtime to calculate the input count.