### PR TITLE
Update default draw transform mapper logic

### DIFF
--- a/src/ComputeSharp.D2D1/Extensions/RECTExtensions.cs
+++ b/src/ComputeSharp.D2D1/Extensions/RECTExtensions.cs
@@ -75,4 +75,27 @@ internal static class RECTExtensions
             bottom = rectangle.Bottom
         };
     }
+
+    /// <summary>
+    /// Creates a <see cref="RECT"/> with the area being the union of two other values.
+    /// </summary>
+    /// <param name="rect">The first input <see cref="RECT"/> instance to read.</param>
+    /// <param name="other">The second input <see cref="RECT"/> instance to read.</param>
+    /// <returns>A <see cref="RECT"/> with the area being the union of that of <paramref name="rect"/> and <paramref name="other"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static RECT Union(this in RECT rect, in RECT other)
+    {
+        int left = Math.Min(rect.left, other.left);
+        int top = Math.Min(rect.top, other.top);
+        int right = Math.Max(rect.right, other.right);
+        int bottom = Math.Max(rect.bottom, other.bottom);
+
+        return new()
+        {
+            left = left,
+            top = top,
+            right = right,
+            bottom = bottom
+        };
+    }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
@@ -71,7 +71,7 @@ public static unsafe class D2D1PixelShaderEffect
         // Setup the input string
         StringBuilder effectInputsBuilder = new();
 
-        for (int i = 0; i < PixelShaderEffect.For<T>.NumberOfInputs; i++)
+        for (int i = 0; i < PixelShaderEffect.For<T>.InputCount; i++)
         {
             effectInputsBuilder.Append("<Input name='Source");
             effectInputsBuilder.Append(i);
@@ -215,7 +215,7 @@ public static unsafe class D2D1PixelShaderEffect
 
         // Effect id and number of inputs
         writer.Write(PixelShaderEffect.For<T>.Id);
-        writer.Write(PixelShaderEffect.For<T>.NumberOfInputs);
+        writer.Write(PixelShaderEffect.For<T>.InputCount);
         
         // Build the XML text
         writer.WriteAsUtf8(@"<?xml version='1.0'?>
@@ -230,7 +230,7 @@ public static unsafe class D2D1PixelShaderEffect
         ");
 
         // Add the input nodes
-        for (int i = 0; i < PixelShaderEffect.For<T>.NumberOfInputs; i++)
+        for (int i = 0; i < PixelShaderEffect.For<T>.InputCount; i++)
         {
             writer.WriteAsUtf8("<Input name='Source");
             writer.WriteAsUtf8(i.ToString(CultureInfo.InvariantCulture));

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
@@ -233,23 +233,32 @@ partial struct PixelShaderEffect
                 // mapping. In this case, the output rect should be the union of the input rects for all
                 // the simple shader inputs, or infinite if there are no simple inputs. The input rects
                 // for complex inputs, if present, are not needed in this scenario, so they're ignored.
-                RECT? unionOfSimpleRects = null;
+                RECT unionOfSimpleRects = default;
+                bool isUnionOfSimpleRectsEmpty = true;
 
                 for (uint i = 0; i < inputRectCount; i++)
                 {
                     if (@this->inputTypes[i] == D2D1PixelShaderInputType.Simple)
                     {
-                        unionOfSimpleRects = (unionOfSimpleRects ?? default).Union(inputRects[i]);
+                        if (isUnionOfSimpleRectsEmpty)
+                        {
+                            unionOfSimpleRects = inputRects[i];
+                            isUnionOfSimpleRectsEmpty = false;
+                        }
+                        else
+                        {
+                            unionOfSimpleRects = unionOfSimpleRects.Union(inputRects[i]);
+                        }
                     }
                 }
 
-                if (unionOfSimpleRects.HasValue)
+                if (isUnionOfSimpleRectsEmpty)
                 {
-                    *outputRect = unionOfSimpleRects.Value;
+                    outputRect->MakeD2D1Infinite();
                 }
                 else
                 {
-                    outputRect->MakeD2D1Infinite();
+                    *outputRect = unionOfSimpleRects;
                 }
 
                 *outputOpaqueSubRect = default;

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
@@ -113,7 +113,7 @@ partial struct PixelShaderEffect
         {
             @this = (PixelShaderEffect*)&((void**)@this)[-1];
 
-            return (uint)@this->numberOfInputs;
+            return (uint)@this->inputCount;
         }
 
         /// <inheritdoc cref="ID2D1DrawTransform.MapOutputRectToInputRects"/>
@@ -122,7 +122,7 @@ partial struct PixelShaderEffect
         {
             @this = (PixelShaderEffect*)&((void**)@this)[-1];
 
-            if (inputRectsCount != @this->numberOfInputs)
+            if (inputRectsCount != @this->inputCount)
             {
                 return E.E_INVALIDARG;
             }
@@ -154,10 +154,24 @@ partial struct PixelShaderEffect
             }
             else
             {
-                // Default mapping
-                for (int i = 0; i < (int)inputRectsCount; i++)
+                // If no custom transform is used, apply the default mapping. In this case, the loop will
+                // automatically handle cases where no inputs are defined. If inputs are present instead,
+                // the default mapping will set the input rect for a simple input to be the same as the
+                // output rect, and the input rect for a complex rect to be infinite. In both cases, D2D
+                // will handle clipping the inputs to the actual output rect area, if needed.
+                for (uint i = 0; i < inputRectsCount; i++)
                 {
-                    inputRects[i] = *outputRect;
+                    switch (@this->inputTypes[i])
+                    {
+                        case D2D1PixelShaderInputType.Simple:
+                            inputRects[i] = *outputRect;
+                            break;
+                        case D2D1PixelShaderInputType.Complex:
+                            inputRects[i].MakeD2D1Infinite();
+                            break;
+                        default:
+                            return E.E_FAIL;
+                    }
                 }
             }
 
@@ -170,7 +184,7 @@ partial struct PixelShaderEffect
         {
             @this = (PixelShaderEffect*)&((void**)@this)[-1];
 
-            if (inputRectCount != @this->numberOfInputs)
+            if (inputRectCount != @this->inputCount)
             {
                 return E.E_INVALIDARG;
             }
@@ -211,16 +225,32 @@ partial struct PixelShaderEffect
                 // transform. In this case, the target area will be the output node anyway.
                 outputRect->MakeD2D1Infinite();
 
-                @this->inputRect = default;
-
                 *outputOpaqueSubRect = default;
             }
             else
             {
-                // Default mapping
-                *outputRect = inputRects[0];
+                // If at least one input is present and no custom mapper is available, apply the default
+                // mapping. In this case, the output rect should be the union of the input rects for all
+                // the simple shader inputs, or infinite if there are no simple inputs. The input rects
+                // for complex inputs, if present, are not needed in this scenario, so they're ignored.
+                RECT? unionOfSimpleRects = null;
 
-                @this->inputRect = inputRects[0];
+                for (uint i = 0; i < inputRectCount; i++)
+                {
+                    if (@this->inputTypes[i] == D2D1PixelShaderInputType.Simple)
+                    {
+                        unionOfSimpleRects = (unionOfSimpleRects ?? default).Union(inputRects[i]);
+                    }
+                }
+
+                if (unionOfSimpleRects.HasValue)
+                {
+                    *outputRect = unionOfSimpleRects.Value;
+                }
+                else
+                {
+                    outputRect->MakeD2D1Infinite();
+                }
 
                 *outputOpaqueSubRect = default;
             }
@@ -233,6 +263,11 @@ partial struct PixelShaderEffect
         public static int MapInvalidRect(PixelShaderEffect* @this, uint inputIndex, RECT invalidInputRect, RECT* invalidOutputRect)
         {
             @this = (PixelShaderEffect*)&((void**)@this)[-1];
+
+            if (inputIndex >= (uint)@this->inputCount)
+            {
+                return E.E_INVALIDARG;
+            }
 
             if (@this->d2D1TransformMapperHandle.Target is D2D1TransformMapper d2D1TransformMapper)
             {
@@ -253,8 +288,19 @@ partial struct PixelShaderEffect
             }
             else
             {
-                // Default mapping
-                *invalidOutputRect = @this->inputRect;
+                // The default mapping in this scenario just needs to set the invalid output rect for simple inputs to
+                // be the invalid input rect, and to set the invalid output rect for complex inputs to an infinite rect.
+                switch (@this->inputTypes[inputIndex])
+                {
+                    case D2D1PixelShaderInputType.Simple:
+                        *invalidOutputRect = invalidInputRect;
+                        break;
+                    case D2D1PixelShaderInputType.Complex:
+                        invalidOutputRect->MakeD2D1Infinite();
+                        break;
+                    default:
+                        return E.E_FAIL;
+                }
             }
 
             return S.S_OK;

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -150,7 +150,16 @@ internal unsafe partial struct PixelShaderEffect
     /// <summary>
     /// The number of inputs for the shader.
     /// </summary>
-    private int numberOfInputs;
+    private int inputCount;
+
+    /// <summary>
+    /// The buffer with the types of inputs for the shader.
+    /// </summary>
+    /// <remarks>
+    /// This buffer is shared among effect instances, so it should not be released. It is
+    /// owned by <see cref="For{T}"/>, which will release it when the target type is unloaded.
+    /// </remarks>
+    private D2D1PixelShaderInputType* inputTypes;
 
     /// <summary>
     /// The shader bytecode.
@@ -168,11 +177,6 @@ internal unsafe partial struct PixelShaderEffect
     private GCHandle d2D1TransformMapperHandle;
 
     /// <summary>
-    /// The current input rectangle.
-    /// </summary>
-    private RECT inputRect;
-
-    /// <summary>
     /// The <see cref="ID2D1DrawInfo"/> instance currently in use.
     /// </summary>
     private ID2D1DrawInfo* d2D1DrawInfo;
@@ -181,7 +185,8 @@ internal unsafe partial struct PixelShaderEffect
     /// The factory method for <see cref="ID2D1Factory1.RegisterEffectFromString"/>.
     /// </summary>
     /// <param name="shaderId">The <see cref="Guid"/> for the shader.</param>
-    /// <param name="numberOfInputs">The number of inputs for the shader.</param>
+    /// <param name="inputCount">The number of inputs for the shader.</param>
+    /// <param name="inputTypes">The buffer with the types of inputs for the shader.</param>
     /// <param name="bytecode">The shader bytecode.</param>
     /// <param name="bytecodeSize">The size of <paramref name="bytecode"/>.</param>
     /// <param name="d2D1TransformMapper">The <see cref="D2D1TransformMapper"/> instance to use for the effect.</param>
@@ -189,7 +194,8 @@ internal unsafe partial struct PixelShaderEffect
     /// <returns>This always returns <c>0</c>.</returns>
     private static int Factory(
         Guid shaderId,
-        int numberOfInputs,
+        int inputCount,
+        D2D1PixelShaderInputType* inputTypes,
         byte* bytecode,
         int bytecodeSize,
         D2D1TransformMapper? d2D1TransformMapper,
@@ -203,7 +209,8 @@ internal unsafe partial struct PixelShaderEffect
         @this->lpVtblForID2D1DrawTransform = VtblForID2D1DrawTransform;
         @this->referenceCount = 1;
         @this->shaderId = shaderId;
-        @this->numberOfInputs = numberOfInputs;
+        @this->inputCount = inputCount;
+        @this->inputTypes = inputTypes;
         @this->bytecode = bytecode;
         @this->bytecodeSize = bytecodeSize;
         @this->d2D1TransformMapperHandle = GCHandle.Alloc(d2D1TransformMapper);

--- a/src/TerraFX.Interop.Windows.D2D1/Windows/shared/winerror/E.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/Windows/shared/winerror/E.cs
@@ -18,5 +18,8 @@ namespace TerraFX.Interop.Windows
 
         [NativeTypeName("#define E_POINTER _HRESULT_TYPEDEF_(0x80004003L)")]
         public const int E_POINTER = unchecked((int)(0x80004003));
+
+        [NativeTypeName("#define E_FAIL _HRESULT_TYPEDEF_(0x80004005L)")]
+        public const int E_FAIL = unchecked((int)(0x80004005));
     }
 }


### PR DESCRIPTION
### Closes #260.

Follow up to #264.

### Description

This PR improves the default draw transform mapper logic.
