### PR TITLE
Fix unit tests assembly initialize methods

### DIFF
--- a/src/ComputeSharp.Dynamic/Attributes/__Internals/ShaderMethodSourceAttribute.HlslGeneration.cs
+++ b/src/ComputeSharp.Dynamic/Attributes/__Internals/ShaderMethodSourceAttribute.HlslGeneration.cs
@@ -17,6 +17,7 @@ partial class ShaderMethodSourceAttribute : Attribute
         {
             if (mapping.Add(constant.Key))
             {
+                builder.Append('\n');
                 builder.Append("#define ");
                 builder.Append(constant.Key);
                 builder.Append(' ');

--- a/tests/ComputeSharp.D2D1.Tests/EndToEndTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/EndToEndTests.cs
@@ -15,7 +15,7 @@ namespace ComputeSharp.D2D1.Tests;
 public class EndToEndTests
 {
     [AssemblyInitialize]
-    public static void ConfigureImageSharp()
+    public static void ConfigureImageSharp(TestContext _)
     {
         Configuration.Default.PreferContiguousImageBuffers = true;
     }

--- a/tests/ComputeSharp.Tests/ImagingTests.cs
+++ b/tests/ComputeSharp.Tests/ImagingTests.cs
@@ -20,7 +20,7 @@ namespace ComputeSharp.Tests;
 public class ImagingTests
 {
     [AssemblyInitialize]
-    public static void ConfigureImageSharp()
+    public static void ConfigureImageSharp(TestContext _)
     {
         Configuration.Default.PreferContiguousImageBuffers = true;
     }

--- a/tests/ComputeSharp.Tests/ImagingTests.cs
+++ b/tests/ComputeSharp.Tests/ImagingTests.cs
@@ -516,7 +516,7 @@ public class ImagingTests
 
         original.Save(expectedPath);
 
-        TolerantImageComparer.AssertEqual(expectedPath, actualPath, 0.00004037f);
+        TolerantImageComparer.AssertEqual(expectedPath, actualPath, 0.00004038f);
     }
 
     [CombinatorialTestMethod]


### PR DESCRIPTION
Fixes the signature of the assembly initialize methods for the unit test projects.
The initialize methods are needed to configure ImageSharp to use contiguous buffers.