### PR TITLE
Rewrite reserved keywords in custom type field names

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -337,15 +337,21 @@ partial class ID2D1ShaderGenerator
                     INamedTypeSymbol fieldType = (INamedTypeSymbol)field.Type;
 
                     // Convert the name to the fully qualified HLSL version
-                    if (!HlslKnownTypes.TryGetMappedName(fieldType.GetFullMetadataName(), out string? mapped))
+                    if (!HlslKnownTypes.TryGetMappedName(fieldType.GetFullMetadataName(), out string? mappedType))
                     {
-                        mapped = fieldType.GetFullMetadataName().ToHlslIdentifierName();
+                        mappedType = fieldType.GetFullMetadataName().ToHlslIdentifierName();
+                    }
+
+                    // Get the field name as a valid HLSL identifier
+                    if (!HlslKnownKeywords.TryGetMappedName(field.Name, out string? mappedName))
+                    {
+                        mappedName = field.Name;
                     }
 
                     structDeclaration = structDeclaration.AddMembers(
                         FieldDeclaration(VariableDeclaration(
-                            IdentifierName(mapped!)).AddVariables(
-                            VariableDeclarator(Identifier(field.Name)))));
+                            IdentifierName(mappedType!)).AddVariables(
+                            VariableDeclarator(Identifier(mappedName!)))));
                 }
 
                 // Insert the trailing ; right after the closing bracket (after normalization)

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -143,7 +143,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(inputCountInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getInputCountMethod = GetInputCount.GetSyntax(item.InputCount);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getInputCountMethod, false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getInputCountMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FilenameHint}.{nameof(GetInputCount)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -158,7 +158,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(inputTypesInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getInputTypeMethod = GetInputType.GetSyntax(item.InputTypes.InputTypes);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getInputTypeMethod, false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getInputTypeMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FilenameHint}.{nameof(GetInputType)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -173,7 +173,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(dispatchDataInfo.Combine(canUseSkipLocalsInit), static (context, item) =>
         {
             MethodDeclarationSyntax loadDispatchDataMethod = LoadDispatchData.GetSyntax(item.Left.Dispatch);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, loadDispatchDataMethod, item.Right);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, loadDispatchDataMethod, canUseSkipLocalsInit: item.Right);
 
             context.AddSource($"{item.Left.Hierarchy.FilenameHint}.{nameof(LoadDispatchData)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -182,7 +182,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(dispatchDataInfo, static (context, item) =>
         {
             MethodDeclarationSyntax loadDispatchDataMethod = InitializeFromDispatchData.GetSyntax(item.Dispatch);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, loadDispatchDataMethod, false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, loadDispatchDataMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FilenameHint}.{nameof(InitializeFromDispatchData)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -264,7 +264,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(embeddedBytecode, static (context, item) =>
         {
             MethodDeclarationSyntax loadBytecodeMethod = LoadBytecode.GetSyntax(item.BytecodeInfo, out Func<SyntaxNode, SourceText> fixup);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, loadBytecodeMethod, false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, loadBytecodeMethod, canUseSkipLocalsInit: false);
             SourceText text = fixup(compilationUnit);
 
             context.AddSource($"{item.Hierarchy.FilenameHint}.{nameof(LoadBytecode)}", text);
@@ -291,7 +291,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(outputBufferInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getOutputBufferMethod = GetOutputBuffer.GetSyntax(item.Info);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getOutputBufferMethod, false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getOutputBufferMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FilenameHint}.{nameof(GetOutputBuffer)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -327,7 +327,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(inputDescriptionsInfo.Combine(canUseSkipLocalsInit), static (context, item) =>
         {
             MethodDeclarationSyntax loadInputDescriptionsMethod = LoadInputDescriptions.GetSyntax(item.Left.Info);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, loadInputDescriptionsMethod, item.Right);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, loadInputDescriptionsMethod, canUseSkipLocalsInit: item.Right);
 
             context.AddSource($"{item.Left.Hierarchy.FilenameHint}.{nameof(LoadInputDescriptions)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -351,7 +351,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(pixelOptionsInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getPixelOptionsMethod = GetPixelOptions.GetSyntax(item.Options);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getPixelOptionsMethod, false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getPixelOptionsMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FilenameHint}.{nameof(GetPixelOptions)}", compilationUnit.GetText(Encoding.UTF8));
         });

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -465,15 +465,21 @@ partial class IShaderGenerator
                     INamedTypeSymbol fieldType = (INamedTypeSymbol)field.Type;
 
                     // Convert the name to the fully qualified HLSL version
-                    if (!HlslKnownTypes.TryGetMappedName(fieldType.GetFullMetadataName(), out string? mapped))
+                    if (!HlslKnownTypes.TryGetMappedName(fieldType.GetFullMetadataName(), out string? mappedType))
                     {
-                        mapped = fieldType.GetFullMetadataName().ToHlslIdentifierName();
+                        mappedType = fieldType.GetFullMetadataName().ToHlslIdentifierName();
+                    }
+
+                    // Get the field name as a valid HLSL identifier
+                    if (!HlslKnownKeywords.TryGetMappedName(field.Name, out string? mappedName))
+                    {
+                        mappedName = field.Name;
                     }
 
                     structDeclaration = structDeclaration.AddMembers(
                         FieldDeclaration(VariableDeclaration(
-                            IdentifierName(mapped!)).AddVariables(
-                            VariableDeclarator(Identifier(field.Name)))));
+                            IdentifierName(mappedType!)).AddVariables(
+                            VariableDeclarator(Identifier(mappedName!)))));
                 }
 
                 // Insert the trailing ; right after the closing bracket (after normalization)

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.cs
@@ -71,7 +71,7 @@ public sealed partial class IShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(hierarchyAndDispatchIdInfo.Combine(supportsDynamicShaders), static (context, item) =>
         {
             MethodDeclarationSyntax getDispatchIdMethod = GetDispatchId.GetSyntax(item.Left.Info.Delegates, item.Right);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, getDispatchIdMethod, false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, getDispatchIdMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Left.Hierarchy.FilenameHint}.{nameof(GetDispatchId)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -159,7 +159,7 @@ public sealed partial class IShaderGenerator : IIncrementalGenerator
                 item.Left.FieldInfos,
                 item.Left.ResourceCount,
                 item.Left.Root32BitConstantCount);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, loadDispatchDataMethod, item.Right);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, loadDispatchDataMethod, canUseSkipLocalsInit: item.Right);
 
             context.AddSource($"{item.Left.Hierarchy.FilenameHint}.{nameof(LoadDispatchData)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -180,7 +180,7 @@ public sealed partial class IShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(hlslSourceInfo.Combine(canUseSkipLocalsInit).Combine(canUseRawMultiLineStringLiterals), static (context, item) =>
         {
             MethodDeclarationSyntax buildHlslStringMethod = BuildHlslSource.GetSyntax(item.Left.Left.SourceInfo, item.Left.Left.SupportsDynamicShaders, item.Left.Left.Hierarchy.Hierarchy.Length, item.Right);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Left.Hierarchy, buildHlslStringMethod, item.Right);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Left.Hierarchy, buildHlslStringMethod, canUseSkipLocalsInit: item.Left.Right);
 
             context.AddSource($"{item.Left.Left.Hierarchy.FilenameHint}.{nameof(BuildHlslSource)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -206,7 +206,7 @@ public sealed partial class IShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(dispatchMetadataInfo.Combine(canUseSkipLocalsInit), static (context, item) =>
         {
             MethodDeclarationSyntax buildHlslStringMethod = LoadDispatchMetadata.GetSyntax(item.Left.MetadataInfo);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, buildHlslStringMethod, item.Right);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, buildHlslStringMethod, canUseSkipLocalsInit: item.Right);
 
             context.AddSource($"{item.Left.Hierarchy.FilenameHint}.{nameof(LoadDispatchMetadata)}", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -264,7 +264,7 @@ public sealed partial class IShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(embeddedBytecode.Combine(supportsDynamicShaders), static (context, item) =>
         {
             MethodDeclarationSyntax tryGetBytecodeMethod = LoadBytecode.GetSyntax(item.Left.BytecodeInfo, item.Right, out Func<SyntaxNode, SourceText> fixup);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, tryGetBytecodeMethod, false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Left.Hierarchy, tryGetBytecodeMethod, canUseSkipLocalsInit: false);
             SourceText text = fixup(compilationUnit);
 
             context.AddSource($"{item.Left.Hierarchy.FilenameHint}.{nameof(LoadBytecode)}", text);

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -33,6 +33,44 @@ namespace ComputeSharp.Tests
         }
 
         [TestMethod]
+        public void ReservedKeywordsInCustomTypes()
+        {
+            _ = ReflectionServices.GetShaderInfo<ReservedKeywordsInCustomTypesShader>();
+        }
+
+        public struct CellData
+        {
+            public float testX;
+            public float testY;
+            public uint seed;
+
+            public float distance;
+            public readonly float dword;
+            public readonly float float2;
+            public readonly int int2x2;
+        }
+
+        [AutoConstructor]
+        public readonly partial struct ReservedKeywordsInCustomTypesShader : IComputeShader
+        {
+            public readonly ReadWriteBuffer<float> row_major;
+            public readonly CellData cellData;
+            public readonly float dword;
+            public readonly float float2;
+            public readonly int int2x2;
+            public readonly CellData cbuffer;
+
+            public void Execute()
+            {
+                float exp = Hlsl.Exp(cellData.distance * row_major[ThreadIds.X]);
+                float log = Hlsl.Log(1 + exp);
+                float temp = log + cellData.dword + cellData.int2x2;
+
+                row_major[ThreadIds.X] = log / dword + float2 + int2x2 + cbuffer.float2;
+            }
+        }
+
+        [TestMethod]
         public void ReservedKeywordsPrecompiled()
         {
             _ = ReflectionServices.GetShaderInfo<ReservedKeywordsPrecompiledShader>();


### PR DESCRIPTION
### Closes #278

### Description

This PR updates the HLSL rewriters to properly handle reserved keywords used as field names in custom types.