### PR TITLE
Fix crash in empty D2D1 shaders generated methods

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateInitializeFromDispatchDataMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateInitializeFromDispatchDataMethod.Syntax.cs
@@ -44,6 +44,12 @@ partial class ID2D1ShaderGenerator
         /// <returns>The sequence of <see cref="StatementSyntax"/> instances to initialize a shader from the serialized dispatch data buffer.</returns>
         private static ImmutableArray<StatementSyntax> GetDispatchDataUnloadingStatements(ImmutableArray<FieldInfo> fieldInfos)
         {
+            // If there are no fields, just return no statements
+            if (fieldInfos.IsEmpty)
+            {
+                return ImmutableArray<StatementSyntax>.Empty;
+            }
+
             ImmutableArray<StatementSyntax>.Builder statements = ImmutableArray.CreateBuilder<StatementSyntax>();
 
             // Insert the fallback for empty shaders. This will generate the following code:

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
@@ -45,6 +45,24 @@ partial class ID2D1ShaderGenerator
         /// <returns>The sequence of <see cref="StatementSyntax"/> instances to load shader dispatch data.</returns>
         private static ImmutableArray<StatementSyntax> GetDispatchDataLoadingStatements(ImmutableArray<FieldInfo> fieldInfos, int root32BitConstantsCount)
         {
+            // If there are no fields, just load an empty buffer
+            if (fieldInfos.IsEmpty)
+            {
+                // loader.LoadConstantBuffer(default);
+                return
+                    ImmutableArray.Create<StatementSyntax>(
+                        ExpressionStatement(
+                            InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    IdentifierName("loader"),
+                                    IdentifierName("LoadConstantBuffer")))
+                            .AddArgumentListArguments(Argument(
+                                LiteralExpression(
+                                    SyntaxKind.DefaultLiteralExpression,
+                                    Token(SyntaxKind.DefaultKeyword))))));
+            }
+
             ImmutableArray<StatementSyntax>.Builder statements = ImmutableArray.CreateBuilder<StatementSyntax>();
 
             // Generate loading statements for each captured field

--- a/src/ComputeSharp.D2D1/Shaders/Dispatching/D2D1EffectDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Dispatching/D2D1EffectDispatchDataLoader.cs
@@ -32,6 +32,11 @@ internal readonly unsafe struct D2D1EffectDispatchDataLoader : ID2D1DispatchData
     /// <inheritdoc/>
     public void LoadConstantBuffer(ReadOnlySpan<uint> data)
     {
+        if (data.IsEmpty)
+        {
+            return;
+        }
+
         this.d2D1Effect->SetValue(
             index: 0,
             type: D2D1_PROPERTY_TYPE.D2D1_PROPERTY_TYPE_BLOB,

--- a/tests/ComputeSharp.D2D1.Tests/Effects/InvertWithThresholdEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/InvertWithThresholdEffect.cs
@@ -4,13 +4,15 @@
 [D2DInputSimple(0)]
 [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
 [AutoConstructor]
-public partial struct InvertEffect : ID2D1PixelShader
+public partial struct InvertWithThresholdEffect : ID2D1PixelShader
 {
+    public float number;
+
     /// <inheritdoc/>
     public float4 Execute()
     {
         float4 color = D2D.GetInput(0);
-        float3 rgb = Hlsl.Saturate(1.0f - color.RGB);
+        float3 rgb = Hlsl.Saturate(this.number - color.RGB);
 
         return new(rgb, 1);
     }

--- a/tests/ComputeSharp.D2D1.Tests/EndToEndTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/EndToEndTests.cs
@@ -14,9 +14,15 @@ namespace ComputeSharp.D2D1.Tests;
 public class EndToEndTests
 {
     [TestMethod]
-    public unsafe void InvertWithCustomThreshold()
+    public unsafe void Invert()
     {
-        RunAndCompareShader(new InvertEffect(1), null, "Landscape.png", "Landscape_Inverted.png");
+        RunAndCompareShader(new InvertEffect(), null, "Landscape.png", "Landscape_Inverted.png");
+    }
+
+    [TestMethod]
+    public unsafe void InvertWithThreshold()
+    {
+        RunAndCompareShader(new InvertWithThresholdEffect(1), null, "Landscape.png", "Landscape_Inverted.png");
     }
 
     [TestMethod]


### PR DESCRIPTION
### Closes #253

### Description

This PR fixes the generated methods for D2D1 shaders with no fields.
This also fixes a crash in `LoadConstantBuffer` specifically.