### PR TITLE
Fix HLSL Interlocked APIs

### DIFF
--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.Void.g.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.Void.g.cs
@@ -346,7 +346,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedadd"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedAdd(int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAdd)}({typeof(int)}, {typeof(int)})");
+    public static void InterlockedAdd(ref int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAdd)}({typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Performs a guaranteed atomic add of a value to a destination.
@@ -357,19 +357,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedadd"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedAdd(uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAdd)}({typeof(uint)}, {typeof(uint)})");
-
-    /// <summary>
-    /// Performs a guaranteed atomic add of a value to a destination.
-    /// </summary>
-    /// <param name="destination">The destination value.</param>
-    /// <param name="value">The input value.</param>
-    /// <param name="original">The original input value.</param>
-    /// <remarks>
-    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedadd"/>.
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
-    /// </remarks>
-    public static void InterlockedAdd(int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAdd)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedAdd(ref uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAdd)}({typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic add of a value to a destination.
@@ -381,7 +369,19 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedadd"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedAdd(uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAdd)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedAdd(ref int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAdd)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+
+    /// <summary>
+    /// Performs a guaranteed atomic add of a value to a destination.
+    /// </summary>
+    /// <param name="destination">The destination value.</param>
+    /// <param name="value">The input value.</param>
+    /// <param name="original">The original input value.</param>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedadd"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    public static void InterlockedAdd(ref uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAdd)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic and of a value to a destination.
@@ -392,7 +392,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedand"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedAnd(int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAnd)}({typeof(int)}, {typeof(int)})");
+    public static void InterlockedAnd(ref int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAnd)}({typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Performs a guaranteed atomic and of a value to a destination.
@@ -403,7 +403,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedand"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedAnd(uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAnd)}({typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedAnd(ref uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAnd)}({typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic and of a value to a destination.
@@ -415,7 +415,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedand"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedAnd(int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAnd)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedAnd(ref int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAnd)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Performs a guaranteed atomic and of a value to a destination.
@@ -427,7 +427,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedand"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedAnd(uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAnd)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedAnd(ref uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedAnd)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Atomically compares the destination with the comparison value. If they are identical, the destination
@@ -441,7 +441,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedcompareexchange"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedCompareExchange(int destination, int comparison, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedCompareExchange)}({typeof(int)}, {typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedCompareExchange(ref int destination, int comparison, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedCompareExchange)}({typeof(int)}, {typeof(int)}, {typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Atomically compares the destination with the comparison value. If they are identical, the destination
@@ -455,7 +455,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedcompareexchange"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedCompareExchange(uint destination, uint comparison, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedCompareExchange)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedCompareExchange(ref uint destination, uint comparison, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedCompareExchange)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Atomically compares the destination to the comparison value. If they
@@ -468,7 +468,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedcomparestore"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedCompareStore(int destination, int comparison, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedCompareStore)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedCompareStore(ref int destination, int comparison, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedCompareStore)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Atomically compares the destination to the comparison value. If they
@@ -481,7 +481,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedcomparestore"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedCompareStore(uint destination, uint comparison, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedCompareStore)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedCompareStore(ref uint destination, uint comparison, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedCompareStore)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Assigns value to dest and returns the original value.
@@ -493,7 +493,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedexchange"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedExchange(int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedExchange)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedExchange(ref int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedExchange)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Assigns value to dest and returns the original value.
@@ -505,7 +505,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedexchange"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedExchange(uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedExchange)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedExchange(ref uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedExchange)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic max.
@@ -516,7 +516,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmax"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedMax(int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMax)}({typeof(int)}, {typeof(int)})");
+    public static void InterlockedMax(ref int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMax)}({typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Performs a guaranteed atomic max.
@@ -527,19 +527,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmax"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedMax(uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMax)}({typeof(uint)}, {typeof(uint)})");
-
-    /// <summary>
-    /// Performs a guaranteed atomic max.
-    /// </summary>
-    /// <param name="destination">The destination value.</param>
-    /// <param name="value">The input value.</param>
-    /// <param name="original">The original input value.</param>
-    /// <remarks>
-    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmax"/>.
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
-    /// </remarks>
-    public static void InterlockedMax(int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMax)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedMax(ref uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMax)}({typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic max.
@@ -551,7 +539,19 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmax"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedMax(uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMax)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedMax(ref int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMax)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+
+    /// <summary>
+    /// Performs a guaranteed atomic max.
+    /// </summary>
+    /// <param name="destination">The destination value.</param>
+    /// <param name="value">The input value.</param>
+    /// <param name="original">The original input value.</param>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmax"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    public static void InterlockedMax(ref uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMax)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic min.
@@ -562,7 +562,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmin"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedMin(int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMin)}({typeof(int)}, {typeof(int)})");
+    public static void InterlockedMin(ref int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMin)}({typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Performs a guaranteed atomic min.
@@ -573,19 +573,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmin"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedMin(uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMin)}({typeof(uint)}, {typeof(uint)})");
-
-    /// <summary>
-    /// Performs a guaranteed atomic min.
-    /// </summary>
-    /// <param name="destination">The destination value.</param>
-    /// <param name="value">The input value.</param>
-    /// <param name="original">The original input value.</param>
-    /// <remarks>
-    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmin"/>.
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
-    /// </remarks>
-    public static void InterlockedMin(int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMin)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedMin(ref uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMin)}({typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic min.
@@ -597,7 +585,19 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmin"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedMin(uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMin)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedMin(ref int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMin)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+
+    /// <summary>
+    /// Performs a guaranteed atomic min.
+    /// </summary>
+    /// <param name="destination">The destination value.</param>
+    /// <param name="value">The input value.</param>
+    /// <param name="original">The original input value.</param>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedmin"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    public static void InterlockedMin(ref uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedMin)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic or.
@@ -608,7 +608,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedor"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedOr(int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedOr)}({typeof(int)}, {typeof(int)})");
+    public static void InterlockedOr(ref int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedOr)}({typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Performs a guaranteed atomic or.
@@ -619,7 +619,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedor"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedOr(uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedOr)}({typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedOr(ref uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedOr)}({typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic or.
@@ -631,7 +631,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedor"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedOr(int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedOr)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedOr(ref int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedOr)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Performs a guaranteed atomic or.
@@ -643,7 +643,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedor"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedOr(uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedOr)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedOr(ref uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedOr)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic xor.
@@ -654,7 +654,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedxor"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedXor(int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedXor)}({typeof(int)}, {typeof(int)})");
+    public static void InterlockedXor(ref int destination, int value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedXor)}({typeof(int)}, {typeof(int)})");
 
     /// <summary>
     /// Performs a guaranteed atomic xor.
@@ -665,19 +665,7 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedxor"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedXor(uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedXor)}({typeof(uint)}, {typeof(uint)})");
-
-    /// <summary>
-    /// Performs a guaranteed atomic xor.
-    /// </summary>
-    /// <param name="destination">The destination value.</param>
-    /// <param name="value">The input value.</param>
-    /// <param name="original">The original input value.</param>
-    /// <remarks>
-    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedxor"/>.
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
-    /// </remarks>
-    public static void InterlockedXor(int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedXor)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+    public static void InterlockedXor(ref uint destination, uint value) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedXor)}({typeof(uint)}, {typeof(uint)})");
 
     /// <summary>
     /// Performs a guaranteed atomic xor.
@@ -689,5 +677,17 @@ partial class Hlsl
     /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedxor"/>.
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
-    public static void InterlockedXor(uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedXor)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
+    public static void InterlockedXor(ref int destination, int value, out int original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedXor)}({typeof(int)}, {typeof(int)}, {typeof(int)})");
+
+    /// <summary>
+    /// Performs a guaranteed atomic xor.
+    /// </summary>
+    /// <param name="destination">The destination value.</param>
+    /// <param name="value">The input value.</param>
+    /// <param name="original">The original input value.</param>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/interlockedxor"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    public static void InterlockedXor(ref uint destination, uint value, out uint original) => throw new InvalidExecutionContextException($"{typeof(Hlsl)}.{nameof(InterlockedXor)}({typeof(uint)}, {typeof(uint)}, {typeof(uint)})");
 }

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.Void.tt
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.Void.tt
@@ -72,7 +72,7 @@ foreach (var intrinsic in Intrinsics)
         }
 
         Write($"public static void {intrinsic.Name}(");
-        Write(string.Join(", ", intrinsic.Parameters.Where(p => p.Name is not "").Zip(overload, (a, b) => $"{(a.IsOut ? "out " : "")}{b} {a.Name}")));
+        Write(string.Join(", ", intrinsic.Parameters.Where(p => p.Name is not "").Zip(overload, (a, b) => $"{(a.IsRef ? "ref " : a.IsOut ? "out " : "")}{b} {a.Name}")));
         Write(")");
 
         Write(" => throw new InvalidExecutionContextException(");

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -22,6 +22,7 @@
     <Compile Include="..\ComputeSharp.Core\Intrinsics\Attributes\HlslIntrinsicNameAttribute.cs" Link="ComputeSharp.Core\Intrinsics\Attributes\HlslIntrinsicNameAttribute.cs" />
     <Compile Include="..\ComputeSharp.Core\Intrinsics\Hlsl.cs" Link="ComputeSharp.Core\Intrinsics\Hlsl.cs" />
     <Compile Include="..\ComputeSharp.Core\Intrinsics\Hlsl.g.cs" Link="ComputeSharp.Core\Intrinsics\Hlsl.g.cs" />
+    <Compile Include="..\ComputeSharp.Core\Intrinsics\Hlsl.Void.g.cs" Link="ComputeSharp.Core\Intrinsics\Hlsl.Void.g.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Bool\Bool.cs" Link="ComputeSharp.Core\Primitives\Bool\Bool.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Bool\Bool2.cs" Link="ComputeSharp.Core\Primitives\Bool\Bool2.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Bool\Bool3.cs" Link="ComputeSharp.Core\Primitives\Bool\Bool3.cs" />

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -279,4 +279,32 @@ public partial class ShaderRewriterTests
             buffer2[7] = exponentUppercaseField;
         }
     }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public void InterlockedOperations(Device device)
+    {
+        using ReadWriteBuffer<int> buffer = device.Get().AllocateReadWriteBuffer<int>(16);
+
+        device.Get().For(16, new InterlockedOperationsShader(buffer));
+
+        int[] result = buffer.ToArray();
+
+        for (int i = 0; i < result.Length; i++)
+        {
+            Assert.AreEqual(i, result[i]);
+        }
+    }
+
+    [AutoConstructor]
+    [EmbeddedBytecode(DispatchAxis.X)]
+    internal readonly partial struct InterlockedOperationsShader : IComputeShader
+    {
+        public readonly ReadWriteBuffer<int> buffer;
+
+        public void Execute()
+        {
+            Hlsl.InterlockedAdd(buffer[ThreadIds.X], ThreadIds.X);
+        }
+    }
 }

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -292,7 +292,7 @@ public partial class ShaderRewriterTests
 
         for (int i = 0; i < result.Length; i++)
         {
-            Assert.AreEqual(i, result[i]);
+            Assert.AreEqual(i * 2, result[i]);
         }
     }
 
@@ -304,7 +304,13 @@ public partial class ShaderRewriterTests
 
         public void Execute()
         {
+            // InterlockedExchange 0, which effectively just writes 0 to the target.
+            // Then InterlockedAdd to increment the value to ThreadIds.X. Finally,
+            // InterlockedCompareExchange with the expected value, setting twice as much.
+            // The result each value in the buffer should have after this is ThreadIds.X * 2.
+            Hlsl.InterlockedExchange(ref buffer[ThreadIds.X], 0, out _);
             Hlsl.InterlockedAdd(ref buffer[ThreadIds.X], ThreadIds.X);
+            Hlsl.InterlockedCompareExchange(ref buffer[ThreadIds.X], ThreadIds.X, ThreadIds.X * 2, out _);
         }
     }
 }

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -304,7 +304,7 @@ public partial class ShaderRewriterTests
 
         public void Execute()
         {
-            Hlsl.InterlockedAdd(buffer[ThreadIds.X], ThreadIds.X);
+            Hlsl.InterlockedAdd(ref buffer[ThreadIds.X], ThreadIds.X);
         }
     }
 }


### PR DESCRIPTION
### Closes #322

### Description

This PR fixes the `Interlocked` APIs for DX12 shaders, and properly adds `ref` to the target location parameters.