### PR TITLE
Improve NuGet packaging

### DIFF
--- a/src/ComputeSharp.Core.Package/ComputeSharp.Core.Package.msbuildproj
+++ b/src/ComputeSharp.Core.Package/ComputeSharp.Core.Package.msbuildproj
@@ -19,4 +19,11 @@
     <ProjectReference Include="..\ComputeSharp.Core.SourceGenerators\ComputeSharp.Core.SourceGenerators.csproj" PackFolder="analyzers\dotnet\cs" />
   </ItemGroup>
 
+  <ItemGroup Label="Package">
+
+    <!-- Include the custom .targets file to check the source generator (.NET 6 is not needed as it guarantees Roslyn 4.x) -->
+    <None Include="..\ComputeSharp.Core\ComputeSharp.Core.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
+    <None Include="..\ComputeSharp.Core\ComputeSharp.Core.targets" PackagePath="build\netstandard2.0" Pack="true" />
+  </ItemGroup>
+
 </Project>

--- a/src/ComputeSharp.Core/ComputeSharp.Core.csproj
+++ b/src/ComputeSharp.Core/ComputeSharp.Core.csproj
@@ -228,11 +228,4 @@
 
   <!-- Shared project with .NET Standard 2.0 polyfills -->
   <Import Condition="'$(TargetFramework)' == 'netstandard2.0'" Project="..\ComputeSharp.Core.NetStandard\ComputeSharp.Core.NetStandard.projitems" Label="Shared" />
-
-  <ItemGroup Label="Package">
-
-    <!-- Include the custom .targets file to check the source generator (.NET 6 is not needed as it guarantees Roslyn 4.x) -->
-    <None Include="ComputeSharp.Core.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
-    <None Include="ComputeSharp.Core.targets" PackagePath="build\netstandard2.0" Pack="true" />
-  </ItemGroup>
 </Project>

--- a/src/ComputeSharp.Core/ComputeSharp.Core.targets
+++ b/src/ComputeSharp.Core/ComputeSharp.Core.targets
@@ -1,17 +1,17 @@
 <Project>
 
   <!-- Get the analyzer from the ComputeSharp.Core NuGet package -->
-  <Target Name="_ComputeSharpGatherAnalyzers">
+  <Target Name="_ComputeSharpCoreGatherAnalyzers">
     <ItemGroup>
-      <_ComputeSharpAnalyzer Include="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' == 'ComputeSharp.Core'" />
+      <_ComputeSharpCoreAnalyzer Include="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' == 'ComputeSharp.Core'" />
     </ItemGroup>
   </Target>
 
   <!-- Remove the analyzer if using Roslyn 3.x (incremental generators require Roslyn 4.x) -->
-  <Target Name="_ComputeSharpRemoveAnalyzersForRoslyn3"
+  <Target Name="_ComputeSharpCoreRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
-          DependsOnTargets="_ComputeSharpGatherAnalyzers">
+          DependsOnTargets="_ComputeSharpCoreGatherAnalyzers">
 
     <!-- Use the CSharpCoreTargetsPath property to find the version of the compiler we are using. This is the same mechanism
          MSBuild uses to find the compiler. We could check the assembly version for any compiler assembly (since they all have
@@ -32,21 +32,21 @@
 
     <!-- If the Roslyn version is < 4.0, disable the source generators -->
     <ItemGroup Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'">
-      <Analyzer Remove="@(_ComputeSharpAnalyzer)"/>
+      <Analyzer Remove="@(_ComputeSharpCoreAnalyzer)"/>
     </ItemGroup>
 
     <!-- There is no need to emit a warning here, as this package is always a transitive dependency from ComputeSharp, which does emit the warning -->
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->
-  <Target Name="_ComputeSharpRemoveAnalyzersForRosynNotFound"
+  <Target Name="_ComputeSharpCoreRemoveAnalyzersForRosynNotFound"
           Condition="'$(CSharpCoreTargetsPath)' == ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
-          DependsOnTargets="_ComputeSharpGatherAnalyzers">
+          DependsOnTargets="_ComputeSharpCoreGatherAnalyzers">
 
     <!-- If no Roslyn assembly could be found, just remove the analyzer without emitting a warning -->
     <ItemGroup>
-      <Analyzer Remove="@(_ComputeSharpAnalyzer)"/>
+      <Analyzer Remove="@(_ComputeSharpCoreAnalyzer)"/>
     </ItemGroup>
   </Target>
 

--- a/src/ComputeSharp.Core/ComputeSharp.Core.targets
+++ b/src/ComputeSharp.Core/ComputeSharp.Core.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn 3.x (incremental generators require Roslyn 4.x) -->
+  <!-- Remove the analyzer if using Roslyn < 4.2 (ComputeSharp.Core's generators require Roslyn 4.2) -->
   <Target Name="_ComputeSharpCoreRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <CurrentCompilerVersion>@(CurrentCompilerAssemblyIdentity->'%(Version)')</CurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(CurrentCompilerVersion), 4.0))">true</CurrentCompilerVersionIsNotNewEnough>
+      <CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(CurrentCompilerVersion), 4.2))">true</CurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.0, disable the source generators -->
+    <!-- If the Roslyn version is < 4.2, disable the source generators -->
     <ItemGroup Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpCoreAnalyzer)"/>
     </ItemGroup>

--- a/src/ComputeSharp.D2D1.Package/ComputeSharp.D2D1.Package.msbuildproj
+++ b/src/ComputeSharp.D2D1.Package/ComputeSharp.D2D1.Package.msbuildproj
@@ -25,4 +25,11 @@
     </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup Label="Package">
+
+    <!-- Include the custom .targets file to check the source generator (.NET 6 is not needed as it guarantees Roslyn 4.x) -->
+    <None Include="..\ComputeSharp.D2D1\ComputeSharp.D2D1.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
+    <None Include="..\ComputeSharp.D2D1\ComputeSharp.D2D1.targets" PackagePath="build\netstandard2.0" Pack="true" />
+  </ItemGroup>
+
 </Project>

--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.csproj
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.csproj
@@ -32,11 +32,4 @@
 
   <!-- Shared project with .NET Standard 2.0 polyfills -->
   <Import Condition="'$(TargetFramework)' == 'netstandard2.0'" Project="..\ComputeSharp.D2D1.NetStandard\ComputeSharp.D2D1.NetStandard.projitems" Label="Shared" />
-
-  <ItemGroup Label="Package">
-
-    <!-- Include the custom .targets file to check the source generator (.NET 6 is not needed as it guarantees Roslyn 4.x) -->
-    <None Include="ComputeSharp.D2D1.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
-    <None Include="ComputeSharp.D2D1.targets" PackagePath="build\netstandard2.0" Pack="true" />
-  </ItemGroup>
 </Project>

--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.csproj
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.csproj
@@ -32,4 +32,11 @@
 
   <!-- Shared project with .NET Standard 2.0 polyfills -->
   <Import Condition="'$(TargetFramework)' == 'netstandard2.0'" Project="..\ComputeSharp.D2D1.NetStandard\ComputeSharp.D2D1.NetStandard.projitems" Label="Shared" />
+
+  <ItemGroup Label="Package">
+
+    <!-- Include the custom .targets file to check the source generator (.NET 6 is not needed as it guarantees Roslyn 4.x) -->
+    <None Include="ComputeSharp.D2D1.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
+    <None Include="ComputeSharp.D2D1.targets" PackagePath="build\netstandard2.0" Pack="true" />
+  </ItemGroup>
 </Project>

--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
@@ -1,17 +1,17 @@
 <Project>
 
   <!-- Get the analyzer from the ComputeSharp.D2D1 NuGet package -->
-  <Target Name="_ComputeSharpGatherAnalyzers">
+  <Target Name="_ComputeSharpD2D1GatherAnalyzers">
     <ItemGroup>
-      <_ComputeSharpAnalyzer Include="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' == 'ComputeSharp.D2D1'" />
+      <_ComputeSharpD2D1Analyzer Include="@(Analyzer)" Condition="'%(Analyzer.NuGetPackageId)' == 'ComputeSharp.D2D1'" />
     </ItemGroup>
   </Target>
 
   <!-- Remove the analyzer if using Roslyn 3.x (incremental generators require Roslyn 4.x) -->
-  <Target Name="_ComputeSharpRemoveAnalyzersForRoslyn3"
+  <Target Name="_ComputeSharpD2D1RemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
-          DependsOnTargets="_ComputeSharpGatherAnalyzers">
+          DependsOnTargets="_ComputeSharpD2D1GatherAnalyzers">
 
     <!-- Use the CSharpCoreTargetsPath property to find the version of the compiler we are using. This is the same mechanism
          MSBuild uses to find the compiler. We could check the assembly version for any compiler assembly (since they all have
@@ -32,7 +32,7 @@
 
     <!-- If the Roslyn version is < 4.0, disable the source generators -->
     <ItemGroup Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'">
-      <Analyzer Remove="@(_ComputeSharpAnalyzer)"/>
+      <Analyzer Remove="@(_ComputeSharpD2D1Analyzer)"/>
     </ItemGroup>
 
     <!-- If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
@@ -42,14 +42,14 @@
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->
-  <Target Name="_ComputeSharpRemoveAnalyzersForRosynNotFound"
+  <Target Name="_ComputeSharpD2D1RemoveAnalyzersForRosynNotFound"
           Condition="'$(CSharpCoreTargetsPath)' == ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
-          DependsOnTargets="_ComputeSharpGatherAnalyzers">
+          DependsOnTargets="_ComputeSharpD2D1GatherAnalyzers">
 
     <!-- If no Roslyn assembly could be found, just remove the analyzer without emitting a warning -->
     <ItemGroup>
-      <Analyzer Remove="@(_ComputeSharpAnalyzer)"/>
+      <Analyzer Remove="@(_ComputeSharpD2D1Analyzer)"/>
     </ItemGroup>
   </Target>
 

--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn 3.x (incremental generators require Roslyn 4.x) -->
+  <!-- Remove the analyzer if using Roslyn < 4.2 (ComputeSharp.D2D1's generators require Roslyn 4.2) -->
   <Target Name="_ComputeSharpD2D1RemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <CurrentCompilerVersion>@(CurrentCompilerAssemblyIdentity->'%(Version)')</CurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(CurrentCompilerVersion), 4.0))">true</CurrentCompilerVersionIsNotNewEnough>
+      <CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(CurrentCompilerVersion), 4.2))">true</CurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.0, disable the source generators -->
+    <!-- If the Roslyn version is < 4.2, disable the source generators -->
     <ItemGroup Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpD2D1Analyzer)"/>
     </ItemGroup>
@@ -38,7 +38,7 @@
     <!-- If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
          emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
          disabled, and that ComputeSharp will not work at all unless a more up to date IDE or compiler version are used. -->
-    <Error Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp.D2D1 source generators have been disabled on the current configuration, as they need Roslyn 4.x in order to work. ComputeSharp.D2D1 requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
+    <Error Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp.D2D1 source generators have been disabled on the current configuration, as they need Roslyn 4.2 in order to work. ComputeSharp.D2D1 requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->

--- a/src/ComputeSharp.Package/ComputeSharp.Package.msbuildproj
+++ b/src/ComputeSharp.Package/ComputeSharp.Package.msbuildproj
@@ -25,4 +25,11 @@
     </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup Label="Package">
+
+    <!-- Include the custom .targets file to check the source generator (.NET 6 is not needed as it guarantees Roslyn 4.x) -->
+    <None Include="..\ComputeSharp\ComputeSharp.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
+    <None Include="..\ComputeSharp\ComputeSharp.targets" PackagePath="build\netstandard2.0" Pack="true" />
+  </ItemGroup>
+
 </Project>

--- a/src/ComputeSharp/ComputeSharp.csproj
+++ b/src/ComputeSharp/ComputeSharp.csproj
@@ -41,11 +41,4 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
-    
-  <ItemGroup Label="Package">
-
-    <!-- Include the custom .targets file to check the source generator (.NET 6 is not needed as it guarantees Roslyn 4.x) -->
-    <None Include="ComputeSharp.targets" PackagePath="buildTransitive\netstandard2.0" Pack="true" />
-    <None Include="ComputeSharp.targets" PackagePath="build\netstandard2.0" Pack="true" />
-  </ItemGroup>
 </Project>

--- a/src/ComputeSharp/ComputeSharp.targets
+++ b/src/ComputeSharp/ComputeSharp.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn 3.x (incremental generators require Roslyn 4.x) -->
+  <!-- Remove the analyzer if using Roslyn < 4.2 (ComputeSharp's generators require Roslyn 4.2) -->
   <Target Name="_ComputeSharpRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <CurrentCompilerVersion>@(CurrentCompilerAssemblyIdentity->'%(Version)')</CurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(CurrentCompilerVersion), 4.0))">true</CurrentCompilerVersionIsNotNewEnough>
+      <CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(CurrentCompilerVersion), 4.2))">true</CurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.0, disable the source generators -->
+    <!-- If the Roslyn version is < 4.2, disable the source generators -->
     <ItemGroup Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpAnalyzer)"/>
     </ItemGroup>
@@ -38,7 +38,7 @@
     <!-- If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
          emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
          disabled, and that ComputeSharp will not work at all unless a more up to date IDE or compiler version are used. -->
-    <Error Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp source generators have been disabled on the current configuration, as they need Roslyn 4.x in order to work. ComputeSharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
+    <Error Condition ="'$(CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp source generators have been disabled on the current configuration, as they need Roslyn 4.2 in order to work. ComputeSharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->


### PR DESCRIPTION
This PR includes some packaging fixes:

- Added missing .targets file to `ComputeSharp.D2D1`
- Fixed `ComputeSharp.Dynamic` accidentally bundling the .targets file from `ComputeSharp.Core`