### PR TITLE
Fix generator with out of range simple inputs

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -116,6 +116,12 @@ partial class ID2D1ShaderGenerator
         /// <returns>Whether the shader only has simple inputs.</returns>
         public static bool IsSimpleInputShader(INamedTypeSymbol structDeclarationSymbol, int inputCount)
         {
+            // If there are no inputs, the shader is as if only had simple inputs
+            if (inputCount == 0)
+            {
+                return true;
+            }
+
             // Build a map of all simple inputs (unmarked inputs default to being complex)
             bool[] simpleInputsMap = new bool[inputCount];
 
@@ -123,8 +129,11 @@ partial class ID2D1ShaderGenerator
             {
                 switch (attributeData.AttributeClass?.GetFullMetadataName())
                 {
-                    case "ComputeSharp.D2D1.D2DInputSimpleAttribute":
-                        simpleInputsMap[(int)attributeData.ConstructorArguments[0].Value!] = true;
+                    // Only retrieve indices of simple inputs that are in range. If an input is out of
+                    // range, the diagnostic for it will already be emitted by a previous generator step.
+                    case "ComputeSharp.D2D1.D2DInputSimpleAttribute"
+                    when attributeData.ConstructorArguments[0].Value is int index && index < inputCount:
+                        simpleInputsMap[index] = true;
                         break;
                 }
             }


### PR DESCRIPTION
### Closes #304

### Description

This PR fixes a generator crash when using out of range simple inputs.

### New behavior

<img width="529" alt="image" src="https://user-images.githubusercontent.com/10199417/172251455-b364380b-5880-4848-bf49-0868568c7006.png">
