### PR TITLE
Fix double literals rewriting

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
@@ -22,6 +22,11 @@ namespace ComputeSharp.D2D1.SourceGenerators.SyntaxRewriters;
 internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
 {
     /// <summary>
+    /// An array with the <c>'.'</c> and <c>'E'</c> characters.
+    /// </summary>
+    private static readonly char[] FloatLiteralSpecialCharacters = { '.', 'E' };
+
+    /// <summary>
     /// The <see cref="SemanticModelProvider"/> instance with semantic info on the target syntax tree.
     /// </summary>
     protected readonly SemanticModelProvider SemanticModel;
@@ -195,7 +200,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
                 string literal = updatedNode.Token.ValueText;
 
                 // If the numeric literal is neither a decimal nor an exponential, add the ".0" suffix
-                if (literal.IndexOfAny(new[] { '.', 'E' }) == -1)
+                if (literal.IndexOfAny(FloatLiteralSpecialCharacters) == -1)
                 {
                     literal += ".0";
                 }
@@ -208,7 +213,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
 
                 // If the numeric literal is neither a decimal nor an exponential, add the ".0L" suffix.
                 // This is necessary because otherwise integer literals would actually be of type long.
-                if (literal.IndexOfAny(new[] { '.', 'E' }) == -1)
+                if (literal.IndexOfAny(FloatLiteralSpecialCharacters) == -1)
                 {
                     literal += ".0L";
                 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
@@ -190,7 +190,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
             // used in the HLSL representation. Floating point values accept either f or F, but they don't work
             // when the literal doesn't contain a decimal point. Since 32 bit floating point values are the default
             // in HLSL, we can remove the suffix entirely. As for 64 bit values, we simply use the 'L' suffix.
-            if (type.GetFullMetadataName().Equals(typeof(float).FullName))
+            if (type.SpecialType == SpecialType.System_Single)
             {
                 string literal = updatedNode.Token.ValueText;
 
@@ -202,9 +202,22 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
 
                 return updatedNode.WithToken(Literal(literal, 0f));
             }
-            else if (type.GetFullMetadataName().Equals(typeof(double).FullName))
+            else if (type.SpecialType == SpecialType.System_Double)
             {
-                return updatedNode.WithToken(Literal(updatedNode.Token.ValueText + "L", 0d));
+                string literal = updatedNode.Token.ValueText;
+
+                // If the numeric literal is neither a decimal nor an exponential, add the ".0L" suffix.
+                // This is necessary because otherwise integer literals would actually be of type long.
+                if (literal.IndexOfAny(new[] { '.', 'E' }) == -1)
+                {
+                    literal += ".0L";
+                }
+                else
+                {
+                    literal += "L";
+                }
+
+                return updatedNode.WithToken(Literal(literal, 0d));
             }
         }
         else if (updatedNode.IsKind(SyntaxKind.StringLiteralExpression))

--- a/src/ComputeSharp.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
@@ -195,7 +195,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
             // used in the HLSL representation. Floating point values accept either f or F, but they don't work
             // when the literal doesn't contain a decimal point. Since 32 bit floating point values are the default
             // in HLSL, we can remove the suffix entirely. As for 64 bit values, we simply use the 'L' suffix.
-            if (type.GetFullMetadataName().Equals(typeof(float).FullName))
+            if (type.SpecialType == SpecialType.System_Single)
             {
                 string literal = updatedNode.Token.ValueText;
 
@@ -207,9 +207,22 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
 
                 return updatedNode.WithToken(Literal(literal, 0f));
             }
-            else if (type.GetFullMetadataName().Equals(typeof(double).FullName))
+            else if (type.SpecialType == SpecialType.System_Double)
             {
-                return updatedNode.WithToken(Literal(updatedNode.Token.ValueText + "L", 0d));
+                string literal = updatedNode.Token.ValueText;
+
+                // If the numeric literal is neither a decimal nor an exponential, add the ".0L" suffix.
+                // This is necessary because otherwise integer literals would actually be of type long.
+                if (literal.IndexOfAny(new[] { '.', 'E' }) == -1)
+                {
+                    literal += ".0L";
+                }
+                else
+                {
+                    literal += "L";
+                }
+
+                return updatedNode.WithToken(Literal(literal, 0d));
             }
         }
         else if (updatedNode.IsKind(SyntaxKind.StringLiteralExpression))

--- a/src/ComputeSharp.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
@@ -22,6 +22,11 @@ namespace ComputeSharp.SourceGenerators.SyntaxRewriters;
 internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
 {
     /// <summary>
+    /// An array with the <c>'.'</c> and <c>'E'</c> characters.
+    /// </summary>
+    private static readonly char[] FloatLiteralSpecialCharacters = { '.', 'E' };
+
+    /// <summary>
     /// The <see cref="SemanticModelProvider"/> instance with semantic info on the target syntax tree.
     /// </summary>
     protected readonly SemanticModelProvider SemanticModel;
@@ -200,7 +205,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
                 string literal = updatedNode.Token.ValueText;
 
                 // If the numeric literal is neither a decimal nor an exponential, add the ".0" suffix
-                if (literal.IndexOfAny(new[] { '.', 'E' }) == -1)
+                if (literal.IndexOfAny(FloatLiteralSpecialCharacters) == -1)
                 {
                     literal += ".0";
                 }
@@ -213,7 +218,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
 
                 // If the numeric literal is neither a decimal nor an exponential, add the ".0L" suffix.
                 // This is necessary because otherwise integer literals would actually be of type long.
-                if (literal.IndexOfAny(new[] { '.', 'E' }) == -1)
+                if (literal.IndexOfAny(FloatLiteralSpecialCharacters) == -1)
                 {
                     literal += ".0L";
                 }

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -147,6 +147,10 @@ public partial class ShaderRewriterTests
         Assert.AreEqual(results[3], -(float)Math.Sin((float)(137.2 / 180.0 * Constants.PI2)), 0.0001f);
         Assert.AreEqual(results[4], (float)Math.Cos(Math.Sin(ConstantsInShaderConstantFieldsShader.sin)), 0.0001f);
         Assert.AreEqual(results[5], (float)(Math.Sin(ConstantsInShaderConstantFieldsShader.sin) + Math.Cos(Math.Sin(ConstantsInShaderConstantFieldsShader.sin))), 0.0001f);
+        Assert.AreEqual(results[6], ConstantsInShaderConstantFieldsShader.exponentLowercase, 0.0001f);
+        Assert.AreEqual(results[7], ConstantsInShaderConstantFieldsShader.exponentUppercase, 0.0001f);
+        Assert.AreEqual(results[8], ConstantsInShaderConstantFieldsShader.exponentLowercaseField, 0.0001f);
+        Assert.AreEqual(results[9], ConstantsInShaderConstantFieldsShader.exponentUppercaseField, 0.0001f);
     }
 
     private static class Constants
@@ -160,11 +164,15 @@ public partial class ShaderRewriterTests
         public const float rot_angle = (float)(137.2 / 180.0 * Math.PI);
         public const float rot_angle2 = rot_angle + (float)Math.E * 100;
         public const float sin = 42;
+        public const float exponentLowercase = 1234567e-4f;
+        public const float exponentUppercase = 1234567E-4f;
 
         private static readonly float rot_11 = Hlsl.Cos(rot_angle);
         private static readonly float rot_12 = -Hlsl.Sin((float)(137.2 / 180.0 * Constants.PI2));
         private static readonly float cos = Hlsl.Cos(Hlsl.Sin(sin));
         private static readonly float lerp = Hlsl.Sin(sin) + cos;
+        public static readonly float exponentLowercaseField = 1234567e-4f;
+        public static readonly float exponentUppercaseField = 1234567E-4f;
 
         public readonly ReadWriteBuffer<float> buffer;
 
@@ -176,6 +184,10 @@ public partial class ShaderRewriterTests
             buffer[3] = rot_12;
             buffer[4] = cos;
             buffer[5] = lerp;
+            buffer[6] = exponentLowercase;
+            buffer[7] = exponentUppercase;
+            buffer[8] = exponentLowercaseField;
+            buffer[9] = exponentUppercaseField;
         }
     }
 
@@ -189,8 +201,8 @@ public partial class ShaderRewriterTests
             Assert.Inconclusive();
         }
 
-        using ReadWriteBuffer<float> buffer1 = device.Get().AllocateReadWriteBuffer<float>(4);
-        using ReadWriteBuffer<double> buffer2 = device.Get().AllocateReadWriteBuffer<double>(4);
+        using ReadWriteBuffer<float> buffer1 = device.Get().AllocateReadWriteBuffer<float>(8);
+        using ReadWriteBuffer<double> buffer2 = device.Get().AllocateReadWriteBuffer<double>(8);
 
         device.Get().For(1, new DoubleConstantsInShaderConstantFieldsShader(buffer1, buffer2));
 
@@ -200,6 +212,10 @@ public partial class ShaderRewriterTests
         Assert.AreEqual(results1[1], DoubleConstantsInShaderConstantFieldsShader.DoubleToFloatField, 0.0001f);
         Assert.AreEqual(results1[2], DoubleConstants.PI, 0.0001f);
         Assert.AreEqual(results1[3], (float)(1 / 255.0), 0.0001f);
+        Assert.AreEqual(results1[4], DoubleConstantsInShaderConstantFieldsShader.floatExponentLowercase, 0.0001f);
+        Assert.AreEqual(results1[5], DoubleConstantsInShaderConstantFieldsShader.floatExponentUppercase, 0.0001f);
+        Assert.AreEqual(results1[6], DoubleConstantsInShaderConstantFieldsShader.floatExponentLowercaseField, 0.0001f);
+        Assert.AreEqual(results1[7], DoubleConstantsInShaderConstantFieldsShader.floatExponentUppercaseField, 0.0001f);
 
         double[] results2 = buffer2.ToArray();
 
@@ -207,6 +223,10 @@ public partial class ShaderRewriterTests
         Assert.AreEqual(results2[1], DoubleConstantsInShaderConstantFieldsShader.DoubleField, 0.0001f);
         Assert.AreEqual(results2[2], DoubleConstants.PI2, 0.0001f);
         Assert.AreEqual(results2[3], 1 / 255.0, 0.0001f);
+        Assert.AreEqual(results2[4], DoubleConstantsInShaderConstantFieldsShader.exponentLowercase, 0.0001f);
+        Assert.AreEqual(results2[5], DoubleConstantsInShaderConstantFieldsShader.exponentUppercase, 0.0001f);
+        Assert.AreEqual(results2[6], DoubleConstantsInShaderConstantFieldsShader.exponentLowercaseField, 0.0001f);
+        Assert.AreEqual(results2[7], DoubleConstantsInShaderConstantFieldsShader.exponentUppercaseField, 0.0001f);
     }
 
     private static class DoubleConstants
@@ -220,9 +240,17 @@ public partial class ShaderRewriterTests
     {
         public const float DoubleToFloatConstant = (float)(1 / 255.0);
         public const double DoubleConstant = 1.0 / 255;
+        public const float floatExponentLowercase = (float)1234567e-4;
+        public const float floatExponentUppercase = (float)1234567E-4;
+        public const double exponentLowercase = 1234567e-4;
+        public const double exponentUppercase = 1234567E-4;
 
         public static readonly float DoubleToFloatField = (float)(1D / 255);
         public static readonly double DoubleField = 1 / 255D;
+        public static readonly float floatExponentLowercaseField = (float)1234567e-4;
+        public static readonly float floatExponentUppercaseField = (float)1234567E-4;
+        public static readonly double exponentLowercaseField = 1234567e-4;
+        public static readonly double exponentUppercaseField = 1234567E-4;
 
         public readonly ReadWriteBuffer<float> buffer1;
         public readonly ReadWriteBuffer<double> buffer2;
@@ -236,11 +264,19 @@ public partial class ShaderRewriterTests
             buffer1[1] = DoubleToFloatField;
             buffer1[2] = DoubleConstants.PI;
             buffer1[3] = localFloat;
+            buffer1[4] = floatExponentLowercase;
+            buffer1[5] = floatExponentUppercase;
+            buffer1[6] = floatExponentLowercaseField;
+            buffer1[7] = floatExponentUppercaseField;
 
             buffer2[0] = DoubleConstant;
             buffer2[1] = DoubleField;
             buffer2[2] = DoubleConstants.PI2;
             buffer2[3] = localDouble;
+            buffer2[4] = exponentLowercase;
+            buffer2[5] = exponentUppercase;
+            buffer2[6] = exponentLowercaseField;
+            buffer2[7] = exponentUppercaseField;
         }
     }
 }


### PR DESCRIPTION
### Closes #279

### Description

This PR fixes the HLSL rewriter handling of non decimal double literals.
