### PR TITLE
Add NuGet build CI logic

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,8 +25,14 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build
-      run: msbuild -t:restore,build /p:Configuration=Debug /p:Platform=x64
+      run: msbuild -t:restore,build /p:Configuration=Debug /p:Platform=x64 /bl
       shell: cmd
+    - name: Upload MSBuild binary log
+      uses: actions/upload-artifact@v2
+      with:
+        name: msbuild_log
+        path: msbuild.binlog
+        if-no-files-found: error
 
   # Build the whole ComputeSharp solution, in Release
   build-solution-release:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,13 +19,36 @@
   -->
   <PropertyGroup>
     <ComputeSharpPackageVersion>2.0.0</ComputeSharpPackageVersion>
+    <IsCommitOnReleaseBranch>false</IsCommitOnReleaseBranch>
   </PropertyGroup>
 
+  <!--
+    Check if the current push is for a release build for NuGet, as that will create a package with a hardcoded version.
+    A release build is one that originates from a push to a branch with the format 'rel/<BUILD_VERSION>(.<SUFFIX>)?'.
+  -->
+  <PropertyGroup>
+    <ReleaseVersionParsingRegex>^rel/(\d{1,4}\.\d{1,4}\.\d{1,4})(?:-(\w+(?:\.\w+)?))?$</ReleaseVersionParsingRegex>
+    <IsBranchNameStartingWithRefPrefix>$([System.Text.RegularExpressions.Regex]::IsMatch($(GITHUB_REF_NAME), $(ReleaseVersionParsingRegex)))</IsBranchNameStartingWithRefPrefix>
+  </PropertyGroup>
+
+  <!-- If the current branch and action match a release for NuGet, override the relative build properties -->
+  <PropertyGroup Condition="'$(GITHUB_EVENT_NAME)' == 'push' AND '$(GITHUB_REF_NAME)' != '' AND '$(IsBranchNameStartingWithRefPrefix)' == 'true'">    
+    <IsCommitOnReleaseBranch>true</IsCommitOnReleaseBranch>
+    <ComputeSharpPackageVersionFromReleaseBranch>$([System.Text.RegularExpressions.Regex]::Match($(GITHUB_REF_NAME), $(ReleaseVersionParsingRegex)).Groups[1].Value)</ComputeSharpPackageVersionFromReleaseBranch>
+    <ComputeSharpPackageVersionSuffixFromReleaseBranch>$([System.Text.RegularExpressions.Regex]::Match($(GITHUB_REF_NAME), $(ReleaseVersionParsingRegex)).Groups[2].Value)</ComputeSharpPackageVersionSuffixFromReleaseBranch>
+    <ComputeSharpPackageVersion>$(ComputeSharpPackageVersionFromReleaseBranch)</ComputeSharpPackageVersion>
+    <VersionSuffix>$(ComputeSharpPackageVersionSuffixFromReleaseBranch)</VersionSuffix>
+  </PropertyGroup>
+
+  <!-- Configure the assembly version and suffix for both normal CI builds and release builds -->
   <PropertyGroup>
     <AssemblyVersion>$(ComputeSharpPackageVersion).0</AssemblyVersion>
     <VersionPrefix>$(ComputeSharpPackageVersion)</VersionPrefix>
-    <VersionSuffix Condition="'$(EXCLUDE_SUFFIX_FROM_VERSION)' != 'true'">alpha</VersionSuffix>
-    <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request'">pr</VersionSuffix>
+    <VersionSuffix Condition="'$(EXCLUDE_SUFFIX_FROM_VERSION)' != 'true' AND '$(IsCommitOnReleaseBranch)' != 'true'">alpha</VersionSuffix>
+    <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request' AND '$(IsCommitOnReleaseBranch)' != 'true'">pr</VersionSuffix>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_RUN_ID)' != ''">true</ContinuousIntegrationBuild>
     <RepositoryUrl>https://github.com/Sergio0694/ComputeSharp/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,19 +15,19 @@
     of dotnet build for some cases, due to the solution having some UWP and WinUI 3 projects, and non SDK-style too).
     The lines setting the prefix have been omitted, as that is already handled in the root .props file.
   -->
-  <PropertyGroup Condition=" '$(Version)' == '' ">
-    <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
-    <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
+  <PropertyGroup Condition="'$(Version)' == ''">
+    <Version Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</Version>
+    <Version Condition="'$(Version)' == ''">$(VersionPrefix)</Version>
+  </PropertyGroup>
+
+  <!-- Set the base package version (this applies to all build types) -->
+  <PropertyGroup>
+    <PackageVersion>$(Version)</PackageVersion>
   </PropertyGroup>
 
   <!-- Settings that are only set for CI builds -->
   <PropertyGroup Condition="'$(GITHUB_RUN_ID)' != ''">
     <PackageVersion Condition="'$(EXCLUDE_RUN_ID_FROM_PACKAGE)' != 'true' AND '$(IsCommitOnReleaseBranch)' != true">$(Version).$(GITHUB_RUN_ID)</PackageVersion>
     <PackageVersion Condition="'$(GITHUB_SHA)' != ''">$(PackageVersion)+$(GITHUB_SHA)</PackageVersion>
-  </PropertyGroup>
-
-  <!-- Settings that are only set for non CI builds -->
-  <PropertyGroup Condition="'$(GITHUB_RUN_ID)' == ''">
-    <PackageVersion>$(Version)</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -22,7 +22,7 @@
 
   <!-- Settings that are only set for CI builds -->
   <PropertyGroup Condition="'$(GITHUB_RUN_ID)' != ''">
-    <PackageVersion Condition="'$(EXCLUDE_RUN_ID_FROM_PACKAGE)' != 'true'">$(Version).$(GITHUB_RUN_ID)</PackageVersion>
+    <PackageVersion Condition="'$(EXCLUDE_RUN_ID_FROM_PACKAGE)' != 'true' AND '$(IsCommitOnReleaseBranch)' != true">$(Version).$(GITHUB_RUN_ID)</PackageVersion>
     <PackageVersion Condition="'$(GITHUB_SHA)' != ''">$(PackageVersion)+$(GITHUB_SHA)</PackageVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description

This PR adds logic so that pushes to branches named `rel/<BUILD_VERSION>(.<SUFFIX>)?` will create a matching package.
It also adds upload for a binary MSBuild log from debug builds.