### PR TITLE
Simplify D2D1 constant buffer load generator, fix size limit

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -430,17 +430,17 @@ internal static class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for a shader with a root signature that is too large.
     /// <para>
-    /// Format: <c>"The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values and resources"</c>.
+    /// Format: <c>"The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor ShaderDispatchDataSizeExceeded = new DiagnosticDescriptor(
         id: "CMPSD2D0032",
         title: "Shader dispatch data size exceeded",
-        messageFormat: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values and resources",
+        messageFormat: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values and resources.",
+        description: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -64,11 +64,11 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
                 ImmutableArray<FieldInfo> fieldInfos = LoadDispatchData.GetInfo(
                     diagnostics,
                     item.Left.Symbol,
-                    out int root32BitConstantCount);
+                    out int constantBufferSizeInBytes);
 
                 token.ThrowIfCancellationRequested();
 
-                DispatchDataInfo dispatchDataInfo = new(fieldInfos, root32BitConstantCount);
+                DispatchDataInfo dispatchDataInfo = new(fieldInfos, constantBufferSizeInBytes);
 
                 // Get the input info for GetInputInfo()
                 GetInputType.GetInfo(

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/DispatchDataInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/DispatchDataInfo.cs
@@ -10,8 +10,8 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// A model representing gathered info on a shader dispatch data.
 /// </summary>
 /// <param name="FieldInfos">The description on shader instance fields.</param>
-/// <param name="Root32BitConstantCount">The size of the shader root signature, in 32 bit constants.</param>
-internal sealed record DispatchDataInfo(ImmutableArray<FieldInfo> FieldInfos, int Root32BitConstantCount)
+/// <param name="ConstantBufferSizeInBytes">The size of the shader constant buffer.</param>
+internal sealed record DispatchDataInfo(ImmutableArray<FieldInfo> FieldInfos, int ConstantBufferSizeInBytes)
 {
     /// <summary>
     /// An <see cref="IEqualityComparer{T}"/> implementation for <see cref="DispatchDataInfo"/>.
@@ -22,7 +22,7 @@ internal sealed record DispatchDataInfo(ImmutableArray<FieldInfo> FieldInfos, in
         protected override void AddToHashCode(ref HashCode hashCode, DispatchDataInfo obj)
         {
             hashCode.AddRange(obj.FieldInfos, FieldInfo.Comparer.Default);
-            hashCode.Add(obj.Root32BitConstantCount);
+            hashCode.Add(obj.ConstantBufferSizeInBytes);
         }
 
         /// <inheritdoc/>
@@ -30,7 +30,7 @@ internal sealed record DispatchDataInfo(ImmutableArray<FieldInfo> FieldInfos, in
         {
             return
                 x.FieldInfos.SequenceEqual(y.FieldInfos, FieldInfo.Comparer.Default) &&
-                x.Root32BitConstantCount == y.Root32BitConstantCount;
+                x.ConstantBufferSizeInBytes == y.ConstantBufferSizeInBytes;
         }
     }
 }

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1DispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1DispatchDataLoader.cs
@@ -14,5 +14,5 @@ public interface ID2D1DispatchDataLoader
     /// Loads the captured values used by the D2D1 shader to be dispatched.
     /// </summary>
     /// <param name="data">The sequence of serialized captured values.</param>
-    void LoadConstantBuffer(ReadOnlySpan<uint> data);
+    void LoadConstantBuffer(ReadOnlySpan<byte> data);
 }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1BufferSizeDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1BufferSizeDispatchDataLoader.cs
@@ -28,9 +28,9 @@ internal unsafe struct D2D1BufferSizeDispatchDataLoader : ID2D1DispatchDataLoade
     }
 
     /// <inheritdoc/>
-    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<byte> data)
     {
-        this.size = data.Length * sizeof(uint);
+        this.size = data.Length;
     }
 
     /// <summary>

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayDispatchDataLoader.cs
@@ -29,8 +29,8 @@ internal struct D2D1ByteArrayDispatchDataLoader : ID2D1DispatchDataLoader
     }
 
     /// <inheritdoc/>
-    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<byte> data)
     {
-        this.data = MemoryMarshal.AsBytes(data).ToArray();
+        this.data = data.ToArray();
     }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteBufferDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteBufferDispatchDataLoader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using ComputeSharp.D2D1.__Internals;
 using TerraFX.Interop.DirectX;
 
@@ -66,13 +65,11 @@ internal unsafe struct D2D1ByteBufferDispatchDataLoader : ID2D1DispatchDataLoade
     }
 
     /// <inheritdoc/>
-    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<byte> data)
     {
-        ReadOnlySpan<byte> constantBuffer = MemoryMarshal.Cast<uint, byte>(data);
-
-        if (constantBuffer.TryCopyTo(new Span<byte>(this.buffer, this.length)))
+        if (data.TryCopyTo(new Span<byte>(this.buffer, this.length)))
         {
-            this.writtenBytes = constantBuffer.Length;
+            this.writtenBytes = data.Length;
         }
     }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1DrawInfoDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1DrawInfoDispatchDataLoader.cs
@@ -29,10 +29,10 @@ internal readonly unsafe struct D2D1DrawInfoDispatchDataLoader : ID2D1DispatchDa
     }
 
     /// <inheritdoc/>
-    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<byte> data)
     {
         this.d2D1DrawInfo->SetPixelShaderConstantBuffer(
             buffer: (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(data)),
-            bufferCount: (uint)data.Length * sizeof(uint));
+            bufferCount: (uint)data.Length);
     }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1EffectDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1EffectDispatchDataLoader.cs
@@ -30,7 +30,7 @@ internal readonly unsafe struct D2D1EffectDispatchDataLoader : ID2D1DispatchData
     }
 
     /// <inheritdoc/>
-    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<uint> data)
+    void ID2D1DispatchDataLoader.LoadConstantBuffer(ReadOnlySpan<byte> data)
     {
         if (data.IsEmpty)
         {
@@ -41,6 +41,6 @@ internal readonly unsafe struct D2D1EffectDispatchDataLoader : ID2D1DispatchData
             index: 0,
             type: D2D1_PROPERTY_TYPE.D2D1_PROPERTY_TYPE_BLOB,
             data: (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(data)),
-            dataSize: (uint)data.Length * sizeof(uint)).Assert();
+            dataSize: (uint)data.Length).Assert();
     }
 }

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.cs
@@ -105,7 +105,7 @@ partial class IShaderGenerator
 
             resourceCount = resourceOffsetAsBox.Value;
 
-            // After all the captured fields have been processed, ansure the reported byte size for
+            // After all the captured fields have been processed, ensure the reported byte size for
             // the local variables is padded to a multiple of a 32 bit value. This is necessary to
             // enable loading all the dispatch data after reinterpreting it to a sequence of values
             // of size 32 bits (via SetComputeRoot32BitConstants), without reading out of bounds.


### PR DESCRIPTION
### Description

This PR cleans up the D2D1 generator for the constant buffer loading (it had a bunch of DX12 copy paste leftovers).
It also bumps the limit of the constant buffer size to reflect what's available on D2D1.