### PR TITLE
Allow custom base interfaces and explicit interface members

### DIFF
--- a/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
+++ b/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
@@ -59,7 +59,7 @@ public sealed partial class AutoConstructorGenerator : IIncrementalGenerator
         {
             return (
                 from fieldSymbol in structDeclarationSymbol.GetMembers().OfType<IFieldSymbol>()
-                where fieldSymbol is { IsConst: false, IsStatic: false, IsFixedSizeBuffer: false }
+                where fieldSymbol is { IsConst: false, IsStatic: false, IsFixedSizeBuffer: false, IsImplicitlyDeclared: false }
                 let typeName = fieldSymbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
                 select new ParameterInfo(typeName, fieldSymbol.Name)).ToImmutableArray();
         }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -413,31 +413,34 @@ internal static class DiagnosticDescriptors
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for a property declaration.
+    /// <para>
+    /// Format: <c>"The D2D1 shader of type {0} contains an invalid property \"{1}\" declaration (only stateless properties explicitly implementing an interface property can be used)"</c>.
+    /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor PropertyDeclaration = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor InvalidPropertyDeclaration = new DiagnosticDescriptor(
         id: "CMPSD2D0031",
-        title: "Property declaration",
-        messageFormat: "Property declarations cannot be used in a compute shader",
+        title: "Invalid property declaration",
+        messageFormat: "The D2D1 shader of type {0} contains an invalid property \"{1}\" declaration (only stateless properties explicitly implementing an interface property can be used)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Property declarations cannot be used in a compute shader.",
+        description: "Property declarations (except for stateless properties explicitly implementing an interface property) cannot be used in a D2D1 shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for a shader with a root signature that is too large.
     /// <para>
-    /// Format: <c>"The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources"</c>.
+    /// Format: <c>"The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values and resources"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor ShaderDispatchDataSizeExceeded = new DiagnosticDescriptor(
         id: "CMPSD2D0032",
         title: "Shader dispatch data size exceeded",
-        messageFormat: "The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources",
+        messageFormat: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values and resources",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources.",
+        description: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values and resources.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -240,6 +240,12 @@ partial class ID2D1ShaderGenerator
                     methodDeclarationSymbol.TypeParameters.Length == 0 &&
                     methodDeclarationSymbol.Parameters.Length == 0;
 
+                // Except for the entry point, ignore explicit interface implementations
+                if (!isShaderEntryPoint && !methodDeclarationSymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
                 // Create the source rewriter for the current method
                 ShaderSourceRewriter shaderSourceRewriter = new(
                     structDeclarationSymbol,
@@ -374,6 +380,12 @@ partial class ID2D1ShaderGenerator
         {
             foreach (var propertySymbol in structDeclarationSymbol.GetMembers().OfType<IPropertySymbol>())
             {
+                // Ignore explicit interface implementations
+                if (!propertySymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+                {
+                    return;
+                }
+
                 diagnostics.Add(DiagnosticDescriptors.PropertyDeclaration, propertySymbol);
             }
         }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -45,7 +45,7 @@ partial class ID2D1ShaderGenerator
             ImmutableArray<Diagnostic>.Builder builder = ImmutableArray.CreateBuilder<Diagnostic>();
 
             // Properties are not supported
-            DetectAndReportPropertyDeclarations(builder, structDeclarationSymbol);
+            DetectAndReportInvalidPropertyDeclarations(builder, structDeclarationSymbol);
 
             // We need to sets to track all discovered custom types and static methods
             HashSet<INamedTypeSymbol> discoveredTypes = new(SymbolEqualityComparer.Default);
@@ -372,21 +372,25 @@ partial class ID2D1ShaderGenerator
         }
 
         /// <summary>
-        /// Finds and reports all declared properties in a shader.
+        /// Finds and reports all invalid declared properties in a shader.
         /// </summary>
         /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
         /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
-        private static void DetectAndReportPropertyDeclarations(ImmutableArray<Diagnostic>.Builder diagnostics, INamedTypeSymbol structDeclarationSymbol)
+        private static void DetectAndReportInvalidPropertyDeclarations(ImmutableArray<Diagnostic>.Builder diagnostics, INamedTypeSymbol structDeclarationSymbol)
         {
-            foreach (var propertySymbol in structDeclarationSymbol.GetMembers().OfType<IPropertySymbol>())
+            foreach (var memberSymbol in structDeclarationSymbol.GetMembers())
             {
-                // Ignore explicit interface implementations
-                if (!propertySymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+                // Detect properties that are not explicit interface implementations
+                if (memberSymbol is IPropertySymbol { ExplicitInterfaceImplementations.IsEmpty: true })
                 {
-                    return;
+                    diagnostics.Add(InvalidPropertyDeclaration, memberSymbol, structDeclarationSymbol, memberSymbol);
                 }
 
-                diagnostics.Add(DiagnosticDescriptors.PropertyDeclaration, propertySymbol);
+                // Detect properties causing a field to be generated
+                if (memberSymbol is IFieldSymbol { AssociatedSymbol: IPropertySymbol associatedProperty })
+                {
+                    diagnostics.Add(InvalidPropertyDeclaration, associatedProperty, structDeclarationSymbol, associatedProperty);
+                }
             }
         }
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.cs
@@ -43,9 +43,7 @@ partial class ID2D1ShaderGenerator
                 foreach (
                    IFieldSymbol fieldSymbol in
                    from fieldSymbol in currentTypeSymbol.GetMembers().OfType<IFieldSymbol>()
-                   where fieldSymbol.Type is INamedTypeSymbol { IsStatic: false } &&
-                         !fieldSymbol.IsConst && !fieldSymbol.IsStatic &&
-                         !fieldSymbol.IsFixedSizeBuffer
+                   where fieldSymbol is { Type: INamedTypeSymbol { IsStatic: false }, IsConst: false, IsStatic: false, IsFixedSizeBuffer: false, IsImplicitlyDeclared: false }
                    select fieldSymbol)
                 {
                     string fieldName = fieldSymbol.Name;

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.Helpers.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.Helpers.cs
@@ -18,7 +18,7 @@ partial class ID2D1ShaderGenerator
     /// <returns>Whether or not <paramref name="typeSymbol"/> implements <paramref name="d2D1PixelShaderSymbol"/>.</returns>
     private static bool IsD2D1PixelShaderType(INamedTypeSymbol typeSymbol, INamedTypeSymbol d2D1PixelShaderSymbol)
     {
-        foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.Interfaces)
+        foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.AllInterfaces)
         {
             if (interfaceSymbol.Name == nameof(ID2D1PixelShader) &&
                  SymbolEqualityComparer.Default.Equals(interfaceSymbol, d2D1PixelShaderSymbol))

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -542,15 +542,18 @@ internal static class DiagnosticDescriptors
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for a property declaration.
+    /// <para>
+    /// Format: <c>"The compute shader of type {0} contains an invalid property \"{1}\" declaration (only stateless properties explicitly implementing an interface property can be used)"</c>.
+    /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor PropertyDeclaration = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor InvalidPropertyDeclaration = new DiagnosticDescriptor(
         id: "CMPS0040",
-        title: "Property declaration",
-        messageFormat: "Property declarations cannot be used in a compute shader",
+        title: "Invalid property declaration",
+        messageFormat: "The compute shader of type {0} contains an invalid property \"{1}\" declaration (only stateless properties explicitly implementing an interface property can be used)",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Property declarations cannot be used in a compute shader.",
+        description: "Property declarations (except for stateless properties explicitly implementing an interface property) cannot be used in a compute shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -354,6 +354,12 @@ partial class IShaderGenerator
                      methodDeclarationSymbol.TypeParameters.Length == 0 &&
                      methodDeclarationSymbol.Parameters.Length == 0);
 
+                // Except for the entry point, ignore explicit interface implementations
+                if (!isShaderEntryPoint && !methodDeclarationSymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
                 // Create the source rewriter for the current method
                 ShaderSourceRewriter shaderSourceRewriter = new(
                     structDeclarationSymbol,
@@ -495,6 +501,12 @@ partial class IShaderGenerator
         {
             foreach (var propertySymbol in structDeclarationSymbol.GetMembers().OfType<IPropertySymbol>())
             {
+                // Ignore explicit interface implementations
+                if (!propertySymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+                {
+                    return;
+                }
+
                 diagnostics.Add(DiagnosticDescriptors.PropertyDeclaration, propertySymbol);
             }
         }

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateGetDispatchIdMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateGetDispatchIdMethod.cs
@@ -23,7 +23,7 @@ partial class IShaderGenerator
                 structDeclarationSymbol
                 .GetMembers()
                 .OfType<IFieldSymbol>()
-                .Where(static member => member.Type is INamedTypeSymbol { TypeKind: TypeKind.Delegate, IsStatic: false })
+                .Where(static member => member is { Type: INamedTypeSymbol { TypeKind: TypeKind.Delegate, IsStatic: false }, IsImplicitlyDeclared: false })
                 .Select(static member => member.Name)
                 .ToImmutableArray();
         }

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.cs
@@ -48,9 +48,7 @@ partial class IShaderGenerator
                 foreach (
                    IFieldSymbol fieldSymbol in
                    from fieldSymbol in currentTypeSymbol.GetMembers().OfType<IFieldSymbol>()
-                   where fieldSymbol.Type is INamedTypeSymbol { IsStatic: false } &&
-                         !fieldSymbol.IsConst && !fieldSymbol.IsStatic &&
-                         !fieldSymbol.IsFixedSizeBuffer
+                   where fieldSymbol is { Type: INamedTypeSymbol { IsStatic: false }, IsConst: false, IsStatic: false, IsFixedSizeBuffer: false, IsImplicitlyDeclared: false }
                    select fieldSymbol)
                 {
                     string fieldName = fieldSymbol.Name;

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.Helpers.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.Helpers.cs
@@ -23,7 +23,7 @@ partial class IShaderGenerator
         INamedTypeSymbol iComputeShaderSymbol,
         INamedTypeSymbol iPixelShaderSymbol)
     {
-        foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.Interfaces)
+        foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.AllInterfaces)
         {
             if (interfaceSymbol.Name == nameof(IComputeShader) &&
                  SymbolEqualityComparer.Default.Equals(interfaceSymbol, iComputeShaderSymbol))

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1254,6 +1254,39 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
+    public void PropertyDeclaration_AutoProp_WithExplicitInterfaceImplementation()
+    {
+        string source = @"
+        using ComputeSharp;
+
+        namespace ComputeSharp
+        {
+            public class ReadWriteBuffer<T> { }
+        }
+
+        namespace MyFancyApp.Sample
+        {
+            public interface IFoo
+            {
+                float Pi { get; }
+            }
+
+            public struct MyShader : IComputeShader, IFoo
+            {
+                public ReadWriteBuffer<float> buffer;
+
+                float IFoo.Pi { get; } = 3.14f;
+
+                public void Execute()
+                {
+                }
+            }
+        }";
+
+        VerifyGeneratedDiagnostics<IShaderGenerator>(source, "CMPS0040", "CMPS0047");
+    }
+
+    [TestMethod]
     public void PropertyDeclaration_GetterBlock()
     {
         string source = @"

--- a/tests/ComputeSharp.Tests/AutoConstructorAttributeTests.cs
+++ b/tests/ComputeSharp.Tests/AutoConstructorAttributeTests.cs
@@ -54,4 +54,35 @@ public unsafe partial class AutoConstructorAttributeTests
         Assert.AreEqual(instance.a, a);
         Assert.AreEqual(instance.b, b);
     }
+
+    public partial interface IAnotherInterface
+    {
+        public int B { get; }
+
+        public void Foo();
+    }
+
+    public partial struct AnotherStruct : IAnotherInterface
+    {
+        public int a;
+        public float b;
+
+        int IAnotherInterface.B { get; }
+
+        void IAnotherInterface.Foo()
+        {
+        }
+    }
+
+    [TestMethod]
+    public void GenerateConstructorWithExplicitInterfaceMembers()
+    {
+        int a = 42;
+        float b = 3.14f;
+
+        AnotherStruct instance = new(a, b);
+
+        Assert.AreEqual(instance.a, a);
+        Assert.AreEqual(instance.b, b);
+    }
 }

--- a/tests/ComputeSharp.Tests/AutoConstructorAttributeTests.cs
+++ b/tests/ComputeSharp.Tests/AutoConstructorAttributeTests.cs
@@ -62,12 +62,13 @@ public unsafe partial class AutoConstructorAttributeTests
         public void Foo();
     }
 
+    [AutoConstructor]
     public partial struct AnotherStruct : IAnotherInterface
     {
         public int a;
         public float b;
 
-        int IAnotherInterface.B { get; }
+        int IAnotherInterface.B => 100;
 
         void IAnotherInterface.Foo()
         {

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -272,6 +272,70 @@ namespace ComputeSharp.Tests
                 this.buffer[ThreadIds.X] *= this.number;
             }
         }
+
+        [TestMethod]
+        public void ComputeShaderWithInheritedShaderInterface()
+        {
+            _ = ReflectionServices.GetShaderInfo<ComputeShaderWithInheritedShaderInterfaceShader>();
+        }
+
+        public interface IMyBaseShader : IComputeShader
+        {
+            public int A { get; }
+
+            public void B();
+        }
+
+        [AutoConstructor]
+        internal readonly partial struct ComputeShaderWithInheritedShaderInterfaceShader : IMyBaseShader
+        {
+            int IMyBaseShader.A { get; }
+
+            void IMyBaseShader.B()
+            {
+            }
+
+            public readonly ReadWriteBuffer<float> buffer;
+            public readonly float number;
+
+            /// <inheritdoc/>
+            public void Execute()
+            {
+                this.buffer[ThreadIds.X] *= this.number;
+            }
+        }
+
+        [TestMethod]
+        public void PixelShaderWithInheritedShaderInterface()
+        {
+            _ = ReflectionServices.GetShaderInfo<PixelShaderWithInheritedShaderInterfaceShader, float4>();
+        }
+
+        public interface IMyBaseShader<T> : IPixelShader<T>
+            where T : unmanaged
+        {
+            public int A { get; }
+
+            public void B();
+        }
+
+        [AutoConstructor]
+        internal readonly partial struct PixelShaderWithInheritedShaderInterfaceShader : IMyBaseShader<float4>
+        {
+            int IMyBaseShader<float4>.A { get; }
+
+            void IMyBaseShader<float4>.B()
+            {
+            }
+
+            public readonly float number;
+
+            /// <inheritdoc/>
+            public float4 Execute()
+            {
+                return default;
+            }
+        }
     }
 }
 

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -289,7 +289,7 @@ namespace ComputeSharp.Tests
         [AutoConstructor]
         internal readonly partial struct ComputeShaderWithInheritedShaderInterfaceShader : IMyBaseShader
         {
-            int IMyBaseShader.A { get; }
+            int IMyBaseShader.A => 42;
 
             void IMyBaseShader.B()
             {
@@ -322,7 +322,7 @@ namespace ComputeSharp.Tests
         [AutoConstructor]
         internal readonly partial struct PixelShaderWithInheritedShaderInterfaceShader : IMyBaseShader<float4>
         {
-            int IMyBaseShader<float4>.A { get; }
+            int IMyBaseShader<float4>.A => 42;
 
             void IMyBaseShader<float4>.B()
             {


### PR DESCRIPTION
### Closes #242, closes #251

### Description

This PR allows shader types to explicitly implement interface members.
It also allows them to implement shader interfaces through a custom base interface.