### PR TITLE
Add support for D2D1 input descriptions

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -48,3 +48,5 @@ CMPSD2D0038 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0039 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0040 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0041 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0042 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0043 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -77,6 +77,7 @@
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\ID2D1PixelShader.cs" Link="ComputeSharp.D2D1\Interfaces\ID2D1PixelShader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1BytecodeLoader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1BytecodeLoader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1DispatchDataLoader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1DispatchDataLoader.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1InputDescriptionsLoader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1InputDescriptionsLoader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1Shader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1Shader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Intrinsics\D2D.cs" Link="ComputeSharp.D2D1\Intrinsics\D2D.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" Link="ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -67,6 +67,7 @@
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1ShaderProfile.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1ShaderProfile.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -586,4 +586,36 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "D2D1 shaders can only use supported types (some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used).",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader with an out of range input description index (or more).
+    /// <para>
+    /// Format: <c>"The D2D1 shader of type {0} is using some out of range input description indices"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor OutOfRangeInputDescriptionIndex = new DiagnosticDescriptor(
+        id: "CMPSD2D0042",
+        title: "Our of range D2D1 shader input description indices",
+        messageFormat: "The D2D1 shader of type {0} is using some out of range input description indices",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A D2D1 shader must have all the indices of its input descriptions in the valid range (between 0 and the number of declared inputs).",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for repeated indices for D2D input descriptions.
+    /// <para>
+    /// Format: <c>"The D2D1 shader of type {0} is using repeated indices for some of its [D2DInputDescription] attributes"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor RepeatedD2DInputDescriptionIndices = new DiagnosticDescriptor(
+        id: "CMPSD2D0043",
+        title: "Repeated D2D1 shader input description indices",
+        messageFormat: "The D2D1 shader of type {0} is using repeated indices for some of its [D2DInputDescription] attributes",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A D2D1 shader must only have unique indices for all of its [D2DInputDescription] attributes.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetInputTypeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetInputTypeMethod.cs
@@ -19,12 +19,12 @@ partial class ID2D1ShaderGenerator
         /// <summary>
         /// Extracts the input info for the current shader.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
         /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
         /// <param name="inputCount">The number of shader inputs to declare.</param>
         /// <param name="inputSimpleIndices">The indicess of the simple shader inputs.</param>
         /// <param name="inputComplexIndices">The indices of the complex shader inputs.</param>
         /// <param name="combinedInputTypes">The combined and serialized input types for each available input.</param>
+        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
         public static void GetInfo(
             INamedTypeSymbol structDeclarationSymbol,
             out int inputCount,

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadInputDescriptionsMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadInputDescriptionsMethod.Syntax.cs
@@ -1,0 +1,148 @@
+﻿using System.Collections.Immutable;
+using ComputeSharp.D2D1.__Internals;
+using ComputeSharp.D2D1.SourceGenerators.Models;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <inheritoc/>
+    private static partial class LoadInputDescriptions
+    {
+        /// <summary>
+        /// Creates a <see cref="MethodDeclarationSyntax"/> instance for the <c>LoadInputDescriptions</c> method.
+        /// </summary>
+        /// <param name="inputDescriptionsInfo">The input descriptions info gathered for the current shader.</param>
+        /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the <c>LoadInputDescriptions</c> method.</returns>
+        public static MethodDeclarationSyntax GetSyntax(InputDescriptionsInfo inputDescriptionsInfo)
+        {
+            // This code produces a method declaration as follows:
+            //
+            // readonly void global::ComputeSharp.D2D1.__Internals.ID2D1Shader.LoadInputDescriptions<TLoader>(ref TLoader loader)
+            // {
+            //     <BODY>
+            // }
+            return
+                MethodDeclaration(PredefinedType(Token(SyntaxKind.VoidKeyword)), Identifier(nameof(LoadInputDescriptions)))
+                .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IdentifierName($"global::ComputeSharp.D2D1.__Internals.{nameof(ID2D1Shader)}")))
+                .AddModifiers(Token(SyntaxKind.ReadOnlyKeyword))
+                .AddTypeParameterListParameters(TypeParameter(Identifier("TLoader")))
+                .AddParameterListParameters(Parameter(Identifier("loader")).AddModifiers(Token(SyntaxKind.RefKeyword)).WithType(IdentifierName("TLoader")))
+                .WithBody(Block(GetInputDescriptionsLoadingStatements(inputDescriptionsInfo.InputDescriptions)));
+        }
+
+        /// <summary>
+        /// Gets a sequence of statements to load the input descriptions for a given shader.
+        /// </summary>
+        /// <param name="inputDescriptions">The array of <see cref="InputDescription"/> values for all available input descriptions.</param>
+        /// <returns>The sequence of <see cref="StatementSyntax"/> instances to load shader dispatch data.</returns>
+        private static ImmutableArray<StatementSyntax> GetInputDescriptionsLoadingStatements(ImmutableArray<InputDescription> inputDescriptions)
+        {
+            // If there are no input descriptions available, just load an empty buffer
+            if (inputDescriptions.IsEmpty)
+            {
+                // loader.LoadInputDescriptions(default);
+                return
+                    ImmutableArray.Create<StatementSyntax>(
+                        ExpressionStatement(
+                            InvocationExpression(
+                                MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    IdentifierName("loader"),
+                                    IdentifierName("LoadInputDescriptions")))
+                            .AddArgumentListArguments(Argument(
+                                LiteralExpression(
+                                    SyntaxKind.DefaultLiteralExpression,
+                                    Token(SyntaxKind.DefaultKeyword))))));
+            }
+
+            ImmutableArray<StatementSyntax>.Builder statements = ImmutableArray.CreateBuilder<StatementSyntax>();
+
+            // The size of the buffer with the input descriptions is the number of input descriptions, times the size of each
+            // input description, which is a struct containing three int-sized fields (index, filter, and level of detail).
+            int inputDescriptionSizeInBytes = inputDescriptions.Length * sizeof(int) * 3;
+
+            // global::System.Span<byte> data = stackalloc byte[<INPUT_DESCRIPTIONS_SIZE>];
+            statements.Insert(0,
+                LocalDeclarationStatement(
+                    VariableDeclaration(
+                        GenericName(Identifier("global::System.Span"))
+                        .AddTypeArgumentListArguments(PredefinedType(Token(SyntaxKind.ByteKeyword))))
+                    .AddVariables(
+                        VariableDeclarator(Identifier("data"))
+                        .WithInitializer(EqualsValueClause(
+                            StackAllocArrayCreationExpression(
+                                ArrayType(PredefinedType(Token(SyntaxKind.ByteKeyword)))
+                                .AddRankSpecifiers(
+                                    ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(
+                                        LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(inputDescriptionSizeInBytes)))))))))));
+
+            // ref byte r0 = ref data[0];
+            statements.Insert(1,
+                LocalDeclarationStatement(
+                    VariableDeclaration(RefType(PredefinedType(Token(SyntaxKind.ByteKeyword))))
+                    .AddVariables(
+                        VariableDeclarator(Identifier("r0"))
+                        .WithInitializer(EqualsValueClause(
+                            RefExpression(
+                                ElementAccessExpression(IdentifierName("data"))
+                                .AddArgumentListArguments(Argument(
+                                    LiteralExpression(
+                                        SyntaxKind.NumericLiteralExpression,
+                                        Literal(0))))))))));
+
+            int offset = 0;
+
+            // Generate loading statements for each input description
+            foreach (InputDescription inputDescription in inputDescriptions)
+            {
+                // Write the index of the current input description:
+                //
+                // global::System.Runtime.CompilerServices.Unsafe.As<byte, uint>(ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint)<OFFSET>)) = <INDEX>;
+                statements.Add(ExpressionStatement(
+                    AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        ParseExpression($"global::System.Runtime.CompilerServices.Unsafe.As<byte, uint>(ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint){offset}))"),
+                        LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal((int)inputDescription.Index)))));
+
+                // Write the filter of the current input description:
+                //
+                // global::System.Runtime.CompilerServices.Unsafe.As<byte, uint>(ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint)<OFFSET> + 4)) = <FILTER>;
+                statements.Add(ExpressionStatement(
+                    AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        ParseExpression($"global::System.Runtime.CompilerServices.Unsafe.As<byte, uint>(ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint){offset + 4}))"),
+                        LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal((int)inputDescription.Filter)))));
+
+                // Write the level of detail of the current input description:
+                //
+                // global::System.Runtime.CompilerServices.Unsafe.As<byte, uint>(ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint)<OFFSET> + 8)) = <LEVEL_OF_DETAIL>;
+                statements.Add(ExpressionStatement(
+                    AssignmentExpression(
+                        SyntaxKind.SimpleAssignmentExpression,
+                        ParseExpression($"global::System.Runtime.CompilerServices.Unsafe.As<byte, uint>(ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint){offset + 8}))"),
+                        LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal((int)inputDescription.LevelOfDetail)))));
+
+                offset += sizeof(int) * 3;
+            }
+
+            // loader.LoadInputDescriptions(data);
+            statements.Add(
+                ExpressionStatement(
+                    InvocationExpression(
+                        MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            IdentifierName("loader"),
+                            IdentifierName("LoadInputDescriptions")))
+                    .AddArgumentListArguments(Argument(IdentifierName("data")))));
+
+            return statements.ToImmutable();
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadInputDescriptionsMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadInputDescriptionsMethod.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.D2D1.SourceGenerators.Models;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using static ComputeSharp.D2D1.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <summary>
+    /// A helper with all logic to generate the <c>LoadInputDescriptions</c> method.
+    /// </summary>
+    private static partial class LoadInputDescriptions
+    {
+        /// <summary>
+        /// Extracts the input descriptions for the current shader.
+        /// </summary>
+        /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
+        /// <param name="inputDescriptions">The produced input descriptions for the shader.</param>
+        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
+        public static void GetInfo(
+            INamedTypeSymbol structDeclarationSymbol,
+            out ImmutableArray<InputDescription> inputDescriptions,
+            out ImmutableArray<Diagnostic> diagnostics)
+        {
+            int inputCount = 0;
+            ImmutableArray<InputDescription>.Builder inputDescriptionsBuilder = ImmutableArray.CreateBuilder<InputDescription>();
+            ImmutableArray<Diagnostic>.Builder diagnosticsBuilder = ImmutableArray.CreateBuilder<Diagnostic>();       
+
+            foreach (AttributeData attributeData in structDeclarationSymbol.GetAttributes())
+            {
+                switch (attributeData.AttributeClass?.GetFullMetadataName())
+                {
+                    case "ComputeSharp.D2D1.D2DInputCountAttribute":
+                        inputCount = (int)attributeData.ConstructorArguments[0].Value!;
+                        break;
+                    case "ComputeSharp.D2D1.D2DInputDescriptionAttribute":
+                        if (attributeData.ConstructorArguments.Length == 2)
+                        {
+                            int index = (int)attributeData.ConstructorArguments[0].Value!;
+                            D2D1Filter filter = (D2D1Filter)attributeData.ConstructorArguments[1].Value!;
+
+                            _ = attributeData.TryGetNamedArgument("LevelOfDetail", out int levelOfDetail);
+
+                            inputDescriptionsBuilder.Add(new InputDescription((uint)index, filter, levelOfDetail));
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            inputDescriptions = ImmutableArray<InputDescription>.Empty;
+
+            // Validate the input count (ignore if invalid, this will be validated by the HLSL source generator)
+            if (inputCount is not (>= 0 and <= 8))
+            {
+                goto End;
+            }
+
+            // All simple indices must be in range
+            if (inputDescriptionsBuilder.Any(description => description.Index >= inputCount))
+            {
+                diagnosticsBuilder.Add(OutOfRangeInputDescriptionIndex, structDeclarationSymbol, structDeclarationSymbol);
+
+                goto End;
+            }
+
+            HashSet<uint> inputDescriptionIndices = new(inputDescriptionsBuilder.Select(description => description.Index));
+
+            // All input description indices must be unique
+            if (inputDescriptionIndices.Count != inputDescriptionsBuilder.Count)
+            {
+                diagnosticsBuilder.Add(RepeatedD2DInputDescriptionIndices, structDeclarationSymbol, structDeclarationSymbol);
+
+                goto End;
+            }
+
+            inputDescriptions = inputDescriptionsBuilder.ToImmutable();
+
+            End:
+            diagnostics = diagnosticsBuilder.ToImmutable();
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/InputDescription.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/InputDescription.cs
@@ -1,0 +1,9 @@
+﻿namespace ComputeSharp.D2D1.SourceGenerators.Models;
+
+/// <summary>
+/// A model representing an input description for a shader.
+/// </summary>
+/// <param name="Index">The index of the input resource the description if for.</param>
+/// <param name="Filter">The input filter to use.</param>
+/// <param name="LevelOfDetail">The level of detail to use.</param>
+internal sealed record InputDescription(uint Index, D2D1Filter Filter, int LevelOfDetail);

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/InputDescriptionsInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/InputDescriptionsInfo.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Helpers;
+
+namespace ComputeSharp.D2D1.SourceGenerators.Models;
+
+/// <summary>
+/// A model representing gathered input descriptions for a shader.
+/// </summary>
+/// <param name="InputDescriptions">The input types for a given shader.</param>
+internal sealed record InputDescriptionsInfo(ImmutableArray<InputDescription> InputDescriptions)
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer{T}"/> implementation for <see cref="InputDescriptionsInfo"/>.
+    /// </summary>
+    public sealed class Comparer : Comparer<InputDescriptionsInfo, Comparer>
+    {
+        /// <inheritdoc/>
+        protected override void AddToHashCode(ref HashCode hashCode, InputDescriptionsInfo obj)
+        {
+            hashCode.AddRange(obj.InputDescriptions);
+        }
+
+        /// <inheritdoc/>
+        protected override bool AreEqual(InputDescriptionsInfo x, InputDescriptionsInfo y)
+        {
+            return x.InputDescriptions.SequenceEqual(y.InputDescriptions);
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1/Attributes/D2DInputDescriptionAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DInputDescriptionAttribute.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// An attribute for a D2D1 shader indicating the description of a given input resource.
+/// This attribute is optional, and not using it will cause no description to be declared.
+/// </summary>
+/// <remarks>
+/// <para>This attribute exposes the options that can be set via <c>D2D1_INPUT_DESCRIPTION</c>.</para>
+/// <para>For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1effectauthor/ns-d2d1effectauthor-d2d1_input_description"/>.</para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Struct, AllowMultiple = true)]
+public sealed class D2DInputDescriptionAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="D2DInputDescriptionAttribute"/> type with the specified arguments.
+    /// </summary>
+    /// <param name="index">The index of the resource to declare the description for.</param>
+    /// <param name="filter">The type of filter to apply to the input texture.</param>
+    public D2DInputDescriptionAttribute(int index, D2D1Filter filter)
+    {
+        Index = index;
+        Filter = filter;
+    }
+
+    /// <summary>
+    /// Gets the index of the resource to declare the description for.
+    /// </summary>
+    public int Index { get; }
+
+    /// <summary>
+    /// Gets the type of filter to apply to the input texture.
+    /// </summary>
+    public D2D1Filter Filter { get; }
+
+    /// <summary>
+    /// Gets the mip level to retrieve from the upstream transform, if specified.
+    /// </summary>
+    public int LevelOfDetail { get; init; }
+}

--- a/src/ComputeSharp.D2D1/Attributes/Enums/D2D1Filter.cs
+++ b/src/ComputeSharp.D2D1/Attributes/Enums/D2D1Filter.cs
@@ -6,6 +6,14 @@ namespace ComputeSharp.D2D1;
 /// Represents the filtering mode that a transform may select to use on input textures.
 /// </summary>
 /// <remarks>
+/// <para>
+/// In most scenarios, or when unsure on what values to use, consider this reference:
+/// <list type="bullet">
+///     <item><description><see cref="MinMagMipPoint"/>: point sampling.</description></item>
+///     <item><description><see cref="MinMagMipLinear"/>: linear sampling.</description></item>
+/// </list>
+/// Other values can be used when explicit fine grained control is needed on how inputs are sampled.
+/// </para>
 /// <para>This type exposes the available values in <see href="https://docs.microsoft.com/windows/win32/api/d2d1effectauthor/ne-d2d1effectauthor-d2d1_filter"/>.</para>
 /// </remarks>
 public enum D2D1Filter

--- a/src/ComputeSharp.D2D1/Attributes/Enums/D2D1Filter.cs
+++ b/src/ComputeSharp.D2D1/Attributes/Enums/D2D1Filter.cs
@@ -1,0 +1,57 @@
+﻿using static TerraFX.Interop.DirectX.D2D1_FILTER;
+
+namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// Represents the filtering mode that a transform may select to use on input textures.
+/// </summary>
+/// <remarks>
+/// <para>This type exposes the available values in <see href="https://docs.microsoft.com/windows/win32/api/d2d1effectauthor/ne-d2d1effectauthor-d2d1_filter"/>.</para>
+/// </remarks>
+public enum D2D1Filter
+{
+    /// <summary>
+    /// Use point sampling for minification, magnification, and mip-level sampling.
+    /// </summary>
+    MinMagMipPoint = (int)D2D1_FILTER_MIN_MAG_MIP_POINT,
+
+    /// <summary>
+    /// Use point sampling for minification and magnification, use linear interpolation for mip-level sampling.
+    /// </summary>
+    MinMagPointMipLinear = (int)D2D1_FILTER_MIN_MAG_POINT_MIP_LINEAR,
+
+    /// <summary>
+    /// Use point sampling for minification, use linear interpolation for magnification, use point sampling for mip-level sampling.
+    /// </summary>
+    MinPointMagLinearMipPoint = (int)D2D1_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT,
+
+    /// <summary>
+    /// Use point sampling for minification, use linear interpolation for magnification and mip-level sampling.
+    /// </summary>
+    MinPointMagMipLinear = (int)D2D1_FILTER_MIN_POINT_MAG_MIP_LINEAR,
+
+    /// <summary>
+    /// Use linear interpolation for minification, use point sampling for magnification and mip-level sampling.
+    /// </summary>
+    MinLinearMagMipPoint = (int)D2D1_FILTER_MIN_LINEAR_MAG_MIP_POINT,
+
+    /// <summary>
+    /// Use linear interpolation for minification, use point sampling for magnification, use linear interpolation for mip-level sampling.
+    /// </summary>
+    MinLinearMagPointMinLinear = (int)D2D1_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR,
+
+    /// <summary>
+    /// Use linear interpolation for minification and magnification, use point sampling for mip-level sampling.
+    /// </summary>
+    MinMagLinearMipPoint = (int)D2D1_FILTER_MIN_MAG_LINEAR_MIP_POINT,
+
+    /// <summary>
+    /// Use linear interpolation for minification, magnification, and mip-level sampling.
+    /// </summary>
+    MinMagMipLinear = (int)D2D1_FILTER_MIN_MAG_MIP_LINEAR,
+
+    /// <summary>
+    /// Use anisotropic interpolation for minification, magnification, and mip-level sampling.
+    /// </summary>
+    Anisotropic = (int)D2D1_FILTER_ANISOTROPIC
+}

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1InputDescriptionsLoader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1InputDescriptionsLoader.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace ComputeSharp.D2D1.__Internals;
+
+/// <summary>
+/// A base <see langword="interface"/> representing a loader for input descriptions in a D2D1 shader.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Obsolete("This interface is not intended to be used directly by user code")]
+public interface ID2D1InputDescriptionsLoader
+{
+    /// <summary>
+    /// Loads the available input descriptions for the shader.
+    /// </summary>
+    /// <param name="data">The sequence of serialized input descriptions.</param>
+    void LoadInputDescriptions(ReadOnlySpan<byte> data);
+}

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
@@ -38,6 +38,16 @@ public interface ID2D1Shader
     uint GetInputType(uint index);
 
     /// <summary>
+    /// Loads the input descriptions for the shader, if any.
+    /// </summary>
+    /// <typeparam name="TLoader">The type of input descriptions loader being used.</typeparam>
+    /// <param name="loader">The <typeparamref name="TLoader"/> instance to use to load the input descriptions.</param>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This method is not intended to be used directly by user code")]
+    void LoadInputDescriptions<TLoader>(ref TLoader loader)
+        where TLoader : struct, ID2D1InputDescriptionsLoader;
+
+    /// <summary>
     /// Gets the output buffer precision and depth for the shader.
     /// </summary>
     /// <param name="precision">The output buffer precision.</param>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1InputDescription.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1InputDescription.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace ComputeSharp.D2D1.Interop;
+
+/// <summary>
+/// A type containing info on a description for a given D2D1 pixel shader input resource.
+/// </summary>
+/// <remarks>
+/// <para>This type exposes the values that can be set via <c>ID2D1RenderInfo::SetInputDescription</c>.</para>
+/// <para>For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1effectauthor/nf-d2d1effectauthor-id2d1renderinfo-setinputdescription"/>.</para>
+/// </remarks>
+public readonly struct D2D1InputDescription
+{
+    /// <summary>
+    /// Creates a new <see cref="D2D1InputDescription"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="index">The index of the resource the description belongs to.</param>
+    /// <param name="filter">The type of filter to apply to the input texture.</param>
+    /// <param name="levelOfDetail">The mip level to retrieve from the upstream transform, if specified.</param>
+    internal D2D1InputDescription(int index, D2D1Filter filter, int levelOfDetail)
+    {
+        Index = index;
+        Filter = filter;
+        LevelOfDetail = levelOfDetail;
+    }
+
+    /// <summary>
+    /// Gets the index of the resource the description belongs to.
+    /// </summary>
+    public int Index { get; }
+
+    /// <summary>
+    /// Gets the type of filter to apply to the input texture.
+    /// </summary>
+    public D2D1Filter Filter { get; }
+
+    /// <summary>
+    /// Gets the mip level to retrieve from the upstream transform, if specified.
+    /// </summary>
+    public int LevelOfDetail { get; }
+}

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using ComputeSharp.D2D1.Helpers;
-using ComputeSharp.D2D1.Shaders.Dispatching;
 using ComputeSharp.D2D1.Shaders.Interop.Buffers;
+using ComputeSharp.D2D1.Shaders.Loaders;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 
@@ -111,6 +111,23 @@ public static class D2D1PixelShader
         }
 
         return (D2D1PixelShaderInputType)shader.GetInputType((uint)index);
+    }
+
+    /// <summary>
+    /// Gets the available input descriptions for a D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the input descriptions for.</typeparam>
+    /// <returns>A <see cref="ReadOnlyMemory{T}"/> with the available input descriptions for the shader.</returns>
+    public static ReadOnlyMemory<D2D1InputDescription> GetInputDescriptions<T>()
+        where T : unmanaged, ID2D1PixelShader
+    {
+        D2D1ByteArrayInputDescriptionsLoader inputDescriptionsLoader = default;
+
+        Unsafe.SkipInit(out T shader);
+
+        shader.LoadInputDescriptions(ref inputDescriptionsLoader);
+
+        return inputDescriptionsLoader.GetResultingInputDescriptions();
     }
 
     /// <summary>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
@@ -8,8 +8,8 @@ using System.Text;
 using ComputeSharp.D2D1.Extensions;
 using ComputeSharp.D2D1.Helpers;
 using ComputeSharp.D2D1.Interop.Effects;
-using ComputeSharp.D2D1.Shaders.Dispatching;
 using ComputeSharp.D2D1.Shaders.Interop.Buffers;
+using ComputeSharp.D2D1.Shaders.Loaders;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -2,7 +2,7 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.D2D1.Extensions;
-using ComputeSharp.D2D1.Shaders.Dispatching;
+using ComputeSharp.D2D1.Shaders.Loaders;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
@@ -331,13 +331,38 @@ partial struct PixelShaderEffect
                 return hresult;
             }
 
+            // If any input descriptions are present, set them
+            if (@this->inputDescriptionCount > 0)
+            {
+                for (int i = 0; i < @this->inputDescriptionCount; i++)
+                {
+                    ref D2D1InputDescription inputDescription = ref @this->inputDescriptions[i];
+
+                    D2D1_INPUT_DESCRIPTION d2D1InputDescription;
+                    d2D1InputDescription.filter = (D2D1_FILTER)inputDescription.Filter;
+                    d2D1InputDescription.levelOfDetailCount = (uint)inputDescription.LevelOfDetail;
+
+                    hresult = drawInfo->SetInputDescription((uint)inputDescription.Index, d2D1InputDescription);
+
+                    if (hresult != S.S_OK)
+                    {
+                        return hresult;
+                    }
+                }
+            }
+
             // If a custom buffer precision or channel depth is requested, set it
             if (@this->bufferPrecision != D2D1BufferPrecision.Unknown ||
                 @this->channelDepth != D2D1ChannelDepth.Default)
             {
-                return drawInfo->SetOutputBuffer(
+                hresult = drawInfo->SetOutputBuffer(
                     (D2D1_BUFFER_PRECISION)@this->bufferPrecision,
                     (D2D1_CHANNEL_DEPTH)@this->channelDepth);
+
+                if (hresult != S.S_OK)
+                {
+                    return hresult;
+                }
             }
 
             return S.S_OK;

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -162,6 +162,20 @@ internal unsafe partial struct PixelShaderEffect
     private D2D1PixelShaderInputType* inputTypes;
 
     /// <summary>
+    /// The number of available input descriptions.
+    /// </summary>
+    private int inputDescriptionCount;
+
+    /// <summary>
+    /// The buffer with the available input descriptions for the shader.
+    /// </summary>
+    /// <remarks>
+    /// This buffer is also shared among effect instances, so it should not be released. It is
+    /// owned by <see cref="For{T}"/>, which will release it when the target type is unloaded.
+    /// </remarks>
+    private D2D1InputDescription* inputDescriptions;
+
+    /// <summary>
     /// The shader bytecode.
     /// </summary>
     private byte* bytecode;
@@ -197,6 +211,8 @@ internal unsafe partial struct PixelShaderEffect
     /// <param name="shaderId">The <see cref="Guid"/> for the shader.</param>
     /// <param name="inputCount">The number of inputs for the shader.</param>
     /// <param name="inputTypes">The buffer with the types of inputs for the shader.</param>
+    /// <param name="inputDescriptionCount">The number of available input descriptions.</param>
+    /// <param name="inputDescriptions">The buffer with the available input descriptions for the shader.</param>
     /// <param name="bytecode">The shader bytecode.</param>
     /// <param name="bytecodeSize">The size of <paramref name="bytecode"/>.</param>
     /// <param name="bufferPrecision">The buffer precision for the resulting output buffer.</param>
@@ -208,6 +224,8 @@ internal unsafe partial struct PixelShaderEffect
         Guid shaderId,
         int inputCount,
         D2D1PixelShaderInputType* inputTypes,
+        int inputDescriptionCount,
+        D2D1InputDescription* inputDescriptions,
         byte* bytecode,
         int bytecodeSize,
         D2D1BufferPrecision bufferPrecision,
@@ -225,6 +243,8 @@ internal unsafe partial struct PixelShaderEffect
         @this->shaderId = shaderId;
         @this->inputCount = inputCount;
         @this->inputTypes = inputTypes;
+        @this->inputDescriptionCount = inputDescriptionCount;
+        @this->inputDescriptions = inputDescriptions;
         @this->bytecode = bytecode;
         @this->bytecodeSize = bytecodeSize;
         @this->bufferPrecision = bufferPrecision;

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayDispatchDataLoader.cs
@@ -6,7 +6,7 @@ using TerraFX.Interop.DirectX;
 
 #pragma warning disable CS0618
 
-namespace ComputeSharp.D2D1.Shaders.Dispatching;
+namespace ComputeSharp.D2D1.Shaders.Loaders;
 
 /// <summary>
 /// A data loader for D2D1 pixel shaders dispatched via <see cref="ID2D1DrawInfo"/>.
@@ -14,7 +14,7 @@ namespace ComputeSharp.D2D1.Shaders.Dispatching;
 internal struct D2D1ByteArrayDispatchDataLoader : ID2D1DispatchDataLoader
 {
     /// <summary>
-    /// The <see cref="ID2D1DrawInfo"/> object in use.
+    /// The resulting array with the constant buffer to use.
     /// </summary>
     private byte[]? data;
 
@@ -29,7 +29,7 @@ internal struct D2D1ByteArrayDispatchDataLoader : ID2D1DispatchDataLoader
     }
 
     /// <inheritdoc/>
-    public void LoadConstantBuffer(ReadOnlySpan<uint> data)
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
     {
         this.data = MemoryMarshal.AsBytes(data).ToArray();
     }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayInputDescriptionsLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayInputDescriptionsLoader.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using ComputeSharp.D2D1.__Internals;
+using ComputeSharp.D2D1.Interop;
+using TerraFX.Interop.DirectX;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.D2D1.Shaders.Loaders;
+
+/// <summary>
+/// An input descriptions loader for D2D1 pixel shaders.
+/// </summary>
+internal struct D2D1ByteArrayInputDescriptionsLoader : ID2D1InputDescriptionsLoader
+{
+    /// <summary>
+    /// The <see cref="ID2D1DrawInfo"/> object in use.
+    /// </summary>
+    private D2D1InputDescription[]? inputDescriptions;
+
+    /// <summary>
+    /// Gets the resulting input descriptions.
+    /// </summary>
+    /// <remarks>A <see cref="D2D1InputDescription"/> array with the available input descriptions.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public D2D1InputDescription[] GetResultingInputDescriptions()
+    {
+        return this.inputDescriptions!;
+    }
+
+    /// <inheritdoc/>
+    void ID2D1InputDescriptionsLoader.LoadInputDescriptions(ReadOnlySpan<byte> data)
+    {
+        this.inputDescriptions = MemoryMarshal.Cast<byte, D2D1InputDescription>(data).ToArray();
+    }
+}

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1DrawInfoDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1DrawInfoDispatchDataLoader.cs
@@ -6,7 +6,7 @@ using TerraFX.Interop.DirectX;
 
 #pragma warning disable CS0618
 
-namespace ComputeSharp.D2D1.Shaders.Dispatching;
+namespace ComputeSharp.D2D1.Shaders.Loaders;
 
 /// <summary>
 /// A data loader for D2D1 pixel shaders dispatched via <see cref="ID2D1DrawInfo"/>.
@@ -29,7 +29,7 @@ internal readonly unsafe struct D2D1DrawInfoDispatchDataLoader : ID2D1DispatchDa
     }
 
     /// <inheritdoc/>
-    public void LoadConstantBuffer(ReadOnlySpan<uint> data)
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
     {
         this.d2D1DrawInfo->SetPixelShaderConstantBuffer(
             buffer: (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(data)),

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1EffectDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1EffectDispatchDataLoader.cs
@@ -7,7 +7,7 @@ using TerraFX.Interop.DirectX;
 
 #pragma warning disable CS0618
 
-namespace ComputeSharp.D2D1.Shaders.Dispatching;
+namespace ComputeSharp.D2D1.Shaders.Loaders;
 
 /// <summary>
 /// A data loader for D2D1 pixel shaders dispatched via <see cref="ID2D1Effect"/>.
@@ -30,7 +30,7 @@ internal readonly unsafe struct D2D1EffectDispatchDataLoader : ID2D1DispatchData
     }
 
     /// <inheritdoc/>
-    public void LoadConstantBuffer(ReadOnlySpan<uint> data)
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
     {
         if (data.IsEmpty)
         {

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ShaderBytecodeLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ShaderBytecodeLoader.cs
@@ -9,7 +9,7 @@ using TerraFX.Interop.Windows;
 
 #pragma warning disable CS0618
 
-namespace ComputeSharp.D2D1.Shaders.Dispatching;
+namespace ComputeSharp.D2D1.Shaders.Loaders;
 
 /// <summary>
 /// A bytecode loader for D2D1 shaders.
@@ -46,7 +46,8 @@ internal unsafe struct D2D1ShaderBytecodeLoader : ID2D1BytecodeLoader
     }
 
     /// <inheritdoc/>
-    public unsafe void LoadDynamicBytecode(IntPtr handle)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    unsafe void ID2D1BytecodeLoader.LoadDynamicBytecode(IntPtr handle)
     {
         if (this.embeddedBytecodePtr is not null ||
             this.d3DBlob.Get() is not null)
@@ -64,7 +65,7 @@ internal unsafe struct D2D1ShaderBytecodeLoader : ID2D1BytecodeLoader
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void LoadEmbeddedBytecode(ReadOnlySpan<byte> bytecode)
+    void ID2D1BytecodeLoader.LoadEmbeddedBytecode(ReadOnlySpan<byte> bytecode)
     {
         if (this.embeddedBytecodePtr is not null ||
             this.d3DBlob.Get() is not null)

--- a/src/ComputeSharp.SourceGeneration/ComputeSharp.SourceGeneration.projitems
+++ b/src/ComputeSharp.SourceGeneration/ComputeSharp.SourceGeneration.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>ComputeSharp.SourceGeneration</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\AttributeDataExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DiagnosticsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\HashCodeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\IEqualityComparerExtensions.cs" />

--- a/src/ComputeSharp.SourceGeneration/Extensions/AttributeDataExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/AttributeDataExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.SourceGeneration.Extensions;
+
+/// <summary>
+/// Extension methods for the <see cref="AttributeData"/> type.
+/// </summary>
+internal static class AttributeDataExtensions
+{
+    /// <summary>
+    /// Tries to get a given named argument value from an <see cref="AttributeData"/> instance, if present.
+    /// </summary>
+    /// <typeparam name="T">The type of argument to check.</typeparam>
+    /// <param name="attributeData">The target <see cref="AttributeData"/> instance to check.</param>
+    /// <param name="name">The name of the argument to check.</param>
+    /// <param name="value">The resulting argument value, if present.</param>
+    /// <returns>Whether or not <paramref name="attributeData"/> contains an argument named <paramref name="name"/> with a valid value.</returns>
+    public static bool TryGetNamedArgument<T>(this AttributeData attributeData, string name, out T? value)
+    {
+        foreach (KeyValuePair<string, TypedConstant> properties in attributeData.NamedArguments)
+        {
+            if (properties.Key == name)
+            {
+                value = (T?)properties.Value.Value;
+
+                return true;
+            }
+        }
+
+        value = default;
+
+        return false;
+    }
+}

--- a/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/D2D1_FILTER.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/D2D1_FILTER.cs
@@ -1,0 +1,21 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/d2d1effectauthor.h in the Windows SDK for Windows 10.0.22000.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.DirectX
+{
+    internal enum D2D1_FILTER : uint
+    {
+        D2D1_FILTER_MIN_MAG_MIP_POINT = 0x00,
+        D2D1_FILTER_MIN_MAG_POINT_MIP_LINEAR = 0x01,
+        D2D1_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT = 0x04,
+        D2D1_FILTER_MIN_POINT_MAG_MIP_LINEAR = 0x05,
+        D2D1_FILTER_MIN_LINEAR_MAG_MIP_POINT = 0x10,
+        D2D1_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR = 0x11,
+        D2D1_FILTER_MIN_MAG_LINEAR_MIP_POINT = 0x14,
+        D2D1_FILTER_MIN_MAG_MIP_LINEAR = 0x15,
+        D2D1_FILTER_ANISOTROPIC = 0x55,
+        D2D1_FILTER_FORCE_DWORD = 0xffffffff
+    }
+}

--- a/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/D2D1_INPUT_DESCRIPTION.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/D2D1_INPUT_DESCRIPTION.cs
@@ -1,0 +1,15 @@
+﻿// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from um/d2d1effectauthor.h in the Windows SDK for Windows 10.0.22000.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+namespace TerraFX.Interop.DirectX
+{
+    internal partial struct D2D1_INPUT_DESCRIPTION
+    {
+        public D2D1_FILTER filter;
+
+        [NativeTypeName("UINT32")]
+        public uint levelOfDetailCount;
+    }
+}

--- a/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/ID2D1DrawInfo.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/ID2D1DrawInfo.cs
@@ -21,6 +21,13 @@ namespace TerraFX.Interop.DirectX
         public void** lpVtbl;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [VtblIndex(3)]
+        public HRESULT SetInputDescription([NativeTypeName("UINT32")] uint inputIndex, D2D1_INPUT_DESCRIPTION inputDescription)
+        {
+            return ((delegate* unmanaged[Stdcall]<ID2D1DrawInfo*, uint, D2D1_INPUT_DESCRIPTION, int>)(lpVtbl[3]))((ID2D1DrawInfo*)Unsafe.AsPointer(ref this), inputIndex, inputDescription);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [VtblIndex(4)]
         public HRESULT SetOutputBuffer(D2D1_BUFFER_PRECISION bufferPrecision, D2D1_CHANNEL_DEPTH channelDepth)
         {

--- a/src/TerraFX.Interop.Windows.D2D1/TerraFX.Interop.Windows.D2D1.projitems
+++ b/src/TerraFX.Interop.Windows.D2D1/TerraFX.Interop.Windows.D2D1.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\TerraFX.Interop.Windows\DirectX\um\d3d11shader\D3D.cs" Link="DirectX\um\d3d11shader\D3D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_CHANGE_TYPE.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_FILTER.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_PIXEL_OPTIONS.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_PROPERTY_BINDING.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\ID2D1DrawTransform.cs" />

--- a/src/TerraFX.Interop.Windows.D2D1/TerraFX.Interop.Windows.D2D1.projitems
+++ b/src/TerraFX.Interop.Windows.D2D1/TerraFX.Interop.Windows.D2D1.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_FILTER.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_PIXEL_OPTIONS.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_PROPERTY_BINDING.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_INPUT_DESCRIPTION.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\ID2D1DrawTransform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\ID2D1EffectContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\ID2D1EffectImpl.cs" />

--- a/tests/ComputeSharp.D2D1.Tests/D2D1InteropServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1InteropServicesTests.cs
@@ -1,4 +1,5 @@
-﻿using ComputeSharp.D2D1.Interop;
+﻿using System;
+using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Tests.Effects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -93,6 +94,72 @@ public partial class D2D1InteropServicesTests
     [D2DInputCount(0)]
     [D2DOutputBuffer(D2D1BufferPrecision.UInt8NormalizedSrgb, D2D1ChannelDepth.One)]
     partial struct CustomBufferOutputShader : ID2D1PixelShader
+    {
+        public Float4 Execute()
+        {
+            return 0;
+        }
+    }
+
+    [TestMethod]
+    public unsafe void GetInputDescriptions_Empty()
+    {
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<CheckerboardClipEffect>().Length, 0);
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<InvertEffect>().Length, 0);
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<InvertWithThresholdEffect>().Length, 0);
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<PixelateEffect.Shader>().Length, 0);
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<ZonePlateEffect>().Length, 0);
+
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<ShaderWithMultipleInputs>().Length, 0);
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<EmptyShader>().Length, 0);
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<OnlyBufferPrecisionShader>().Length, 0);
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<OnlyChannelDepthShader>().Length, 0);
+        Assert.AreEqual(D2D1PixelShader.GetInputDescriptions<CustomBufferOutputShader>().Length, 0);
+    }
+
+    [TestMethod]
+    public unsafe void GetInputDescriptions_Custom()
+    {
+        ReadOnlyMemory<D2D1InputDescription> inputDescriptions = D2D1PixelShader.GetInputDescriptions<ShaderWithInputDescriptions>();
+
+        Assert.AreEqual(inputDescriptions.Length, 5);
+
+        ReadOnlySpan<D2D1InputDescription> span = inputDescriptions.Span;
+
+        Assert.AreEqual(span[0].Index, 0);
+        Assert.AreEqual(span[0].Filter, D2D1Filter.MinPointMagLinearMipPoint);
+        Assert.AreEqual(span[0].LevelOfDetail, 0);
+
+        Assert.AreEqual(span[1].Index, 1);
+        Assert.AreEqual(span[1].Filter, D2D1Filter.Anisotropic);
+        Assert.AreEqual(span[1].LevelOfDetail, 0);
+
+        Assert.AreEqual(span[2].Index, 2);
+        Assert.AreEqual(span[2].Filter, D2D1Filter.MinLinearMagPointMinLinear);
+        Assert.AreEqual(span[2].LevelOfDetail, 4);
+
+        Assert.AreEqual(span[3].Index, 5);
+        Assert.AreEqual(span[3].Filter, D2D1Filter.MinMagPointMipLinear);
+        Assert.AreEqual(span[3].LevelOfDetail, 0);
+
+        Assert.AreEqual(span[4].Index, 6);
+        Assert.AreEqual(span[4].Filter, D2D1Filter.MinPointMagMipLinear);
+        Assert.AreEqual(span[4].LevelOfDetail, 3);
+    }
+
+    [D2DInputCount(7)]
+    [D2DInputSimple(0)]
+    [D2DInputSimple(2)]
+    [D2DInputComplex(1)]
+    [D2DInputComplex(3)]
+    [D2DInputComplex(5)]
+    [D2DInputSimple(6)]
+    [D2DInputDescription(0, D2D1Filter.MinPointMagLinearMipPoint)]
+    [D2DInputDescription(1, D2D1Filter.Anisotropic)]
+    [D2DInputDescription(2, D2D1Filter.MinLinearMagPointMinLinear, LevelOfDetail = 4)]
+    [D2DInputDescription(5, D2D1Filter.MinMagPointMipLinear)]
+    [D2DInputDescription(6, D2D1Filter.MinPointMagMipLinear, LevelOfDetail = 3)]
+    partial struct ShaderWithInputDescriptions : ID2D1PixelShader
     {
         public Float4 Execute()
         {


### PR DESCRIPTION
### Closes #261

### Description

This PR adds support for specifying input descriptions for a D2D1 shader.
These can either be retrieved manually via `D2D1PixelShader`, or used automatically via `D2D1PixelShaderEffect`.

### API breakdown

> **NOTE:** the API design deliberately follows the same design as the D2D1 APIs.

```csharp
namespace ComputeSharp.D2D1
{
    [AttributeUsage(AttributeTargets.Struct, AllowMultiple = true)]
    public sealed class D2DInputDescriptionAttribute : Attribute
    {
        public D2DInputDescriptionAttribute(int index, D2D1Filter filter);

        public int Index { get; }
        public D2D1Filter Filter { get; }
        public int LevelOfDetail { get; init; }
    }

    public enum D2D1Filter
    {
        MinMagMipPoint,
        MinMagPointMipLinear,
        MinPointMagLinearMipPoint,
        MinPointMagMipLinear,
        MinLinearMagMipPoint,
        MinLinearMagPointMinLinear,
        MinMagLinearMipPoint,
        MinMagMipLinear,
        Anisotropic
    }
}

namespace ComputeSharp.D2D1.Interop
{
    public readonly struct D2D1InputDescription
    {
        public int Index { get; }
        public D2D1Filter Filter { get; }
        public int LevelOfDetail { get; }
    }

    public static class D2D1PixelShader
    {
        public static ReadOnlyMemory<D2D1InputDescription> GetInputDescriptions<T>() where T : unmanaged, ID2D1PixelShader;
    }
}
```