### PR TITLE
Fix GC holes in CommandList and GraphicsDevice execute logic

### DIFF
--- a/src/ComputeSharp/Graphics/Commands/CommandList.cs
+++ b/src/ComputeSharp/Graphics/Commands/CommandList.cs
@@ -48,8 +48,8 @@ internal unsafe struct CommandList : IDisposable
 
         device.GetCommandListAndAllocator(
             d3D12CommandListType,
-            out *(ID3D12GraphicsCommandList**)Unsafe.AsPointer(ref this.d3D12GraphicsCommandList),
-            out *(ID3D12CommandAllocator**)Unsafe.AsPointer(ref this.d3D12CommandAllocator));
+            out this.d3D12GraphicsCommandList.GetPinnableReference(),
+            out this.d3D12CommandAllocator.GetPinnableReference());
 
         // Set the heap descriptor if the command list is not for copy operations
         if (d3D12CommandListType is not D3D12_COMMAND_LIST_TYPE_COPY)
@@ -73,8 +73,8 @@ internal unsafe struct CommandList : IDisposable
 
         device.GetCommandListAndAllocator(
             d3D12PipelineState,
-            out *(ID3D12GraphicsCommandList**)Unsafe.AsPointer(ref this.d3D12GraphicsCommandList),
-            out *(ID3D12CommandAllocator**)Unsafe.AsPointer(ref this.d3D12CommandAllocator));
+            out this.d3D12GraphicsCommandList.GetPinnableReference(),
+            out this.d3D12CommandAllocator.GetPinnableReference());
 
         // Set the heap descriptor for the command list
         device.SetDescriptorHeapForCommandList(this.d3D12GraphicsCommandList);
@@ -125,9 +125,12 @@ internal unsafe struct CommandList : IDisposable
     /// </summary>
     /// <returns>A double pointer to the current <see cref="ID3D12CommandList"/> object to execute.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly ID3D12CommandList** GetD3D12CommandListAddressOf()
+    public ref ID3D12CommandList* GetD3D12CommandListPinnableAddressOf()
     {
-        return (ID3D12CommandList**)this.d3D12GraphicsCommandList.GetAddressOf();
+        fixed (ID3D12GraphicsCommandList** d3D12GraphicsCommandList = this.d3D12GraphicsCommandList)
+        {
+            return ref *(ID3D12CommandList**)d3D12GraphicsCommandList;
+        }
     }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/GraphicsDevice.Execute.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.Execute.cs
@@ -67,7 +67,10 @@ unsafe partial class GraphicsDevice
         }
 
         // Execute the command list
-        d3D12CommandQueue->ExecuteCommandLists(1, commandList.GetD3D12CommandListAddressOf());
+        fixed (ID3D12CommandList** d3D12CommandList = &commandList.GetD3D12CommandListPinnableAddressOf())
+        {
+            d3D12CommandQueue->ExecuteCommandLists(1, d3D12CommandList);
+        }
 
 #if NET6_0_OR_GREATER
         ulong updatedFenceValue = Interlocked.Increment(ref d3D12FenceValue);
@@ -98,7 +101,10 @@ unsafe partial class GraphicsDevice
     internal ValueTask ExecuteCommandListAsync(ref CommandList commandList)
     {
         // Execute the command list
-        this.d3D12ComputeCommandQueue.Get()->ExecuteCommandLists(1, commandList.GetD3D12CommandListAddressOf());
+        fixed (ID3D12CommandList** d3D12CommandList = &commandList.GetD3D12CommandListPinnableAddressOf())
+        {
+            this.d3D12ComputeCommandQueue.Get()->ExecuteCommandLists(1, d3D12CommandList);
+        }
 
 #if NET6_0_OR_GREATER
         ulong updatedFenceValue = Interlocked.Increment(ref this.nextD3D12ComputeFenceValue);


### PR DESCRIPTION
### Description

This PR fixes some GC holes in the command list and execute logic, which were causing intermittent AVs when dispatching compute contexts. In particular, these were more frequent on lower end devices where the GC would kick-in more often.