### PR TITLE
Fix [SkipLocalsInit] visibility

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -27,7 +27,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
             context.CompilationProvider
             .Select(static (compilation, token) =>
                 compilation.Options is CSharpCompilationOptions { AllowUnsafe: true } &&
-                compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.SkipLocalsInitAttribute") is not null);
+                compilation.HasAccessibleTypeWithMetadataName("System.Runtime.CompilerServices.SkipLocalsInitAttribute"));
 
         // Get all declared struct types and their type symbols
         IncrementalValuesProvider<(StructDeclarationSyntax Syntax, INamedTypeSymbol Symbol)> structDeclarations =

--- a/src/ComputeSharp.SourceGeneration/ComputeSharp.SourceGeneration.projitems
+++ b/src/ComputeSharp.SourceGeneration/ComputeSharp.SourceGeneration.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AttributeDataExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\CompilationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DiagnosticsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\HashCodeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\IEqualityComparerExtensions.cs" />

--- a/src/ComputeSharp.SourceGeneration/Extensions/CompilationExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/CompilationExtensions.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.SourceGeneration.Extensions;
+
+/// <summary>
+/// Extension methods for the <see cref="Compilation"/> type.
+/// </summary>
+internal static class CompilationExtensions
+{
+    /// <summary>
+    /// <para>
+    /// Checks whether or not a type with a specified metadata name is accessible from a given <see cref="Compilation"/> instance.
+    /// </para>
+    /// <para>
+    /// This method enumerates candidate type symbols to find a match in the following order:
+    /// <list type="number">
+    ///   <item><description>
+    ///     If only one type with the given name is found within the compilation and its referenced assemblies, check its accessibility.
+    ///   </description></item>
+    ///   <item><description>
+    ///     If the current <paramref name="compilation"/> defines the symbol, check its accessibility.
+    ///   </description></item>
+    ///   <item><description>
+    ///     Otherwise, check whether the type exists and is accessible from any of the referenced assemblies.
+    ///   </description></item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>
+    /// <param name="fullyQualifiedMetadataName">The fully-qualified metadata type name to find.</param>
+    /// <returns>Whether a type with the specified metadata name can be accessed from the given compilation.</returns>
+    public static bool HasAccessibleTypeWithMetadataName(this Compilation compilation, string fullyQualifiedMetadataName)
+    {
+        // Try to get the unique type with this name
+        INamedTypeSymbol? type = compilation.GetTypeByMetadataName(fullyQualifiedMetadataName);
+
+        // If there is only a single matching symbol, check its accessibility
+        if (type is not null)
+        {
+            return type.CanBeAccessedFrom(compilation.Assembly);
+        }
+
+        // Otherwise, try to get the unique type with this name originally defined in 'compilation'
+        type ??= compilation.Assembly.GetTypeByMetadataName(fullyQualifiedMetadataName);
+
+        if (type is not null)
+        {
+            return type.CanBeAccessedFrom(compilation.Assembly);
+        }
+
+        // Otherwise, check whether the type is defined and accessible from any of the referenced assemblies
+        foreach (IModuleSymbol module in compilation.Assembly.Modules)
+        {
+            foreach (IAssemblySymbol referencedAssembly in module.ReferencedAssemblySymbols)
+            {
+                if (referencedAssembly.GetTypeByMetadataName(fullyQualifiedMetadataName) is not INamedTypeSymbol currentType)
+                {
+                    continue;
+                }
+
+                switch (currentType.GetEffectiveAccessibility())
+                {
+                    case Accessibility.Public:
+                    case Accessibility.Internal when referencedAssembly.GivesAccessTo(compilation.Assembly):
+                        return true;
+                    default:
+                        continue;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/ComputeSharp.SourceGeneration/Extensions/ISymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/ISymbolExtensions.cs
@@ -180,4 +180,57 @@ internal static class ISymbolExtensions
 
         return false;
     }
+
+    /// <summary>
+    /// Calculates the effective accessibility for a given symbol.
+    /// </summary>
+    /// <param name="symbol">The <see cref="ISymbol"/> instance to check.</param>
+    /// <returns>The effective accessibility for <paramref name="symbol"/>.</returns>
+    public static Accessibility GetEffectiveAccessibility(this ISymbol symbol)
+    {
+        // Start by assuming it's visible
+        Accessibility visibility = Accessibility.Public;
+
+        // Handle special cases
+        switch (symbol.Kind)
+        {
+            case SymbolKind.Alias: return Accessibility.Private;
+            case SymbolKind.Parameter: return GetEffectiveAccessibility(symbol.ContainingSymbol);
+            case SymbolKind.TypeParameter: return Accessibility.Private;
+        }
+
+        // Traverse the symbol hierarchy to determine the effective accessibility
+        while (symbol is not null && symbol.Kind != SymbolKind.Namespace)
+        {
+            switch (symbol.DeclaredAccessibility)
+            {
+                case Accessibility.NotApplicable:
+                case Accessibility.Private:
+                    return Accessibility.Private;
+                case Accessibility.Internal:
+                case Accessibility.ProtectedAndInternal:
+                    visibility = Accessibility.Internal;
+                    break;
+            }
+
+            symbol = symbol.ContainingSymbol;
+        }
+
+        return visibility;
+    }
+
+    /// <summary>
+    /// Checks whether or not a given symbol can be accessed from a specified assembly.
+    /// </summary>
+    /// <param name="symbol">The input <see cref="ISymbol"/> instance to check.</param>
+    /// <param name="assembly">The assembly to check the accessibility of <paramref name="symbol"/> for.</param>
+    /// <returns>Whether <paramref name="assembly"/> can access <paramref name="symbol"/>.</returns>
+    public static bool CanBeAccessedFrom(this ISymbol symbol, IAssemblySymbol assembly)
+    {
+        Accessibility accessibility = symbol.GetEffectiveAccessibility();
+
+        return
+            accessibility == Accessibility.Public ||
+            accessibility == Accessibility.Internal && symbol.ContainingAssembly.GivesAccessTo(assembly);
+    }
 }

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.cs
@@ -28,7 +28,7 @@ public sealed partial class IShaderGenerator : IIncrementalGenerator
             context.CompilationProvider
             .Select(static (compilation, token) =>
                 compilation.Options is CSharpCompilationOptions { AllowUnsafe: true } &&
-                compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.SkipLocalsInitAttribute") is not null);
+                compilation.HasAccessibleTypeWithMetadataName("System.Runtime.CompilerServices.SkipLocalsInitAttribute"));
 
         // Check whether or not dynamic shaders are supported
         IncrementalValueProvider<bool> supportsDynamicShaders =


### PR DESCRIPTION
### Description

This PR adds proper logic to check accessibility of types so that `[SkipLocalsInit]` isn't incorrectly used by the source generators when consuming projects have `<AllowUnsafeBlocks>` set and the attribute somewhere across all referenced assemblies, but not actually accessible to the consuming assembly. Eg. this is the case in a blank UWP project with `<AllowUnsafeBlocks>`.