### PR TITLE
Add more HLSL reserved keywords to HLSL rewriter

### DIFF
--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
@@ -31,7 +31,16 @@ internal static partial class HlslKnownKeywords
             "sampler", "shared", "snorm", "stateblock", "stateblock_state", "tbuffer",
             "technique", "typedef", "triangle", "triangleadj", "uniform", "unorm",
             "unsigned", "vector", "vertexfragment", "zero", "float1", "double1",
-            "int1", "uint1", "bool1"
+            "int1", "uint1", "bool1", "fragmentKeyword", "compile_fragment", "shaderProfile",
+            "maxvertexcount", "TriangleStream", "Buffer", "ByteAddressBuffer", "ConsumeStructuredBuffer",
+            "InputPatch", "OutputPatch", "RWBuffer", "RWByteAddressBuffer", "RWStructuredBuffer",
+            "RWTexture1D", "RWTexture1DArray", "RWTexture2D", "RWTexture2DArray", "RWTexture3D",
+            "StructuredBuffer", "Texture1D", "Texture1DArray", "Texture2D", "Texture2DArray",
+            "Texture3D", "Texture2DMS", "Texture2DMSArray", "TextureCube", "TextureCubeArray",
+            "SV_DispatchThreadID", "SV_DomainLocation", "SV_GroupID", "SV_GroupIndex", "SV_GroupThreadID",
+            "SV_GSInstanceID", "SV_InsideTessFactor", "SV_OutputControlPointID", "SV_TessFactor",
+            "SV_InnerCoverage", "SV_StencilRef"
+
         });
 
         // HLSL primitive names

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -70,6 +70,48 @@ namespace ComputeSharp.Tests
             }
         }
 
+        // See https://github.com/Sergio0694/ComputeSharp/issues/313
+        [TestMethod]
+        public void ReservedKeywordsFromHlslTypesAndBuiltInValues()
+        {
+            _ = ReflectionServices.GetShaderInfo<ReservedKeywordsFromHlslTypesAndBuiltInValuesShader>();
+        }
+
+        [AutoConstructor]
+        public readonly partial struct ReservedKeywordsFromHlslTypesAndBuiltInValuesShader : IComputeShader
+        {
+            public readonly ReadWriteBuffer<float> fragmentKeyword;
+            public readonly ReadWriteBuffer<float> compile_fragment;
+            public readonly ReadWriteBuffer<float> shaderProfile;
+            public readonly ReadWriteBuffer<float> maxvertexcount;
+            public readonly ReadWriteBuffer<float> TriangleStream;
+            public readonly ReadWriteBuffer<float> Buffer;
+            public readonly ReadWriteBuffer<float> ByteAddressBuffer;
+            public readonly int ConsumeStructuredBuffer;
+            public readonly int RWTexture2D;
+            public readonly int Texture2D;
+            public readonly int Texture2DArray;
+            public readonly int SV_DomainLocation;
+            public readonly int SV_GroupIndex;
+            public readonly int SV_OutputControlPointID;
+            public readonly int SV_StencilRef;
+
+            public void Execute()
+            {
+                float sum = ConsumeStructuredBuffer + RWTexture2D + Texture2D + Texture2DArray;
+
+                sum += SV_DomainLocation + SV_GroupIndex + SV_OutputControlPointID + SV_StencilRef;
+
+                fragmentKeyword[ThreadIds.X] = sum;
+                compile_fragment[ThreadIds.X] = sum;
+                shaderProfile[ThreadIds.X] = sum;
+                maxvertexcount[ThreadIds.X] = sum;
+                TriangleStream[ThreadIds.X] = sum;
+                Buffer[ThreadIds.X] = sum;
+                ByteAddressBuffer[ThreadIds.X] = sum;
+            }
+        }
+
         [TestMethod]
         public void ReservedKeywordsPrecompiled()
         {


### PR DESCRIPTION
### Fixes #313

### Description

This PR adds more HLSL reserved keywords and unit tests.