### PR TITLE
Add public D2D1 shader compiler APIs

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -83,8 +83,8 @@
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1Shader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1Shader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Intrinsics\D2D.cs" Link="ComputeSharp.D2D1\Intrinsics\D2D.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" Link="ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" />
-    <Compile Include="..\ComputeSharp.D2D1\Shaders\Translation\D2D1ShaderCompiler.cs" Link="ComputeSharp.D2D1\Shaders\Translation\D2D1ShaderCompiler.cs" />
-    <Compile Include="..\ComputeSharp.D2D1\Shaders\Translation\D2D1ShaderCompiler.ID3DInclude.cs" Link="ComputeSharp.D2D1\Shaders\Translation\D2D1ShaderCompiler.ID3DInclude.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Shaders\Translation\D3DCompiler.cs" Link="ComputeSharp.D2D1\Shaders\Translation\D3DCompiler.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Shaders\Translation\D3DCompiler.ID3DInclude.cs" Link="ComputeSharp.D2D1\Shaders\Translation\D3DCompiler.ID3DInclude.cs" />
     <EmbeddedResource Include="..\ComputeSharp.D2D1\Shaders\Translation\Headers\d2d1effecthelpers.hlsli" Link="ComputeSharp.D2D1\Shaders\Translation\Headers\d2d1effecthelpers.hlsli" />
   </ItemGroup>
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -92,7 +92,7 @@ partial class ID2D1ShaderGenerator
                 token.ThrowIfCancellationRequested();
 
                 // Compile the shader bytecode
-                using ComPtr<ID3DBlob> dxcBlobBytecode = D2D1ShaderCompiler.Compile(
+                using ComPtr<ID3DBlob> dxcBlobBytecode = D3DCompiler.Compile(
                     sourceInfo.HlslSource.AsSpan(),
                     sourceInfo.ShaderProfile.Value,
                     sourceInfo.IsLinkingSupported);

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderCompiler.cs
@@ -19,22 +19,22 @@ public static class D2D1ShaderCompiler
     /// <summary>
     /// Compiles a new HLSL shader from the input source code.
     /// </summary>
-    /// <param name="source">The HLSL source code to compile.</param>
+    /// <param name="hlslSource">The HLSL source code to compile.</param>
     /// <param name="entryPoint">The entry point of the shader being compiled.</param>
     /// <param name="shaderProfile">The shader profile to use to compile the shader.</param>
     /// <param name="options">The compiler options to use to compile the shader.</param>
     /// <returns>The bytecode for the compiled shader.</returns>
     /// <exception cref="FxcCompilationException">Thrown if the compilation fails.</exception>
     public static ReadOnlyMemory<byte> Compile(
-        ReadOnlySpan<char> source,
+        ReadOnlySpan<char> hlslSource,
         ReadOnlySpan<char> entryPoint,
         D2D1ShaderProfile shaderProfile,
         D2D1ShaderCompilerOptions options)
     {
         // Encode the HLSL source to ASCII
-        int maxSourceLength = Encoding.ASCII.GetMaxByteCount(source.Length);
+        int maxSourceLength = Encoding.ASCII.GetMaxByteCount(hlslSource.Length);
         byte[] sourceBuffer = ArrayPool<byte>.Shared.Rent(maxSourceLength);
-        int sourceWrittenBytes = Encoding.ASCII.GetBytes(source, sourceBuffer);
+        int sourceWrittenBytes = Encoding.ASCII.GetBytes(hlslSource, sourceBuffer);
 
         // Encode the entry point to ASCII
         int maxEntryPointLength = Encoding.ASCII.GetMaxByteCount(entryPoint.Length);
@@ -50,15 +50,15 @@ public static class D2D1ShaderCompiler
     /// <summary>
     /// Compiles a new HLSL shader from the input source code.
     /// </summary>
-    /// <param name="source">The HLSL source code to compile (in ASCII).</param>
-    /// <param name="entryPoint">The entry point of the shader being compiled (in ASCII).</param>
+    /// <param name="hlslSourceAscii">The HLSL source code to compile (in ASCII).</param>
+    /// <param name="entryPointAscii">The entry point of the shader being compiled (in ASCII).</param>
     /// <param name="shaderProfile">The shader profile to use to compile the shader.</param>
     /// <param name="options">The compiler options to use to compile the shader.</param>
     /// <returns>The bytecode for the compiled shader.</returns>
     /// <exception cref="FxcCompilationException">Thrown if the compilation fails.</exception>
     public static unsafe ReadOnlyMemory<byte> Compile(
-        ReadOnlySpan<byte> source,
-        ReadOnlySpan<byte> entryPoint,
+        ReadOnlySpan<byte> hlslSourceAscii,
+        ReadOnlySpan<byte> entryPointAscii,
         D2D1ShaderProfile shaderProfile,
         D2D1ShaderCompilerOptions options)
     {
@@ -70,10 +70,10 @@ public static class D2D1ShaderCompiler
 
         // Compile the standalone D2D1 full shader
         using ComPtr<ID3DBlob> d3DBlobFullShader = D3DCompiler.CompileShader(
-            source: source,
+            source: hlslSourceAscii,
             macro: D3DCompiler.ASCII.D2D_FULL_SHADER,
-            d2DEntry: entryPoint,
-            entryPoint: entryPoint,
+            d2DEntry: entryPointAscii,
+            entryPoint: entryPointAscii,
             target: D3DCompiler.ASCII.GetPixelShaderProfile(shaderProfile),
             flags: (uint)options);
 
@@ -87,9 +87,9 @@ public static class D2D1ShaderCompiler
 
         // Compile the export function
         using ComPtr<ID3DBlob> d3DBlobFunction = D3DCompiler.CompileShader(
-            source: source,
+            source: hlslSourceAscii,
             macro: D3DCompiler.ASCII.D2D_FUNCTION,
-            d2DEntry: entryPoint,
+            d2DEntry: entryPointAscii,
             entryPoint: default,
             target: D3DCompiler.ASCII.GetLibraryProfile(shaderProfile),
             flags: (uint)options);

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderCompiler.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Buffers;
+using System.Text;
+using ComputeSharp.D2D1.Exceptions;
+#if !NET6_0_OR_GREATER
+using ComputeSharp.D2D1.NetStandard.System.Text;
+#endif
+using ComputeSharp.D2D1.Shaders.Translation;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
+
+namespace ComputeSharp.D2D1.Interop;
+
+/// <summary>
+/// Provides methods to manually compile D2D1 shaders.
+/// </summary>
+public static class D2D1ShaderCompiler
+{
+    /// <summary>
+    /// Compiles a new HLSL shader from the input source code.
+    /// </summary>
+    /// <param name="source">The HLSL source code to compile.</param>
+    /// <param name="entryPoint">The entry point of the shader being compiled.</param>
+    /// <param name="shaderProfile">The shader profile to use to compile the shader.</param>
+    /// <param name="options">The compiler options to use to compile the shader.</param>
+    /// <returns>The bytecode for the compiled shader.</returns>
+    /// <exception cref="FxcCompilationException">Thrown if the compilation fails.</exception>
+    public static ReadOnlyMemory<byte> Compile(
+        ReadOnlySpan<char> source,
+        ReadOnlySpan<char> entryPoint,
+        D2D1ShaderProfile shaderProfile,
+        D2D1ShaderCompilerOptions options)
+    {
+        // Encode the HLSL source to ASCII
+        int maxSourceLength = Encoding.ASCII.GetMaxByteCount(source.Length);
+        byte[] sourceBuffer = ArrayPool<byte>.Shared.Rent(maxSourceLength);
+        int sourceWrittenBytes = Encoding.ASCII.GetBytes(source, sourceBuffer);
+
+        // Encode the entry point to ASCII
+        int maxEntryPointLength = Encoding.ASCII.GetMaxByteCount(entryPoint.Length);
+        byte[] entryPointBuffer = ArrayPool<byte>.Shared.Rent(maxEntryPointLength);
+        int entryPointWrittenBytes = Encoding.ASCII.GetBytes(entryPoint, entryPointBuffer);
+
+        ReadOnlySpan<byte> sourceAscii = sourceBuffer.AsSpan(0, sourceWrittenBytes);
+        ReadOnlySpan<byte> entryPointAscii = entryPointBuffer.AsSpan(0, entryPointWrittenBytes);
+
+        return Compile(sourceAscii, entryPointAscii, shaderProfile, options);
+    }
+
+    /// <summary>
+    /// Compiles a new HLSL shader from the input source code.
+    /// </summary>
+    /// <param name="source">The HLSL source code to compile (in ASCII).</param>
+    /// <param name="entryPoint">The entry point of the shader being compiled (in ASCII).</param>
+    /// <param name="shaderProfile">The shader profile to use to compile the shader.</param>
+    /// <param name="options">The compiler options to use to compile the shader.</param>
+    /// <returns>The bytecode for the compiled shader.</returns>
+    /// <exception cref="FxcCompilationException">Thrown if the compilation fails.</exception>
+    public static unsafe ReadOnlyMemory<byte> Compile(
+        ReadOnlySpan<byte> source,
+        ReadOnlySpan<byte> entryPoint,
+        D2D1ShaderProfile shaderProfile,
+        D2D1ShaderCompilerOptions options)
+    {
+        // Check linking support
+        bool enableLinking = (options & D2D1ShaderCompilerOptions.EnableLinking) == D2D1ShaderCompilerOptions.EnableLinking;
+
+        // Remove the linking flag to make the options blittable to flags
+        options &= ~D2D1ShaderCompilerOptions.EnableLinking;
+
+        // Compile the standalone D2D1 full shader
+        using ComPtr<ID3DBlob> d3DBlobFullShader = D3DCompiler.CompileShader(
+            source: source,
+            macro: D3DCompiler.ASCII.D2D_FULL_SHADER,
+            d2DEntry: entryPoint,
+            entryPoint: entryPoint,
+            target: D3DCompiler.ASCII.GetPixelShaderProfile(shaderProfile),
+            flags: (uint)options);
+
+        if (!enableLinking)
+        {
+            void* blobFullShaderPtr = d3DBlobFullShader.Get()->GetBufferPointer();
+            nuint blobFullShaderSize = d3DBlobFullShader.Get()->GetBufferSize();
+
+            return new Span<byte>(blobFullShaderPtr, (int)blobFullShaderSize).ToArray();
+        }
+
+        // Compile the export function
+        using ComPtr<ID3DBlob> d3DBlobFunction = D3DCompiler.CompileShader(
+            source: source,
+            macro: D3DCompiler.ASCII.D2D_FUNCTION,
+            d2DEntry: entryPoint,
+            entryPoint: default,
+            target: D3DCompiler.ASCII.GetLibraryProfile(shaderProfile),
+            flags: (uint)options);
+
+        // Embed it as private data if requested
+        using ComPtr<ID3DBlob> d3DBlobLinked = D3DCompiler.SetD3DPrivateData(d3DBlobFullShader.Get(), d3DBlobFunction.Get());
+
+        void* blobLinkedPtr = d3DBlobLinked.Get()->GetBufferPointer();
+        nuint blobLinkedSize = d3DBlobLinked.Get()->GetBufferSize();
+
+        return new Span<byte>(blobLinkedPtr, (int)blobLinkedSize).ToArray();
+    }
+}

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderCompilerOptions.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderCompilerOptions.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using TerraFX.Interop.DirectX;
+
+namespace ComputeSharp.D2D1.Interop;
+
+/// <summary>
+/// Flags to control the options that can be used to compile a D2D1 shader.
+/// </summary>
+/// <remarks>
+/// For more info, see For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/d3dcompile-constants"/>.
+/// </remarks>
+[Flags]
+public enum D2D1ShaderCompilerOptions
+{
+    /// <summary>
+    /// Directs the compiler to insert debug file/line/type/symbol information into the output code.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_DEBUG</c> and <c>/Zi</c>.
+    /// </remarks>
+    Debug = D3DCOMPILE.D3DCOMPILE_DEBUG,
+
+    /// <summary>
+    /// Directs the compiler not to validate the generated code against known capabilities and constraints.
+    /// This option should only be used with shaders that have been successfully compiled in the past.
+    /// DirectX always validates shaders before it sets them to a device.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_SKIP_VALIDATION</c> and <c>/Vd</c>.
+    /// </remarks>
+    SkipValidation = D3DCOMPILE.D3DCOMPILE_SKIP_VALIDATION,
+
+    /// <summary>
+    /// Directs the compiler to skip optimization steps during code generation.
+    /// This option should only be used for debug purposes.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_SKIP_OPTIMIZATION</c> and <c>/Od</c>.
+    /// </remarks>
+    SkipOptimization = D3DCOMPILE.D3DCOMPILE_SKIP_OPTIMIZATION,
+
+    /// <summary>
+    /// Directs the compiler to pack matrices in row-major order on input and output from the shader.
+    /// </summary>
+    /// <remarks>
+    /// <para>This value is needed to have the constant buffer loading from generated shaders map to compiled shaders.</para>
+    /// <para>This flag maps to <c>D3DCOMPILE_PACK_MATRIX_ROW_MAJOR</c> and <c>/Zpr</c>.</para>
+    /// </remarks>
+    PackMatrixRowMajor = D3DCOMPILE.D3DCOMPILE_PACK_MATRIX_ROW_MAJOR,
+
+    /// <summary>
+    /// Directs the compiler to pack matrices in column-major order on input and output from the shader.
+    /// This type of packing is generally more efficient because a series of dot-products can then
+    /// perform vector-matrix multiplication.
+    /// </summary>
+    /// <remarks>
+    /// <para>Using this flag makes shaders incompatible with the constant buffer loading code produced by ComputeSharp.D2D1.</para>
+    /// <para>That is, trying to load a constant buffer from a shader processed by the source generator is undefined behavior.</para>
+    /// <para>This flag maps to <c>D3DCOMPILE_PACK_MATRIX_COLUMN_MAJOR</c> and <c>/Zpc</c>.</para>
+    /// </remarks>
+    PackMatrixColumnMajor = D3DCOMPILE.D3DCOMPILE_PACK_MATRIX_COLUMN_MAJOR,
+
+    /// <summary>
+    /// Directs the compiler to perform all computations with partial precision.
+    /// If this flag is set, the compiled code might run faster on some hardware.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_PARTIAL_PRECISION</c> and <c>/Gpp</c>.
+    /// </remarks>
+    PartialPrecision = D3DCOMPILE.D3DCOMPILE_PARTIAL_PRECISION,
+
+    /// <summary>
+    /// Directs the compiler to not use flow-control constructs where possible.	
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_AVOID_FLOW_CONTROL</c> and <c>/Gfa</c>.
+    /// </remarks>
+    AvoidFlowControl = D3DCOMPILE.D3DCOMPILE_AVOID_FLOW_CONTROL,
+
+    /// <summary>
+    /// Forces strict compile, which might not allow for legacy syntax.
+    /// By default, the compiler disables strictness on deprecated syntax.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_ENABLE_STRICTNESS</c> and <c>/Ges</c>.
+    /// </remarks>
+    EnableStrictness = D3DCOMPILE.D3DCOMPILE_ENABLE_STRICTNESS,
+
+    /// <summary>
+    /// Forces the IEEE strict compile which avoids optimizations that may break IEEE rules.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_IEEE_STRICTNESS</c> and <c>/Gis</c>.
+    /// </remarks>
+    IeeeStrictness = D3DCOMPILE.D3DCOMPILE_IEEE_STRICTNESS,
+
+    /// <summary>
+    /// Directs the compiler to enable older shaders to compile to 5_0 targets.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY</c> and <c>/Gec</c>.
+    /// </remarks>
+    EnableBackwardsCompatibility = D3DCOMPILE.D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY,
+
+    /// <summary>
+    /// Directs the compiler to use the lowest optimization level. If this option is set, the compiler
+    /// might produce slower code but produces the code more quickly. This option should be set when
+    /// shaders are developed iteratively, as it can reduce compilation times.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_OPTIMIZATION_LEVEL0</c> and <c>/O0</c>.
+    /// </remarks>
+    OptimizationLevel0 = D3DCOMPILE.D3DCOMPILE_OPTIMIZATION_LEVEL0,
+
+    /// <summary>
+    /// Directs the compiler to use the second lowest optimization level.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_OPTIMIZATION_LEVEL1</c> and <c>/O1</c>.
+    /// </remarks>
+    OptimizationLevel1 = D3DCOMPILE.D3DCOMPILE_OPTIMIZATION_LEVEL1,
+
+    /// <summary>
+    /// Directs the compiler to use the second highest optimization level.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_OPTIMIZATION_LEVEL2</c> and <c>/O2</c>.
+    /// </remarks>
+    OptimizationLevel2 = D3DCOMPILE.D3DCOMPILE_OPTIMIZATION_LEVEL2,
+
+    /// <summary>
+    /// Directs the compiler to use the highest optimization level. If this option is set, the compiler
+    /// produces the best possible code but might take significantly longer to do so. This option should
+    /// be set for final builds of an application when performance is the most important factor.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_OPTIMIZATION_LEVEL3</c> and <c>/O3</c>.
+    /// </remarks>
+    OptimizationLevel3 = D3DCOMPILE.D3DCOMPILE_OPTIMIZATION_LEVEL3,
+
+    /// <summary>
+    /// Directs the compiler to treat all warnings as errors when it compiles the shader code. This 
+    /// option is recommended for new shader code, so that warnings can be resolved and the
+    /// number of hard-to-find code defects can be minimized.	
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>D3DCOMPILE_WARNINGS_ARE_ERRORS</c> and <c>/WX</c>.
+    /// </remarks>
+    WarningsAreErrors = D3DCOMPILE.D3DCOMPILE_WARNINGS_ARE_ERRORS,
+
+    /// <summary>
+    /// This flag enables the support for shader linking. Specifically, when set, this flag causes the APIs from
+    /// <see cref="D2D1ShaderCompiler"/> to compile the input shader twice: once as a full D2D1 shader, and once
+    /// as an export function, which is then set as private blob data into the final bytecode that is returned.
+    /// </summary>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/en-us/windows/win32/direct2d/effect-shader-linking"/>.
+    /// </remarks>
+    EnableLinking = 1 << 31,
+
+    /// <summary>
+    /// The default options for shaders compiled by ComputeSharp.D2D1. Specifically, this combination
+    /// of options is the one used by precompiled shaders (ie. when using <see cref="D2DEmbeddedBytecodeAttribute"/>),
+    /// and when using <see cref="D2D1PixelShader.LoadBytecode{T}()"/> or any of the overloads.
+    /// </summary>
+    /// <remarks>
+    /// This option does not include <see cref="EnableLinking"/>, which is instead automatically enabled by shaders
+    /// compiled using any of the APIs mentioned above. When manually compiling shaders from source using the APIs
+    /// from <see cref="D2D1ShaderCompiler"/> instance, <see cref="EnableLinking"/> should be manually used when needed.
+    /// </remarks>
+    Default = OptimizationLevel3 | WarningsAreErrors | PackMatrixRowMajor
+}

--- a/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.ID3DInclude.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.ID3DInclude.cs
@@ -14,7 +14,7 @@ using UnmanagedCallersOnlyAttribute = ComputeSharp.NetStandard.System.Runtime.In
 namespace ComputeSharp.D2D1.Shaders.Translation;
 
 /// <inheritdoc/>
-partial class D2D1ShaderCompiler
+partial class D3DCompiler
 {
     /// <summary>
     /// A custom <see cref="ID3DInclude"/> fallback implementation to use on systems with no support for it.

--- a/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.cs
@@ -32,9 +32,9 @@ internal static unsafe partial class D3DCompiler
     /// </summary>
     /// <param name="source">The HLSL source code to compile.</param>
     /// <param name="shaderProfile">The shader profile to use to compile the shader.</param>
-    /// <param name="enableLinkingSupport">Whether to enable linking support for the shader.</param>
+    /// <param name="enableLinking">Whether to enable linking for the shader.</param>
     /// <returns>The bytecode for the compiled shader.</returns>
-    public static ComPtr<ID3DBlob> Compile(ReadOnlySpan<char> source, D2D1ShaderProfile shaderProfile, bool enableLinkingSupport)
+    public static ComPtr<ID3DBlob> Compile(ReadOnlySpan<char> source, D2D1ShaderProfile shaderProfile, bool enableLinking)
     {
         int maxLength = Encoding.ASCII.GetMaxByteCount(source.Length);
         byte[] buffer = ArrayPool<byte>.Shared.Rent(maxLength);
@@ -51,7 +51,7 @@ internal static unsafe partial class D3DCompiler
                 target: ASCII.GetPixelShaderProfile(shaderProfile),
                 flags: D3DCOMPILE.D3DCOMPILE_OPTIMIZATION_LEVEL3 | D3DCOMPILE.D3DCOMPILE_WARNINGS_ARE_ERRORS | D3DCOMPILE.D3DCOMPILE_PACK_MATRIX_ROW_MAJOR);
 
-            if (!enableLinkingSupport)
+            if (!enableLinking)
             {
                 return d3DBlobFullShader.Move();
             }
@@ -158,7 +158,7 @@ internal static unsafe partial class D3DCompiler
     /// <param name="shaderBlob">The bytecode for the full shader.</param>
     /// <param name="exportBlob">The bytecode for the shader function to export.</param>
     /// <returns>An <see cref="ID3DBlob"/> instance with the combined data of <paramref name="shaderBlob"/> and <paramref name="exportBlob"/>.</returns>
-    private static ComPtr<ID3DBlob> SetD3DPrivateData(ID3DBlob* shaderBlob, ID3DBlob* exportBlob)
+    public static ComPtr<ID3DBlob> SetD3DPrivateData(ID3DBlob* shaderBlob, ID3DBlob* exportBlob)
     {
         void* shaderPtr = shaderBlob->GetBufferPointer();
         nuint shaderSize = shaderBlob->GetBufferSize();
@@ -209,7 +209,7 @@ internal static unsafe partial class D3DCompiler
     /// <summary>
     /// A container for ASCII encoded, null-terminated constant strings.
     /// </summary>
-    private static class ASCII
+    public static class ASCII
     {
         /// <summary>
         /// Gets a <see cref="ReadOnlySpan{T}"/> with the <c>"D2D_FUNCTION"</c> ASCII text.

--- a/src/ComputeSharp.D2D1/Shaders/Translation/__Internals/D2D1ShaderCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/__Internals/D2D1ShaderCompiler.cs
@@ -28,7 +28,7 @@ public static class D2D1ShaderCompiler
     {
         Unsafe.AsRef(in shader).BuildHlslSource(out string hlslSource);
 
-        using ComPtr<ID3DBlob> d3DBlobBytecode = Shaders.Translation.D2D1ShaderCompiler.Compile(
+        using ComPtr<ID3DBlob> d3DBlobBytecode = Shaders.Translation.D3DCompiler.Compile(
             hlslSource.AsSpan(),
             shaderProfile ?? D2D1ShaderProfile.PixelShader50,
             enableLinkingSupport);

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using ComputeSharp.D2D1.Exceptions;
+using ComputeSharp.D2D1.Interop;
+using ComputeSharp.D2D1.Tests.Effects;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.D2D1.Tests;
+
+[TestClass]
+[TestCategory("D2D1ShaderCompilerTests")]
+public partial class D2D1ShaderCompilerTests
+{
+    [TestMethod]
+    public unsafe void CompileInvertEffectWithDefaultOptions()
+    {
+        const string source = @"
+            #define D2D_INPUT_COUNT 1
+            #define D2D_INPUT0_SIMPLE
+
+            #include ""d2d1effecthelpers.hlsli""
+
+
+            D2D_PS_ENTRY(PSMain)
+            {
+                float4 color = D2DGetInput(0);
+                float3 rgb = saturate(1.0 - color.rgb);
+                return float4(rgb, 1);
+            }";
+
+        ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
+            source,
+            "PSMain",
+            D2D1ShaderProfile.PixelShader40Level93,
+            D2D1ShaderCompilerOptions.Default);
+
+        Assert.IsTrue(bytecode.Length > 0);
+    }
+
+    [TestMethod]
+    public unsafe void CompileInvertEffectWithDefaultOptionsAndLinking()
+    {
+        const string source = @"
+            #define D2D_INPUT_COUNT 1
+            #define D2D_INPUT0_SIMPLE
+
+            #include ""d2d1effecthelpers.hlsli""
+
+
+            D2D_PS_ENTRY(PSMain)
+            {
+                float4 color = D2DGetInput(0);
+                float3 rgb = saturate(1.0 - color.rgb);
+                return float4(rgb, 1);
+            }";
+
+        ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
+            source,
+            "PSMain",
+            D2D1ShaderProfile.PixelShader40Level93,
+            D2D1ShaderCompilerOptions.Default | D2D1ShaderCompilerOptions.EnableLinking);
+
+        Assert.IsTrue(bytecode.Length > 0);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(FxcCompilationException))]
+    public unsafe void CompileInvertEffectWithInvalidEntryPoint()
+    {
+        const string source = @"
+            #define D2D_INPUT_COUNT 1
+            #define D2D_INPUT0_SIMPLE
+
+            #include ""d2d1effecthelpers.hlsli""
+
+
+            D2D_PS_ENTRY(PSMain)
+            {
+                float4 color = D2DGetInput(0);
+                float3 rgb = saturate(1.0 - color.rgb);
+                return float4(rgb, 1);
+            }";
+
+        ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
+            source,
+            "Execute",
+            D2D1ShaderProfile.PixelShader40Level93,
+            D2D1ShaderCompilerOptions.Default);
+
+        Assert.IsTrue(bytecode.Length > 0);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(FxcCompilationException))]
+    public unsafe void CompileInvertEffectWithErrors()
+    {
+        const string source = @"
+            #define D2D_INPUT_COUNT 1
+            #define D2D_INPUT0_SIMPLE
+
+            #include ""d2d1effecthelpers.hlsli""
+
+
+            D2D_PS_ENTRY(PSMain)
+            {
+                float4 color = D2DGetInput(99);
+                float3 rgb2 = saturate(1.0 - color.rgb);
+                return float4(rgb, 1, 4.0);
+            }";
+
+        ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
+            source,
+            "PSMain",
+            D2D1ShaderProfile.PixelShader40Level93,
+            D2D1ShaderCompilerOptions.Default);
+
+        Assert.IsTrue(bytecode.Length > 0);
+    }
+
+    [TestMethod]
+    public unsafe void CompilePixelateEffectWithDefaultOptions()
+    {
+        const string source = @"
+            #define D2D_INPUT_COUNT 1
+            #define D2D_INPUT0_COMPLEX
+            #define D2D_REQUIRES_SCENE_POSITION
+
+            #include ""d2d1effecthelpers.hlsli""
+
+            struct ComputeSharp_D2D1_Tests_Effects_PixelateEffect_Shader_Constants
+            {
+                int inputWidth;
+                int inputHeight;
+                int cellSize;
+            };
+
+            ComputeSharp_D2D1_Tests_Effects_PixelateEffect_Shader_Constants constants;
+
+            D2D_PS_ENTRY(PSMain)
+            {
+                float2 scenePos = D2DGetScenePosition().xy;
+                uint x = (uint)floor(scenePos.x);
+                uint y = (uint)floor(scenePos.y);
+                int cellX = (int)floor(x / constants.cellSize);
+                int cellY = (int)floor(y / constants.cellSize);
+                int x0 = cellX * constants.cellSize;
+                int y0 = cellY * constants.cellSize;
+                int x1 = min(constants.inputWidth, x0 + constants.cellSize) - 1;
+                int y1 = min(constants.inputHeight, y0 + constants.cellSize) - 1;
+                float4 sample0 = D2DSampleInputAtPosition(0, int2(x0, y0));
+                float4 sample1 = D2DSampleInputAtPosition(0, int2(x1, y0));
+                float4 sample2 = D2DSampleInputAtPosition(0, int2(x0, y1));
+                float4 sample3 = D2DSampleInputAtPosition(0, int2(x1, y1));
+                float4 color = (sample0 + sample1 + sample2 + sample3) / 4;
+                return color;
+            }";
+
+        ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
+            source,
+            "PSMain",
+            D2D1ShaderProfile.PixelShader40,
+            D2D1ShaderCompilerOptions.Default);
+
+        Assert.IsTrue(bytecode.Length > 0);
+    }
+}


### PR DESCRIPTION
### Closes #272

### Description

This PR exposes new interop APIs in ComputeSharp.D2D1 to manually compile HLSL code for a D2D1 pixel shader.

### API breakdown

```csharp
namespace ComputeSharp.D2D1.Interop;

public static class D2D1ShaderCompiler
{
    public static ReadOnlyMemory<byte> Compile(
        ReadOnlySpan<char> source,
        ReadOnlySpan<char> entryPoint,
        D2D1ShaderProfile shaderProfile,
        D2D1ShaderCompilerOptions options);

    public static ReadOnlyMemory<byte> Compile(
        ReadOnlySpan<byte> source,
        ReadOnlySpan<byte> entryPoint,
        D2D1ShaderProfile shaderProfile,
        D2D1ShaderCompilerOptions options);
}

[Flags]
public enum D2D1ShaderCompilerOptions
{
    Debug = D3DCOMPILE_DEBUG,
    SkipValidation = D3DCOMPILE_SKIP_VALIDATION,
    SkipOptimization = D3DCOMPILE_SKIP_OPTIMIZATION,
    PackMatrixRowMajor = D3DCOMPILE_PACK_MATRIX_ROW_MAJOR,
    PackMatrixColumnMajor = D3DCOMPILE_PACK_MATRIX_COLUMN_MAJOR,
    PartialPrecision = D3DCOMPILE_PARTIAL_PRECISION,
    AvoidFlowControl = D3DCOMPILE_AVOID_FLOW_CONTROL,
    EnableStrictness = D3DCOMPILE_ENABLE_STRICTNESS,
    IeeeStrictness = D3DCOMPILE_IEEE_STRICTNESS,
    EnableBackwardsCompatibility = D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY,
    OptimizationLevel0 = D3DCOMPILE_OPTIMIZATION_LEVEL0,
    OptimizationLevel1 = D3DCOMPILE_OPTIMIZATION_LEVEL1,
    OptimizationLevel2 = D3DCOMPILE_OPTIMIZATION_LEVEL2,
    OptimizationLevel3 = D3DCOMPILE_OPTIMIZATION_LEVEL3,
    WarningsAreErrors = D3DCOMPILE_WARNINGS_ARE_ERRORS,
    EnableLinking = 1 << 31,
    Default = OptimizationLevel3 | WarningsAreErrors | PackMatrixRowMajor
}
```
