### PR TITLE
Fix resource manager ref count

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
@@ -248,8 +248,16 @@ unsafe partial struct PixelShaderEffect
             }
         }
 
+        ref ID2D1ResourceTextureManager* currentResourceTextureManager = ref this.resourceTextureManagerBuffer[resourceTextureIndex];
+
+        // If there's already an existing manager at this index, release it
+        if (currentResourceTextureManager is not null)
+        {
+            ((IUnknown*)currentResourceTextureManager)->Release();
+        }
+
         // Store the resource texture manager into the buffer
-        this.resourceTextureManagerBuffer[resourceTextureIndex] = resourceTextureManager.Detach();
+        currentResourceTextureManager = resourceTextureManager.Detach();
 
         return S.S_OK;
     }


### PR DESCRIPTION
### Description

This PR fixes resource texture managers not being released when setting a new one to an already used slot.