### PR TITLE
Enforce multithread factories

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ResourceTextureManager.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ResourceTextureManager.cs
@@ -116,6 +116,17 @@ public sealed unsafe class D2D1ResourceTextureManager : ICustomQueryInterface
     /// <param name="filter">The filter for the resource to create.</param>
     /// <param name="extendModes">The extend modes for the resource to create.</param>
     /// <exception cref="Exception">Thrown if creating or initializing the <see cref="D2D1ResourceTextureManager"/> instance failed.</exception>
+    /// <remarks>
+    /// <para>
+    /// Since <see cref="D2D1ResourceTextureManager"/> has a finalizer, which can be invoked at any point on the finalizer
+    /// thread, it can only be used in effects associated with a device context using a factory that supports multithreaded
+    /// use (ie. the underlying <c>ID2D1Factory</c> has to be created using <c>D2D1_FACTORY_TYPE_MULTI_THREADED </c>).
+    /// Not doing so will cause the resource texture manager to fail to be initialized when used in an effect.
+    /// </para>
+    /// <para>
+    /// For more info, see <see href="https://docs.microsoft.com/en-us/windows/win32/api/d2d1/ne-d2d1-d2d1_factory_type"/>.
+    /// </para>
+    /// </remarks>
     public D2D1ResourceTextureManager(
         ReadOnlySpan<uint> extents,
         D2D1BufferPrecision bufferPrecision,
@@ -144,6 +155,17 @@ public sealed unsafe class D2D1ResourceTextureManager : ICustomQueryInterface
     /// <param name="filter">The filter for the resource to create.</param>
     /// <param name="extendModes">The extend modes for the resource to create.</param>
     /// <exception cref="Exception">Thrown if creating or initializing the <see cref="D2D1ResourceTextureManager"/> instance failed.</exception>
+    /// <remarks>
+    /// <para>
+    /// Since <see cref="D2D1ResourceTextureManager"/> has a finalizer, which can be invoked at any point on the finalizer
+    /// thread, it can only be used in effects associated with a device context using a factory that supports multithreaded
+    /// use (ie. the underlying <c>ID2D1Factory</c> has to be created using <c>D2D1_FACTORY_TYPE_MULTI_THREADED </c>).
+    /// Not doing so will cause the resource texture manager to fail to be initialized when used in an effect.
+    /// </para>
+    /// <para>
+    /// For more info, see <see href="https://docs.microsoft.com/en-us/windows/win32/api/d2d1/ne-d2d1-d2d1_factory_type"/>.
+    /// </para>
+    /// </remarks>
     public D2D1ResourceTextureManager(
         Guid resourceId,
         ReadOnlySpan<uint> extents,
@@ -174,6 +196,17 @@ public sealed unsafe class D2D1ResourceTextureManager : ICustomQueryInterface
     /// <param name="data">The data to load in the resource to create.</param>
     /// <param name="strides">The strides for the data supplied for the resource to create.</param>
     /// <exception cref="Exception">Thrown if creating or initializing the <see cref="D2D1ResourceTextureManager"/> instance failed.</exception>
+    /// <remarks>
+    /// <para>
+    /// Since <see cref="D2D1ResourceTextureManager"/> has a finalizer, which can be invoked at any point on the finalizer
+    /// thread, it can only be used in effects associated with a device context using a factory that supports multithreaded
+    /// use (ie. the underlying <c>ID2D1Factory</c> has to be created using <c>D2D1_FACTORY_TYPE_MULTI_THREADED </c>).
+    /// Not doing so will cause the resource texture manager to fail to be initialized when used in an effect.
+    /// </para>
+    /// <para>
+    /// For more info, see <see href="https://docs.microsoft.com/en-us/windows/win32/api/d2d1/ne-d2d1-d2d1_factory_type"/>.
+    /// </para>
+    /// </remarks>
     public D2D1ResourceTextureManager(
         ReadOnlySpan<uint> extents,
         D2D1BufferPrecision bufferPrecision,
@@ -206,6 +239,17 @@ public sealed unsafe class D2D1ResourceTextureManager : ICustomQueryInterface
     /// <param name="data">The data to load in the resource to create.</param>
     /// <param name="strides">The strides for the data supplied for the resource to create.</param>
     /// <exception cref="Exception">Thrown if creating or initializing the <see cref="D2D1ResourceTextureManager"/> instance failed.</exception>
+    /// <remarks>
+    /// <para>
+    /// Since <see cref="D2D1ResourceTextureManager"/> has a finalizer, which can be invoked at any point on the finalizer
+    /// thread, it can only be used in effects associated with a device context using a factory that supports multithreaded
+    /// use (ie. the underlying <c>ID2D1Factory</c> has to be created using <c>D2D1_FACTORY_TYPE_MULTI_THREADED </c>).
+    /// Not doing so will cause the resource texture manager to fail to be initialized when used in an effect.
+    /// </para>
+    /// <para>
+    /// For more info, see <see href="https://docs.microsoft.com/en-us/windows/win32/api/d2d1/ne-d2d1-d2d1_factory_type"/>.
+    /// </para>
+    /// </remarks>
     public D2D1ResourceTextureManager(
         Guid resourceId,
         ReadOnlySpan<uint> extents,
@@ -263,7 +307,7 @@ public sealed unsafe class D2D1ResourceTextureManager : ICustomQueryInterface
 
         fixed (D2D1ResourceTextureManagerImpl** d2D1ResourceManagerImpl = &this.d2D1ResourceManagerImpl)
         {
-            D2D1ResourceTextureManagerImpl.Factory(d2D1ResourceManagerImpl);
+            D2D1ResourceTextureManagerImpl.Factory(d2D1ResourceManagerImpl, requiresMultithread: true);
         }
 
         fixed (uint* pExtents = extents)
@@ -382,9 +426,13 @@ public sealed unsafe class D2D1ResourceTextureManager : ICustomQueryInterface
     /// Creates a new <c>ID2D1ResourceTextureManager</c> instance.
     /// </summary>
     /// <param name="resourceTextureManager">A pointer to the resulting <c>ID2D1ResourceTextureManager</c> instance.</param>
+    /// <remarks>
+    /// The resulting <c>ID2D1ResourceTextureManager</c> instance does not require multithread support for the factory that is
+    /// assigned to it when initialized from an effect. Callers have the responsibility of ensuring thread safety when using it.
+    /// </remarks>
     public static void Create(void** resourceTextureManager)
     {
-        D2D1ResourceTextureManagerImpl.Factory((D2D1ResourceTextureManagerImpl**)resourceTextureManager);
+        D2D1ResourceTextureManagerImpl.Factory((D2D1ResourceTextureManagerImpl**)resourceTextureManager, requiresMultithread: false);
     }
 
     /// <summary>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.ID2D1ResourceTextureManagerInternal.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.ID2D1ResourceTextureManagerInternal.cs
@@ -116,9 +116,18 @@ partial struct D2D1ResourceTextureManagerImpl
 
                     int hresult = effectContext->GetD2D1Multithread(d2D1Multithread.GetAddressOf());
 
-                    // If an ID2D1Multithread object is available, we can safely store the context
+                    // If an ID2D1Multithread object is available, we can safely store the context. That
+                    // is, under the condition that the required multithread support is also available.
                     if (Windows.SUCCEEDED(hresult))
                     {
+                        if (@this->requiresMultithread > d2D1Multithread.Get()->GetMultithreadProtected())
+                        {
+                            return E.E_INVALIDARG;
+                        }
+
+                        // Now, the effect context can actually be stored safely while holding the lock.
+                        // This is guaranteed to be the case here, as this method is only called (as per
+                        // contact of the COM interface) from ID2D1EffectImpl, which holds the D2D lock.
                         _ = effectContext->AddRef();
 
                         @this->d2D1EffectContext = effectContext;

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.cs
@@ -96,6 +96,15 @@ internal unsafe partial struct D2D1ResourceTextureManagerImpl
     private volatile int referenceCount;
 
     /// <summary>
+    /// Indicates whether the current instance requires multithread support to work safely.
+    /// </summary>
+    /// <remarks>
+    /// This is used when the object is wrapped in a RCW with a finalizer, which could run at any time.
+    /// In that case, multithread support is required, and using a single thread factory is an error.
+    /// </remarks>
+    private int requiresMultithread;
+
+    /// <summary>
     /// The <see cref="ID2D1EffectContext"/> object currently wrapped by the current instance.
     /// </summary>
     private ID2D1EffectContext* d2D1EffectContext;
@@ -156,7 +165,8 @@ internal unsafe partial struct D2D1ResourceTextureManagerImpl
     /// The factory method for <see cref="D2D1ResourceTextureManagerImpl"/> instances.
     /// </summary>
     /// <param name="resourceTextureManager">The resulting resource texture manager instance.</param>
-    public static void Factory(D2D1ResourceTextureManagerImpl** resourceTextureManager)
+    /// <param name="requiresMultithread">Indicates whether the current instance requires multithread support to work safely.</param>
+    public static void Factory(D2D1ResourceTextureManagerImpl** resourceTextureManager, bool requiresMultithread)
     {
         D2D1ResourceTextureManagerImpl* @this = (D2D1ResourceTextureManagerImpl*)NativeMemory.Alloc((nuint)sizeof(D2D1ResourceTextureManagerImpl));
 
@@ -168,6 +178,7 @@ internal unsafe partial struct D2D1ResourceTextureManagerImpl
         @this->d2D1EffectContext = null;
         @this->d2D1Multithread = null;
         @this->d2D1ResourceTexture = null;
+        @this->requiresMultithread = requiresMultithread ? 1 : 0;
         @this->resourceId = null;
         @this->resourceTextureProperties = default;
         @this->data = null;

--- a/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1_1/ID2D1Multithread.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1_1/ID2D1Multithread.cs
@@ -46,6 +46,13 @@ namespace TerraFX.Interop.DirectX
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [VtblIndex(3)]
+        public int GetMultithreadProtected()
+        {
+            return ((delegate* unmanaged[Stdcall]<ID2D1Multithread*, int>)(lpVtbl[3]))((ID2D1Multithread*)Unsafe.AsPointer(ref this));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [VtblIndex(4)]
         public void Enter()
         {

--- a/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1Helper.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1Helper.cs
@@ -13,8 +13,9 @@ internal static class D2D1Helper
     /// <summary>
     /// Creates an <see cref="ID2D1Factory2"/> instance.
     /// </summary>
+    /// <param name="singleThreaded">Indicates whether or not the factory should be created as single threaded.</param>
     /// <returns>A new <see cref="ID2D1Factory2"/> instance.</returns>
-    public static unsafe ComPtr<ID2D1Factory2> CreateD2D1Factory2()
+    public static unsafe ComPtr<ID2D1Factory2> CreateD2D1Factory2(bool singleThreaded = false)
     {
         using ComPtr<ID2D1Factory2> d2D1Factory2 = default;
 
@@ -22,7 +23,7 @@ internal static class D2D1Helper
 
         // Create a Direct2D factory
         DirectX.D2D1CreateFactory(
-            factoryType: D2D1_FACTORY_TYPE.D2D1_FACTORY_TYPE_SINGLE_THREADED,
+            factoryType: singleThreaded ? D2D1_FACTORY_TYPE.D2D1_FACTORY_TYPE_SINGLE_THREADED : D2D1_FACTORY_TYPE.D2D1_FACTORY_TYPE_MULTI_THREADED,
             riid: Windows.__uuidof<ID2D1Factory2>(),
             pFactoryOptions: &d2D1FactoryOptions,
             ppIFactory: (void**)d2D1Factory2.GetAddressOf()).Assert();


### PR DESCRIPTION
### Description

This PR enforces having multithread factories when using the RCW for `ID2D1ResourceTextureManager`.