### PR TITLE
Fix ComputeSharp.Core packing within ComputeSharp.Dynamic

### DIFF
--- a/src/ComputeSharp.Dynamic.Package/ComputeSharp.Dynamic.Package.msbuildproj
+++ b/src/ComputeSharp.Dynamic.Package/ComputeSharp.Dynamic.Package.msbuildproj
@@ -22,6 +22,14 @@
     <ProjectReference Include="..\ComputeSharp.Package\ComputeSharp.Package.msbuildproj" TargetFramework="netstandard2.0">
       <AdditionalProperties>PackageVersion=$(PackageVersion)</AdditionalProperties>
     </ProjectReference>
+
+    <!-- Also include the ComputeSharp.Core reference, so that it's packed as a package reference, and not as binaries -->
+    <ProjectReference Include="..\ComputeSharp.Core.Package\ComputeSharp.Core.Package.msbuildproj" TargetFramework="net6.0">
+      <AdditionalProperties>PackageVersion=$(PackageVersion)</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="..\ComputeSharp.Core.Package\ComputeSharp.Core.Package.msbuildproj" TargetFramework="netstandard2.0">
+      <AdditionalProperties>PackageVersion=$(PackageVersion)</AdditionalProperties>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Follow up to #309. This PR fixes the `ComputeSharp.Core` packing within `ComputeSharp.Dynamic`.
Previously, `ComputeSharp.Core` was added as binaries in the NuGet package.
This PR fixes the packing so that `ComputeSharp.Core` is instead added as a NuGet package reference.