### PR TITLE
Add [D2DEmbeddedBytecode] and [D2DCompileOptions] assembly-level support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -157,6 +157,9 @@ jobs:
     - name: Run ComputeSharp.D2D1.Tests
       run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -v n -l "console;verbosity=detailed"
       shell: cmd
+    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes
+      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -v n -l "console;verbosity=detailed"
+      shell: cmd
 
   # Run all the local samples to ensure they build and run with no errors
   run-dx12-samples:

--- a/ComputeSharp.sln
+++ b/ComputeSharp.sln
@@ -98,49 +98,9 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ComputeSharp.SourceGenerati
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComputeSharp.D2D1.Tests", "tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj", "{209C95A3-FA53-431B-B688-3299CA6C29D2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComputeSharp.D2D1.Tests.AssemblyLevelAttributes", "tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj", "{94178D51-0097-4AD2-B3D0-827E40D62F2E}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		samples\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.projitems*{0071701e-b9c5-4098-be5f-ef556c4553c6}*SharedItemsImports = 5
-		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{0071701e-b9c5-4098-be5f-ef556c4553c6}*SharedItemsImports = 5
-		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{0800bd51-499d-44c2-9417-fd1f7fdfe9c4}*SharedItemsImports = 13
-		src\ComputeSharp.UI\ComputeSharp.UI.projitems*{0c82ede1-5b8a-4df3-87da-700b29d5e265}*SharedItemsImports = 13
-		src\TerraFX.Interop.Windows.Dynamic\TerraFX.Interop.Windows.Dynamic.projitems*{158f984d-cd96-4062-bd02-2268946031a0}*SharedItemsImports = 13
-		src\ComputeSharp.D2D1.NetStandard\ComputeSharp.D2D1.NetStandard.projitems*{2608eb41-f98b-4be5-9f4d-68fed6115088}*SharedItemsImports = 13
-		src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems*{314eb353-e7e3-4146-8111-685cc83ec1de}*SharedItemsImports = 5
-		src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems*{314eb353-e7e3-4146-8111-685cc83ec1de}*SharedItemsImports = 5
-		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{3acacf03-6b20-40ba-b8ec-11ac1624d2c9}*SharedItemsImports = 13
-		src\ComputeSharp.D2D1.NetStandard\ComputeSharp.D2D1.NetStandard.projitems*{4d7d9ba8-a821-4b1c-9ee2-cbcf5849906e}*SharedItemsImports = 5
-		src\TerraFX.Interop.Windows.D2D1\TerraFX.Interop.Windows.D2D1.projitems*{4d7d9ba8-a821-4b1c-9ee2-cbcf5849906e}*SharedItemsImports = 5
-		src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems*{514ff00e-bbf0-4d55-a47c-eeeb6208adce}*SharedItemsImports = 13
-		src\ComputeSharp.SourceGeneration\ComputeSharp.SourceGeneration.projitems*{51d5a422-d3a5-4c4d-8a6d-a048940bf279}*SharedItemsImports = 13
-		samples\ComputeSharp.Sample.Shared\ComputeSharp.Sample.Shared.projitems*{7048deea-0a6f-46a0-b951-b682a8f1cb75}*SharedItemsImports = 5
-		samples\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.projitems*{751bb05b-563d-4b3a-94c6-15e2d79d35ea}*SharedItemsImports = 13
-		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{764bc0f5-0c5e-49ad-abaa-e3874c0f3286}*SharedItemsImports = 5
-		src\TerraFX.Interop.Windows.Dynamic\TerraFX.Interop.Windows.Dynamic.projitems*{76c66257-fdaa-47ab-85e7-ef757eab10c0}*SharedItemsImports = 5
-		samples\ComputeSharp.Sample.Shared\ComputeSharp.Sample.Shared.projitems*{8cefc324-ca6c-4845-9ad9-70b92bd87057}*SharedItemsImports = 13
-		src\ComputeSharp.SourceGeneration.Hlsl\ComputeSharp.SourceGeneration.Hlsl.projitems*{9ac496a3-bbf0-4c8f-a50d-a20bf01c5e05}*SharedItemsImports = 13
-		src\TerraFX.Interop.Windows.D2D1\TerraFX.Interop.Windows.D2D1.projitems*{9da1da9f-f8b2-4b25-be80-c21f773029e3}*SharedItemsImports = 13
-		src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems*{a5997814-d8d2-4541-87ac-c3e53caa67c0}*SharedItemsImports = 13
-		src\ComputeSharp.UI\ComputeSharp.UI.projitems*{afaafdc9-be42-45d4-8c79-0ee8c8edbf52}*SharedItemsImports = 5
-		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{bfb003d1-788b-48de-8065-39479c162cb0}*SharedItemsImports = 5
-		src\ComputeSharp.SourceGeneration\ComputeSharp.SourceGeneration.projitems*{bfb003d1-788b-48de-8065-39479c162cb0}*SharedItemsImports = 5
-		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
-		src\ComputeSharp.D2D1.NetStandard\ComputeSharp.D2D1.NetStandard.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
-		src\ComputeSharp.SourceGeneration.Hlsl\ComputeSharp.SourceGeneration.Hlsl.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
-		src\ComputeSharp.SourceGeneration\ComputeSharp.SourceGeneration.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
-		src\TerraFX.Interop.Windows.D2D1\TerraFX.Interop.Windows.D2D1.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
-		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{e7c9247d-016b-4819-af9f-0e9b3591e04b}*SharedItemsImports = 5
-		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{e91f4d24-922a-4921-a8d7-9c45a143c45d}*SharedItemsImports = 5
-		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
-		src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
-		src\ComputeSharp.SourceGeneration.Hlsl\ComputeSharp.SourceGeneration.Hlsl.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
-		src\ComputeSharp.SourceGeneration\ComputeSharp.SourceGeneration.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
-		src\TerraFX.Interop.Windows.Dynamic\TerraFX.Interop.Windows.Dynamic.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
-		src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
-		src\ComputeSharp.UI\ComputeSharp.UI.projitems*{fa18ba9f-76bf-4de0-8d24-02fc7657e6cb}*SharedItemsImports = 5
-		samples\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.projitems*{fbd388a5-7855-4408-98ff-e689f509db5a}*SharedItemsImports = 4
-		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{fbd388a5-7855-4408-98ff-e689f509db5a}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|ARM64 = Debug|ARM64
@@ -438,6 +398,18 @@ Global
 		{209C95A3-FA53-431B-B688-3299CA6C29D2}.Release|ARM64.Build.0 = Release|Any CPU
 		{209C95A3-FA53-431B-B688-3299CA6C29D2}.Release|x64.ActiveCfg = Release|Any CPU
 		{209C95A3-FA53-431B-B688-3299CA6C29D2}.Release|x64.Build.0 = Release|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Debug|x64.Build.0 = Debug|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Release|ARM64.Build.0 = Release|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Release|x64.ActiveCfg = Release|Any CPU
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -466,8 +438,51 @@ Global
 		{2608EB41-F98B-4BE5-9F4D-68FED6115088} = {8DCE343F-BA78-4FE1-B562-B57C603A8BAA}
 		{3ACACF03-6B20-40BA-B8EC-11AC1624D2C9} = {8DCE343F-BA78-4FE1-B562-B57C603A8BAA}
 		{209C95A3-FA53-431B-B688-3299CA6C29D2} = {F8EFBB27-4EE2-4463-A75B-7EFDFB55D0F7}
+		{94178D51-0097-4AD2-B3D0-827E40D62F2E} = {F8EFBB27-4EE2-4463-A75B-7EFDFB55D0F7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4664C5E3-0340-4E22-BCFD-98AAEDF5F2DC}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		samples\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.projitems*{0071701e-b9c5-4098-be5f-ef556c4553c6}*SharedItemsImports = 5
+		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{0071701e-b9c5-4098-be5f-ef556c4553c6}*SharedItemsImports = 5
+		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{0800bd51-499d-44c2-9417-fd1f7fdfe9c4}*SharedItemsImports = 13
+		src\ComputeSharp.UI\ComputeSharp.UI.projitems*{0c82ede1-5b8a-4df3-87da-700b29d5e265}*SharedItemsImports = 13
+		src\TerraFX.Interop.Windows.Dynamic\TerraFX.Interop.Windows.Dynamic.projitems*{158f984d-cd96-4062-bd02-2268946031a0}*SharedItemsImports = 13
+		src\ComputeSharp.D2D1.NetStandard\ComputeSharp.D2D1.NetStandard.projitems*{2608eb41-f98b-4be5-9f4d-68fed6115088}*SharedItemsImports = 13
+		src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems*{314eb353-e7e3-4146-8111-685cc83ec1de}*SharedItemsImports = 5
+		src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems*{314eb353-e7e3-4146-8111-685cc83ec1de}*SharedItemsImports = 5
+		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{3acacf03-6b20-40ba-b8ec-11ac1624d2c9}*SharedItemsImports = 13
+		src\ComputeSharp.D2D1.NetStandard\ComputeSharp.D2D1.NetStandard.projitems*{4d7d9ba8-a821-4b1c-9ee2-cbcf5849906e}*SharedItemsImports = 5
+		src\TerraFX.Interop.Windows.D2D1\TerraFX.Interop.Windows.D2D1.projitems*{4d7d9ba8-a821-4b1c-9ee2-cbcf5849906e}*SharedItemsImports = 5
+		src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems*{514ff00e-bbf0-4d55-a47c-eeeb6208adce}*SharedItemsImports = 13
+		src\ComputeSharp.SourceGeneration\ComputeSharp.SourceGeneration.projitems*{51d5a422-d3a5-4c4d-8a6d-a048940bf279}*SharedItemsImports = 13
+		samples\ComputeSharp.Sample.Shared\ComputeSharp.Sample.Shared.projitems*{7048deea-0a6f-46a0-b951-b682a8f1cb75}*SharedItemsImports = 5
+		samples\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.projitems*{751bb05b-563d-4b3a-94c6-15e2d79d35ea}*SharedItemsImports = 13
+		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{764bc0f5-0c5e-49ad-abaa-e3874c0f3286}*SharedItemsImports = 5
+		src\TerraFX.Interop.Windows.Dynamic\TerraFX.Interop.Windows.Dynamic.projitems*{76c66257-fdaa-47ab-85e7-ef757eab10c0}*SharedItemsImports = 5
+		samples\ComputeSharp.Sample.Shared\ComputeSharp.Sample.Shared.projitems*{8cefc324-ca6c-4845-9ad9-70b92bd87057}*SharedItemsImports = 13
+		src\ComputeSharp.SourceGeneration.Hlsl\ComputeSharp.SourceGeneration.Hlsl.projitems*{9ac496a3-bbf0-4c8f-a50d-a20bf01c5e05}*SharedItemsImports = 13
+		src\TerraFX.Interop.Windows.D2D1\TerraFX.Interop.Windows.D2D1.projitems*{9da1da9f-f8b2-4b25-be80-c21f773029e3}*SharedItemsImports = 13
+		src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems*{a5997814-d8d2-4541-87ac-c3e53caa67c0}*SharedItemsImports = 13
+		src\ComputeSharp.UI\ComputeSharp.UI.projitems*{afaafdc9-be42-45d4-8c79-0ee8c8edbf52}*SharedItemsImports = 5
+		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{bfb003d1-788b-48de-8065-39479c162cb0}*SharedItemsImports = 5
+		src\ComputeSharp.SourceGeneration\ComputeSharp.SourceGeneration.projitems*{bfb003d1-788b-48de-8065-39479c162cb0}*SharedItemsImports = 5
+		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
+		src\ComputeSharp.D2D1.NetStandard\ComputeSharp.D2D1.NetStandard.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
+		src\ComputeSharp.SourceGeneration.Hlsl\ComputeSharp.SourceGeneration.Hlsl.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
+		src\ComputeSharp.SourceGeneration\ComputeSharp.SourceGeneration.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
+		src\TerraFX.Interop.Windows.D2D1\TerraFX.Interop.Windows.D2D1.projitems*{e44053bd-a761-47fb-aa78-087a599672ea}*SharedItemsImports = 5
+		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{e7c9247d-016b-4819-af9f-0e9b3591e04b}*SharedItemsImports = 5
+		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{e91f4d24-922a-4921-a8d7-9c45a143c45d}*SharedItemsImports = 5
+		src\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
+		src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
+		src\ComputeSharp.SourceGeneration.Hlsl\ComputeSharp.SourceGeneration.Hlsl.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
+		src\ComputeSharp.SourceGeneration\ComputeSharp.SourceGeneration.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
+		src\TerraFX.Interop.Windows.Dynamic\TerraFX.Interop.Windows.Dynamic.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
+		src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems*{eb52cb67-4162-4722-874b-44ea8da5450e}*SharedItemsImports = 5
+		src\ComputeSharp.UI\ComputeSharp.UI.projitems*{fa18ba9f-76bf-4de0-8d24-02fc7657e6cb}*SharedItemsImports = 5
+		samples\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.projitems*{fbd388a5-7855-4408-98ff-e689f509db5a}*SharedItemsImports = 4
+		samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems*{fbd388a5-7855-4408-98ff-e689f509db5a}*SharedItemsImports = 4
 	EndGlobalSection
 EndGlobal

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -622,16 +622,16 @@ internal static class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for the PackMatrixColumnMajor option being used.
     /// <para>
-    /// Format: <c>"The D2D1 shader of type {0} is using the PackMatrixColumnMajor option in its [D2DCompileOptions] attribute"</c>.
+    /// Format: <c>"The D2D1 shader of type (or assembly) {0} is using the PackMatrixColumnMajor option in its [D2DCompileOptions] attribute"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidPackMatrixColumnMajorOption = new DiagnosticDescriptor(
         id: "CMPSD2D0044",
         title: "Invalid PackMatrixColumnMajor compile option",
-        messageFormat: "The D2D1 shader of type {0} is using the PackMatrixColumnMajor option in its [D2DCompileOptions] attribute",
+        messageFormat: "The D2D1 shader of type (or assembly) {0} is using the PackMatrixColumnMajor option in its [D2DCompileOptions] attribute",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A D2D1 shader generated with ComputeSharp.D2D1 cannot use the PackMatrixColumnMajor option, as that is not compatible with the generated code used to load shader constant buffers.",
+        description: "A D2D1 shader generated with ComputeSharp.D2D1 (or an assembly) cannot use the PackMatrixColumnMajor option, as that is not compatible with the generated code used to load shader constant buffers.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -38,6 +38,11 @@ partial class ID2D1ShaderGenerator
                 return (D2D1ShaderProfile)attributeData!.ConstructorArguments[0].Value!;
             }
 
+            if (structDeclarationSymbol.ContainingAssembly.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DEmbeddedBytecodeAttribute", out attributeData))
+            {
+                return (D2D1ShaderProfile)attributeData!.ConstructorArguments[0].Value!;
+            }
+
             return null;
         }
 
@@ -63,6 +68,12 @@ partial class ID2D1ShaderGenerator
 
                 // PackMatrixRowMajor is always automatically enabled
                 return options | D2D1CompileOptions.PackMatrixRowMajor;
+            }
+
+            if (structDeclarationSymbol.ContainingAssembly.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute", out attributeData))
+            {
+                // No need to validate against PackMatrixColumnMajor as that's checked separately
+                return (D2D1CompileOptions)attributeData!.ConstructorArguments[0].Value! | D2D1CompileOptions.PackMatrixRowMajor;
             }
 
             return null;

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -11,6 +11,7 @@ using ComputeSharp.D2D1.SourceGenerators.Models;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Models;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
@@ -77,6 +78,75 @@ partial class ID2D1ShaderGenerator
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="IncrementalValuesProvider{TValues}"/> instance producing <see cref="Diagnostic"/>-s for invalid assembly-level <c>[D2D1CompileOptions]</c> attributes.
+        /// </summary>
+        /// <param name="syntaxProvider">The input <see cref="SyntaxValueProvider"/> instance to use to produce the diagnostics.</param>
+        /// <returns>The diagnostic for the attribute, if invalid.</returns>
+        public static IncrementalValuesProvider<Diagnostic> GetAssemblyLevelCompileOptionsDiagnostics(SyntaxValueProvider syntaxProvider)
+        {
+            // In order to emit diagnostics for [D2D1CompileOptions] attributes at the assembly level, the following is needed:
+            //   - The type symbol for the attribute, to be able to check it's actually [D2D1CompileOptions].
+            //   - The syntax node representing the attribute targeting the assembly, to get a location.
+            //   - The input D2D1CompileOptions value, which can be retrieved as a constant argument to the attribute.
+            //
+            // The first step to do this is to find all AttributeListSyntax values and filter those targeting the assembly.
+            static bool IsAssemblyTargetingAttributeNode(SyntaxNode node, CancellationToken token)
+            {
+                return node is AttributeListSyntax attributeList && attributeList.Target?.Identifier.IsKind(SyntaxKind.AssemblyKeyword) == true;
+            }
+
+            // Helper that detects invalid [D2D1CompileOptions] uses and produces a diagnostic
+            static Diagnostic? TryGetDiagnosticForAssemblyLevelCompileOptions(GeneratorSyntaxContext context, CancellationToken token)
+            {
+                Location? location = null;
+                D2D1CompileOptions? options = null;
+
+                // The input is an AttributeListSyntax object, so first traverse all its containing attributes
+                foreach (AttributeSyntax attributeSyntax in ((AttributeListSyntax)context.Node).Attributes)
+                {
+                    // Match the symbol (retrieved from the constructor symbol) to check it's a [D2D1CompileOptions] attribute
+                    if (context.SemanticModel.GetSymbolInfo(attributeSyntax, token).Symbol is IMethodSymbol attributeConstructorSymbol &&
+                        attributeConstructorSymbol.ContainingType.HasFullyQualifiedName("ComputeSharp.D2D1.D2DCompileOptionsAttribute"))
+                    {
+                        // Get the value from the expression (get the argument expression and the constant value from there)
+                        if (attributeSyntax.ArgumentList?.Arguments.FirstOrDefault() is AttributeArgumentSyntax argumentSyntax &&
+                            context.SemanticModel.GetConstantValue(argumentSyntax.Expression, token) is { HasValue: true, Value: int rawOptions })
+                        {
+                            options = (D2D1CompileOptions)rawOptions;
+                        }
+
+                        // Also get the location from the attribute syntax node
+                        location = attributeSyntax.GetLocation();
+
+                        break;
+                    }
+                }
+
+                // Check that some options were actually found, and that they were incorrect.
+                // The attribute can't be repeated, so checking for multiple values isn't needed.
+                if (options is not null &&
+                    (options & D2D1CompileOptions.PackMatrixColumnMajor) != 0)
+                {
+                    IAssemblySymbol assemblySymbol = context.SemanticModel.Compilation.Assembly;
+
+                    // Emit the diagnostic targeting the assembly (instead of a shader type)
+                    return Diagnostic.Create(
+                        InvalidPackMatrixColumnMajorOption,
+                        location,
+                        assemblySymbol);
+                }
+
+                return null;
+            }
+
+            // Create the incremental collection and only retrieve non null items
+            return
+                syntaxProvider
+                .CreateSyntaxProvider(IsAssemblyTargetingAttributeNode, TryGetDiagnosticForAssemblyLevelCompileOptions)
+                .Where(static diagnostic => diagnostic is not null)!;
         }
 
         /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -116,6 +116,12 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         // Output the diagnostics
         context.ReportDiagnostics(shaderInfoWithErrors.Select(static (item, token) => item.Diagnostics));
 
+        // Get all errors for invalid [D2D1CompileOptions] attributes added to the assembly level
+        IncrementalValuesProvider<Diagnostic> d2DCompileOptionsAtAssemblyLevelErrors = LoadBytecode.GetAssemblyLevelCompileOptionsDiagnostics(context.SyntaxProvider);
+
+        // Output the diagnostics
+        context.ReportDiagnostics(d2DCompileOptionsAtAssemblyLevelErrors.Select(static (item, token) => item));
+
         // Filter all items to enable caching at a coarse level, and remove diagnostics
         IncrementalValuesProvider<(HierarchyInfo Hierarchy, DispatchDataInfo Dispatch, InputTypesInfo InputTypes, HlslShaderSourceInfo Source)> shaderInfo =
             shaderInfoWithErrors

--- a/src/ComputeSharp.D2D1/Attributes/D2DCompileOptionsAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DCompileOptionsAttribute.cs
@@ -16,12 +16,17 @@ namespace ComputeSharp.D2D1;
 /// </para>
 /// <para>
 /// </para>
+/// <para>
 /// Note that the <see cref="D2D1CompileOptions.PackMatrixRowMajor"/> is always enabled automatically and does not need to be
 /// specified. This option is mandatory, as the generated code to load the constant buffer from a shader assumes the layout
 /// for matrix types is row major. For the same reason, using <see cref="D2D1CompileOptions.PackMatrixColumnMajor"/> is not
 /// allowed, as it would cause the constant buffer retrieved from a shader to be potentially incorrect.
+/// </para>
+/// <para>
+/// This attribute can also be added to a whole assembly, and will be used by default if not overridden by a shader type.
+/// </para>
 /// </summary>
-[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = false)]
 public sealed class D2DCompileOptionsAttribute : Attribute
 {
     /// <summary>

--- a/src/ComputeSharp.D2D1/Attributes/D2DEmbeddedBytecodeAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DEmbeddedBytecodeAttribute.cs
@@ -16,10 +16,15 @@ namespace ComputeSharp.D2D1;
 /// </para>
 /// <para>
 /// </para>
+/// <para>
 /// The runtime compilation will automatically be skipped if the shader bytecode is then retrieved using a matching profile,
 /// otherwise the usual runtime compilation will be used as fallback (or an exception will be thrown, depending on the API).
+/// </para>
+/// <para>
+/// This attribute can also be added to a whole assembly, and will be used by default if not overridden by a shader type.
+/// </para>
 /// </summary>
-[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = false)]
 public sealed class D2DEmbeddedBytecodeAttribute : Attribute
 {
     /// <summary>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ComputeSharp.Core\ComputeSharp.Core.csproj" />
+    <ProjectReference Include="..\..\src\ComputeSharp.Core.SourceGenerators\ComputeSharp.Core.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\..\src\ComputeSharp.D2D1\ComputeSharp.D2D1.csproj" />
+    <ProjectReference Include="..\..\src\ComputeSharp.D2D1.SourceGenerators\ComputeSharp.D2D1.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using ComputeSharp.D2D1.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.D2D1.Tests.AssemblyLevelAttributes;
+
+[TestClass]
+[TestCategory("D2D1PixelShader")]
+public partial class D2D1PixelShaderTests
+{
+    [TestMethod]
+    public unsafe void ShaderWithAssemblyLevelAttributes()
+    {
+        ReadOnlyMemory<byte> bytecode = D2D1PixelShader.LoadBytecode<ShaderWithNoCompileAttributes>();
+
+        // Verify the shader was precompiled
+        Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out MemoryManager<byte>? manager));
+        Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
+
+        D2D1PixelShader.LoadBytecode<ShaderWithNoCompileAttributes>(
+            shaderProfile: D2D1ShaderProfile.PixelShader41,
+            options: D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.PartialPrecision);
+
+        // Verify the expected options were used
+        Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out manager));
+        Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
+    }
+
+    [D2DInputCount(3)]
+    [D2DInputSimple(0)]
+    [D2DInputSimple(1)]
+    [D2DInputSimple(2)]
+    private readonly partial struct ShaderWithNoCompileAttributes : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            float4 dst = D2D.GetInput(0);
+            float4 src = D2D.GetInput(1);
+            float4 srcMask = D2D.GetInput(2);
+            float4 result = ((1 - srcMask) * dst) + (srcMask * src);
+
+            return result;
+        }
+    }
+
+    [TestMethod]
+    public unsafe void ShaderWithAssemblyLevelAttributesAndOverriddenProfile()
+    {
+        ReadOnlyMemory<byte> bytecode = D2D1PixelShader.LoadBytecode<ShaderWithOverriddenProfile>();
+
+        Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out MemoryManager<byte>? manager));
+        Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
+
+        D2D1PixelShader.LoadBytecode<ShaderWithOverriddenProfile>(
+            shaderProfile: D2D1ShaderProfile.PixelShader50,
+            options: D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.PartialPrecision);
+
+        Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out manager));
+        Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
+    }
+
+    [D2DInputCount(3)]
+    [D2DInputSimple(0)]
+    [D2DInputSimple(1)]
+    [D2DInputSimple(2)]
+    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+    private readonly partial struct ShaderWithOverriddenProfile : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            float4 dst = D2D.GetInput(0);
+            float4 src = D2D.GetInput(1);
+            float4 srcMask = D2D.GetInput(2);
+            float4 result = ((1 - srcMask) * dst) + (srcMask * src);
+
+            return result;
+        }
+    }
+
+    [TestMethod]
+    public unsafe void ShaderWithAssemblyLevelAttributesAndOverriddenOptions()
+    {
+        ReadOnlyMemory<byte> bytecode = D2D1PixelShader.LoadBytecode<ShaderWithOverriddenOptions>();
+
+        Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out MemoryManager<byte>? manager));
+        Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
+
+        D2D1PixelShader.LoadBytecode<ShaderWithOverriddenOptions>(
+            shaderProfile: D2D1ShaderProfile.PixelShader41,
+            options: D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision);
+
+        Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out manager));
+        Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
+    }
+
+    [D2DInputCount(3)]
+    [D2DInputSimple(0)]
+    [D2DInputSimple(1)]
+    [D2DInputSimple(2)]
+    [D2DCompileOptions(D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision)]
+    private readonly partial struct ShaderWithOverriddenOptions : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            float4 dst = D2D.GetInput(0);
+            float4 src = D2D.GetInput(1);
+            float4 srcMask = D2D.GetInput(2);
+            float4 result = ((1 - srcMask) * dst) + (srcMask * src);
+
+            return result;
+        }
+    }
+
+    [TestMethod]
+    public unsafe void ShaderWithAssemblyLevelAttributesAndEverythingOverridden()
+    {
+        ReadOnlyMemory<byte> bytecode = D2D1PixelShader.LoadBytecode<ShaderWithOverriddenProfileAndOptions>();
+
+        Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out MemoryManager<byte>? manager));
+        Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
+
+        D2D1PixelShader.LoadBytecode<ShaderWithOverriddenProfileAndOptions>(
+            shaderProfile: D2D1ShaderProfile.PixelShader50,
+            options: D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision);
+
+        Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out manager));
+        Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
+    }
+
+    [D2DInputCount(3)]
+    [D2DInputSimple(0)]
+    [D2DInputSimple(1)]
+    [D2DInputSimple(2)]
+    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+    [D2DCompileOptions(D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision)]
+    private readonly partial struct ShaderWithOverriddenProfileAndOptions : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            float4 dst = D2D.GetInput(0);
+            float4 src = D2D.GetInput(1);
+            float4 srcMask = D2D.GetInput(2);
+            float4 result = ((1 - srcMask) * dst) + (srcMask * src);
+
+            return result;
+        }
+    }
+}

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/Properties/AssemblyInfo.cs
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using ComputeSharp.D2D1;
+
+[assembly: D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader41)]
+[assembly: D2DCompileOptions(D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.PartialPrecision)]


### PR DESCRIPTION
### Closes #289

### Description

This PR enables `[D2DEmbeddedBytecode]` and `[D2DCompileOptions]` to be used at the assembly level. If they're also used to a annotate a given shader type, those attributes will take precedence. Otherwise, the assembly-level ones will be used.