### PR TITLE
Add diagnostic for missing [D2DRequiresPosition] attribute

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -51,3 +51,4 @@ CMPSD2D0041 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0042 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0043 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0044 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0045 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -634,4 +634,20 @@ internal static class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A D2D1 shader generated with ComputeSharp.D2D1 (or an assembly) cannot use the PackMatrixColumnMajor option, as that is not compatible with the generated code used to load shader constant buffers.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[D2DRequiresPosition]</c> attribute is missing.
+    /// <para>
+    /// Format: <c>"The D2D1 shader of type {0} is calling a D2D1 API or another method that require the [D2DRequiresPosition] attribute to be used, but the shader type is not annotated accordingly"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor MissingD2DRequiresPositionAttribute = new DiagnosticDescriptor(
+        id: "CMPSD2D0045",
+        title: "Missing [D2DRequiresPosition] attribute",
+        messageFormat: "The D2D1 shader of type {0} is calling a D2D1 API or another method that require the [D2DRequiresPosition] attribute to be used, but the shader type is not annotated accordingly",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A D2D1 shader using functionality that needs position info (ie. when [D2DRequiresPosition] is used) needs to be annotated accordingly.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -638,16 +638,16 @@ internal static class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[D2DRequiresPosition]</c> attribute is missing.
     /// <para>
-    /// Format: <c>"The D2D1 shader of type {0} is calling a D2D1 API or another method that require the [D2DRequiresPosition] attribute to be used, but the shader type is not annotated accordingly"</c>.
+    /// Format: <c>"The D2D1 shader of type {0} is using D2D1 APIs that require the [D2DRequiresPosition] attribute to be used (that is, D2D1.GetScenePosition() and D2D1.SampleInputAtPosition(int, float2)), but the shader type is not annotated accordingly"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor MissingD2DRequiresPositionAttribute = new DiagnosticDescriptor(
         id: "CMPSD2D0045",
         title: "Missing [D2DRequiresPosition] attribute",
-        messageFormat: "The D2D1 shader of type {0} is calling a D2D1 API or another method that require the [D2DRequiresPosition] attribute to be used, but the shader type is not annotated accordingly",
+        messageFormat: "The D2D1 shader of type {0} is using D2D1 APIs that require the [D2DRequiresPosition] attribute to be used (that is, D2D.GetScenePosition() and D2D.SampleInputAtPosition(int, float2)), but the shader type is not annotated accordingly",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A D2D1 shader using functionality that needs position info (ie. when [D2DRequiresPosition] is used) needs to be annotated accordingly.",
+        description: "A D2D1 shader using functionality that needs position info (ie. when [D2DRequiresPosition] is used, which is mandatory when calling either D2D.GetScenePosition() or D2D.SampleInputAtPosition(int, float2)) needs to be annotated accordingly.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
@@ -10,6 +10,17 @@ namespace ComputeSharp.SourceGeneration.Mappings;
 /// <inheritdoc/>
 partial class HlslKnownMethods
 {
+    /// <summary>
+    /// Checks whether or not a method name (previous matched with <see cref="TryGetMappedName(string, out string?)"/>
+    /// needs the <c>[D2DRequiresPosition]</c> annotation on its containing shader in order to be used.
+    /// </summary>
+    /// <param name="name">The fully qualified metadata name.</param>
+    /// <returns>Whether the method needs the <c>[D2DRequiresPosition]</c> annotation.</returns>
+    public static bool NeedsD2DRequiresPositionAttribute(string name)
+    {
+        return name == "ComputeSharp.D2D1.D2D.GetScenePosition";
+    }
+
     /// <inheritdoc/>
 
     static partial void AddKnownMethods(IDictionary<string, string> knownMethods)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
@@ -18,7 +18,7 @@ partial class HlslKnownMethods
     /// <returns>Whether the method needs the <c>[D2DRequiresPosition]</c> annotation.</returns>
     public static bool NeedsD2DRequiresPositionAttribute(string name)
     {
-        return name == "ComputeSharp.D2D1.D2D.GetScenePosition";
+        return name is "ComputeSharp.D2D1.D2D.GetScenePosition" or "ComputeSharp.D2D1.D2D.SampleInputAtPosition";
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp.D2D1.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/SyntaxRewriters/HlslSourceRewriter.cs
@@ -65,6 +65,11 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
         Diagnostics = diagnostics;
     }
 
+    /// <summary>
+    /// Gets whether or not the shader needs the <c>[D2DRequiresPosition]</c> attribute.
+    /// </summary>
+    public bool NeedsD2DRequiresPositionAttribute { get; protected set; }
+
     /// <inheritdoc/>
     public override SyntaxNode VisitCastExpression(CastExpressionSyntax node)
     {

--- a/src/ComputeSharp.D2D1.SourceGenerators/SyntaxRewriters/StaticFieldRewriter.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/SyntaxRewriters/StaticFieldRewriter.cs
@@ -94,9 +94,16 @@ internal sealed class StaticFieldRewriter : HlslSourceRewriter
             operation.TargetMethod is IMethodSymbol method &&
             method.IsStatic)
         {
+            string metadataName = method.GetFullMetadataName();
+
             // Rewrite HLSL intrinsic methods
-            if (HlslKnownMethods.TryGetMappedName(method.GetFullMetadataName(), out string? mapping))
+            if (HlslKnownMethods.TryGetMappedName(metadataName, out string? mapping))
             {
+                if (HlslKnownMethods.NeedsD2DRequiresPositionAttribute(metadataName))
+                {
+                    NeedsD2DRequiresPositionAttribute = true;
+                }
+
                 return updatedNode.WithExpression(ParseExpression(mapping!));
             }
         }


### PR DESCRIPTION
### Closes #293

### Description

This PR adds a new diagnostic when a shader uses APIs that require scene position, without the attribute on the shader type.

![image](https://user-images.githubusercontent.com/10199417/183300180-e92d9cb4-ad14-4945-9ebc-ae08080a283d.png)