### PR TITLE
Add [D2DPixelShaderSource] attribute

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -63,3 +63,4 @@ CMPSD2D0053 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0054 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0055 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0056 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0057 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -58,3 +58,8 @@ CMPSD2D0048 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0049 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0050 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0051 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0052 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0053 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0054 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0055 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0056 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -72,7 +72,7 @@
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOptions.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOptions.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DCompileOptionsAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DCompileOptionsAttribute.cs" />
-    <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DEmbeddedBytecodeAttribute.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DShaderProfileAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DShaderProfileAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputComplexAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputSimpleAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputSimpleAttribute.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -76,6 +76,7 @@
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputCountAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DInputSimpleAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DInputSimpleAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DRequiresScenePositionAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DRequiresScenePositionAttribute.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Attributes\D2DPixelShaderSourceAttribute.cs" Link="ComputeSharp.D2D1\Attributes\D2DPixelShaderSourceAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Extensions\ComPtrExtensions.cs" Link="ComputeSharp.D2D1\Extensions\ComPtrExtensions.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Extensions\HResultExtensions.cs" Link="ComputeSharp.D2D1\Extensions\HResultExtensions.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\ID2D1PixelShader.cs" Link="ComputeSharp.D2D1\Interfaces\ID2D1PixelShader.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -64,6 +64,7 @@
     <Compile Include="..\ComputeSharp\Shaders\Dispatching\__Internals\ArrayPoolStringBuilder.cs" Link="ComputeSharp\Shaders\Dispatching\__Internals\ArrayPoolStringBuilder.cs" />
 
     <!-- ComputeSharp.D2D1 APIs -->
+    <Compile Include="..\ComputeSharp.D2D1\Properties\Polyfills\StringSyntaxAttribute.cs" Link="ComputeSharp.D2D1\Properties\Polyfills\StringSyntaxAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1ShaderProfile.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1ShaderProfile.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1BufferPrecision.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1ChannelDepth.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.Syntax.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Text;
+using ComputeSharp.D2D1.SourceGenerators.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class D2DPixelShaderSourceGenerator
+{
+    /// <inheritdoc/>
+    partial class Execute
+    {
+        /// <summary>
+        /// Creates a <see cref="MethodDeclarationSyntax"/> instance for the <c>TryGetBytecode</c> method.
+        /// </summary>
+        /// <param name="bytecodeInfo">The input bytecode info.</param>
+        /// <param name="fixup">An opaque <see cref="Func{TResult}"/> instance to transform the final tree into text.</param>
+        /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the target method.</returns>
+        public static MethodDeclarationSyntax GetSyntax(EmbeddedBytecodeInfo bytecodeInfo, out Func<SyntaxNode, SourceText> fixup)
+        {
+            // If there is no precompiled bytecode, just emit a span with a 0 value
+            string bytecodeLiterals = bytecodeInfo.Bytecode.IsDefaultOrEmpty
+                ? "0"
+                : ID2D1ShaderGenerator.LoadBytecode.BuildShaderBytecodeExpressionString(bytecodeInfo.Bytecode.AsSpan());
+
+            // Prepare the fixup function
+            fixup = tree => SourceText.From(tree.ToFullString().Replace("__EMBEDDED_SHADER_BYTECODE", bytecodeLiterals), Encoding.UTF8);
+
+            // This code produces a branch as follows:
+            //
+            // /// <inheritdoc/>
+            // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
+            // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+            // <MODIFIERS> global::System.ReadOnlySpan<byte> <METHOD_NAME>()
+            // {
+            //     return new byte[] { __EMBEDDED_SHADER_BYTECODE };
+            // }
+            //
+            // As in the ID2D1Shader generator, the __EMBEDDED_SHADER_BYTECODE identifier will be replaced with the bytecode
+            // after the full string for the syntax tree has been generated, to avoid every literal going through a token.
+            return
+                MethodDeclaration(
+                    GenericName(Identifier("global::System.ReadOnlySpan"))
+                    .AddTypeArgumentListArguments(PredefinedType(Token(SyntaxKind.ByteKeyword))),
+                    Identifier("TheMethodName")).AddModifiers(Token(SyntaxKind.PartialKeyword))
+                .AddAttributeLists(
+                    AttributeList(SingletonSeparatedList(
+                        Attribute(IdentifierName("global::System.CodeDom.Compiler.GeneratedCode"))
+                        .AddArgumentListArguments(
+                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(D2DPixelShaderSourceAttribute).FullName))),
+                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(D2DPixelShaderSourceAttribute).Assembly.GetName().Version.ToString()))))))
+                    .WithOpenBracketToken(Token(TriviaList(Comment(
+                        $"/// <inheritdoc/>")),
+                        SyntaxKind.OpenBracketToken,
+                        TriviaList())),
+                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage")))))
+                .WithBody(Block(
+                    ReturnStatement(
+                        ArrayCreationExpression(
+                            ArrayType(PredefinedType(Token(SyntaxKind.ByteKeyword)))
+                            .AddRankSpecifiers(ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(OmittedArraySizeExpression()))))
+                        .WithInitializer(
+                            InitializerExpression(
+                                SyntaxKind.ArrayInitializerExpression,
+                                SingletonSeparatedList<ExpressionSyntax>(IdentifierName("__EMBEDDED_SHADER_BYTECODE")))))));
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.Syntax.cs
@@ -24,31 +24,68 @@ partial class D2DPixelShaderSourceGenerator
         /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the target method.</returns>
         public static MethodDeclarationSyntax GetSyntax(EmbeddedBytecodeMethodInfo bytecodeInfo, out Func<SyntaxNode, SourceText> fixup)
         {
-            // If there is no precompiled bytecode, just emit a span with a 0 value
-            string bytecodeLiterals = bytecodeInfo.Bytecode.IsDefaultOrEmpty
-                ? "0"
-                : ID2D1ShaderGenerator.LoadBytecode.BuildShaderBytecodeExpressionString(bytecodeInfo.Bytecode.AsSpan());
+            // Get the TypeSyntax for the return type (either ReadOnlySpan<byte>, or an invalid one).
+            // This is done so that if the user picks an invalid type, the code is still generated,
+            // just returning default, so that proper diagnostic can be generated, without also
+            // having hard to understand compiler errors due to the mismatched return type here.
+            TypeSyntax returnType = bytecodeInfo.InvalidReturnType is string invalidReturnType
+                ? IdentifierName(invalidReturnType)
+                : GenericName(Identifier("global::System.ReadOnlySpan"))
+                    .AddTypeArgumentListArguments(PredefinedType(Token(SyntaxKind.ByteKeyword)));
 
-            // Prepare the fixup function
-            fixup = tree => SourceText.From(tree.ToFullString().Replace("__EMBEDDED_SHADER_BYTECODE", bytecodeLiterals), Encoding.UTF8);
+            BlockSyntax methodBlock;
+
+            if (bytecodeInfo.Bytecode.IsDefaultOrEmpty)
+            {
+                // This code generates the following block:
+                //
+                // {
+                //     return default;
+                // }
+                methodBlock =
+                    Block(ReturnStatement(
+                        LiteralExpression(
+                            SyntaxKind.DefaultLiteralExpression,
+                            Token(SyntaxKind.DefaultKeyword))));
+
+                fixup = tree => tree.GetText(Encoding.UTF8);
+            }
+            else
+            {
+                // This code generates the following block:
+                //
+                // {
+                //     return new byte[] { __EMBEDDED_SHADER_BYTECODE };
+                // }
+                //
+                // As in the ID2D1Shader generator, the __EMBEDDED_SHADER_BYTECODE identifier will be replaced with the bytecode
+                // after the full string for the syntax tree has been generated, to avoid every literal going through a token.
+                methodBlock =
+                    Block(
+                        ReturnStatement(
+                            ArrayCreationExpression(
+                                ArrayType(PredefinedType(Token(SyntaxKind.ByteKeyword)))
+                                .AddRankSpecifiers(ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(OmittedArraySizeExpression()))))
+                            .WithInitializer(
+                                InitializerExpression(
+                                    SyntaxKind.ArrayInitializerExpression,
+                                    SingletonSeparatedList<ExpressionSyntax>(IdentifierName("__EMBEDDED_SHADER_BYTECODE"))))));
+
+                string bytecodeLiterals = ID2D1ShaderGenerator.LoadBytecode.BuildShaderBytecodeExpressionString(bytecodeInfo.Bytecode.AsSpan());
+
+                // Prepare the fixup function
+                fixup = tree => SourceText.From(tree.ToFullString().Replace("__EMBEDDED_SHADER_BYTECODE", bytecodeLiterals), Encoding.UTF8);
+            }
 
             // This code produces a branch as follows:
             //
             // /// <inheritdoc/>
             // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
             // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
-            // <MODIFIERS> global::System.ReadOnlySpan<byte> <METHOD_NAME>()
-            // {
-            //     return new byte[] { __EMBEDDED_SHADER_BYTECODE };
-            // }
-            //
-            // As in the ID2D1Shader generator, the __EMBEDDED_SHADER_BYTECODE identifier will be replaced with the bytecode
-            // after the full string for the syntax tree has been generated, to avoid every literal going through a token.
+            // <MODIFIERS> <RETURN_TYPE> <METHOD_NAME>()
+            // <METHOD_BODY>
             return
-                MethodDeclaration(
-                    GenericName(Identifier("global::System.ReadOnlySpan"))
-                    .AddTypeArgumentListArguments(PredefinedType(Token(SyntaxKind.ByteKeyword))),
-                    Identifier(bytecodeInfo.MethodName))
+                MethodDeclaration(returnType, Identifier(bytecodeInfo.MethodName))
                 .AddModifiers(bytecodeInfo.Modifiers.Select(Token).ToArray())
                 .AddAttributeLists(
                     AttributeList(SingletonSeparatedList(
@@ -61,15 +98,7 @@ partial class D2DPixelShaderSourceGenerator
                         SyntaxKind.OpenBracketToken,
                         TriviaList())),
                     AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage")))))
-                .WithBody(Block(
-                    ReturnStatement(
-                        ArrayCreationExpression(
-                            ArrayType(PredefinedType(Token(SyntaxKind.ByteKeyword)))
-                            .AddRankSpecifiers(ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(OmittedArraySizeExpression()))))
-                        .WithInitializer(
-                            InitializerExpression(
-                                SyntaxKind.ArrayInitializerExpression,
-                                SingletonSeparatedList<ExpressionSyntax>(IdentifierName("__EMBEDDED_SHADER_BYTECODE")))))));
+                .WithBody(methodBlock);
         }
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.Syntax.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
 using ComputeSharp.D2D1.SourceGenerators.Models;
 using Microsoft.CodeAnalysis;
@@ -21,7 +22,7 @@ partial class D2DPixelShaderSourceGenerator
         /// <param name="bytecodeInfo">The input bytecode info.</param>
         /// <param name="fixup">An opaque <see cref="Func{TResult}"/> instance to transform the final tree into text.</param>
         /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the target method.</returns>
-        public static MethodDeclarationSyntax GetSyntax(EmbeddedBytecodeInfo bytecodeInfo, out Func<SyntaxNode, SourceText> fixup)
+        public static MethodDeclarationSyntax GetSyntax(EmbeddedBytecodeMethodInfo bytecodeInfo, out Func<SyntaxNode, SourceText> fixup)
         {
             // If there is no precompiled bytecode, just emit a span with a 0 value
             string bytecodeLiterals = bytecodeInfo.Bytecode.IsDefaultOrEmpty
@@ -47,7 +48,8 @@ partial class D2DPixelShaderSourceGenerator
                 MethodDeclaration(
                     GenericName(Identifier("global::System.ReadOnlySpan"))
                     .AddTypeArgumentListArguments(PredefinedType(Token(SyntaxKind.ByteKeyword))),
-                    Identifier("TheMethodName")).AddModifiers(Token(SyntaxKind.PartialKeyword))
+                    Identifier(bytecodeInfo.MethodName))
+                .AddModifiers(bytecodeInfo.Modifiers.Select(Token).ToArray())
                 .AddAttributeLists(
                     AttributeList(SingletonSeparatedList(
                         Attribute(IdentifierName("global::System.CodeDom.Compiler.GeneratedCode"))

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -24,6 +24,35 @@ partial class D2DPixelShaderSourceGenerator
     private static partial class Execute
     {
         /// <summary>
+        /// Validates that the return type of the annotated method is valid and returns the type name.
+        /// </summary>
+        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
+        /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
+        /// <returns>The HLSL source to compile, if present.</returns>
+        public static string? GetInvalidReturnType(ImmutableArray<Diagnostic>.Builder diagnostics, IMethodSymbol methodSymbol)
+        {
+            if (!(methodSymbol.ReturnType is INamedTypeSymbol
+                {
+                    Name: "ReadOnlySpan",
+                    ContainingNamespace.Name: "System",
+                    IsGenericType: true,
+                    TypeParameters.Length: 1
+                } returnType && returnType.TypeArguments[0].SpecialType == SpecialType.System_Byte))
+            {
+                diagnostics.Add(
+                    InvalidD2DPixelShaderSourceMethodReturnType,
+                    methodSymbol,
+                    methodSymbol.Name,
+                    methodSymbol.ContainingType,
+                    methodSymbol.ReturnType);
+
+                return methodSymbol.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Extracts the HLSL source from a method with the <see cref="D2DPixelShaderSourceAttribute"/> annotation.
         /// </summary>
         /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using ComputeSharp.D2D1.Exceptions;
+using ComputeSharp.D2D1.Shaders.Translation;
+using ComputeSharp.D2D1.SourceGenerators.Models;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class D2DPixelShaderSourceGenerator
+{
+    /// <summary>
+    /// A container for all the logic for <see cref="D2DPixelShaderSourceGenerator"/>.
+    /// </summary>
+    private static partial class Execute
+    {
+        /// <summary>
+        /// Extracts the HLSL source from a method with the <see cref="D2DPixelShaderSourceAttribute"/> annotation.
+        /// </summary>
+        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
+        /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
+        /// <returns>The HLSL source to compile, if present.</returns>
+        public static string? GetHlslSource(ImmutableArray<Diagnostic>.Builder diagnostics, IMethodSymbol methodSymbol)
+        {
+            _ = methodSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DPixelShaderSourceAttribute", out AttributeData? attributeData);
+
+            if (!attributeData!.TryGetConstructorArgument(0, out string? hlslSource))
+            {
+                // TODO: no string diagnostic
+            }
+
+            return hlslSource;
+        }
+
+        /// <summary>
+        /// Extracts the shader profile for a target method, if present.
+        /// </summary>
+        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
+        /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
+        /// <returns>The shader profile to use to compile the shader, if present.</returns>
+        public static D2D1ShaderProfile? GetShaderProfile(ImmutableArray<Diagnostic>.Builder diagnostics, IMethodSymbol methodSymbol)
+        {
+            if (methodSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DEmbeddedBytecodeAttribute", out AttributeData? attributeData))
+            {
+                return (D2D1ShaderProfile)attributeData!.ConstructorArguments[0].Value!;
+            }
+
+            if (methodSymbol.ContainingAssembly.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DEmbeddedBytecodeAttribute", out attributeData))
+            {
+                return (D2D1ShaderProfile)attributeData!.ConstructorArguments[0].Value!;
+            }
+
+            // TODO: diagnostics
+
+            return null;
+        }
+
+        /// <summary>
+        /// Extracts the compile options for the current shader.
+        /// </summary>
+        /// <param name="diagnostics">The collection of produced <see cref="Diagnostic"/> instances.</param>
+        /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
+        /// <returns>The compile options to use to compile the shader, if present.</returns>
+        public static D2D1CompileOptions? GetCompileOptions(ImmutableArray<Diagnostic>.Builder diagnostics, IMethodSymbol methodSymbol)
+        {
+            if (methodSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute", out AttributeData? attributeData))
+            {
+                return (D2D1CompileOptions)attributeData!.ConstructorArguments[0].Value!;
+            }
+
+            if (methodSymbol.ContainingAssembly.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute", out attributeData))
+            {
+                return (D2D1CompileOptions)attributeData!.ConstructorArguments[0].Value!;
+            }
+
+            // TODO: diagnostics
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets an <see cref="ImmutableArray{T}"/> instance with the compiled bytecode for the current shader.
+        /// </summary>
+        /// <param name="sourceInfo">The source info for the shader to compile.</param>
+        /// <param name="token">The <see cref="CancellationToken"/> used to cancel the operation, if needed.</param>
+        /// <param name="diagnostic">The resulting diagnostic from the processing operation, if any.</param>
+        /// <returns>The <see cref="ImmutableArray{T}"/> instance with the compiled shader bytecode.</returns>
+        public static unsafe ImmutableArray<byte> GetBytecode(HlslShaderSourceInfo sourceInfo, CancellationToken token, out DiagnosticInfo? diagnostic)
+        {
+            ImmutableArray<byte> bytecode = ImmutableArray<byte>.Empty;
+
+            // Skip compilation if there are any errors
+            if (sourceInfo is { HasErrors: true })
+            {
+                diagnostic = null;
+
+                goto End;
+            }
+
+            try
+            {
+                token.ThrowIfCancellationRequested();
+
+                // Compile the shader bytecode using the requested parameters
+                using ComPtr<ID3DBlob> dxcBlobBytecode = D3DCompiler.Compile(
+                    sourceInfo.HlslSource.AsSpan(),
+                    sourceInfo.ShaderProfile!.Value,
+                    sourceInfo.CompileOptions!.Value);
+
+                token.ThrowIfCancellationRequested();
+
+                byte* buffer = (byte*)dxcBlobBytecode.Get()->GetBufferPointer();
+                int length = checked((int)dxcBlobBytecode.Get()->GetBufferSize());
+
+                byte[] array = new ReadOnlySpan<byte>(buffer, length).ToArray();
+
+                bytecode = Unsafe.As<byte[], ImmutableArray<byte>>(ref array);
+                diagnostic = null;
+            }
+            catch (Win32Exception e)
+            {
+                diagnostic = new DiagnosticInfo(
+                    null!, // TODO
+                    e.HResult,
+                    ID2D1ShaderGenerator.LoadBytecode.FixupExceptionMessage(e.Message));
+            }
+            catch (FxcCompilationException e)
+            {
+                diagnostic = new DiagnosticInfo(
+                    null!, // TODO
+                    ID2D1ShaderGenerator.LoadBytecode.FixupExceptionMessage(e.Message));
+            }
+
+            End:
+            return bytecode;
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -99,7 +99,7 @@ partial class D2DPixelShaderSourceGenerator
         /// <param name="token">The <see cref="CancellationToken"/> used to cancel the operation, if needed.</param>
         /// <param name="diagnostic">The resulting diagnostic from the processing operation, if any.</param>
         /// <returns>The <see cref="ImmutableArray{T}"/> instance with the compiled shader bytecode.</returns>
-        public static unsafe ImmutableArray<byte> GetBytecode(HlslShaderSourceInfo sourceInfo, CancellationToken token, out DiagnosticInfo? diagnostic)
+        public static unsafe ImmutableArray<byte> GetBytecode(HlslShaderMethodSourceInfo sourceInfo, CancellationToken token, out DiagnosticInfo? diagnostic)
         {
             ImmutableArray<byte> bytecode = ImmutableArray<byte>.Empty;
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -82,12 +82,12 @@ partial class D2DPixelShaderSourceGenerator
         /// <returns>The shader profile to use to compile the shader, if present.</returns>
         public static D2D1ShaderProfile GetShaderProfile(ImmutableArray<Diagnostic>.Builder diagnostics, IMethodSymbol methodSymbol)
         {
-            if (methodSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DEmbeddedBytecodeAttribute", out AttributeData? attributeData))
+            if (methodSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DShaderProfileAttribute", out AttributeData? attributeData))
             {
                 return (D2D1ShaderProfile)attributeData!.ConstructorArguments[0].Value!;
             }
 
-            if (methodSymbol.ContainingAssembly.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DEmbeddedBytecodeAttribute", out attributeData))
+            if (methodSymbol.ContainingAssembly.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DShaderProfileAttribute", out attributeData))
             {
                 return (D2D1ShaderProfile)attributeData!.ConstructorArguments[0].Value!;
             }

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -41,6 +41,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                 // Get all necessary info for the current shader
                 ImmutableArray<SyntaxKind> modifiers = item.Syntax.Modifiers.Select(token => token.Kind()).ToImmutableArray();
                 string methodName = item.Symbol.Name;
+                string? invalidReturnType = Execute.GetInvalidReturnType(diagnostics, item.Symbol);
                 string hlslSource = Execute.GetHlslSource(diagnostics, item.Symbol);
                 D2D1ShaderProfile shaderProfile = Execute.GetShaderProfile(diagnostics, item.Symbol);
                 D2D1CompileOptions compileOptions = Execute.GetCompileOptions(diagnostics, item.Symbol);
@@ -48,6 +49,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                 HlslShaderMethodSourceInfo sourceInfo = new(
                     modifiers,
                     methodName,
+                    invalidReturnType,
                     hlslSource,
                     shaderProfile,
                     compileOptions,
@@ -82,6 +84,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                 EmbeddedBytecodeMethodInfo bytecodeInfo = new(
                     item.Source.Modifiers,
                     item.Source.MethodName,
+                    item.Source.InvalidReturnType,
                     item.Source.HlslSource,
                     bytecode);
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -41,9 +41,9 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                 // Get all necessary info for the current shader
                 ImmutableArray<SyntaxKind> modifiers = item.Syntax.Modifiers.Select(token => token.Kind()).ToImmutableArray();
                 string methodName = item.Symbol.Name;
-                string? hlslSource = Execute.GetHlslSource(diagnostics, item.Symbol) ?? "";
-                D2D1ShaderProfile? shaderProfile = Execute.GetShaderProfile(diagnostics, item.Symbol);
-                D2D1CompileOptions? compileOptions = Execute.GetCompileOptions(diagnostics, item.Symbol);
+                string hlslSource = Execute.GetHlslSource(diagnostics, item.Symbol);
+                D2D1ShaderProfile shaderProfile = Execute.GetShaderProfile(diagnostics, item.Symbol);
+                D2D1CompileOptions compileOptions = Execute.GetCompileOptions(diagnostics, item.Symbol);
 
                 HlslShaderMethodSourceInfo sourceInfo = new(
                     modifiers,

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using ComputeSharp.D2D1.SourceGenerators.Models;
@@ -123,7 +122,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
             CompilationUnitSyntax compilationUnit = item.Hierarchy.GetSyntax(loadBytecodeMethod);
             SourceText text = fixup(compilationUnit);
 
-            context.AddSource($"{item.Hierarchy.FilenameHint}.TESTMETHOD", text);
+            context.AddSource($"{item.Hierarchy.FilenameHint}.{item.BytecodeInfo.MethodName}", text);
         });
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.D2D1.SourceGenerators.Models;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A source generator compiling methods annotated with <see cref="D2DPixelShaderSourceAttribute"/>.
+/// </summary>
+[Generator(LanguageNames.CSharp)]
+public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerator
+{
+    /// <inheritdoc/>
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        // Get all method declarations with the [D2DPixelShaderSource] attribute
+        IncrementalValuesProvider<IMethodSymbol> methodSymbols =
+            context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => node is MethodDeclarationSyntax { Parent: ClassDeclarationSyntax, AttributeLists.Count: > 0 },
+                static (context, _) => (IMethodSymbol)context.SemanticModel.GetDeclaredSymbol(context.Node)!)
+            .Where(static symbol => symbol.HasAttributeWithFullyQualifiedName("ComputeSharp.D2D1.D2DPixelShaderSourceAttribute"));
+
+        // Gather info for all annotated methods
+        IncrementalValuesProvider<(HierarchyInfo Hierarchy, HlslShaderSourceInfo Source, ImmutableArray<Diagnostic> Diagnostics)> shaderInfoWithErrors =
+            methodSymbols
+            .Select(static (item, _) =>
+            {
+                ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+
+                // Get all necessary info for the current shader
+                string? hlslSource = Execute.GetHlslSource(diagnostics, item) ?? "";
+                D2D1ShaderProfile? shaderProfile = Execute.GetShaderProfile(diagnostics, item);
+                D2D1CompileOptions? compileOptions = Execute.GetCompileOptions(diagnostics, item);
+
+                HlslShaderSourceInfo sourceInfo = new(
+                    hlslSource,
+                    shaderProfile,
+                    compileOptions,
+                    IsLinkingSupported: false,
+                    HasErrors: diagnostics.Count > 0);
+
+                HierarchyInfo hierarchy = HierarchyInfo.From(item.ContainingType!);
+
+                return (hierarchy, sourceInfo, diagnostics.ToImmutable());
+            });
+
+        // Output the diagnostics
+        context.ReportDiagnostics(shaderInfoWithErrors.Select(static (item, _) => item.Diagnostics));
+
+        // Filter all items to enable caching at a coarse level, and remove diagnostics
+        IncrementalValuesProvider<(HierarchyInfo Hierarchy, HlslShaderSourceInfo Source)> shaderInfo =
+            shaderInfoWithErrors
+            .Select(static (item, token) => (item.Hierarchy, item.Source))
+            .WithComparers(HierarchyInfo.Comparer.Default, EqualityComparer<HlslShaderSourceInfo>.Default);
+
+        // Compile the requested shader bytecodes
+        IncrementalValuesProvider<(HierarchyInfo Hierarchy, EmbeddedBytecodeInfo BytecodeInfo, DiagnosticInfo? Diagnostic)> embeddedBytecodeWithErrors =
+            shaderInfo
+            .Select(static (item, token) =>
+            {
+                ImmutableArray<byte> bytecode = Execute.GetBytecode(
+                    item.Source,
+                    token,
+                    out DiagnosticInfo? diagnostic);
+
+                token.ThrowIfCancellationRequested();
+
+                EmbeddedBytecodeInfo bytecodeInfo = new(
+                    item.Source.HlslSource,
+                    item.Source.ShaderProfile,
+                    item.Source.CompileOptions,
+                    bytecode);
+
+                return (item.Hierarchy, bytecodeInfo, diagnostic);
+            });
+
+        // Gather the diagnostics
+        IncrementalValuesProvider<Diagnostic> embeddedBytecodeDiagnostics =
+            embeddedBytecodeWithErrors
+            .Select(static (item, token) => (item.Hierarchy.FullyQualifiedMetadataName, item.Diagnostic))
+            .Where(static item => item.Diagnostic is not null)
+            .Combine(context.CompilationProvider)
+            .Select(static (item, token) =>
+            {
+                INamedTypeSymbol typeSymbol = item.Right.GetTypeByMetadataName(item.Left.FullyQualifiedMetadataName)!;
+                
+                return Diagnostic.Create(
+                    item.Left.Diagnostic!.Descriptor,
+                    typeSymbol.Locations.FirstOrDefault(),
+                    new object[] { typeSymbol }.Concat(item.Left.Diagnostic.Args).ToArray());
+            });
+
+        // Output the diagnostics
+        context.ReportDiagnostics(embeddedBytecodeDiagnostics);
+
+        // Get the filtered sequence to enable caching
+        IncrementalValuesProvider<(HierarchyInfo Hierarchy, EmbeddedBytecodeInfo BytecodeInfo)> embeddedBytecode =
+            embeddedBytecodeWithErrors
+            .Select(static (item, token) => (item.Hierarchy, item.BytecodeInfo))
+            .WithComparers(HierarchyInfo.Comparer.Default, EmbeddedBytecodeInfo.Comparer.Default);
+
+        // Generate the shader bytecode methods
+        context.RegisterSourceOutput(embeddedBytecode, static (context, item) =>
+        {
+            MethodDeclarationSyntax loadBytecodeMethod = Execute.GetSyntax(item.BytecodeInfo, out Func<SyntaxNode, SourceText> fixup);
+            CompilationUnitSyntax compilationUnit = item.Hierarchy.GetSyntax(loadBytecodeMethod);
+            SourceText text = fixup(compilationUnit);
+
+            context.AddSource($"{item.Hierarchy.FilenameHint}.TESTMETHOD", text);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -824,4 +824,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Precompiled shaders using [D2DPixelShaderSource] must explicitly indicate the compile options.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when a method with [D2DPixelShaderSource] has an invalid return type.
+    /// <para>
+    /// Format: <c>"The method \"{0}\" (in type {1}) is using [D2DPixelShaderSource] but has an invalid return type {2} (it must return a ReadOnlySpan&lt;byte&gt;)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidD2DPixelShaderSourceMethodReturnType = new DiagnosticDescriptor(
+        id: "CMPSD2D0057",
+        title: "Missing compile options for D2D pixel shader source",
+        messageFormat: "The method \"{0}\" (in type {1}) is using [D2DPixelShaderSource] but has an invalid return type {2} (it must return a ReadOnlySpan<byte>)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Methods using using [D2DPixelShaderSource] must use ReadOnlySpan<byte> as the return type.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -463,7 +463,7 @@ partial class DiagnosticDescriptors
     /// Format: <c>"The shader of type {0} failed to compile due to an HLSL compiler error (Message: "{1}")"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor EmbeddedBytecodeFailedWithDxcCompilationException = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor EmbeddedBytecodeFailedWithFxcCompilationException = new DiagnosticDescriptor(
         id: "CMPSD2D0034",
         title: "Embedded bytecode compilation failed due to an HLSL compiler error",
         messageFormat: "The shader of type {0} failed to compile due to an HLSL compiler error (Message: \"{1}\")",
@@ -743,5 +743,85 @@ partial class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "The element type of D2D1 resource texture fields in a D2D1 shader must be either float or float4.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an invalid HLSL source in <c>[D2DPixelShaderSource]</c>.
+    /// <para>
+    /// Format: <c>"The method \"{0}\" (in type {1}) is using [D2DPixelShaderSource] with an invalid HLSL source argument"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidD2DPixelShaderSource = new DiagnosticDescriptor(
+        id: "CMPSD2D0052",
+        title: "Invalid [D2DPixelShaderSource] HLSL source argument",
+        messageFormat: "The method \"{0}\" (in type {1}) is using [D2DPixelShaderSource] with an invalid HLSL source argument",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Methods using [D2DPixelShaderSource] must pass a valid string as the HLSL source argument.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode D2D shader failed due to a Win32 exception.
+    /// <para>
+    /// Format: <c>"Compiling the HLSL source for method \"{1}\" (in type {0}) failed due to a Win32 exception (HRESULT: {2:X8}, Message: \"{3}\")"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor D2DPixelShaderSourceCompilationFailedWithWin32Exception = new DiagnosticDescriptor(
+        id: "CMPSD2D0053",
+        title: "D2D shader compilation failed due to Win32 exception",
+        messageFormat: "Compiling the HLSL source for method \"{1}\" (in type {0}) failed due to a Win32 exception (HRESULT: {2:X8}, Message: \"{3}\")",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The embedded bytecode for an input HLSl source failed to be compiled due to a Win32 exception.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode D2D shader failed due to an HLSL compilation exception.
+    /// <para>
+    /// Format: <c>"Compiling the HLSL source for method \"{1}\" (in type {0}) failed due to an HLSL compiler error (Message: \"{2}\")"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor D2DPixelShaderSourceCompilationFailedWithFxcCompilationException = new DiagnosticDescriptor(
+        id: "CMPSD2D0054",
+        title: "D2D shader compilation failed due to an HLSL compiler error",
+        messageFormat: "Compiling the HLSL source for method \"{1}\" (in type {0}) failed due to an HLSL compiler error (Message: \"{2}\")",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The embedded bytecode for an input HLSl source failed to be compiled due to an HLSL compiler error.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode D2D shader with no shader profile set.
+    /// <para>
+    /// Format: <c>"The method \"{0}\" (in type {1}) is using [D2DPixelShaderSource] but has not specified the shader profile to use"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor MissingShaderProfileForD2DPixelShaderSource = new DiagnosticDescriptor(
+        id: "CMPSD2D0055",
+        title: "Missing shader profile for D2D pixel shader source",
+        messageFormat: "The method \"{0}\" (in type {1}) is using [D2DPixelShaderSource] but has not specified the shader profile to use",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Precompiled shaders using [D2DPixelShaderSource] must explicitly indicate the shader profile to use.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode D2D shader with no compile options set.
+    /// <para>
+    /// Format: <c>"The method \"{0}\" (in type {1}) is using [D2DPixelShaderSource] but has not specified the compile options to use"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor MissingCompileOptionsForD2DPixelShaderSource = new DiagnosticDescriptor(
+        id: "CMPSD2D0056",
+        title: "Missing compile options for D2D pixel shader source",
+        messageFormat: "The method \"{0}\" (in type {1}) is using [D2DPixelShaderSource] but has not specified the compile options to use",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Precompiled shaders using [D2DPixelShaderSource] must explicitly indicate the compile options.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.Syntax.cs
@@ -214,7 +214,7 @@ partial class ID2D1ShaderGenerator
         /// </summary>
         /// <param name="bytecode">The input shader bytecode to serialize.</param>
         /// <returns>A formatted <see cref="string"/> with the serialized data.</returns>
-        private static string BuildShaderBytecodeExpressionString(ReadOnlySpan<byte> bytecode)
+        internal static string BuildShaderBytecodeExpressionString(ReadOnlySpan<byte> bytecode)
         {
             //The estimation is 4 characters per byte (up to "255" in hex), plus ", " to separate sequential values
             using ArrayPoolStringBuilder builder = ArrayPoolStringBuilder.Create(bytecode.Length * 6);

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -11,8 +11,6 @@ using ComputeSharp.D2D1.SourceGenerators.Models;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Models;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
@@ -25,7 +23,7 @@ partial class ID2D1ShaderGenerator
     /// <summary>
     /// A helper with all logic to generate the <c>LoadBytecode</c> method.
     /// </summary>
-    private static partial class LoadBytecode
+    internal static partial class LoadBytecode
     {
         /// <summary>
         /// Extracts the shader profile for the current shader.
@@ -142,7 +140,7 @@ partial class ID2D1ShaderGenerator
         }
 
         /// <summary>
-        /// Gets a <see cref="BlockSyntax"/> instance with the logic to try to get a compiled shader bytecode.
+        /// Gets an <see cref="ImmutableArray{T}"/> instance with the compiled bytecode for the current shader.
         /// </summary>
         /// <param name="sourceInfo">The source info for the shader to compile.</param>
         /// <param name="token">The <see cref="CancellationToken"/> used to cancel the operation, if needed.</param>
@@ -212,7 +210,7 @@ partial class ID2D1ShaderGenerator
         /// </summary>
         /// <param name="message">The input exception message.</param>
         /// <returns>The updated exception message.</returns>
-        private static string FixupExceptionMessage(string message)
+        internal static string FixupExceptionMessage(string message)
         {
             // Add square brackets around error headers
             message = Regex.Replace(message, @"((?:error|warning) \w+):", static m => $"[{m.Groups[1].Value}]:");

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -32,12 +32,12 @@ partial class ID2D1ShaderGenerator
         /// <returns>The shader profile to use to compile the shader, if present.</returns>
         public static D2D1ShaderProfile? GetShaderProfile(INamedTypeSymbol structDeclarationSymbol)
         {
-            if (structDeclarationSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DEmbeddedBytecodeAttribute", out AttributeData? attributeData))
+            if (structDeclarationSymbol.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DShaderProfileAttribute", out AttributeData? attributeData))
             {
                 return (D2D1ShaderProfile)attributeData!.ConstructorArguments[0].Value!;
             }
 
-            if (structDeclarationSymbol.ContainingAssembly.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DEmbeddedBytecodeAttribute", out attributeData))
+            if (structDeclarationSymbol.ContainingAssembly.TryGetAttributeWithFullMetadataName("ComputeSharp.D2D1.D2DShaderProfileAttribute", out attributeData))
             {
                 return (D2D1ShaderProfile)attributeData!.ConstructorArguments[0].Value!;
             }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -198,7 +198,7 @@ partial class ID2D1ShaderGenerator
             catch (FxcCompilationException e)
             {
                 options = default;
-                diagnostic = new DiagnosticInfo(EmbeddedBytecodeFailedWithDxcCompilationException, FixupExceptionMessage(e.Message));
+                diagnostic = new DiagnosticInfo(EmbeddedBytecodeFailedWithFxcCompilationException, FixupExceptionMessage(e.Message));
             }
 
             End:

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeInfo.cs
@@ -7,7 +7,7 @@ using ComputeSharp.SourceGeneration.Helpers;
 namespace ComputeSharp.D2D1.SourceGenerators.Models;
 
 /// <summary>
-/// A model representing a shared and its compiled bytecode, if available.
+/// A model representing info on a shader that has requested to be precompiled at build time.
 /// </summary>
 /// <param name="HlslSource">The HLSL source for the shader.</param>
 /// <param name="ShaderProfile">The shader profile to use to compile the shader, if requested.</param>

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeMethodInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeMethodInfo.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Helpers;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ComputeSharp.D2D1.SourceGenerators.Models;
+
+/// <summary>
+/// A model representing info on a shader method that has requested to be precompiled at build time.
+/// </summary>
+///<param name="Modifiers">The modifiers for the annotated method.</param>
+/// <param name="MethodName">The name of the annotated method.</param>
+/// <param name="HlslSource">The HLSL source.</param>
+/// <param name="Bytecode">The compiled shader bytecode, if available.</param>
+internal sealed record EmbeddedBytecodeMethodInfo(
+    ImmutableArray<SyntaxKind> Modifiers,
+    string MethodName,
+    string HlslSource,
+    ImmutableArray<byte> Bytecode)
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer{T}"/> implementation for <see cref="EmbeddedBytecodeMethodInfo"/>.
+    /// </summary>
+    public sealed class Comparer : Comparer<EmbeddedBytecodeMethodInfo, Comparer>
+    {
+        /// <inheritdoc/>
+        protected override void AddToHashCode(ref HashCode hashCode, EmbeddedBytecodeMethodInfo obj)
+        {
+            hashCode.AddRange(obj.Modifiers);
+            hashCode.Add(obj.MethodName);
+            hashCode.Add(obj.HlslSource);
+            hashCode.AddBytes(obj.Bytecode.AsSpan());
+        }
+
+        /// <inheritdoc/>
+        protected override bool AreEqual(EmbeddedBytecodeMethodInfo x, EmbeddedBytecodeMethodInfo y)
+        {
+            return
+                MemoryMarshal.Cast<SyntaxKind, ushort>(x.Modifiers.AsSpan()).SequenceEqual(MemoryMarshal.Cast<SyntaxKind, ushort>(y.Modifiers.AsSpan())) &&
+                x.MethodName == y.MethodName &&
+                x.HlslSource == y.HlslSource &&
+                x.Bytecode.SequenceEqual(y.Bytecode);
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeMethodInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeMethodInfo.cs
@@ -11,13 +11,15 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// <summary>
 /// A model representing info on a shader method that has requested to be precompiled at build time.
 /// </summary>
-///<param name="Modifiers">The modifiers for the annotated method.</param>
+/// <param name="Modifiers">The modifiers for the annotated method.</param>
 /// <param name="MethodName">The name of the annotated method.</param>
+/// <param name="InvalidReturnType">The fully qualified name of the return type, if invalid.</param>
 /// <param name="HlslSource">The HLSL source.</param>
 /// <param name="Bytecode">The compiled shader bytecode, if available.</param>
 internal sealed record EmbeddedBytecodeMethodInfo(
     ImmutableArray<SyntaxKind> Modifiers,
     string MethodName,
+    string? InvalidReturnType,
     string HlslSource,
     ImmutableArray<byte> Bytecode)
 {
@@ -31,6 +33,7 @@ internal sealed record EmbeddedBytecodeMethodInfo(
         {
             hashCode.AddRange(obj.Modifiers);
             hashCode.Add(obj.MethodName);
+            hashCode.Add(obj.InvalidReturnType);
             hashCode.Add(obj.HlslSource);
             hashCode.AddBytes(obj.Bytecode.AsSpan());
         }
@@ -41,6 +44,7 @@ internal sealed record EmbeddedBytecodeMethodInfo(
             return
                 MemoryMarshal.Cast<SyntaxKind, ushort>(x.Modifiers.AsSpan()).SequenceEqual(MemoryMarshal.Cast<SyntaxKind, ushort>(y.Modifiers.AsSpan())) &&
                 x.MethodName == y.MethodName &&
+                x.InvalidReturnType == y.InvalidReturnType &&
                 x.HlslSource == y.HlslSource &&
                 x.Bytecode.SequenceEqual(y.Bytecode);
         }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/HlslShaderMethodSourceInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/HlslShaderMethodSourceInfo.cs
@@ -13,15 +13,15 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// <param name="Modifiers">The modifiers for the annotated method.</param>
 /// <param name="MethodName">The name of the annotated method.</param>
 /// <param name="HlslSource">The HLSL source.</param>
-/// <param name="ShaderProfile">The shader profile to use to compile the shader, if requested.</param>
+/// <param name="ShaderProfile">The shader profile to use to compile the shader.</param>
 /// <param name="CompileOptions">The compile options to use to compile the shader.</param>
 /// <param name="HasErrors">Whether any errors have been detected, and therefore the shader compilation should be skipped.</param>
 internal sealed record HlslShaderMethodSourceInfo(
     ImmutableArray<SyntaxKind> Modifiers,
     string MethodName,
     string HlslSource,
-    D2D1ShaderProfile? ShaderProfile,
-    D2D1CompileOptions? CompileOptions,
+    D2D1ShaderProfile ShaderProfile,
+    D2D1CompileOptions CompileOptions,
     bool HasErrors)
 {
     /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/HlslShaderMethodSourceInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/HlslShaderMethodSourceInfo.cs
@@ -12,6 +12,7 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// </summary>
 /// <param name="Modifiers">The modifiers for the annotated method.</param>
 /// <param name="MethodName">The name of the annotated method.</param>
+/// <param name="InvalidReturnType">The fully qualified name of the return type, if invalid.</param>
 /// <param name="HlslSource">The HLSL source.</param>
 /// <param name="ShaderProfile">The shader profile to use to compile the shader.</param>
 /// <param name="CompileOptions">The compile options to use to compile the shader.</param>
@@ -19,6 +20,7 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 internal sealed record HlslShaderMethodSourceInfo(
     ImmutableArray<SyntaxKind> Modifiers,
     string MethodName,
+    string? InvalidReturnType,
     string HlslSource,
     D2D1ShaderProfile ShaderProfile,
     D2D1CompileOptions CompileOptions,
@@ -34,6 +36,7 @@ internal sealed record HlslShaderMethodSourceInfo(
         {
             hashCode.AddRange(obj.Modifiers);
             hashCode.Add(obj.MethodName);
+            hashCode.Add(obj.InvalidReturnType);
             hashCode.Add(obj.HlslSource);
             hashCode.Add(obj.ShaderProfile);
             hashCode.Add(obj.CompileOptions);
@@ -46,6 +49,7 @@ internal sealed record HlslShaderMethodSourceInfo(
             return
                 MemoryMarshal.Cast<SyntaxKind, ushort>(x.Modifiers.AsSpan()).SequenceEqual(MemoryMarshal.Cast<SyntaxKind, ushort>(y.Modifiers.AsSpan())) &&
                 x.MethodName == y.MethodName &&
+                x.InvalidReturnType == y.InvalidReturnType &&
                 x.HlslSource == y.HlslSource &&
                 x.ShaderProfile == y.ShaderProfile &&
                 x.CompileOptions == y.CompileOptions &&

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/HlslShaderMethodSourceInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/HlslShaderMethodSourceInfo.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Helpers;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ComputeSharp.D2D1.SourceGenerators.Models;
+
+/// <summary>
+/// A model for extracted info on a processed HLSL shader method.
+/// </summary>
+/// <param name="Modifiers">The modifiers for the annotated method.</param>
+/// <param name="MethodName">The name of the annotated method.</param>
+/// <param name="HlslSource">The HLSL source.</param>
+/// <param name="ShaderProfile">The shader profile to use to compile the shader, if requested.</param>
+/// <param name="CompileOptions">The compile options to use to compile the shader.</param>
+/// <param name="HasErrors">Whether any errors have been detected, and therefore the shader compilation should be skipped.</param>
+internal sealed record HlslShaderMethodSourceInfo(
+    ImmutableArray<SyntaxKind> Modifiers,
+    string MethodName,
+    string HlslSource,
+    D2D1ShaderProfile? ShaderProfile,
+    D2D1CompileOptions? CompileOptions,
+    bool HasErrors)
+{
+    /// <summary>
+    /// An <see cref="IEqualityComparer{T}"/> implementation for <see cref="HlslShaderMethodSourceInfo"/>.
+    /// </summary>
+    public sealed class Comparer : Comparer<HlslShaderMethodSourceInfo, Comparer>
+    {
+        /// <inheritdoc/>
+        protected override void AddToHashCode(ref HashCode hashCode, HlslShaderMethodSourceInfo obj)
+        {
+            hashCode.AddRange(obj.Modifiers);
+            hashCode.Add(obj.MethodName);
+            hashCode.Add(obj.HlslSource);
+            hashCode.Add(obj.ShaderProfile);
+            hashCode.Add(obj.CompileOptions);
+            hashCode.Add(obj.HasErrors);
+        }
+
+        /// <inheritdoc/>
+        protected override bool AreEqual(HlslShaderMethodSourceInfo x, HlslShaderMethodSourceInfo y)
+        {
+            return
+                MemoryMarshal.Cast<SyntaxKind, ushort>(x.Modifiers.AsSpan()).SequenceEqual(MemoryMarshal.Cast<SyntaxKind, ushort>(y.Modifiers.AsSpan())) &&
+                x.MethodName == y.MethodName &&
+                x.HlslSource == y.HlslSource &&
+                x.ShaderProfile == y.ShaderProfile &&
+                x.CompileOptions == y.CompileOptions &&
+                x.HasErrors == y.HasErrors;
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1/Attributes/D2DCompileOptionsAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DCompileOptionsAttribute.cs
@@ -4,7 +4,7 @@ namespace ComputeSharp.D2D1;
 
 /// <summary>
 /// An attribute that indicates the compile options that should be used when compiling a given D2D1 shader.
-/// This applies when the shader is precompiled (through <see cref="D2DEmbeddedBytecodeAttribute"/>) as well.
+/// This applies when the shader is precompiled (through <see cref="D2DShaderProfileAttribute"/>) as well.
 /// <para>
 /// This attribute can be used to annotate shader types as follows:
 /// <code>

--- a/src/ComputeSharp.D2D1/Attributes/D2DCompileOptionsAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DCompileOptionsAttribute.cs
@@ -26,7 +26,7 @@ namespace ComputeSharp.D2D1;
 /// This attribute can also be added to a whole assembly, and will be used by default if not overridden by a shader type.
 /// </para>
 /// </summary>
-[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly | AttributeTargets.Method, AllowMultiple = false)]
 public sealed class D2DCompileOptionsAttribute : Attribute
 {
     /// <summary>

--- a/src/ComputeSharp.D2D1/Attributes/D2DEmbeddedBytecodeAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DEmbeddedBytecodeAttribute.cs
@@ -24,7 +24,7 @@ namespace ComputeSharp.D2D1;
 /// This attribute can also be added to a whole assembly, and will be used by default if not overridden by a shader type.
 /// </para>
 /// </summary>
-[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = false)]
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly | AttributeTargets.Method, AllowMultiple = false)]
 public sealed class D2DEmbeddedBytecodeAttribute : Attribute
 {
     /// <summary>

--- a/src/ComputeSharp.D2D1/Attributes/D2DPixelShaderSourceAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DPixelShaderSourceAttribute.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// An attribute that indicates that a given D2D1 shader should be precompiled at build time and embedded
+/// directly into the containing assembly as static bytecode, to be retrieved as a <see cref="ReadOnlySpan{T}"/>.
+/// <para>
+/// This attribute can be used to annotate methods as follows:
+/// <code>
+/// [D2DPixelShaderSource("""
+///     #define D2D_INPUT_COUNT 1
+///     #define D2D_INPUT0_SIMPLE
+///
+///     #include ""d2d1effecthelpers.hlsli""
+///
+///     D2D_PS_ENTRY(PSMain)
+///     {
+///         float4 color = D2DGetInput(0);
+///         float3 rgb = saturate(1.0 - color.rgb);
+///         return float4(rgb, 1);
+///     }
+///     """")]
+/// static partial ReadOnlySpan&lt;byte&gt; GetBytecode();
+/// </code>
+/// </para>
+/// <para>
+/// </para>
+/// <para>
+/// Methods can also be annotated with <see cref="D2DEmbeddedBytecodeAttribute"/> and <see cref="D2DCompileOptionsAttribute"/>
+/// to further customize the shader profile to use when compiling the HLSL source, and the compile options to use.
+/// </para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class D2DPixelShaderSourceAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="D2DPixelShaderSourceAttribute"/> type with the specified arguments.
+    /// </summary>
+    /// <param name="hlslSource">The number of texture inputs for the shader.</param>
+    public D2DPixelShaderSourceAttribute(string hlslSource)
+    {
+        HlslSource = hlslSource;
+    }
+
+    /// <summary>
+    /// Gets the number of texture inputs for the shader.
+    /// </summary>
+    public string HlslSource { get; }
+}

--- a/src/ComputeSharp.D2D1/Attributes/D2DPixelShaderSourceAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DPixelShaderSourceAttribute.cs
@@ -28,7 +28,7 @@ namespace ComputeSharp.D2D1;
 /// <para>
 /// </para>
 /// <para>
-/// Methods can also be annotated with <see cref="D2DEmbeddedBytecodeAttribute"/> and <see cref="D2DCompileOptionsAttribute"/>
+/// Methods can also be annotated with <see cref="D2DShaderProfileAttribute"/> and <see cref="D2DCompileOptionsAttribute"/>
 /// to further customize the shader profile to use when compiling the HLSL source, and the compile options to use.
 /// </para>
 /// </summary>

--- a/src/ComputeSharp.D2D1/Attributes/D2DPixelShaderSourceAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DPixelShaderSourceAttribute.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ComputeSharp.D2D1;
 
@@ -38,7 +39,7 @@ public sealed class D2DPixelShaderSourceAttribute : Attribute
     /// Creates a new instance of the <see cref="D2DPixelShaderSourceAttribute"/> type with the specified arguments.
     /// </summary>
     /// <param name="hlslSource">The number of texture inputs for the shader.</param>
-    public D2DPixelShaderSourceAttribute(string hlslSource)
+    public D2DPixelShaderSourceAttribute([StringSyntax("Hlsl")] string hlslSource)
     {
         HlslSource = hlslSource;
     }

--- a/src/ComputeSharp.D2D1/Attributes/D2DShaderProfileAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DShaderProfileAttribute.cs
@@ -3,12 +3,12 @@
 namespace ComputeSharp.D2D1;
 
 /// <summary>
-/// An attribute that indicates that a given D2D1 shader should be precompiled at build time and embedded
-/// directly into the containing assembly as static bytecode, to avoid compiling it at runtime.
+/// An attribute that indicates that a given D2D1 shader should be precompiled at build time using a specific shader
+/// profile and embedded directly into the containing assembly as static bytecode, to avoid compiling it at runtime.
 /// <para>
 /// This attribute can be used to annotate shader types as follows:
 /// <code>
-/// [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+/// [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 /// struct MyShader : ID2D1PixelShader
 /// {
 /// }
@@ -25,19 +25,19 @@ namespace ComputeSharp.D2D1;
 /// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly | AttributeTargets.Method, AllowMultiple = false)]
-public sealed class D2DEmbeddedBytecodeAttribute : Attribute
+public sealed class D2DShaderProfileAttribute : Attribute
 {
     /// <summary>
-    /// Creates a new <see cref="D2DEmbeddedBytecodeAttribute"/> instance with the specified parameters.
+    /// Creates a new <see cref="D2DShaderProfileAttribute"/> instance with the specified parameters.
     /// </summary>
     /// <param name="shaderProfile">The target shader profile to use to compile the shader.</param>
-    public D2DEmbeddedBytecodeAttribute(D2D1ShaderProfile shaderProfile)
+    public D2DShaderProfileAttribute(D2D1ShaderProfile shaderProfile)
     {
         ShaderProfile = shaderProfile;
     }
 
     /// <summary>
-    /// Gets the number of threads in each thread group for the X axis
+    /// The shader profile used to compile the annotated D2D1 pixel shader.
     /// </summary>
     public D2D1ShaderProfile ShaderProfile { get; }
 }

--- a/src/ComputeSharp.D2D1/Attributes/Enums/D2D1CompileOptions.cs
+++ b/src/ComputeSharp.D2D1/Attributes/Enums/D2D1CompileOptions.cs
@@ -163,7 +163,7 @@ public enum D2D1CompileOptions
 
     /// <summary>
     /// The default options for shaders compiled by ComputeSharp.D2D1. Specifically, this combination
-    /// of options is the one used by precompiled shaders (ie. when using <see cref="D2DEmbeddedBytecodeAttribute"/>),
+    /// of options is the one used by precompiled shaders (ie. when using <see cref="D2DShaderProfileAttribute"/>),
     /// and when using <see cref="D2D1PixelShader.LoadBytecode{T}()"/> or any of the overloads.
     /// </summary>
     /// <remarks>

--- a/src/ComputeSharp.D2D1/Attributes/Enums/D2D1ShaderProfile.cs
+++ b/src/ComputeSharp.D2D1/Attributes/Enums/D2D1ShaderProfile.cs
@@ -1,7 +1,7 @@
 ﻿namespace ComputeSharp.D2D1;
 
 /// <summary>
-/// A <see langword="enum"/> to be used with <see cref="D2DEmbeddedBytecodeAttribute"/> to indicate the shader profile to use to precompile a shader.
+/// A <see langword="enum"/> to be used with <see cref="D2DShaderProfileAttribute"/> to indicate the shader profile to use to precompile a shader.
 /// </summary>
 public enum D2D1ShaderProfile
 {

--- a/src/ComputeSharp.D2D1/Properties/Polyfills/StringSyntaxAttribute.cs
+++ b/src/ComputeSharp.D2D1/Properties/Polyfills/StringSyntaxAttribute.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Specifies the syntax used in a string.
+/// </summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+internal sealed class StringSyntaxAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.
+    /// </summary>
+    /// <param name="syntax">The syntax identifier.</param>
+    public StringSyntaxAttribute(string syntax)
+    {
+        Syntax = syntax;
+        Arguments = Array.Empty<object?>();
+    }
+
+    /// <summary>
+    /// Initializes the <see cref="StringSyntaxAttribute"/> with the identifier of the syntax used.
+    /// </summary>
+    /// <param name="syntax">The syntax identifier.</param>
+    /// <param name="arguments">Optional arguments associated with the specific syntax employed.</param>
+    public StringSyntaxAttribute(string syntax, params object?[] arguments)
+    {
+        Syntax = syntax;
+        Arguments = arguments;
+    }
+
+    /// <summary>
+    /// Gets the identifier of the syntax used.
+    /// </summary>
+    public string Syntax { get; }
+
+    /// <summary>
+    /// Optional arguments associated with the specific syntax employed.
+    /// </summary>
+    public object?[] Arguments { get; }
+}

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -21,7 +21,7 @@ public static class D2D1ReflectionServices
     /// <typeparam name="T">The type of D2D1 shader to retrieve info for.</typeparam>
     /// <returns>The resulting <see cref="D2D1ShaderInfo"/> instance.</returns>
     /// <remarks>
-    /// If the target shader type <typeparamref name="T"/> is precompiled (ie. it's annotated with <see cref="D2DEmbeddedBytecodeAttribute"/>), that bytecode will
+    /// If the target shader type <typeparamref name="T"/> is precompiled (ie. it's annotated with <see cref="D2DShaderProfileAttribute"/>), that bytecode will
     /// be reused to reflect on the shader, so the same shader profile and compile options will be reused, which can make the returned metadata more accurate.
     /// <para>
     /// If the shader is not precompiled, it will be compiled on the fly using the default settings for both the shader profile and the compile options. That is,

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
@@ -65,7 +65,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(0)]
     [D2DInputSimple(1)]
     [D2DInputSimple(2)]
-    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     private readonly partial struct ShaderWithOverriddenProfile : ID2D1PixelShader
     {
         public float4 Execute()
@@ -133,7 +133,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(0)]
     [D2DInputSimple(1)]
     [D2DInputSimple(2)]
-    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DCompileOptions(D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision)]
     private readonly partial struct ShaderWithOverriddenProfileAndOptions : ID2D1PixelShader
     {

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/Properties/AssemblyInfo.cs
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 ﻿using ComputeSharp.D2D1;
 
-[assembly: D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader41)]
+[assembly: D2DShaderProfile(D2D1ShaderProfile.PixelShader41)]
 [assembly: D2DCompileOptions(D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.PartialPrecision)]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -212,7 +212,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(2)]
     [D2DInputComplex(1)]
     [D2DInputComplex(3)]
-    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [AutoConstructor]
     partial struct ShaderWithResourceTextures : ID2D1PixelShader
     {
@@ -291,7 +291,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(0)]
     [D2DInputSimple(1)]
     [D2DInputSimple(2)]
-    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader40Level91)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader40Level91)]
     private readonly partial struct ShaderWithEmbeddedBytecode : ID2D1PixelShader
     {
         public float4 Execute()
@@ -337,7 +337,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(0)]
     [D2DInputSimple(1)]
     [D2DInputSimple(2)]
-    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader40Level91)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader40Level91)]
     [D2DCompileOptions(D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2)]
     private readonly partial struct ShaderWithEmbeddedBytecodeAndCompileOptions : ID2D1PixelShader
     {

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
@@ -18,7 +18,6 @@ public partial class D2D1ShaderCompilerTests
 
             #include ""d2d1effecthelpers.hlsli""
 
-
             D2D_PS_ENTRY(PSMain)
             {
                 float4 color = D2DGetInput(0);
@@ -43,7 +42,6 @@ public partial class D2D1ShaderCompilerTests
             #define D2D_INPUT0_SIMPLE
 
             #include ""d2d1effecthelpers.hlsli""
-
 
             D2D_PS_ENTRY(PSMain)
             {
@@ -71,7 +69,6 @@ public partial class D2D1ShaderCompilerTests
 
             #include ""d2d1effecthelpers.hlsli""
 
-
             D2D_PS_ENTRY(PSMain)
             {
                 float4 color = D2DGetInput(0);
@@ -97,7 +94,6 @@ public partial class D2D1ShaderCompilerTests
             #define D2D_INPUT0_SIMPLE
 
             #include ""d2d1effecthelpers.hlsli""
-
 
             D2D_PS_ENTRY(PSMain)
             {

--- a/tests/ComputeSharp.D2D1.Tests/D2DPixelShaderSourceTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2DPixelShaderSourceTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.D2D1.Tests;
+
+[TestClass]
+[TestCategory("D2DPixelShaderSource")]
+public partial class D2DPixelShaderSourceTests
+{
+    [D2DPixelShaderSource(@"
+        #define D2D_INPUT_COUNT 1
+        #define D2D_INPUT0_SIMPLE
+
+        #include ""d2d1effecthelpers.hlsli""
+
+        D2D_PS_ENTRY(Execute)
+        {
+            float4 color = D2DGetInput(0);
+            float3 rgb = saturate(1.0 - color.rgb);
+            return float4(rgb, 1);
+        }
+        ")]
+    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+    [D2DCompileOptions(D2D1CompileOptions.OptimizationLevel0)]
+    private static partial ReadOnlySpan<byte> InvertEffect();
+
+    [TestMethod]
+    public void VerifyInvertEffectBytecode()
+    {
+        ReadOnlySpan<byte> bytecode = InvertEffect();
+
+        Assert.IsTrue(bytecode.Length > 0);
+    }
+}

--- a/tests/ComputeSharp.D2D1.Tests/D2DPixelShaderSourceTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2DPixelShaderSourceTests.cs
@@ -20,7 +20,7 @@ public partial class D2DPixelShaderSourceTests
             return float4(rgb, 1);
         }
         ")]
-    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DCompileOptions(D2D1CompileOptions.OptimizationLevel0)]
     private static partial ReadOnlySpan<byte> InvertEffect();
 

--- a/tests/ComputeSharp.D2D1.Tests/Effects/CheckerboardClipEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/CheckerboardClipEffect.cs
@@ -3,7 +3,7 @@
 [D2DInputCount(1)]
 [D2DInputSimple(0)]
 [D2DRequiresScenePosition]
-[D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+[D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [AutoConstructor]
 public partial struct CheckerboardClipEffect : ID2D1PixelShader
 {

--- a/tests/ComputeSharp.D2D1.Tests/Effects/InvertEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/InvertEffect.cs
@@ -2,7 +2,7 @@
 
 [D2DInputCount(1)]
 [D2DInputSimple(0)]
-[D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+[D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 public partial struct InvertEffect : ID2D1PixelShader
 {
     /// <inheritdoc/>

--- a/tests/ComputeSharp.D2D1.Tests/Effects/InvertWithThresholdEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/InvertWithThresholdEffect.cs
@@ -2,7 +2,7 @@
 
 [D2DInputCount(1)]
 [D2DInputSimple(0)]
-[D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+[D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [AutoConstructor]
 public partial struct InvertWithThresholdEffect : ID2D1PixelShader
 {

--- a/tests/ComputeSharp.D2D1.Tests/Effects/PixelateEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/PixelateEffect.cs
@@ -27,7 +27,7 @@ public sealed partial class PixelateEffect : ID2D1TransformMapper<PixelateEffect
     [D2DInputCount(1)]
     [D2DInputComplex(0)]
     [D2DRequiresScenePosition]
-    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader40)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader40)]
     [AutoConstructor]
     public partial struct Shader : ID2D1PixelShader
     {

--- a/tests/ComputeSharp.D2D1.Tests/Effects/ZonePlateEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/ZonePlateEffect.cs
@@ -4,7 +4,7 @@ namespace ComputeSharp.D2D1.Tests.Effects;
 
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
-[D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
+[D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [AutoConstructor]
 public readonly partial struct ZonePlateEffect : ID2D1PixelShader
 {


### PR DESCRIPTION
### Closes #341

### Description

This PR implements `[D2DPixelShaderSource]` and necessary generator logic.

### API breakdown

```csharp
namespace ComputeSharp.D2D1;

[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
public sealed class D2DPixelShaderSourceAttribute : Attribute
{
    public D2DPixelShaderSourceAttribute([StringSyntax("Hlsl")] string hlslSource);

    public string HlslSource { get; }
}
```