### PR TITLE
Add D2D1PixelOption support

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -68,7 +68,7 @@
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" />
-    <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOption.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOption.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOptions.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOptions.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -68,6 +68,7 @@
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOption.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOption.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetPixelOptionsMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetPixelOptionsMethod.Syntax.cs
@@ -1,0 +1,36 @@
+﻿using ComputeSharp.D2D1.__Internals;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <inheritdoc/>
+    partial class GetPixelOptions
+    {
+        /// <summary>
+        /// Creates a <see cref="MethodDeclarationSyntax"/> instance for the <c>GetPixelOptions</c> method.
+        /// </summary>
+        /// <param name="pixelOptions">The pixel options for the shader.</param>
+        /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the <c>GetPixelOptions</c> method.</returns>
+        public static MethodDeclarationSyntax GetSyntax(D2D1PixelOption pixelOptions)
+        {
+            // This code produces a method declaration as follows:
+            //
+            // readonly uint global::ComputeSharp.D2D1.__Internals.ID2D1Shader.GetPixelOptions()
+            // {
+            //     return <PIXEL_OPTIONS>;
+            // }
+            return
+                MethodDeclaration(PredefinedType(Token(SyntaxKind.UIntKeyword)), Identifier(nameof(GetPixelOptions)))
+                .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IdentifierName($"global::ComputeSharp.D2D1.__Internals.{nameof(ID2D1Shader)}")))
+                .AddModifiers(Token(SyntaxKind.ReadOnlyKeyword))
+                .WithBody(Block(ReturnStatement(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal((int)pixelOptions)))));
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetPixelOptionsMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetPixelOptionsMethod.Syntax.cs
@@ -18,7 +18,7 @@ partial class ID2D1ShaderGenerator
         /// </summary>
         /// <param name="pixelOptions">The pixel options for the shader.</param>
         /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the <c>GetPixelOptions</c> method.</returns>
-        public static MethodDeclarationSyntax GetSyntax(D2D1PixelOption pixelOptions)
+        public static MethodDeclarationSyntax GetSyntax(D2D1PixelOptions pixelOptions)
         {
             // This code produces a method declaration as follows:
             //

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetPixelOptionsMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetPixelOptionsMethod.cs
@@ -1,0 +1,31 @@
+﻿using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <summary>
+    /// A helper with all logic to generate the <c>GetPixelOptions</c> method.
+    /// </summary>
+    private static partial class GetPixelOptions
+    {
+        /// <summary>
+        /// Extracts the pixel options for the current shader.
+        /// </summary>
+        /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
+        /// <param name="pixelOptions">The pixel options for the shader.</param>
+        public static void GetInfo(INamedTypeSymbol structDeclarationSymbol, out D2D1PixelOption pixelOptions)
+        {
+            if (structDeclarationSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DPixelOptionsAttribute", out AttributeData? attributeData))
+            {
+                pixelOptions = (D2D1PixelOption)attributeData!.ConstructorArguments[0].Value!;
+            }
+            else
+            {
+                pixelOptions = D2D1PixelOption.None;
+            }
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetPixelOptionsMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetPixelOptionsMethod.cs
@@ -16,15 +16,15 @@ partial class ID2D1ShaderGenerator
         /// </summary>
         /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
         /// <param name="pixelOptions">The pixel options for the shader.</param>
-        public static void GetInfo(INamedTypeSymbol structDeclarationSymbol, out D2D1PixelOption pixelOptions)
+        public static void GetInfo(INamedTypeSymbol structDeclarationSymbol, out D2D1PixelOptions pixelOptions)
         {
             if (structDeclarationSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DPixelOptionsAttribute", out AttributeData? attributeData))
             {
-                pixelOptions = (D2D1PixelOption)attributeData!.ConstructorArguments[0].Value!;
+                pixelOptions = (D2D1PixelOptions)attributeData!.ConstructorArguments[0].Value!;
             }
             else
             {
-                pixelOptions = D2D1PixelOption.None;
+                pixelOptions = D2D1PixelOptions.None;
             }
         }
     }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -308,18 +308,18 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
 
         // Get the pixel options, again independently from other generation steps.
         // This can also be immediately cached at a fine grained level.
-        IncrementalValuesProvider<(HierarchyInfo Hierarchy, D2D1PixelOption Options)> pixelOptionsInfo =
+        IncrementalValuesProvider<(HierarchyInfo Hierarchy, D2D1PixelOptions Options)> pixelOptionsInfo =
             shaderDeclarations
             .Select(static (item, token) =>
             {
                 // GetPixelOptions() info
-                GetPixelOptions.GetInfo(item.Symbol, out D2D1PixelOption pixelOptions);
+                GetPixelOptions.GetInfo(item.Symbol, out D2D1PixelOptions pixelOptions);
 
                 token.ThrowIfCancellationRequested();
 
                 return (item.Hierarchy, pixelOptions);
             })
-            .WithComparers(HierarchyInfo.Comparer.Default, EqualityComparer<D2D1PixelOption>.Default);
+            .WithComparers(HierarchyInfo.Comparer.Default, EqualityComparer<D2D1PixelOptions>.Default);
 
         // Generate the GetPixelOptions() methods
         context.RegisterSourceOutput(pixelOptionsInfo, static (context, item) =>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -305,5 +305,29 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
 
             context.AddSource($"{item.Left.Hierarchy.FilenameHint}.{nameof(LoadInputDescriptions)}", compilationUnit.ToFullString());
         });
+
+        // Get the pixel options, again independently from other generation steps.
+        // This can also be immediately cached at a fine grained level.
+        IncrementalValuesProvider<(HierarchyInfo Hierarchy, D2D1PixelOption Options)> pixelOptionsInfo =
+            shaderDeclarations
+            .Select(static (item, token) =>
+            {
+                // GetPixelOptions() info
+                GetPixelOptions.GetInfo(item.Symbol, out D2D1PixelOption pixelOptions);
+
+                token.ThrowIfCancellationRequested();
+
+                return (item.Hierarchy, pixelOptions);
+            })
+            .WithComparers(HierarchyInfo.Comparer.Default, EqualityComparer<D2D1PixelOption>.Default);
+
+        // Generate the GetPixelOptions() methods
+        context.RegisterSourceOutput(pixelOptionsInfo, static (context, item) =>
+        {
+            MethodDeclarationSyntax getPixelOptionsMethod = GetPixelOptions.GetSyntax(item.Options);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getPixelOptionsMethod, false);
+
+            context.AddSource($"{item.Hierarchy.FilenameHint}.{nameof(GetPixelOptions)}", compilationUnit.ToFullString());
+        });
     }
 }

--- a/src/ComputeSharp.D2D1/Attributes/D2DPixelOptions.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DPixelOptions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// An attribute for a D2D1 shader indicating the pixel options to use.
+/// Using this attribute is optional when defining a D2D1 shader.
+/// </summary>
+/// <remarks>
+/// For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1effectauthor/ne-d2d1effectauthor-d2d1_pixel_options"/>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+public sealed class D2DPixelOptionsAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="D2DPixelOptionsAttribute"/> type with the specified arguments.
+    /// </summary>
+    /// <param name="options">The options to specify for the shader.</param>
+    public D2DPixelOptionsAttribute(D2D1PixelOption options)
+    {
+        Options = options;
+    }
+
+    /// <summary>
+    /// Gets the options to specify for the shader.
+    /// </summary>
+    public D2D1PixelOption Options { get; }
+}

--- a/src/ComputeSharp.D2D1/Attributes/D2DPixelOptions.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DPixelOptions.cs
@@ -16,7 +16,7 @@ public sealed class D2DPixelOptionsAttribute : Attribute
     /// Creates a new instance of the <see cref="D2DPixelOptionsAttribute"/> type with the specified arguments.
     /// </summary>
     /// <param name="options">The options to specify for the shader.</param>
-    public D2DPixelOptionsAttribute(D2D1PixelOption options)
+    public D2DPixelOptionsAttribute(D2D1PixelOptions options)
     {
         Options = options;
     }
@@ -24,5 +24,5 @@ public sealed class D2DPixelOptionsAttribute : Attribute
     /// <summary>
     /// Gets the options to specify for the shader.
     /// </summary>
-    public D2D1PixelOption Options { get; }
+    public D2D1PixelOptions Options { get; }
 }

--- a/src/ComputeSharp.D2D1/Attributes/Enums/D2D1PixelOption.cs
+++ b/src/ComputeSharp.D2D1/Attributes/Enums/D2D1PixelOption.cs
@@ -1,0 +1,22 @@
+﻿namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// Indicates how the sampling of a D2D1 pixel shader will be restricted. This indicates whether the vertex buffer
+/// is large and tends to change infrequently or smaller and changes frequently (typically frame over frame). 
+/// </summary>
+/// <remarks>
+/// This type exposes the available values in <see href="https://docs.microsoft.com/windows/win32/api/d2d1effectauthor/ne-d2d1effectauthor-d2d1_pixel_options"/>.
+/// </remarks>
+public enum D2D1PixelOption
+{
+    /// <summary>
+    /// The pixel shader is not restricted in its sampling.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// The pixel shader samples inputs only at the same scene coordinate as the output pixel
+    /// and returns transparent black whenever the input pixels are also transparent black.
+    /// </summary>
+    TrivialSampling
+}

--- a/src/ComputeSharp.D2D1/Attributes/Enums/D2D1PixelOptions.cs
+++ b/src/ComputeSharp.D2D1/Attributes/Enums/D2D1PixelOptions.cs
@@ -1,22 +1,25 @@
-﻿namespace ComputeSharp.D2D1;
+﻿using System;
+using static TerraFX.Interop.DirectX.D2D1_PIXEL_OPTIONS;
+
+namespace ComputeSharp.D2D1;
 
 /// <summary>
-/// Indicates how the sampling of a D2D1 pixel shader will be restricted. This indicates whether the vertex buffer
-/// is large and tends to change infrequently or smaller and changes frequently (typically frame over frame). 
+/// Indicates how the sampling of a D2D1 pixel shader will be restricted.
 /// </summary>
 /// <remarks>
 /// This type exposes the available values in <see href="https://docs.microsoft.com/windows/win32/api/d2d1effectauthor/ne-d2d1effectauthor-d2d1_pixel_options"/>.
 /// </remarks>
-public enum D2D1PixelOption
+[Flags]
+public enum D2D1PixelOptions
 {
     /// <summary>
     /// The pixel shader is not restricted in its sampling.
     /// </summary>
-    None,
+    None = (int)D2D1_PIXEL_OPTIONS_NONE,
 
     /// <summary>
     /// The pixel shader samples inputs only at the same scene coordinate as the output pixel
     /// and returns transparent black whenever the input pixels are also transparent black.
     /// </summary>
-    TrivialSampling
+    TrivialSampling = (int)D2D1_PIXEL_OPTIONS_TRIVIAL_SAMPLING
 }

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
@@ -20,6 +20,14 @@ public interface ID2D1Shader
     void InitializeFromDispatchData(ReadOnlySpan<byte> data);
 
     /// <summary>
+    /// Gets the pixel options for the current shader.
+    /// </summary>
+    /// <returns>The pixel options for the current shader.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("This method is not intended to be used directly by user code")]
+    uint GetPixelOptions();
+
+    /// <summary>
     /// Gets the number of inputs for the current shader.
     /// </summary>
     /// <returns>The number of inputs for the current shader.</returns>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
@@ -85,12 +85,12 @@ public static class D2D1PixelShader
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to get the pixel options for.</typeparam>
     /// <returns>The pixel options for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
-    public static D2D1PixelOption GetPixelOptions<T>()
+    public static D2D1PixelOptions GetPixelOptions<T>()
         where T : unmanaged, ID2D1PixelShader
     {
         Unsafe.SkipInit(out T shader);
 
-        return (D2D1PixelOption)shader.GetPixelOptions();
+        return (D2D1PixelOptions)shader.GetPixelOptions();
     }
 
     /// <summary>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
@@ -81,6 +81,19 @@ public static class D2D1PixelShader
     }
 
     /// <summary>
+    /// Gets the pixel options from an input D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the pixel options for.</typeparam>
+    /// <returns>The pixel options for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static D2D1PixelOption GetPixelOptions<T>()
+        where T : unmanaged, ID2D1PixelShader
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return (D2D1PixelOption)shader.GetPixelOptions();
+    }
+
+    /// <summary>
     /// Gets the number of inputs from an input D2D1 pixel shader.
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to get the input count for.</typeparam>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.For{T}.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.For{T}.cs
@@ -67,7 +67,7 @@ internal unsafe partial struct PixelShaderEffect
         /// <summary>
         /// The pixel options for the shader.
         /// </summary>
-        private static D2D1PixelOption pixelOptions;
+        private static D2D1PixelOptions pixelOptions;
 
         /// <summary>
         /// The shader bytecode.
@@ -124,7 +124,7 @@ internal unsafe partial struct PixelShaderEffect
                     byte* bytecode = (byte*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(For<T>), bytecodeSize);
                     D2D1BufferPrecision bufferPrecision = D2D1PixelShader.GetOutputBufferPrecision<T>();
                     D2D1ChannelDepth channelDepth = D2D1PixelShader.GetOutputBufferChannelDepth<T>();
-                    D2D1PixelOption pixelOptions = D2D1PixelShader.GetPixelOptions<T>();
+                    D2D1PixelOptions pixelOptions = D2D1PixelShader.GetPixelOptions<T>();
 
                     // Prepare the inputs info
                     int inputCount = D2D1PixelShader.GetInputCount<T>();

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.For{T}.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.For{T}.cs
@@ -65,6 +65,11 @@ internal unsafe partial struct PixelShaderEffect
         private static D2D1InputDescription* inputDescriptions;
 
         /// <summary>
+        /// The pixel options for the shader.
+        /// </summary>
+        private static D2D1PixelOption pixelOptions;
+
+        /// <summary>
         /// The shader bytecode.
         /// </summary>
         private static byte* bytecode;
@@ -119,6 +124,7 @@ internal unsafe partial struct PixelShaderEffect
                     byte* bytecode = (byte*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(For<T>), bytecodeSize);
                     D2D1BufferPrecision bufferPrecision = D2D1PixelShader.GetOutputBufferPrecision<T>();
                     D2D1ChannelDepth channelDepth = D2D1PixelShader.GetOutputBufferChannelDepth<T>();
+                    D2D1PixelOption pixelOptions = D2D1PixelShader.GetPixelOptions<T>();
 
                     // Prepare the inputs info
                     int inputCount = D2D1PixelShader.GetInputCount<T>();
@@ -145,6 +151,7 @@ internal unsafe partial struct PixelShaderEffect
                     For<T>.inputTypes = inputTypes;
                     For<T>.inputDescriptionCount = inputDescriptionCount;
                     For<T>.inputDescriptions = inputDescriptions;
+                    For<T>.pixelOptions = pixelOptions;
                     For<T>.bytecode = bytecode;
                     For<T>.bytecodeSize = bytecodeSize;
                     For<T>.bufferPrecision = bufferPrecision;
@@ -228,6 +235,7 @@ internal unsafe partial struct PixelShaderEffect
                 inputTypes,
                 inputDescriptionCount,
                 inputDescriptions,
+                pixelOptions,
                 bytecode,
                 bytecodeSize,
                 bufferPrecision,

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
@@ -324,7 +324,7 @@ partial struct PixelShaderEffect
             @this->d2D1DrawInfo = drawInfo;
 
             // Set the pixel shader for the effect
-            HRESULT hresult = drawInfo->SetPixelShader(&@this->shaderId);
+            HRESULT hresult = drawInfo->SetPixelShader(&@this->shaderId, (D2D1_PIXEL_OPTIONS)@this->pixelOptions);
 
             if (hresult != S.S_OK)
             {

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -176,6 +176,11 @@ internal unsafe partial struct PixelShaderEffect
     private D2D1InputDescription* inputDescriptions;
 
     /// <summary>
+    /// The pixel options for the shader.
+    /// </summary>
+    private D2D1PixelOption pixelOptions;
+
+    /// <summary>
     /// The shader bytecode.
     /// </summary>
     private byte* bytecode;
@@ -213,6 +218,7 @@ internal unsafe partial struct PixelShaderEffect
     /// <param name="inputTypes">The buffer with the types of inputs for the shader.</param>
     /// <param name="inputDescriptionCount">The number of available input descriptions.</param>
     /// <param name="inputDescriptions">The buffer with the available input descriptions for the shader.</param>
+    /// <param name="pixelOptions">The pixel options for the shader.</param>
     /// <param name="bytecode">The shader bytecode.</param>
     /// <param name="bytecodeSize">The size of <paramref name="bytecode"/>.</param>
     /// <param name="bufferPrecision">The buffer precision for the resulting output buffer.</param>
@@ -226,6 +232,7 @@ internal unsafe partial struct PixelShaderEffect
         D2D1PixelShaderInputType* inputTypes,
         int inputDescriptionCount,
         D2D1InputDescription* inputDescriptions,
+        D2D1PixelOption pixelOptions,
         byte* bytecode,
         int bytecodeSize,
         D2D1BufferPrecision bufferPrecision,
@@ -245,6 +252,7 @@ internal unsafe partial struct PixelShaderEffect
         @this->inputTypes = inputTypes;
         @this->inputDescriptionCount = inputDescriptionCount;
         @this->inputDescriptions = inputDescriptions;
+        @this->pixelOptions = pixelOptions;
         @this->bytecode = bytecode;
         @this->bytecodeSize = bytecodeSize;
         @this->bufferPrecision = bufferPrecision;

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -178,7 +178,7 @@ internal unsafe partial struct PixelShaderEffect
     /// <summary>
     /// The pixel options for the shader.
     /// </summary>
-    private D2D1PixelOption pixelOptions;
+    private D2D1PixelOptions pixelOptions;
 
     /// <summary>
     /// The shader bytecode.
@@ -232,7 +232,7 @@ internal unsafe partial struct PixelShaderEffect
         D2D1PixelShaderInputType* inputTypes,
         int inputDescriptionCount,
         D2D1InputDescription* inputDescriptions,
-        D2D1PixelOption pixelOptions,
+        D2D1PixelOptions pixelOptions,
         byte* bytecode,
         int bytecodeSize,
         D2D1BufferPrecision bufferPrecision,


### PR DESCRIPTION
### Closes #268

### Description

This PR adds support for specifying the D2D1 pixel options on a D2D1 shader.
The API breakdown is available in the linked issue.
