### PR TITLE
Add zero-alloc D2D1PixelShader.GetConstantBuffer APIs

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
@@ -264,6 +264,17 @@ public static class D2D1PixelShader
     }
 
     /// <summary>
+    /// Gets the size of the constant buffer for a D2D1 pixel shader of a specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to retrieve info for.</typeparam>
+    /// <returns>The size of the constant buffer for a D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static int GetConstantBufferSize<T>()
+        where T : unmanaged, ID2D1PixelShader
+    {
+        return D2D1BufferSizeDispatchDataLoader.For<T>.ConstantBufferSize;
+    }
+
+    /// <summary>
     /// Gets the constant buffer from an input D2D1 pixel shader.
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to retrieve info for.</typeparam>

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1BufferSizeDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1BufferSizeDispatchDataLoader.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using ComputeSharp.D2D1.__Internals;
+using TerraFX.Interop.DirectX;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.D2D1.Shaders.Loaders;
+
+/// <summary>
+/// A data loader for D2D1 pixel shaders dispatched via <see cref="ID2D1DrawInfo"/>, to just retrieve the constant buffer size.
+/// </summary>
+internal unsafe struct D2D1BufferSizeDispatchDataLoader : ID2D1DispatchDataLoader
+{
+    /// <summary>
+    /// The size of the constant buffer.
+    /// </summary>
+    private int size;
+
+    /// <summary>
+    /// Gets the size of the constant buffer.
+    /// </summary>
+    /// <returns>The size of the constant buffer.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int GetConstantBufferSize()
+    {
+        return this.size;
+    }
+
+    /// <inheritdoc/>
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
+    {
+        this.size = data.Length * sizeof(uint);
+    }
+
+    /// <summary>
+    /// A helper class caching computed constant buffer sizes for generic shaders.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to retrieve info for.</typeparam>
+    public static class For<T>
+        where T : unmanaged, ID2D1PixelShader
+    {
+        /// <summary>
+        /// Gets the constant buffer size for a shader of type <typeparamref name="T"/>.
+        /// </summary>
+        public static int ConstantBufferSize { get; } = GetConstantBufferSize();
+
+        /// <summary>
+        /// Calculates the constant buffer size for a shader of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <returns>The constant buffer size for a shader of type <typeparamref name="T"/>.</returns>
+        private static int GetConstantBufferSize()
+        {
+            D2D1BufferSizeDispatchDataLoader dataLoader = default;
+
+            Unsafe.SkipInit(out T shader);
+
+            shader.LoadDispatchData(ref dataLoader);
+
+            return dataLoader.GetConstantBufferSize();
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayDispatchDataLoader.cs
@@ -21,7 +21,7 @@ internal struct D2D1ByteArrayDispatchDataLoader : ID2D1DispatchDataLoader
     /// <summary>
     /// Gets the resulting pixel shader constant buffer.
     /// </summary>
-    /// <remarks>A <see cref="byte"/> array with the constant buffer for the current shader.</remarks>
+    /// <returns>A <see cref="byte"/> array with the constant buffer for the current shader.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public byte[] GetResultingDispatchData()
     {

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayInputDescriptionsLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayInputDescriptionsLoader.cs
@@ -22,7 +22,7 @@ internal struct D2D1ByteArrayInputDescriptionsLoader : ID2D1InputDescriptionsLoa
     /// <summary>
     /// Gets the resulting input descriptions.
     /// </summary>
-    /// <remarks>A <see cref="D2D1InputDescription"/> array with the available input descriptions.</remarks>
+    /// <returns>A <see cref="D2D1InputDescription"/> array with the available input descriptions.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public D2D1InputDescription[] GetResultingInputDescriptions()
     {

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteBufferDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteBufferDispatchDataLoader.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using ComputeSharp.D2D1.__Internals;
+using TerraFX.Interop.DirectX;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.D2D1.Shaders.Loaders;
+
+/// <summary>
+/// A data loader for D2D1 pixel shaders dispatched via <see cref="ID2D1DrawInfo"/>.
+/// </summary>
+internal unsafe struct D2D1ByteBufferDispatchDataLoader : ID2D1DispatchDataLoader
+{
+    /// <summary>
+    /// The target buffer to write data to.
+    /// </summary>
+    private readonly byte* buffer;
+
+    /// <summary>
+    /// The length of the buffer pointed to by <see cref="buffer"/>.
+    /// </summary>
+    private readonly int length;
+
+    /// <summary>
+    /// The number of written bytes.
+    /// </summary>
+    private int writtenBytes;
+
+    /// <summary>
+    /// Creates a new <see cref="D2D1ByteBufferDispatchDataLoader"/> instance.
+    /// </summary>
+    /// <param name="buffer">The target buffer to write data to.</param>
+    /// <param name="length">The length of the buffer pointed to by <see cref="buffer"/>.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal D2D1ByteBufferDispatchDataLoader(byte* buffer, int length)
+    {
+        this.buffer = buffer;
+        this.length = length;
+        this.writtenBytes = 0;
+    }
+
+    /// <summary>
+    /// Gets the number of written bytes, or <c>0</c> in case of failure.
+    /// </summary>
+    /// <param name="writtenBytes">The number of written bytes, of <c>0</c> in case of failure.</param>
+    /// <returns>Whether or not the constant buffer was retrieved successfully.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetWrittenBytes(out int writtenBytes)
+    {
+        return (writtenBytes = this.writtenBytes) != 0;
+    }
+
+    /// <inheritdoc/>
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
+    {
+        ReadOnlySpan<byte> constantBuffer = MemoryMarshal.Cast<uint, byte>(data);
+
+        if (constantBuffer.TryCopyTo(new Span<byte>(this.buffer, this.length)))
+        {
+            this.writtenBytes = constantBuffer.Length;
+        }
+    }
+}

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -277,6 +277,19 @@ public partial class D2D1PixelShaderTests
     }
 
     [TestMethod]
+    public unsafe void GetConstantBufferSize()
+    {
+        int size = D2D1PixelShader.GetConstantBufferSize<ShaderWithScalarVectorAndMatrixTypes>();
+
+        Assert.AreEqual(size, 124);
+
+        // Repeated calls always return the same result
+        size = D2D1PixelShader.GetConstantBufferSize<ShaderWithScalarVectorAndMatrixTypes>();
+
+        Assert.AreEqual(size, 124);
+    }
+
+    [TestMethod]
     public unsafe void GetConstantBuffer_ReadOnlyMemory()
     {
         GetShaderWithScalarVectorAndMatrixTypes(out ShaderWithScalarVectorAndMatrixTypes shader);


### PR DESCRIPTION
### Closes #306 

### Description

This PR adds two `Span<byte>`-based APIs to get the constant buffer of a pixel shader.

### API breakdown

```csharp
namespace ComputeSharp.D2D1.Interop;

public static class D2D1PixelShader
{
    static int GetConstantBufferSize<T>();
    static int GetConstantBuffer<T>(in T shader, Span<byte> span);
    static bool TryGetConstantBuffer<T>(in T shader, Span<byte> span, out int bytesWritten);
}
```