### PR TITLE
Add missing ID2D1DrawInfo::AddRef calls

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
@@ -321,6 +321,15 @@ partial struct PixelShaderEffect
         {
             @this = (PixelShaderEffect*)&((void**)@this)[-1];
 
+            // Free the previous ID2D1DrawInfo object, if present
+            if (@this->d2D1DrawInfo is not null)
+            {
+                _ = @this->d2D1DrawInfo->Release();
+            }
+
+            // Store the new ID2D1DrawInfo object
+            _ = drawInfo->AddRef();
+
             @this->d2D1DrawInfo = drawInfo;
 
             // Set the pixel shader for the effect

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -374,6 +374,11 @@ internal unsafe partial struct PixelShaderEffect
 
             this.d2D1TransformMapperHandle.Free();
 
+            if (this.d2D1DrawInfo is not null)
+            {
+                _ = this.d2D1DrawInfo->Release();
+            }
+
             NativeMemory.Free(Unsafe.AsPointer(ref this));
         }
 

--- a/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/ID2D1DrawInfo.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/ID2D1DrawInfo.cs
@@ -21,6 +21,22 @@ namespace TerraFX.Interop.DirectX
         public void** lpVtbl;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [VtblIndex(1)]
+        [return: NativeTypeName("ULONG")]
+        public uint AddRef()
+        {
+            return ((delegate* unmanaged[Stdcall]<IUnknown*, uint>)(lpVtbl[1]))((IUnknown*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [VtblIndex(2)]
+        [return: NativeTypeName("ULONG")]
+        public uint Release()
+        {
+            return ((delegate* unmanaged[Stdcall]<IUnknown*, uint>)(lpVtbl[2]))((IUnknown*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [VtblIndex(3)]
         public HRESULT SetInputDescription([NativeTypeName("UINT32")] uint inputIndex, D2D1_INPUT_DESCRIPTION inputDescription)
         {


### PR DESCRIPTION
### Closes #286

### Description

This PR adds missing `ID2D1DrawInfo::AddRef` calls in the `ID2D1Effect` implementation.