### PR TITLE
Make D2D1 resource texture types generic

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -57,3 +57,4 @@ CMPSD2D0047 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0048 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0049 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0050 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0051 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -82,7 +82,7 @@
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1BytecodeLoader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1BytecodeLoader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1DispatchDataLoader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1DispatchDataLoader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1InputDescriptionsLoader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1InputDescriptionsLoader.cs" />
-	<Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1ResourceTextureDescriptionsLoader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1ResourceTextureDescriptionsLoader.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1ResourceTextureDescriptionsLoader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1ResourceTextureDescriptionsLoader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\__Internals\ID2D1Shader.cs" Link="ComputeSharp.D2D1\Interfaces\__Internals\ID2D1Shader.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Intrinsics\D2D.cs" Link="ComputeSharp.D2D1\Intrinsics\D2D.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" Link="ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -728,4 +728,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "All fields of a D2D1 resource texture type must be annotated using the [D2DResourceTextureIndex] attribute.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a resource texture using an invalid element type.
+    /// <para>
+    /// Format: <c>"The field \"{0}\" (in type {1}) using a D2D1 resource texture of type {2} has an invalid element type (only float and float4 type arguments are supported)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidResourceTextureElementType = new DiagnosticDescriptor(
+        id: "CMPSD2D0051",
+        title: "Missing [D2DResourceTextureIndex] attribute",
+        messageFormat: "The field \"{0}\" (in type {1}) using a D2D1 resource texture of type {2} has an invalid element type (only float and float4 type arguments are supported)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The element type of D2D1 resource texture fields in a D2D1 shader must be either float or float4.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -132,6 +132,20 @@ partial class ID2D1ShaderGenerator
                 // Handle resource textures as a special case
                 if (HlslKnownTypes.IsResourceTextureType(metadataName))
                 {
+                    ITypeSymbol resourceTextureTypeArgumentSymbol = typeSymbol.TypeArguments[0];
+
+                    // Validate that the type argument is only either float or float4
+                    if (!resourceTextureTypeArgumentSymbol.HasFullyQualifiedName("System.Single") &&
+                        !resourceTextureTypeArgumentSymbol.HasFullyQualifiedName("ComputeSharp.Float4"))
+                    {
+                        diagnostics.Add(
+                            InvalidResourceTextureElementType,
+                            fieldSymbol,
+                            fieldSymbol.Name,
+                            structDeclarationSymbol,
+                            fieldSymbol.Type);
+                    }
+
                     int index = 0;
 
                     // If [D2DResourceTextureIndex] is present, get the resource texture index.

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadResourceTextureDescriptionsMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadResourceTextureDescriptionsMethod.cs
@@ -46,8 +46,8 @@ partial class ID2D1ShaderGenerator
                 // Check that the field is a resource texture type (if not, it will be processed by the HLSL rewriter too)
                 if (HlslKnownTypes.IsResourceTextureType(metadataName))
                 {
-                    // The type name will be ComputeSharp.D2D1.D2D1ResourceTexture1D or the 2D/3D versions
-                    int rank = int.Parse(metadataName.Substring(metadataName.Length - 2, 1));
+                    // The type name will be ComputeSharp.D2D1.D2D1ResourceTexture1D`1 or the 2D/3D versions
+                    int rank = int.Parse(metadataName.Substring(metadataName.Length - 4, 1));
                     int? index = null;
 
                     // Get the index from the [D2DResourceTextureIndex] attribute over the field

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
@@ -43,11 +43,11 @@ partial class HlslKnownMethods
     {
         return new Dictionary<string, string?>
         {
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture1D.Sample({typeof(float).FullName})"] = null,
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D.Sample({typeof(float).FullName}, {typeof(float).FullName})"] = "float2",
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D.Sample({typeof(Float2).FullName})"] = null,
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D.Sample({typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName})"] = "float3",
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D.Sample({typeof(Float3).FullName})"] = null
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture1D`1.Sample({typeof(float).FullName})"] = null,
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Sample({typeof(float).FullName}, {typeof(float).FullName})"] = "float2",
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Sample({typeof(Float2).FullName})"] = null,
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Sample({typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName})"] = "float3",
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Sample({typeof(Float3).FullName})"] = null
         };
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownProperties.cs
@@ -10,8 +10,8 @@ partial class HlslKnownProperties
     {
         return new Dictionary<string, string>
         {
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3"
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3"
         };
     }
 
@@ -20,12 +20,12 @@ partial class HlslKnownProperties
     {
         return new Dictionary<string, (int, int)>
         {
-            ["ComputeSharp.D2D1.D2D1ResourceTexture1D.Width"] = (1, 0),
-            ["ComputeSharp.D2D1.D2D1ResourceTexture2D.Width"] = (2, 0),
-            ["ComputeSharp.D2D1.D2D1ResourceTexture2D.Height"] = (2, 1),
-            ["ComputeSharp.D2D1.D2D1ResourceTexture3D.Width"] = (3, 0),
-            ["ComputeSharp.D2D1.D2D1ResourceTexture3D.Height"] = (3, 1),
-            ["ComputeSharp.D2D1.D2D1ResourceTexture3D.Depth"] = (3, 2)
+            ["ComputeSharp.D2D1.D2D1ResourceTexture1D`1.Width"] = (1, 0),
+            ["ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Width"] = (2, 0),
+            ["ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Height"] = (2, 1),
+            ["ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Width"] = (3, 0),
+            ["ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Height"] = (3, 1),
+            ["ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Depth"] = (3, 2)
         };
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownTypes.cs
@@ -16,9 +16,9 @@ partial class HlslKnownTypes
     {
         return typeName switch
         {
-            "ComputeSharp.D2D1.D2D1ResourceTexture1D" or
-            "ComputeSharp.D2D1.D2D1ResourceTexture2D" or
-            "ComputeSharp.D2D1.D2D1ResourceTexture3D" => true,
+            "ComputeSharp.D2D1.D2D1ResourceTexture1D`1" or
+            "ComputeSharp.D2D1.D2D1ResourceTexture2D`1" or
+            "ComputeSharp.D2D1.D2D1ResourceTexture3D`1" => true,
             _ => false
         };
     }
@@ -31,11 +31,16 @@ partial class HlslKnownTypes
         // Special case for resource texture types
         if (IsResourceTextureType(typeName))
         {
+            string genericArgumentName = ((INamedTypeSymbol)typeSymbol.TypeArguments[0]).GetFullMetadataName();
+
+            // Get the HLSL name for the type argument (it can only be either float or float4)
+            _ = KnownHlslTypes.TryGetValue(genericArgumentName, out string? mappedElementType);
+
             return typeName switch
             {
-                "ComputeSharp.D2D1.D2D1ResourceTexture1D" => "Texture1D",
-                "ComputeSharp.D2D1.D2D1ResourceTexture2D" => "Texture2D",
-                "ComputeSharp.D2D1.D2D1ResourceTexture3D" => "Texture3D",
+                "ComputeSharp.D2D1.D2D1ResourceTexture1D`1" => $"Texture1D<{mappedElementType}>",
+                "ComputeSharp.D2D1.D2D1ResourceTexture2D`1" => $"Texture2D<{mappedElementType}>",
+                "ComputeSharp.D2D1.D2D1ResourceTexture3D`1" => $"Texture3D<{mappedElementType}>",
                 _ => throw new ArgumentException()
             };
         }

--- a/src/ComputeSharp.D2D1/Resources/D2D1ResourceTexture1D{T}.cs
+++ b/src/ComputeSharp.D2D1/Resources/D2D1ResourceTexture1D{T}.cs
@@ -6,26 +6,28 @@ namespace ComputeSharp.D2D1;
 /// A <see langword="struct"/> representing a <see cref="Float4"/> readonly 1D texture stored on GPU memory.
 /// This can be used from D2D1 pixel shaders to be able to pass arbitrary inputs to them.
 /// </summary>
+/// <typeparam name="T">The type of items stored on the texture (only <see langword="float"/> and <see cref="Float4"/> are supported).</typeparam>
 [AutoConstructorBehavior(AutoConstructorBehavior.IgnoreAndSetToDefault)]
-public readonly struct D2D1ResourceTexture1D
+public readonly struct D2D1ResourceTexture1D<T>
+    where T : unmanaged
 {
     /// <summary>
     /// Gets the width of the current texture.
     /// </summary>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public int Width => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture1D)}.{nameof(Width)}");
+    public int Width => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture1D<T>)}.{nameof(Width)}");
 
     /// <summary>
     /// Gets a single <see cref="Float4"/> value from the current readonly texture.
     /// </summary>
     /// <param name="x">The horizontal offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 this[int x] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D)}[{typeof(int)}]");
+    public ref readonly T this[int x] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture1D<T>)}[{typeof(int)}]");
 
     /// <summary>
     /// Retrieves a single <see cref="Float4"/> value from the current readonly texture with linear sampling.
     /// </summary>
     /// <param name="u">The horizontal normalized offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 Sample(float u) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D)}.{nameof(Sample)}({typeof(float)})");
+    public ref readonly T Sample(float u) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture1D<T>)}.{nameof(Sample)}({typeof(float)})");
 }

--- a/src/ComputeSharp.D2D1/Resources/D2D1ResourceTexture2D{T}.cs
+++ b/src/ComputeSharp.D2D1/Resources/D2D1ResourceTexture2D{T}.cs
@@ -3,59 +3,53 @@
 namespace ComputeSharp.D2D1;
 
 /// <summary>
-/// A <see langword="struct"/> representing a <see cref="Float4"/> readonly 3D texture stored on GPU memory.
+/// A <see langword="struct"/> representing a <see cref="Float4"/> readonly 2D texture stored on GPU memory.
 /// This can be used from D2D1 pixel shaders to be able to pass arbitrary inputs to them.
 /// </summary>
+/// <typeparam name="T">The type of items stored on the texture (only <see langword="float"/> and <see cref="Float4"/> are supported).</typeparam>
 [AutoConstructorBehavior(AutoConstructorBehavior.IgnoreAndSetToDefault)]
-public readonly struct D2D1ResourceTexture3D
+public readonly struct D2D1ResourceTexture2D<T>
+    where T : unmanaged
 {
     /// <summary>
     /// Gets the width of the current texture.
     /// </summary>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public int Width => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D)}.{nameof(Width)}");
+    public int Width => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D<T>)}.{nameof(Width)}");
 
     /// <summary>
     /// Gets the height of the current texture.
     /// </summary>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public int Height => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D)}.{nameof(Height)}");
-
-    /// <summary>
-    /// Gets the depth of the current texture.
-    /// </summary>
-    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public int Depth => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D)}.{nameof(Depth)}");
+    public int Height => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D<T>)}.{nameof(Height)}");
 
     /// <summary>
     /// Gets a single <see cref="Float4"/> value from the current readonly texture.
     /// </summary>
     /// <param name="x">The horizontal offset of the value to get.</param>
     /// <param name="y">The vertical offset of the value to get.</param>
-    /// <param name="z">The depthwise offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 this[int x, int y, int z] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D)}[{typeof(int)}, {typeof(int)}, {typeof(int)}]");
+    public ref readonly T this[int x, int y] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D<T>)}[{typeof(int)}, {typeof(int)}]");
 
     /// <summary>
     /// Gets a single <see cref="Float4"/> value from the current readonly texture.
     /// </summary>
-    /// <param name="xyz">The coordinates of the value to get.</param>
+    /// <param name="xy">The coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 this[Int3 xyz] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D)}[{typeof(Int3)}]");
+    public ref readonly T this[Int2 xy] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D<T>)}[{typeof(Int2)}]");
 
     /// <summary>
     /// Retrieves a single <see cref="Float4"/> value from the current readonly texture with linear sampling.
     /// </summary>
     /// <param name="u">The horizontal normalized offset of the value to get.</param>
     /// <param name="v">The vertical normalized offset of the value to get.</param>
-    /// <param name="w">The depthwise offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 Sample(float u, float v, float w) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D)}.{nameof(Sample)}({typeof(float)}, {typeof(float)}, {typeof(float)})");
+    public ref readonly T Sample(float u, float v) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D<T>)}.{nameof(Sample)}({typeof(float)}, {typeof(float)})");
 
     /// <summary>
     /// Retrieves a single <see cref="Float4"/> value from the current readonly texture with linear sampling.
     /// </summary>
-    /// <param name="uvw">The normalized coordinates of the value to get.</param>
+    /// <param name="uv">The normalized coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 Sample(Float3 uvw) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D)}.{nameof(Sample)}({typeof(Float3)})");
+    public ref readonly T Sample(Float2 uv) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D<T>)}.{nameof(Sample)}({typeof(Float2)})");
 }

--- a/src/ComputeSharp.D2D1/Resources/D2D1ResourceTexture3D{T}.cs
+++ b/src/ComputeSharp.D2D1/Resources/D2D1ResourceTexture3D{T}.cs
@@ -3,51 +3,61 @@
 namespace ComputeSharp.D2D1;
 
 /// <summary>
-/// A <see langword="struct"/> representing a <see cref="Float4"/> readonly 2D texture stored on GPU memory.
+/// A <see langword="struct"/> representing a <see cref="Float4"/> readonly 3D texture stored on GPU memory.
 /// This can be used from D2D1 pixel shaders to be able to pass arbitrary inputs to them.
 /// </summary>
+/// <typeparam name="T">The type of items stored on the texture (only <see langword="float"/> and <see cref="Float4"/> are supported).</typeparam>
 [AutoConstructorBehavior(AutoConstructorBehavior.IgnoreAndSetToDefault)]
-public readonly struct D2D1ResourceTexture2D
+public readonly struct D2D1ResourceTexture3D<T>
+    where T : unmanaged
 {
     /// <summary>
     /// Gets the width of the current texture.
     /// </summary>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public int Width => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D)}.{nameof(Width)}");
+    public int Width => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D<T>)}.{nameof(Width)}");
 
     /// <summary>
     /// Gets the height of the current texture.
     /// </summary>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public int Height => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D)}.{nameof(Height)}");
+    public int Height => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D<T>)}.{nameof(Height)}");
+
+    /// <summary>
+    /// Gets the depth of the current texture.
+    /// </summary>
+    /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
+    public int Depth => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D<T>)}.{nameof(Depth)}");
 
     /// <summary>
     /// Gets a single <see cref="Float4"/> value from the current readonly texture.
     /// </summary>
     /// <param name="x">The horizontal offset of the value to get.</param>
     /// <param name="y">The vertical offset of the value to get.</param>
+    /// <param name="z">The depthwise offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 this[int x, int y] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D)}[{typeof(int)}, {typeof(int)}]");
+    public ref readonly T this[int x, int y, int z] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D<T>)}[{typeof(int)}, {typeof(int)}, {typeof(int)}]");
 
     /// <summary>
     /// Gets a single <see cref="Float4"/> value from the current readonly texture.
     /// </summary>
-    /// <param name="xy">The coordinates of the value to get.</param>
+    /// <param name="xyz">The coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 this[Int2 xy] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D)}[{typeof(Int2)}]");
+    public ref readonly T this[Int3 xyz] => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D<T>)}[{typeof(Int3)}]");
 
     /// <summary>
     /// Retrieves a single <see cref="Float4"/> value from the current readonly texture with linear sampling.
     /// </summary>
     /// <param name="u">The horizontal normalized offset of the value to get.</param>
     /// <param name="v">The vertical normalized offset of the value to get.</param>
+    /// <param name="w">The depthwise offset of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 Sample(float u, float v) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D)}.{nameof(Sample)}({typeof(float)}, {typeof(float)})");
+    public ref readonly T Sample(float u, float v, float w) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D<T>)}.{nameof(Sample)}({typeof(float)}, {typeof(float)}, {typeof(float)})");
 
     /// <summary>
     /// Retrieves a single <see cref="Float4"/> value from the current readonly texture with linear sampling.
     /// </summary>
-    /// <param name="uv">The normalized coordinates of the value to get.</param>
+    /// <param name="uvw">The normalized coordinates of the value to get.</param>
     /// <remarks>This API can only be used from a compute shader, and will always throw if used anywhere else.</remarks>
-    public ref readonly Float4 Sample(Float2 uv) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture2D)}.{nameof(Sample)}({typeof(Float2)})");
+    public ref readonly T Sample(Float3 uvw) => throw new InvalidExecutionContextException($"{typeof(D2D1ResourceTexture3D<T>)}.{nameof(Sample)}({typeof(Float3)})");
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ResourceTextureDescription.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ResourceTextureDescription.cs
@@ -9,11 +9,11 @@ public readonly struct D2D1ResourceTextureDescription
     /// Creates a new <see cref="D2D1ResourceTextureDescription"/> instance with the specified parameters.
     /// </summary>
     /// <param name="index">The index of the resource texture the description belongs to.</param>
-    /// <param name="rank">The rank of the resource texture the description belongs to.</param>
-    internal D2D1ResourceTextureDescription(int index, int rank)
+    /// <param name="dimensions">The number of dimensions of the resource texture the description belongs to.</param>
+    internal D2D1ResourceTextureDescription(int index, int dimensions)
     {
         Index = index;
-        Rank = rank;
+        Dimensions = dimensions;
     }
 
     /// <summary>
@@ -24,5 +24,5 @@ public readonly struct D2D1ResourceTextureDescription
     /// <summary>
     /// Gets the rank of the resource texture the description belongs to.
     /// </summary>
-    public int Rank { get; }
+    public int Dimensions { get; }
 }

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -195,16 +195,16 @@ public partial class D2D1PixelShaderTests
         ReadOnlySpan<D2D1ResourceTextureDescription> span = resourceTextureDescriptions.Span;
 
         Assert.AreEqual(span[0].Index, 5);
-        Assert.AreEqual(span[0].Rank, 1);
+        Assert.AreEqual(span[0].Dimensions, 1);
 
         Assert.AreEqual(span[1].Index, 6);
-        Assert.AreEqual(span[1].Rank, 2);
+        Assert.AreEqual(span[1].Dimensions, 2);
 
         Assert.AreEqual(span[2].Index, 7);
-        Assert.AreEqual(span[2].Rank, 3);
+        Assert.AreEqual(span[2].Dimensions, 3);
 
         Assert.AreEqual(span[3].Index, 8);
-        Assert.AreEqual(span[3].Rank, 2);
+        Assert.AreEqual(span[3].Dimensions, 2);
     }
 
     [D2DInputCount(4)]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -215,13 +215,13 @@ public partial class D2D1PixelShaderTests
         float number;
 
         [D2DResourceTextureIndex(5)]
-        D2D1ResourceTexture1D myTexture1;
+        D2D1ResourceTexture1D<float4> myTexture1;
 
         [D2DResourceTextureIndex(6)]
-        D2D1ResourceTexture2D myTexture2;
+        D2D1ResourceTexture2D<float4> myTexture2;
 
         [D2DResourceTextureIndex(7)]
-        D2D1ResourceTexture3D myTexture3;
+        D2D1ResourceTexture3D<float4> myTexture3;
 
         public Float4 Execute()
         {

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -190,7 +190,7 @@ public partial class D2D1PixelShaderTests
     {
         ReadOnlyMemory<D2D1ResourceTextureDescription> resourceTextureDescriptions = D2D1PixelShader.GetResourceTextureDescriptions<ShaderWithResourceTextures>();
 
-        Assert.AreEqual(resourceTextureDescriptions.Length, 3);
+        Assert.AreEqual(resourceTextureDescriptions.Length, 4);
 
         ReadOnlySpan<D2D1ResourceTextureDescription> span = resourceTextureDescriptions.Span;
 
@@ -202,6 +202,9 @@ public partial class D2D1PixelShaderTests
 
         Assert.AreEqual(span[2].Index, 7);
         Assert.AreEqual(span[2].Rank, 3);
+
+        Assert.AreEqual(span[3].Index, 8);
+        Assert.AreEqual(span[3].Rank, 2);
     }
 
     [D2DInputCount(4)]
@@ -209,6 +212,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(2)]
     [D2DInputComplex(1)]
     [D2DInputComplex(3)]
+    [D2DEmbeddedBytecode(D2D1ShaderProfile.PixelShader50)]
     [AutoConstructor]
     partial struct ShaderWithResourceTextures : ID2D1PixelShader
     {
@@ -223,6 +227,9 @@ public partial class D2D1PixelShaderTests
         [D2DResourceTextureIndex(7)]
         D2D1ResourceTexture3D<float4> myTexture3;
 
+        [D2DResourceTextureIndex(8)]
+        D2D1ResourceTexture2D<float> myTexture4;
+
         public Float4 Execute()
         {
             float4 pixel1 = myTexture1[0];
@@ -231,6 +238,8 @@ public partial class D2D1PixelShaderTests
             float4 pixel4 = myTexture2.Sample(0.4f, 0.3f);
             float4 pixel5 = myTexture3[0, 1, 2];
             float4 pixel6 = myTexture3.Sample(0.4f, 0.5f, 0.6f);
+            float number1 = myTexture4[0, 2];
+            float number2 = myTexture4.Sample(0.4f, 0.6f);
 
             return 0;
         }


### PR DESCRIPTION
### Follow up for #271

### Description

This PR makes the D2D1 resource texture types generic to allow 1 and 4 channels on the shader side.