### PR TITLE
Improve WinUI 3 sample app

### DIFF
--- a/samples/ComputeSharp.SwapChain.WinUI/App.xaml.cs
+++ b/samples/ComputeSharp.SwapChain.WinUI/App.xaml.cs
@@ -1,4 +1,6 @@
-﻿using ComputeSharp.SwapChain.WinUI.Views;
+﻿using System;
+using System.Threading;
+using ComputeSharp.SwapChain.WinUI.Views;
 using Microsoft.UI.Xaml;
 
 namespace ComputeSharp.SwapChain.WinUI;
@@ -6,12 +8,18 @@ namespace ComputeSharp.SwapChain.WinUI;
 /// <summary>
 /// Provides application-specific behavior to supplement the default Application class.
 /// </summary>
-public partial class App : Application
+public sealed partial class App : Application
 {
     /// <summary>
     /// The main application window
     /// </summary>
-    private Window? mainWindow;
+    private MainWindow? mainWindow;
+
+    /// <summary>
+    /// A timer to force shutdown after a given amount of time.
+    /// </summary>
+    /// <remarks>This field is needed to keep the timer alive.</remarks>
+    private Timer? shutdownTimer;
 
     /// <summary>
     /// Initializes the singleton application object.  This is the first line of authored code
@@ -26,7 +34,18 @@ public partial class App : Application
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
         mainWindow = new MainWindow();
-        mainWindow.Closed += (_, _) => Exit();
+        mainWindow.Closed += (_, _) =>
+        {
+            // Due to an issue (https://discord.com/channels/372137812037730304/663434534087426129/979543152853663744), the WinUI 3 app
+            // will keep running after the window is closed if any render thread is still going. To work around this, each loaded shader
+            // panel is tracked in a conditional weak table, and then when the window is closed they're all manually stopped by setting
+            // their shader runners to null. After this, the app should just be able to close automatically when the panels are done.
+            mainWindow.OnShutdown();
+
+            // For good measure, also start a timer of one second. If the app is still alive by then (ie. if the timer callback is
+            // executed at all), then just force the whole process to terminate, and exit with the E_APPLICATION_EXITING error code.
+            shutdownTimer = new Timer(_ => Environment.Exit(unchecked((int)(0x8000001A))), this, 1000, Timeout.Infinite);
+        };
         mainWindow.Activate();
     }
 }

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -5,7 +5,7 @@
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>ComputeSharp.SwapChain.WinUI</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <Platforms>x64;ARM64</Platforms>
+    <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
     <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
@@ -13,11 +13,6 @@
     <DefineConstants>$(DefineConstants);SAMPLE_APP</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest">
-      <SubType>Designer</SubType>
-    </AppxManifest>
-  </ItemGroup>
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />
@@ -38,6 +33,11 @@
     <PackageReference Include="CommunityToolkit.WinUI.UI.Media" Version="7.1.2" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
+    
+  <!-- Ensure the MSIX extension is activated even if the WinAppSDK package hasn't been restored yet -->
+  <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
+    <ProjectCapability Include="Msix"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ComputeSharp.Core.SourceGenerators\ComputeSharp.Core.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
@@ -46,6 +46,5 @@
   </ItemGroup>
 
   <Import Project="..\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems" Label="Shared" />
-
   <Import Project="..\ComputeSharp.SwapChain.Core.Shared\ComputeSharp.SwapChain.Core.Shared.projitems" Label="Shared" />
 </Project>

--- a/samples/ComputeSharp.SwapChain.WinUI/Properties/PublishProfiles/win10-arm64.pubxml
+++ b/samples/ComputeSharp.SwapChain.WinUI/Properties/PublishProfiles/win10-arm64.pubxml
@@ -1,19 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-https://go.microsoft.com/fwlink/?LinkID=208121.
--->
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>ARM64</Platform>
+    <Platform>arm64</Platform>
     <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
-   <!-- 
-    See https://github.com/microsoft/CsWinRT/issues/373
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <!-- 
+      See https://github.com/microsoft/CsWinRT/issues/373
+      <PublishTrimmed>True</PublishTrimmed>
     -->
   </PropertyGroup>
 </Project>

--- a/samples/ComputeSharp.SwapChain.WinUI/Properties/PublishProfiles/win10-x64.pubxml
+++ b/samples/ComputeSharp.SwapChain.WinUI/Properties/PublishProfiles/win10-x64.pubxml
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-https://go.microsoft.com/fwlink/?LinkID=208121.
--->
+<!-- https://go.microsoft.com/fwlink/?LinkID=208121 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
@@ -10,10 +8,11 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
-   <!-- 
-    See https://github.com/microsoft/CsWinRT/issues/373
-    <PublishTrimmed>True</PublishTrimmed>
+    <PublishReadyToRun Condition="'$(Configuration)' == 'Debug'">False</PublishReadyToRun>
+    <PublishReadyToRun Condition="'$(Configuration)' != 'Debug'">True</PublishReadyToRun>
+    <!-- 
+      See https://github.com/microsoft/CsWinRT/issues/373
+      <PublishTrimmed>True</PublishTrimmed>
     -->
   </PropertyGroup>
 </Project>

--- a/samples/ComputeSharp.SwapChain.WinUI/Views/MainWindow.xaml
+++ b/samples/ComputeSharp.SwapChain.WinUI/Views/MainWindow.xaml
@@ -119,7 +119,7 @@
                                     <Grid>
 
                                         <!--  Shader preview  -->
-                                        <computesharp:AnimatedComputeShaderPanel ShaderRunner="{x:Bind ShaderRunner}" />
+                                        <computesharp:AnimatedComputeShaderPanel Loaded="AnimatedComputeShaderPanel_Loaded" ShaderRunner="{x:Bind ShaderRunner}" />
 
                                         <!--
                                             Note: here we have a selection property to work around {x:Bind} not working correctly outside of the

--- a/samples/ComputeSharp.SwapChain.WinUI/Views/MainWindow.xaml.cs
+++ b/samples/ComputeSharp.SwapChain.WinUI/Views/MainWindow.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using ComputeSharp.SwapChain.Core.Services;
 using ComputeSharp.SwapChain.Core.ViewModels;
+using ComputeSharp.WinUI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Input;
 
@@ -11,6 +13,11 @@ namespace ComputeSharp.SwapChain.WinUI.Views;
 /// </summary>
 public sealed partial class MainWindow : Window
 {
+    /// <summary>
+    /// The mapping of currently alive shader panels.
+    /// </summary>
+    private readonly ConditionalWeakTable<AnimatedComputeShaderPanel, object?> shaderPanels = new();
+
     public MainWindow()
     {
         this.InitializeComponent();
@@ -25,6 +32,19 @@ public sealed partial class MainWindow : Window
     /// Gets the <see cref="MainViewModel"/> instance for the current view.
     /// </summary>
     public MainViewModel ViewModel => (MainViewModel)Root.DataContext;
+
+    /// <summary>
+    /// Stops all rendering when the application is closing.
+    /// </summary>
+    public void OnShutdown()
+    {
+        ShaderPanel.ShaderRunner = null;
+
+        foreach (var (panel, _) in this.shaderPanels)
+        {
+            panel.ShaderRunner = null;
+        }
+    }
 
     // Opens the shader selection panel
     private void OpenShaderSelectionPanelButton_Click(object sender, RoutedEventArgs e)
@@ -43,5 +63,11 @@ public sealed partial class MainWindow : Window
     private void UserControl_SizeChanged(object sender, WindowSizeChangedEventArgs e)
     {
         ShadersListContainerPanel.Height = Math.Round(e.Size.Height * 0.35);
+    }
+
+    // Tracks the current panel
+    private void AnimatedComputeShaderPanel_Loaded(object sender, RoutedEventArgs e)
+    {
+        this.shaderPanels.AddOrUpdate((AnimatedComputeShaderPanel)sender, null);
     }
 }


### PR DESCRIPTION
### Description

This PR fixes the WinUI 3 sample app always crashing when closing the window.
It also makes Debug builds faster by disabling ReadyToRun in that configuration.
