### PR TITLE
Pack DXC native libs with generator

### DIFF
--- a/src/ComputeSharp.Package/ComputeSharp.Package.msbuildproj
+++ b/src/ComputeSharp.Package/ComputeSharp.Package.msbuildproj
@@ -30,6 +30,12 @@
     <!-- Include the custom .targets file to check the source generator -->
     <None Include="..\ComputeSharp\ComputeSharp.targets" PackagePath="buildTransitive\ComputeSharp.targets" Pack="true" />
     <None Include="..\ComputeSharp\ComputeSharp.targets" PackagePath="build\ComputeSharp.targets" Pack="true" />
+
+    <!-- Include the DXC compiler files -->
+    <None Include="..\ComputeSharp.Dynamic\Libraries\x64\dxcompiler.dll" PackagePath="analyzers\dotnet\cs\Libraries\x64\dxcompiler.dll" Pack="true" />
+    <None Include="..\ComputeSharp.Dynamic\Libraries\x64\dxil.dll" PackagePath="analyzers\dotnet\cs\Libraries\x64\dxil.dll" Pack="true" />
+    <None Include="..\ComputeSharp.Dynamic\Libraries\arm64\dxcompiler.dll" PackagePath="analyzers\dotnet\cs\Libraries\arm64\dxcompiler.dll" Pack="true" />
+    <None Include="..\ComputeSharp.Dynamic\Libraries\arm64\dxil.dll" PackagePath="analyzers\dotnet\cs\Libraries\arm64\dxil.dll" Pack="true" />
   </ItemGroup>
 
 </Project>

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -94,10 +94,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="..\ComputeSharp.Dynamic\Libraries\x64\dxcompiler.dll" Link="ComputeSharp\Libraries\x64\dxcompiler.dll" />
-    <EmbeddedResource Include="..\ComputeSharp.Dynamic\Libraries\x64\dxil.dll" Link="ComputeSharp\Libraries\x64\dxil.dll" />
-    <EmbeddedResource Include="..\ComputeSharp.Dynamic\Libraries\arm64\dxcompiler.dll" Link="ComputeSharp\Libraries\arm64\dxcompiler.dll" />
-    <EmbeddedResource Include="..\ComputeSharp.Dynamic\Libraries\arm64\dxil.dll" Link="ComputeSharp\Libraries\arm64\dxil.dll" />
+    <None Include="..\ComputeSharp.Dynamic\Libraries\x64\dxcompiler.dll"
+          Link="Libraries\x64\dxcompiler.dll"
+          Visible="False"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\ComputeSharp.Dynamic\Libraries\x64\dxil.dll"
+          Link="Libraries\x64\dxil.dll"
+          Visible="False"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\ComputeSharp.Dynamic\Libraries\arm64\dxcompiler.dll"
+          Link="Libraries\arm64\dxcompiler.dll"
+          Visible="False"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\ComputeSharp.Dynamic\Libraries\arm64\dxil.dll"
+          Link="Libraries\arm64\dxil.dll"
+          Visible="False"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- Shared project with common helpers -->

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadBytecodeMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadBytecodeMethod.cs
@@ -218,29 +218,6 @@ partial class IShaderGenerator
         /// <exception cref="Win32Exception">Thrown if a library fails to load.</exception>
         private static void LoadNativeDxcLibraries()
         {
-            // Extracts a specified native library for a given runtime identifier
-            static string ExtractLibrary(string folder, string rid, string name)
-            {
-                string sourceFilename = $"ComputeSharp.SourceGenerators.ComputeSharp.Libraries.{rid}.{name}.dll";
-                string targetFilename = Path.Combine(folder, rid, $"{name}.dll");
-
-                _ = Directory.CreateDirectory(Path.GetDirectoryName(targetFilename));
-
-                using Stream sourceStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(sourceFilename);
-
-                try
-                {
-                    using Stream destinationStream = File.Open(targetFilename, FileMode.CreateNew, FileAccess.Write);
-
-                    sourceStream.CopyTo(destinationStream);
-                }
-                catch (IOException)
-                {
-                }
-
-                return targetFilename;
-            }
-
             // Loads a target native library
             static unsafe void LoadLibrary(string filename)
             {
@@ -267,10 +244,10 @@ partial class IShaderGenerator
                     _ => throw new NotSupportedException("Invalid process architecture")
                 };
 
-                string folder = Path.Combine(Path.GetTempPath(), "ComputeSharp.SourceGenerators", Path.GetRandomFileName());
+                string folder = Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Libraries", rid);
 
-                LoadLibrary(ExtractLibrary(folder, rid, "dxil"));
-                LoadLibrary(ExtractLibrary(folder, rid, "dxcompiler"));
+                LoadLibrary(Path.Combine(folder, "dxil.dll"));
+                LoadLibrary(Path.Combine(folder, "dxcompiler.dll"));
 
                 areDxcLibrariesLoaded = true;
             }


### PR DESCRIPTION
### Closes #348

### Description

This PR packs the DXC native libs (dxcompiler and dxil) so the generator can load them directly.
These are copied (and packed) into `Libraries\<RID>\` relative to the generator assembly.