### PR TITLE
Add [D2D1CompileOptions] attribute to control bytecode generation

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -51,4 +51,3 @@ CMPSD2D0041 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0042 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0043 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0044 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
-CMPSD2D0045 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -51,3 +51,4 @@ CMPSD2D0041 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0042 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0043 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0044 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0045 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -50,3 +50,4 @@ CMPSD2D0040 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0041 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0042 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0043 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0044 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -67,8 +67,10 @@
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1ShaderProfile.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1ShaderProfile.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1CompileOptions.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1CompileOptions.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOptions.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOptions.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DCompileOptionsAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DCompileOptionsAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -618,4 +618,20 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A D2D1 shader must only have unique indices for all of its [D2DInputDescription] attributes.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for the PackMatrixColumnMajor option being used.
+    /// <para>
+    /// Format: <c>"The D2D1 shader of type {0} is using the PackMatrixColumnMajor option in its [D2DCompileOptions] attribute"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidPackMatrixColumnMajorOption = new DiagnosticDescriptor(
+        id: "CMPSD2D0044",
+        title: "Invalid PackMatrixColumnMajor compile option",
+        messageFormat: "The D2D1 shader of type {0} is using the PackMatrixColumnMajor option in its [D2DCompileOptions] attribute",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A D2D1 shader generated with ComputeSharp.D2D1 cannot use the PackMatrixColumnMajor option, as that is not compatible with the generated code used to load shader constant buffers.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -634,4 +634,20 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A D2D1 shader generated with ComputeSharp.D2D1 cannot use the PackMatrixColumnMajor option, as that is not compatible with the generated code used to load shader constant buffers.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for the EnableLinking option being used.
+    /// <para>
+    /// Format: <c>"The D2D1 shader of type {0} is using the EnableLinking option in its [D2DCompileOptions] attribute for a non-linkable shader"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidEnableLinkingOption = new DiagnosticDescriptor(
+        id: "CMPSD2D0045",
+        title: "Invalid EnableLinking compile option",
+        messageFormat: "The D2D1 shader of type {0} is using the EnableLinking option in its [D2DCompileOptions] attribute for a non-linkable shader",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A D2D1 shader generated with ComputeSharp.D2D1 cannot use the EnableLinking option if the shader is non-linkable (ie. if it has any complex inputs).",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -634,20 +634,4 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A D2D1 shader generated with ComputeSharp.D2D1 cannot use the PackMatrixColumnMajor option, as that is not compatible with the generated code used to load shader constant buffers.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
-
-    /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for the EnableLinking option being used.
-    /// <para>
-    /// Format: <c>"The D2D1 shader of type {0} is using the EnableLinking option in its [D2DCompileOptions] attribute for a non-linkable shader"</c>.
-    /// </para>
-    /// </summary>
-    public static readonly DiagnosticDescriptor InvalidEnableLinkingOption = new DiagnosticDescriptor(
-        id: "CMPSD2D0045",
-        title: "Invalid EnableLinking compile option",
-        messageFormat: "The D2D1 shader of type {0} is using the EnableLinking option in its [D2DCompileOptions] attribute for a non-linkable shader",
-        category: "ComputeSharp.D2D1.Shaders",
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true,
-        description: "A D2D1 shader generated with ComputeSharp.D2D1 cannot use the EnableLinking option if the shader is non-linkable (ie. if it has any complex inputs).",
-        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.Syntax.cs
@@ -95,13 +95,13 @@ partial class ID2D1ShaderGenerator
 
             // This code produces a method declaration as follows:
             //
-            // ComputeSharp.D2D1.__Internals.D2D1ShaderCompiler.LoadDynamicBytecode(ref loader, in this, shaderProfile ?? <DEFAULT_PROFILE>, options ?? <REQUESTED_OPTIONS>);
+            // global::ComputeSharp.D2D1.__Internals.D2D1ShaderCompiler.LoadDynamicBytecode(ref loader, in this, shaderProfile ?? <DEFAULT_PROFILE>, options ?? <REQUESTED_OPTIONS>);
             ExpressionStatementSyntax dynamicLoadingStatement =
                 ExpressionStatement(
                     InvocationExpression(
                         MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
-                            IdentifierName("ComputeSharp.D2D1.__Internals.D2D1ShaderCompiler"),
+                            IdentifierName("global::ComputeSharp.D2D1.__Internals.D2D1ShaderCompiler"),
                             IdentifierName("LoadDynamicBytecode")))
                     .AddArgumentListArguments(
                         Argument(IdentifierName("loader")).WithRefKindKeyword(Token(SyntaxKind.RefKeyword)),

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.Syntax.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using ComputeSharp.__Internals;
 using ComputeSharp.D2D1.__Internals;
 using ComputeSharp.D2D1.SourceGenerators.Models;
@@ -39,7 +40,7 @@ partial class ID2D1ShaderGenerator
 
             // This code produces a method declaration as follows:
             //
-            // readonly void global::ComputeSharp.D2D1.__Internals.ID2D1Shader.LoadBytecode<TLoader>(ref TLoader loader, global::ComputeSharp.D2D1.D2D1ShaderProfile? shaderProfile)
+            // readonly void global::ComputeSharp.D2D1.__Internals.ID2D1Shader.LoadBytecode<TLoader>(ref TLoader loader, global::ComputeSharp.D2D1.D2D1ShaderProfile? shaderProfile, global::ComputeSharp.D2D1.D2D1CompileOptions? options)
             // {
             //     <BODY>
             // }
@@ -50,7 +51,8 @@ partial class ID2D1ShaderGenerator
                 .AddTypeParameterListParameters(TypeParameter(Identifier("TLoader")))
                 .AddParameterListParameters(
                     Parameter(Identifier("loader")).AddModifiers(Token(SyntaxKind.RefKeyword)).WithType(IdentifierName("TLoader")),
-                    Parameter(Identifier("shaderProfile")).WithType(NullableType(IdentifierName("global::ComputeSharp.D2D1.D2D1ShaderProfile"))))
+                    Parameter(Identifier("shaderProfile")).WithType(NullableType(IdentifierName("global::ComputeSharp.D2D1.D2D1ShaderProfile"))),
+                    Parameter(Identifier("options")).WithType(NullableType(IdentifierName("global::ComputeSharp.D2D1.D2D1CompileOptions"))))
                 .WithBody(block);
         }
 
@@ -62,9 +64,38 @@ partial class ID2D1ShaderGenerator
         /// <returns>The <see cref="BlockSyntax"/> instance trying to retrieve the precompiled shader.</returns>
         private static unsafe BlockSyntax GetShaderBytecodeBody(EmbeddedBytecodeInfo bytecodeInfo, out string? bytecodeLiterals)
         {
+            // This method needs to handle several different scenarions, which are as follows:
+            //   1) If [EmbeddedBytecode] is used, then the shader is precompiled and stored as a ReadOnlySpan<byte>. In this case,
+            //      this bytecode would have been generated with some specific D2D1ShaderProfile and D2D1CompileOptions values. So,
+            //      a branch is generated to try to retrieve this precompiled bytecode, which can be returned if and only if the
+            //      requested shader profile and compile options are either null, or either matches the values that have been used
+            //      to generate that bytecode. If this is the case, then no further work is done and that binary data is returned.
+            //   2) If either the requested shader profile or options do not match the values used to create the shader bytecode,
+            //      then a call to the internal D2D1ShaderCompiler.LoadDynamicBytecode API is used, to create the shader on the fly.
+            //   3) If [EmbeddedBytecode] is not used, then regardless of the requested profile and options, a new shader is compiled.
+            //   4) If this is the case and either the shader profile or the options are null, then this method will manually set the
+            //      value being null to the default one to use. That is, D2D1ShaderProfile.PixelShader50 will be used as the target,
+            //      and the options will be set to D2D1CompileOptions.Default (and optionally, D2D1CompileOptions.EnableLinking too).
+
+            // Get a formatted representation of the compile options being used
+            ExpressionSyntax optionsExpression =
+                ParseExpression(
+                    bytecodeInfo.CompileOptions
+                    .GetValueOrDefault()
+                    .ToString(CultureInfo.InvariantCulture)
+                    .Split(',')
+                    .Select(static name => $"global::ComputeSharp.D2D1.D2D1CompileOptions.{name.Trim()}")
+                    .Aggregate("", static (left, right) => left.Length > 0 ? $"{left} | {right}" : right));
+
+            // Add parantheses if needed
+            if (optionsExpression is BinaryExpressionSyntax)
+            {
+                optionsExpression = ParenthesizedExpression(optionsExpression);
+            }
+
             // This code produces a method declaration as follows:
             //
-            // ComputeSharp.D2D1.__Internals.D2D1ShaderCompiler.LoadDynamicBytecode(ref loader, in this, shaderProfile, <ENABLE_LINKING_SUPPORT>);
+            // ComputeSharp.D2D1.__Internals.D2D1ShaderCompiler.LoadDynamicBytecode(ref loader, in this, shaderProfile ?? <DEFAULT_PROFILE>, options ?? <REQUESTED_OPTIONS>);
             ExpressionStatementSyntax dynamicLoadingStatement =
                 ExpressionStatement(
                     InvocationExpression(
@@ -75,8 +106,14 @@ partial class ID2D1ShaderGenerator
                     .AddArgumentListArguments(
                         Argument(IdentifierName("loader")).WithRefKindKeyword(Token(SyntaxKind.RefKeyword)),
                         Argument(ThisExpression()).WithRefKindKeyword(Token(SyntaxKind.InKeyword)),
-                        Argument(IdentifierName("shaderProfile")),
-                        Argument(LiteralExpression(bytecodeInfo.IsLinkingSupported ? SyntaxKind.TrueLiteralExpression : SyntaxKind.FalseLiteralExpression))));
+                        Argument(BinaryExpression(
+                            SyntaxKind.CoalesceExpression,
+                            IdentifierName("shaderProfile"),
+                            IdentifierName($"global::ComputeSharp.D2D1.D2D1ShaderProfile.{D2D1ShaderProfile.PixelShader50}"))),
+                        Argument(BinaryExpression(
+                            SyntaxKind.CoalesceExpression,
+                            IdentifierName("options"),
+                            optionsExpression))));
 
             // If there is no precompiled bytecode, just return the dynamic path
             if (bytecodeInfo.Bytecode.IsDefaultOrEmpty)
@@ -90,7 +127,7 @@ partial class ID2D1ShaderGenerator
 
             // This code produces a branch as follows:
             //
-            // if (shaderProfile is null or <SHADER_PROFILE>)
+            // if (shaderProfile is null or <SHADER_PROFILE> && options is null or <OPTIONS>)
             // {
             //     global::System.ReadOnlySpan<byte> bytecode = new byte[] { __EMBEDDED_SHADER_BYTECODE };
             //     loader.LoadEmbeddedBytecode(bytecode);
@@ -101,16 +138,24 @@ partial class ID2D1ShaderGenerator
             // having to create/parse tens of thousands of literal expression nodes for every shader.
             IfStatementSyntax embeddedBranch =
                 IfStatement(
-                    IsPatternExpression(
-                        IdentifierName("shaderProfile"),
-                        BinaryPattern(
-                            SyntaxKind.OrPattern,
-                            ConstantPattern(LiteralExpression(SyntaxKind.NullLiteralExpression)),
-                            ConstantPattern(
-                                MemberAccessExpression(
-                                    SyntaxKind.SimpleMemberAccessExpression,
-                                    IdentifierName("global::ComputeSharp.D2D1.D2D1ShaderProfile"),
-                                    IdentifierName(bytecodeInfo.ShaderProfile.GetValueOrDefault().ToString(CultureInfo.InvariantCulture)))))),
+                    BinaryExpression(
+                        SyntaxKind.LogicalAndExpression,
+                        IsPatternExpression(
+                            IdentifierName("shaderProfile"),
+                            BinaryPattern(
+                                SyntaxKind.OrPattern,
+                                ConstantPattern(LiteralExpression(SyntaxKind.NullLiteralExpression)),
+                                ConstantPattern(
+                                    MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("global::ComputeSharp.D2D1.D2D1ShaderProfile"),
+                                        IdentifierName(bytecodeInfo.ShaderProfile.GetValueOrDefault().ToString(CultureInfo.InvariantCulture)))))),
+                        IsPatternExpression(
+                            IdentifierName("options"),
+                            BinaryPattern(
+                                SyntaxKind.OrPattern,
+                                ConstantPattern(LiteralExpression(SyntaxKind.NullLiteralExpression)),
+                                ConstantPattern(optionsExpression)))),
                     Block(
                         LocalDeclarationStatement(
                             VariableDeclaration(

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -42,6 +42,32 @@ partial class ID2D1ShaderGenerator
         }
 
         /// <summary>
+        /// Extracts the compile options for the current shader.
+        /// </summary>
+        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
+        /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
+        /// <returns>The compile options to use to compile the shader, if present.</returns>
+        public static D2D1CompileOptions? GetCompileOptions(ImmutableArray<Diagnostic>.Builder diagnostics, INamedTypeSymbol structDeclarationSymbol)
+        {
+            if (structDeclarationSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute", out AttributeData? attributeData))
+            {
+                D2D1CompileOptions options = (D2D1CompileOptions)attributeData!.ConstructorArguments[0].Value!;
+
+                if ((options & D2D1CompileOptions.PackMatrixColumnMajor) != 0)
+                {
+                    diagnostics.Add(
+                        InvalidPackMatrixColumnMajorOption,
+                        structDeclarationSymbol,
+                        structDeclarationSymbol);
+                }
+
+                return options;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Extracts the metadata definition for the current shader.
         /// </summary>
         /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.cs
@@ -23,14 +23,14 @@ partial class ID2D1ShaderGenerator
         /// <summary>
         /// Explores a given type hierarchy and generates statements to load fields.
         /// </summary>
+        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
         /// <param name="structDeclarationSymbol">The current shader type being explored.</param>
         /// <param name="root32BitConstantCount">The total number of needed 32 bit constants in the shader root signature.</param>
-        /// <param name="diagnostics">The resulting diagnostics from the processing operation.</param>
         /// <returns>The sequence of <see cref="FieldInfo"/> instances for all captured resources and values.</returns>
         public static ImmutableArray<FieldInfo> GetInfo(
+            ImmutableArray<Diagnostic>.Builder diagnostics,
             ITypeSymbol structDeclarationSymbol,
-            out int root32BitConstantCount,
-            out ImmutableArray<Diagnostic> diagnostics)
+            out int root32BitConstantCount)
         {
             // Helper method that uses boxes instead of ref-s (illegal in enumerators)
             static IEnumerable<FieldInfo> GetCapturedFieldInfos(
@@ -78,8 +78,6 @@ partial class ID2D1ShaderGenerator
                 }
             }
 
-            ImmutableArray<Diagnostic>.Builder builder = ImmutableArray.CreateBuilder<Diagnostic>();
-
             // Setup the resource and byte offsets for tracking
             StrongBox<int> rawDataOffsetAsBox = new();
 
@@ -107,10 +105,8 @@ partial class ID2D1ShaderGenerator
 
             if (rootSignatureDwordSize > 64)
             {
-                builder.Add(ShaderDispatchDataSizeExceeded, structDeclarationSymbol, structDeclarationSymbol);
+                diagnostics.Add(ShaderDispatchDataSizeExceeded, structDeclarationSymbol, structDeclarationSymbol);
             }
-
-            diagnostics = builder.ToImmutable();
 
             return fieldInfos;
         }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -93,11 +93,13 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
 
                 // Get the shader profile and linking info for LoadBytecode()
                 D2D1ShaderProfile? shaderProfile = LoadBytecode.GetShaderProfile(item.Left.Symbol);
+                D2D1CompileOptions? compileOptions = LoadBytecode.GetCompileOptions(diagnostics, item.Left.Symbol);
                 bool isLinkingSupported = diagnostics.Count == 0 && LoadBytecode.IsSimpleInputShader(item.Left.Symbol, inputCount);
 
                 HlslShaderSourceInfo sourceInfo = new(
                     hlslSource,
                     shaderProfile,
+                    compileOptions,
                     isLinkingSupported,
                     diagnostics.Count > 0);
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -92,9 +92,9 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
                 token.ThrowIfCancellationRequested();
 
                 // Get the shader profile and linking info for LoadBytecode()
+                bool isLinkingSupported = LoadBytecode.IsSimpleInputShader(item.Left.Symbol, inputCount);
                 D2D1ShaderProfile? shaderProfile = LoadBytecode.GetShaderProfile(item.Left.Symbol);
-                D2D1CompileOptions? compileOptions = LoadBytecode.GetCompileOptions(diagnostics, item.Left.Symbol);
-                bool isLinkingSupported = diagnostics.Count == 0 && LoadBytecode.IsSimpleInputShader(item.Left.Symbol, inputCount);
+                D2D1CompileOptions? compileOptions = LoadBytecode.GetCompileOptions(diagnostics, item.Left.Symbol, isLinkingSupported);
 
                 HlslShaderSourceInfo sourceInfo = new(
                     hlslSource,

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeInfo.cs
@@ -11,9 +11,9 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// </summary>
 /// <param name="HlslSource">The HLSL source for the shader.</param>
 /// <param name="ShaderProfile">The shader profile to use to compile the shader, if requested.</param>
-/// <param name="IsLinkingSupported">Whether linking is supported for the current shader.</param>
+/// <param name="CompileOptions">The compile options to use to compile the shader.</param>
 /// <param name="Bytecode">The compiled shader bytecode, if available.</param>
-internal sealed record EmbeddedBytecodeInfo(string HlslSource, D2D1ShaderProfile? ShaderProfile, bool IsLinkingSupported, ImmutableArray<byte> Bytecode)
+internal sealed record EmbeddedBytecodeInfo(string HlslSource, D2D1ShaderProfile? ShaderProfile, D2D1CompileOptions? CompileOptions, ImmutableArray<byte> Bytecode)
 {
     /// <summary>
     /// An <see cref="IEqualityComparer{T}"/> implementation for <see cref="EmbeddedBytecodeInfo"/>.
@@ -25,7 +25,7 @@ internal sealed record EmbeddedBytecodeInfo(string HlslSource, D2D1ShaderProfile
         {
             hashCode.Add(obj.HlslSource);
             hashCode.Add(obj.ShaderProfile);
-            hashCode.Add(obj.IsLinkingSupported);
+            hashCode.Add(obj.CompileOptions);
             hashCode.AddBytes(obj.Bytecode.AsSpan());
         }
 
@@ -35,7 +35,7 @@ internal sealed record EmbeddedBytecodeInfo(string HlslSource, D2D1ShaderProfile
             return
                 x.HlslSource == y.HlslSource &&
                 x.ShaderProfile == y.ShaderProfile &&
-                x.IsLinkingSupported == y.IsLinkingSupported &&
+                x.CompileOptions == y.CompileOptions &&
                 x.Bytecode.SequenceEqual(y.Bytecode);
         }
     }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/HlslShaderSourceInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/HlslShaderSourceInfo.cs
@@ -5,6 +5,12 @@
 /// </summary>
 /// <param name="HlslSource">The HLSL source.</param>
 /// <param name="ShaderProfile">The shader profile to use to compile the shader, if requested.</param>
+/// <param name="CompileOptions">The compile options to use to compile the shader.</param>
 /// <param name="IsLinkingSupported">Whether the shader supports linking.</param>
 /// <param name="HasErrors">Whether any errors have been detected, and therefore the shader compilation should be skipped.</param>
-internal sealed record HlslShaderSourceInfo(string HlslSource, D2D1ShaderProfile? ShaderProfile, bool IsLinkingSupported, bool HasErrors);
+internal sealed record HlslShaderSourceInfo(
+    string HlslSource,
+    D2D1ShaderProfile? ShaderProfile,
+    D2D1CompileOptions? CompileOptions,
+    bool IsLinkingSupported,
+    bool HasErrors);

--- a/src/ComputeSharp.D2D1/Attributes/D2DCompileOptionsAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DCompileOptionsAttribute.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// An attribute that indicates the compile options that should be used when compiling a given D2D1 shader.
+/// This applies when the shader is precompiled (through <see cref="D2DEmbeddedBytecodeAttribute"/>) as well.
+/// <para>
+/// This attribute can be used to annotate shader types as follows:
+/// <code>
+/// [D2DCompileOptions(D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel3)]
+/// struct MyShader : ID2D1PixelShader
+/// {
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// </para>
+/// Note that the <see cref="D2D1CompileOptions.PackMatrixRowMajor"/> is always enabled automatically and does not need to be
+/// specified. This option is mandatory, as the generated code to load the constant buffer from a shader assumes the layout
+/// for matrix types is row major. For the same reason, using <see cref="D2D1CompileOptions.PackMatrixColumnMajor"/> is not
+/// allowed, as it would cause the constant buffer retrieved from a shader to be potentially incorrect.
+/// </summary>
+[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+public sealed class D2DCompileOptionsAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new <see cref="D2DCompileOptionsAttribute"/> instance with the specified parameters.
+    /// </summary>
+    /// <param name="options">The compiler options to use to compile the shader.</param>
+    public D2DCompileOptionsAttribute(D2D1CompileOptions options)
+    {
+        Options = options;
+    }
+
+    /// <summary>
+    /// Gets the number of threads in each thread group for the X axis
+    /// </summary>
+    public D2D1CompileOptions Options { get; }
+}

--- a/src/ComputeSharp.D2D1/Attributes/D2DEmbeddedBytecodeAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DEmbeddedBytecodeAttribute.cs
@@ -8,7 +8,6 @@ namespace ComputeSharp.D2D1;
 /// <para>
 /// This attribute can be used to annotate shader types as follows:
 /// <code>
-/// // A compute shader that is dispatched on a target buffer
 /// [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
 /// struct MyShader : ID2D1PixelShader
 /// {

--- a/src/ComputeSharp.D2D1/Attributes/Enums/D2D1CompileOptions.cs
+++ b/src/ComputeSharp.D2D1/Attributes/Enums/D2D1CompileOptions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+#if !SOURCE_GENERATOR
 using ComputeSharp.D2D1.Interop;
+#endif
 using TerraFX.Interop.DirectX;
 
 namespace ComputeSharp.D2D1;

--- a/src/ComputeSharp.D2D1/Attributes/Enums/D2D1CompileOptions.cs
+++ b/src/ComputeSharp.D2D1/Attributes/Enums/D2D1CompileOptions.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using ComputeSharp.D2D1.Interop;
 using TerraFX.Interop.DirectX;
 
-namespace ComputeSharp.D2D1.Interop;
+namespace ComputeSharp.D2D1;
 
 /// <summary>
 /// Flags to control the options that can be used to compile a D2D1 shader.
@@ -10,7 +11,7 @@ namespace ComputeSharp.D2D1.Interop;
 /// For more info, see For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/d3dcompile-constants"/>.
 /// </remarks>
 [Flags]
-public enum D2D1ShaderCompilerOptions
+public enum D2D1CompileOptions
 {
     /// <summary>
     /// Directs the compiler to insert debug file/line/type/symbol information into the output code.

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
@@ -88,9 +88,10 @@ public interface ID2D1Shader
     /// <typeparam name="TLoader">The type of bytecode loader being used.</typeparam>
     /// <param name="loader">The <typeparamref name="TLoader"/> instance to use to load the bytecode.</param>
     /// <param name="shaderProfile">The shader profile to use to get the shader bytecode (if <see langword="null"/>, the precompiled shader will be used).</param>
+    /// <param name="options">The compile options to use to get the shader bytecode (if <see langword="null"/>, the precompiled shader will be used).</param>
     /// <exception cref="InvalidOperationException">Thrown if a precompiled bytecode was requested (<paramref name="shaderProfile"/> is <see langword="null"/>), but it wasn't availablle.</exception>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This method is not intended to be used directly by user code")]
-    void LoadBytecode<TLoader>(ref TLoader loader, D2D1ShaderProfile? shaderProfile)
+    void LoadBytecode<TLoader>(ref TLoader loader, D2D1ShaderProfile? shaderProfile, D2D1CompileOptions? options)
         where TLoader : struct, ID2D1BytecodeLoader;
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
@@ -63,6 +63,31 @@ public static class D2D1PixelShader
     /// Loads the bytecode from an input D2D1 pixel shader.
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to load the bytecode for.</typeparam>
+    /// <param name="options">The compile options to use to get the shader bytecode.</param>
+    /// <returns>A <see cref="ReadOnlyMemory{T}"/> instance with the resulting shader bytecode.</returns>
+    /// <remarks>
+    /// <para>
+    /// If precompiled shader with the requested options does not exist, the shader will be compiled with the input options. If additional compile
+    /// options have been specified on the shader type <typeparamref name="T"/> (through <see cref="D2DCompileOptionsAttribute"/>), they will be ignored.
+    /// </para>
+    /// <para>
+    /// If the shader needs to be recompiled, the shader profile that will be used is <see cref="D2D1ShaderProfile.PixelShader50"/>.
+    /// </para>
+    /// <para>
+    /// If the input shader was precompiled, the returned <see cref="ReadOnlyMemory{T}"/> instance will wrap a pinned memory buffer (from the PE section).
+    /// If the shader was compiled at runtime, the returned <see cref="ReadOnlyMemory{T}"/> instance will wrap a <see cref="byte"/> array with the bytecode.
+    /// </para>
+    /// </remarks>
+    public static ReadOnlyMemory<byte> LoadBytecode<T>(D2D1CompileOptions options)
+        where T : unmanaged, ID2D1PixelShader
+    {
+        return LoadOrCompileBytecode<T>(null, options);
+    }
+
+    /// <summary>
+    /// Loads the bytecode from an input D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to load the bytecode for.</typeparam>
     /// <param name="shaderProfile">The shader profile to use to get the shader bytecode.</param>
     /// <param name="options">The compile options to use to get the shader bytecode.</param>
     /// <returns>A <see cref="ReadOnlyMemory{T}"/> instance with the resulting shader bytecode.</returns>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -29,7 +29,7 @@ public static class D2D1ReflectionServices
 
         D2D1ShaderBytecodeLoader bytecodeLoader = default;
 
-        shader.LoadBytecode(ref bytecodeLoader, D2D1ShaderProfile.PixelShader50);
+        shader.LoadBytecode(ref bytecodeLoader, D2D1ShaderProfile.PixelShader50, D2D1CompileOptions.Default);
 
         using ComPtr<ID3DBlob> dynamicBytecode = bytecodeLoader.GetResultingShaderBytecode(out ReadOnlySpan<byte> precompiledBytecode);
 

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderCompiler.cs
@@ -29,7 +29,7 @@ public static class D2D1ShaderCompiler
         ReadOnlySpan<char> hlslSource,
         ReadOnlySpan<char> entryPoint,
         D2D1ShaderProfile shaderProfile,
-        D2D1ShaderCompilerOptions options)
+        D2D1CompileOptions options)
     {
         // Encode the HLSL source to ASCII
         int maxSourceLength = Encoding.ASCII.GetMaxByteCount(hlslSource.Length);
@@ -60,13 +60,13 @@ public static class D2D1ShaderCompiler
         ReadOnlySpan<byte> hlslSourceAscii,
         ReadOnlySpan<byte> entryPointAscii,
         D2D1ShaderProfile shaderProfile,
-        D2D1ShaderCompilerOptions options)
+        D2D1CompileOptions options)
     {
         // Check linking support
-        bool enableLinking = (options & D2D1ShaderCompilerOptions.EnableLinking) == D2D1ShaderCompilerOptions.EnableLinking;
+        bool enableLinking = (options & D2D1CompileOptions.EnableLinking) == D2D1CompileOptions.EnableLinking;
 
         // Remove the linking flag to make the options blittable to flags
-        options &= ~D2D1ShaderCompilerOptions.EnableLinking;
+        options &= ~D2D1CompileOptions.EnableLinking;
 
         // Compile the standalone D2D1 full shader
         using ComPtr<ID3DBlob> d3DBlobFullShader = D3DCompiler.CompileShader(

--- a/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.cs
@@ -32,9 +32,9 @@ internal static unsafe partial class D3DCompiler
     /// </summary>
     /// <param name="source">The HLSL source code to compile.</param>
     /// <param name="shaderProfile">The shader profile to use to compile the shader.</param>
-    /// <param name="enableLinking">Whether to enable linking for the shader.</param>
+    /// <param name="options">The options to use to compile the shader.</param>
     /// <returns>The bytecode for the compiled shader.</returns>
-    public static ComPtr<ID3DBlob> Compile(ReadOnlySpan<char> source, D2D1ShaderProfile shaderProfile, bool enableLinking)
+    public static ComPtr<ID3DBlob> Compile(ReadOnlySpan<char> source, D2D1ShaderProfile shaderProfile, D2D1CompileOptions options)
     {
         int maxLength = Encoding.ASCII.GetMaxByteCount(source.Length);
         byte[] buffer = ArrayPool<byte>.Shared.Rent(maxLength);
@@ -49,9 +49,9 @@ internal static unsafe partial class D3DCompiler
                 d2DEntry: ASCII.Execute,
                 entryPoint: ASCII.Execute,
                 target: ASCII.GetPixelShaderProfile(shaderProfile),
-                flags: D3DCOMPILE.D3DCOMPILE_OPTIMIZATION_LEVEL3 | D3DCOMPILE.D3DCOMPILE_WARNINGS_ARE_ERRORS | D3DCOMPILE.D3DCOMPILE_PACK_MATRIX_ROW_MAJOR);
+                flags: (uint)(options & ~D2D1CompileOptions.EnableLinking));
 
-            if (!enableLinking)
+            if ((options & D2D1CompileOptions.EnableLinking) == 0)
             {
                 return d3DBlobFullShader.Move();
             }
@@ -63,7 +63,7 @@ internal static unsafe partial class D3DCompiler
                 d2DEntry: ASCII.Execute,
                 entryPoint: default,
                 target: ASCII.GetLibraryProfile(shaderProfile),
-                flags: D3DCOMPILE.D3DCOMPILE_OPTIMIZATION_LEVEL3 | D3DCOMPILE.D3DCOMPILE_WARNINGS_ARE_ERRORS | D3DCOMPILE.D3DCOMPILE_PACK_MATRIX_ROW_MAJOR);
+                flags: (uint)(options & ~D2D1CompileOptions.EnableLinking));
 
             // Embed it as private data if requested
             using ComPtr<ID3DBlob> d3DBlobLinked = SetD3DPrivateData(d3DBlobFullShader.Get(), d3DBlobFunction.Get());

--- a/src/ComputeSharp.D2D1/Shaders/Translation/__Internals/D2D1ShaderCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/__Internals/D2D1ShaderCompiler.cs
@@ -31,7 +31,7 @@ public static class D2D1ShaderCompiler
         using ComPtr<ID3DBlob> d3DBlobBytecode = Shaders.Translation.D3DCompiler.Compile(
             hlslSource.AsSpan(),
             shaderProfile ?? D2D1ShaderProfile.PixelShader50,
-            enableLinkingSupport);
+            D2D1CompileOptions.Default | (enableLinkingSupport ? D2D1CompileOptions.EnableLinking : 0));
 
         loader.LoadDynamicBytecode((IntPtr)d3DBlobBytecode.Get());
     }

--- a/src/ComputeSharp.D2D1/Shaders/Translation/__Internals/D2D1ShaderCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/__Internals/D2D1ShaderCompiler.cs
@@ -21,8 +21,8 @@ public static class D2D1ShaderCompiler
     /// <param name="loader">The <typeparamref name="TLoader"/> instance to use to load the bytecode.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the D2D1 shader to run.</param>
     /// <param name="shaderProfile">The shader profile to use to compile the shader.</param>
-    /// <param name="enableLinkingSupport">Whether to enable linking support for the shader.</param>
-    public static unsafe void LoadDynamicBytecode<TLoader, T>(ref TLoader loader, in T shader, D2D1ShaderProfile? shaderProfile, bool enableLinkingSupport)
+    /// <param name="options">The compiler options to use to compile the shader.</param>
+    public static unsafe void LoadDynamicBytecode<TLoader, T>(ref TLoader loader, in T shader, D2D1ShaderProfile shaderProfile, D2D1CompileOptions options)
         where TLoader : struct, ID2D1BytecodeLoader
         where T : struct, ID2D1Shader
     {
@@ -30,8 +30,8 @@ public static class D2D1ShaderCompiler
 
         using ComPtr<ID3DBlob> d3DBlobBytecode = Shaders.Translation.D3DCompiler.Compile(
             hlslSource.AsSpan(),
-            shaderProfile ?? D2D1ShaderProfile.PixelShader50,
-            D2D1CompileOptions.Default | (enableLinkingSupport ? D2D1CompileOptions.EnableLinking : 0));
+            shaderProfile,
+            options);
 
         loader.LoadDynamicBytecode((IntPtr)d3DBlobBytecode.Get());
     }

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
@@ -31,7 +31,7 @@ public partial class D2D1ShaderCompilerTests
             source,
             "PSMain",
             D2D1ShaderProfile.PixelShader40Level93,
-            D2D1ShaderCompilerOptions.Default);
+            D2D1CompileOptions.Default);
 
         Assert.IsTrue(bytecode.Length > 0);
     }
@@ -57,7 +57,7 @@ public partial class D2D1ShaderCompilerTests
             source,
             "PSMain",
             D2D1ShaderProfile.PixelShader40Level93,
-            D2D1ShaderCompilerOptions.Default | D2D1ShaderCompilerOptions.EnableLinking);
+            D2D1CompileOptions.Default | D2D1CompileOptions.EnableLinking);
 
         Assert.IsTrue(bytecode.Length > 0);
     }
@@ -84,7 +84,7 @@ public partial class D2D1ShaderCompilerTests
             source,
             "Execute",
             D2D1ShaderProfile.PixelShader40Level93,
-            D2D1ShaderCompilerOptions.Default);
+            D2D1CompileOptions.Default);
 
         Assert.IsTrue(bytecode.Length > 0);
     }
@@ -111,7 +111,7 @@ public partial class D2D1ShaderCompilerTests
             source,
             "PSMain",
             D2D1ShaderProfile.PixelShader40Level93,
-            D2D1ShaderCompilerOptions.Default);
+            D2D1CompileOptions.Default);
 
         Assert.IsTrue(bytecode.Length > 0);
     }
@@ -158,7 +158,7 @@ public partial class D2D1ShaderCompilerTests
             source,
             "PSMain",
             D2D1ShaderProfile.PixelShader40,
-            D2D1ShaderCompilerOptions.Default);
+            D2D1CompileOptions.Default);
 
         Assert.IsTrue(bytecode.Length > 0);
     }


### PR DESCRIPTION
### Closes #276

### Description

This PR is a superset of the requested option to disable linking, and adds the `[D2D1CompileOptions]` attribute to have full control over how bytecode is generated both for embedded shaders and for those compiled at runtime.

### API breakdown

```csharp
namespace ComputeSharp.D2D1;

[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
public sealed class D2DCompileOptionsAttribute : Attribute
{
    public D2DCompileOptionsAttribute(D2D1CompileOptions options);

    public D2D1CompileOptions Options { get; }
}

// Renamed D2D1ShaderCompilerOptions to D2D1CompileOptions.
// Moved D2D1CompileOptions to the ComputeSharp.D2D1 namespace.
```