### PR TITLE
Add HLSL bitwise operators

### DIFF
--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Bool2
 {
     /// <summary>
-    /// Gets an <see cref="Bool2"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool2 TrueX => new(true, false);
-
-    /// <summary>
-    /// Gets an <see cref="Bool2"/> value with the <see cref="Y"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool2 TrueY => new(false, true);
-
-    /// <summary>
     /// Creates a new <see cref="Bool2"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Bool2
 {
     /// <summary>
-    /// Gets an <see cref="Bool2"/> value with all components set to <see langword="false"/>.
-    /// </summary>
-    public static Bool2 False => false;
-
-    /// <summary>
-    /// Gets an <see cref="Bool2"/> value with all components set to <see langword="true"/>.
-    /// </summary>
-    public static Bool2 True => true;
-
-    /// <summary>
     /// Gets an <see cref="Bool2"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
     /// </summary>
     public static Bool2 TrueX => new(true, false);

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
@@ -33,6 +33,16 @@ public unsafe partial struct Bool2
     public readonly ref bool this[int i] => ref *(bool*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Bool2"/> value with all components set to <see langword="false"/>.
+    /// </summary>
+    public static Bool2 False => false;
+
+    /// <summary>
+    /// Gets a <see cref="Bool2"/> value with all components set to <see langword="true"/>.
+    /// </summary>
+    public static Bool2 True => true;
+
+    /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
@@ -43,6 +43,16 @@ public unsafe partial struct Bool2
     public static Bool2 True => true;
 
     /// <summary>
+    /// Gets a <see cref="Bool2"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool2 TrueX => new(true, false);
+
+    /// <summary>
+    /// Gets a <see cref="Bool2"/> value with the <see cref="Y"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool2 TrueY => new(false, true);
+
+    /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.cs
@@ -8,21 +8,6 @@ namespace ComputeSharp;
 public partial struct Bool3
 {
     /// <summary>
-    /// Gets an <see cref="Bool3"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool3 TrueX => new(true, false, false);
-
-    /// <summary>
-    /// Gets an <see cref="Bool3"/> value with the <see cref="Y"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool3 TrueY => new(false, true, false);
-
-    /// <summary>
-    /// Gets an <see cref="Bool3"/> value with the <see cref="Z"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool3 TrueZ => new(false, false, true);
-
-    /// <summary>
     /// Creates a new <see cref="Bool3"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Bool3
 {
     /// <summary>
-    /// Gets an <see cref="Bool3"/> value with all components set to <see langword="false"/>.
-    /// </summary>
-    public static Bool3 False => false;
-
-    /// <summary>
-    /// Gets an <see cref="Bool3"/> value with all components set to <see langword="true"/>.
-    /// </summary>
-    public static Bool3 True => true;
-
-    /// <summary>
     /// Gets an <see cref="Bool3"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
     /// </summary>
     public static Bool3 TrueX => new(true, false, false);

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
@@ -36,6 +36,16 @@ public unsafe partial struct Bool3
     public readonly ref bool this[int i] => ref *(bool*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Bool3"/> value with all components set to <see langword="false"/>.
+    /// </summary>
+    public static Bool3 False => false;
+
+    /// <summary>
+    /// Gets a <see cref="Bool3"/> value with all components set to <see langword="true"/>.
+    /// </summary>
+    public static Bool3 True => true;
+
+    /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
@@ -46,6 +46,21 @@ public unsafe partial struct Bool3
     public static Bool3 True => true;
 
     /// <summary>
+    /// Gets a <see cref="Bool3"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool3 TrueX => new(true, false, false);
+
+    /// <summary>
+    /// Gets a <see cref="Bool3"/> value with the <see cref="Y"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool3 TrueY => new(false, true, false);
+
+    /// <summary>
+    /// Gets a <see cref="Bool3"/> value with the <see cref="Z"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool3 TrueZ => new(false, false, true);
+
+    /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Bool4
 {
     /// <summary>
-    /// Gets an <see cref="Bool4"/> value with all components set to <see langword="false"/>.
-    /// </summary>
-    public static Bool4 False => false;
-
-    /// <summary>
-    /// Gets an <see cref="Bool4"/> value with all components set to <see langword="true"/>.
-    /// </summary>
-    public static Bool4 True => true;
-
-    /// <summary>
     /// Gets an <see cref="Bool4"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
     /// </summary>
     public static Bool4 TrueX => new(true, false, false, false);

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.cs
@@ -8,26 +8,6 @@ namespace ComputeSharp;
 public partial struct Bool4
 {
     /// <summary>
-    /// Gets an <see cref="Bool4"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool4 TrueX => new(true, false, false, false);
-
-    /// <summary>
-    /// Gets an <see cref="Bool4"/> value with the <see cref="Y"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool4 TrueY => new(false, true, false, false);
-
-    /// <summary>
-    /// Gets an <see cref="Bool4"/> value with the <see cref="Z"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool4 TrueZ => new(false, false, true, false);
-
-    /// <summary>
-    /// Gets an <see cref="Bool4"/> value with the <see cref="W"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
-    /// </summary>
-    public static Bool4 TrueW => new(false, false, false, true);
-
-    /// <summary>
     /// Creates a new <see cref="Bool4"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
@@ -39,6 +39,16 @@ public unsafe partial struct Bool4
     public readonly ref bool this[int i] => ref *(bool*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Bool4"/> value with all components set to <see langword="false"/>.
+    /// </summary>
+    public static Bool4 False => false;
+
+    /// <summary>
+    /// Gets a <see cref="Bool4"/> value with all components set to <see langword="true"/>.
+    /// </summary>
+    public static Bool4 True => true;
+
+    /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
@@ -49,6 +49,26 @@ public unsafe partial struct Bool4
     public static Bool4 True => true;
 
     /// <summary>
+    /// Gets a <see cref="Bool4"/> value with the <see cref="X"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool4 TrueX => new(true, false, false, false);
+
+    /// <summary>
+    /// Gets a <see cref="Bool4"/> value with the <see cref="Y"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool4 TrueY => new(false, true, false, false);
+
+    /// <summary>
+    /// Gets a <see cref="Bool4"/> value with the <see cref="Z"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool4 TrueZ => new(false, false, true, false);
+
+    /// <summary>
+    /// Gets a <see cref="Bool4"/> value with the <see cref="W"/> component set to <see langword="true"/>, and the others to <see langword="false"/>.
+    /// </summary>
+    public static Bool4 TrueW => new(false, false, false, true);
+
+    /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Double/Double2.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double2.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Double2
 {
     /// <summary>
-    /// Gets an <see cref="Double2"/> value with all components set to 0.
-    /// </summary>
-    public static Double2 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Double2"/> value with all components set to 1.
-    /// </summary>
-    public static Double2 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Double2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Double2 UnitX => new(1, 0);

--- a/src/ComputeSharp.Core/Primitives/Double/Double2.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double2.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Double2
 {
     /// <summary>
-    /// Gets an <see cref="Double2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double2 UnitX => new(1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Double2"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double2 UnitY => new(0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Double2"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Double/Double2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double2.g.cs
@@ -38,6 +38,16 @@ public unsafe partial struct Double2
     public readonly ref double this[int i] => ref *(double*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Double2"/> value with all components set to 0.
+    /// </summary>
+    public static Double2 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Double2"/> value with all components set to 1.
+    /// </summary>
+    public static Double2 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref double X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Double/Double2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double2.g.cs
@@ -48,6 +48,16 @@ public unsafe partial struct Double2
     public static Double2 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Double2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double2 UnitX => new(1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Double2"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double2 UnitY => new(0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref double X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Double/Double3.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double3.cs
@@ -8,21 +8,6 @@ namespace ComputeSharp;
 public partial struct Double3
 {
     /// <summary>
-    /// Gets an <see cref="Double3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double3 UnitX => new(1, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Double3"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double3 UnitY => new(0, 1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Double3"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double3 UnitZ => new(0, 0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Double3"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Double/Double3.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double3.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Double3
 {
     /// <summary>
-    /// Gets an <see cref="Double3"/> value with all components set to 0.
-    /// </summary>
-    public static Double3 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Double3"/> value with all components set to 1.
-    /// </summary>
-    public static Double3 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Double3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Double3 UnitX => new(1, 0, 0);

--- a/src/ComputeSharp.Core/Primitives/Double/Double3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double3.g.cs
@@ -41,6 +41,16 @@ public unsafe partial struct Double3
     public readonly ref double this[int i] => ref *(double*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Double3"/> value with all components set to 0.
+    /// </summary>
+    public static Double3 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Double3"/> value with all components set to 1.
+    /// </summary>
+    public static Double3 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref double X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Double/Double3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double3.g.cs
@@ -51,6 +51,21 @@ public unsafe partial struct Double3
     public static Double3 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Double3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double3 UnitX => new(1, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Double3"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double3 UnitY => new(0, 1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Double3"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double3 UnitZ => new(0, 0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref double X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Double/Double4.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double4.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Double4
 {
     /// <summary>
-    /// Gets an <see cref="Double4"/> value with all components set to 0.
-    /// </summary>
-    public static Double4 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Double4"/> value with all components set to 1.
-    /// </summary>
-    public static Double4 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Double4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Double4 UnitX => new(1, 0, 0, 0);

--- a/src/ComputeSharp.Core/Primitives/Double/Double4.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double4.cs
@@ -8,26 +8,6 @@ namespace ComputeSharp;
 public partial struct Double4
 {
     /// <summary>
-    /// Gets an <see cref="Double4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double4 UnitX => new(1, 0, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Double4"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double4 UnitY => new(0, 1, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Double4"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double4 UnitZ => new(0, 0, 1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Double4"/> value with the <see cref="W"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Double4 UnitW => new(0, 0, 0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Double4"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Double/Double4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double4.g.cs
@@ -44,6 +44,16 @@ public unsafe partial struct Double4
     public readonly ref double this[int i] => ref *(double*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Double4"/> value with all components set to 0.
+    /// </summary>
+    public static Double4 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Double4"/> value with all components set to 1.
+    /// </summary>
+    public static Double4 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref double X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Double/Double4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double4.g.cs
@@ -54,6 +54,26 @@ public unsafe partial struct Double4
     public static Double4 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Double4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double4 UnitX => new(1, 0, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Double4"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double4 UnitY => new(0, 1, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Double4"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double4 UnitZ => new(0, 0, 1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Double4"/> value with the <see cref="W"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Double4 UnitW => new(0, 0, 0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref double X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Float/Float2.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float2.cs
@@ -10,16 +10,6 @@ namespace ComputeSharp;
 public partial struct Float2
 {
     /// <summary>
-    /// Gets an <see cref="Float2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float2 UnitX => new(1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Float2"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float2 UnitY => new(0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Float2"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Float/Float2.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float2.cs
@@ -10,16 +10,6 @@ namespace ComputeSharp;
 public partial struct Float2
 {
     /// <summary>
-    /// Gets an <see cref="Float2"/> value with all components set to 0.
-    /// </summary>
-    public static Float2 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Float2"/> value with all components set to 1.
-    /// </summary>
-    public static Float2 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Float2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Float2 UnitX => new(1, 0);

--- a/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
@@ -38,6 +38,16 @@ public unsafe partial struct Float2
     public readonly ref float this[int i] => ref *(float*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Float2"/> value with all components set to 0.
+    /// </summary>
+    public static Float2 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Float2"/> value with all components set to 1.
+    /// </summary>
+    public static Float2 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref float X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
@@ -48,6 +48,16 @@ public unsafe partial struct Float2
     public static Float2 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Float2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float2 UnitX => new(1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Float2"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float2 UnitY => new(0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref float X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Float/Float3.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float3.cs
@@ -10,16 +10,6 @@ namespace ComputeSharp;
 public partial struct Float3
 {
     /// <summary>
-    /// Gets an <see cref="Float3"/> value with all components set to 0.
-    /// </summary>
-    public static Float3 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Float3"/> value with all components set to 1.
-    /// </summary>
-    public static Float3 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Float3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Float3 UnitX => new(1, 0, 0);

--- a/src/ComputeSharp.Core/Primitives/Float/Float3.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float3.cs
@@ -10,21 +10,6 @@ namespace ComputeSharp;
 public partial struct Float3
 {
     /// <summary>
-    /// Gets an <see cref="Float3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float3 UnitX => new(1, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Float3"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float3 UnitY => new(0, 1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Float3"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float3 UnitZ => new(0, 0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Float3"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
@@ -41,6 +41,16 @@ public unsafe partial struct Float3
     public readonly ref float this[int i] => ref *(float*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Float3"/> value with all components set to 0.
+    /// </summary>
+    public static Float3 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Float3"/> value with all components set to 1.
+    /// </summary>
+    public static Float3 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref float X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
@@ -51,6 +51,21 @@ public unsafe partial struct Float3
     public static Float3 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Float3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float3 UnitX => new(1, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Float3"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float3 UnitY => new(0, 1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Float3"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float3 UnitZ => new(0, 0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref float X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Float/Float4.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float4.cs
@@ -10,16 +10,6 @@ namespace ComputeSharp;
 public partial struct Float4
 {
     /// <summary>
-    /// Gets an <see cref="Float4"/> value with all components set to 0.
-    /// </summary>
-    public static Float4 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Float4"/> value with all components set to 1.
-    /// </summary>
-    public static Float4 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Float4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Float4 UnitX => new(1, 0, 0, 0);

--- a/src/ComputeSharp.Core/Primitives/Float/Float4.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float4.cs
@@ -10,26 +10,6 @@ namespace ComputeSharp;
 public partial struct Float4
 {
     /// <summary>
-    /// Gets an <see cref="Float4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float4 UnitX => new(1, 0, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Float4"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float4 UnitY => new(0, 1, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Float4"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float4 UnitZ => new(0, 0, 1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Float4"/> value with the <see cref="W"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Float4 UnitW => new(0, 0, 0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Float4"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
@@ -54,6 +54,26 @@ public unsafe partial struct Float4
     public static Float4 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Float4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float4 UnitX => new(1, 0, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Float4"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float4 UnitY => new(0, 1, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Float4"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float4 UnitZ => new(0, 0, 1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Float4"/> value with the <see cref="W"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Float4 UnitW => new(0, 0, 0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref float X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
@@ -44,6 +44,16 @@ public unsafe partial struct Float4
     public readonly ref float this[int i] => ref *(float*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Float4"/> value with all components set to 0.
+    /// </summary>
+    public static Float4 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Float4"/> value with all components set to 1.
+    /// </summary>
+    public static Float4 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref float X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Int2
 {
     /// <summary>
-    /// Gets an <see cref="Int2"/> value with all components set to 0.
-    /// </summary>
-    public static Int2 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Int2"/> value with all components set to 1.
-    /// </summary>
-    public static Int2 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Int2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Int2 UnitX => new(1, 0);

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Int2
 {
     /// <summary>
-    /// Gets an <see cref="Int2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int2 UnitX => new(1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Int2"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int2 UnitY => new(0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Int2"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
@@ -48,6 +48,16 @@ public unsafe partial struct Int2
     public static Int2 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Int2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int2 UnitX => new(1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Int2"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int2 UnitY => new(0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref int X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
@@ -38,6 +38,16 @@ public unsafe partial struct Int2
     public readonly ref int this[int i] => ref *(int*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Int2"/> value with all components set to 0.
+    /// </summary>
+    public static Int2 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Int2"/> value with all components set to 1.
+    /// </summary>
+    public static Int2 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref int X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
@@ -544,6 +544,106 @@ public unsafe partial struct Int2
     public static Bool2 operator <=(Int2 left, Int2 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="xy"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator ~(Int2 xy) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator >>(Int2 xy, Int2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator >>(Int2 xy, UInt2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator <<(Int2 xy, Int2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator <<(Int2 xy, UInt2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator &(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator &(Int2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator |(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator |(Int2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator ^(Int2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator ^(Int2 left, UInt2 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="Int2"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="Int2"/> value to compare.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Int3
 {
     /// <summary>
-    /// Gets an <see cref="Int3"/> value with all components set to 0.
-    /// </summary>
-    public static Int3 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Int3"/> value with all components set to 1.
-    /// </summary>
-    public static Int3 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Int3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Int3 UnitX => new(1, 0, 0);

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.cs
@@ -8,21 +8,6 @@ namespace ComputeSharp;
 public partial struct Int3
 {
     /// <summary>
-    /// Gets an <see cref="Int3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int3 UnitX => new(1, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Int3"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int3 UnitY => new(0, 1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Int3"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int3 UnitZ => new(0, 0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Int3"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
@@ -51,6 +51,21 @@ public unsafe partial struct Int3
     public static Int3 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Int3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int3 UnitX => new(1, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Int3"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int3 UnitY => new(0, 1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Int3"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int3 UnitZ => new(0, 0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref int X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
@@ -1630,6 +1630,106 @@ public unsafe partial struct Int3
     public static Bool3 operator <=(Int3 left, Int3 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="xyz"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator ~(Int3 xyz) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator >>(Int3 xyz, Int3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator >>(Int3 xyz, UInt3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator <<(Int3 xyz, Int3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator <<(Int3 xyz, UInt3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator &(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator &(Int3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator |(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator |(Int3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator ^(Int3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator ^(Int3 left, UInt3 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="Int3"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="Int3"/> value to compare.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
@@ -41,6 +41,16 @@ public unsafe partial struct Int3
     public readonly ref int this[int i] => ref *(int*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Int3"/> value with all components set to 0.
+    /// </summary>
+    public static Int3 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Int3"/> value with all components set to 1.
+    /// </summary>
+    public static Int3 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref int X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.cs
@@ -8,26 +8,6 @@ namespace ComputeSharp;
 public partial struct Int4
 {
     /// <summary>
-    /// Gets an <see cref="Int4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int4 UnitX => new(1, 0, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Int4"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int4 UnitY => new(0, 1, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Int4"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int4 UnitZ => new(0, 0, 1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="Int4"/> value with the <see cref="W"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static Int4 UnitW => new(0, 0, 0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="Int4"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct Int4
 {
     /// <summary>
-    /// Gets an <see cref="Int4"/> value with all components set to 0.
-    /// </summary>
-    public static Int4 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="Int4"/> value with all components set to 1.
-    /// </summary>
-    public static Int4 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="Int4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static Int4 UnitX => new(1, 0, 0, 0);

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
@@ -44,6 +44,16 @@ public unsafe partial struct Int4
     public readonly ref int this[int i] => ref *(int*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="Int4"/> value with all components set to 0.
+    /// </summary>
+    public static Int4 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="Int4"/> value with all components set to 1.
+    /// </summary>
+    public static Int4 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref int X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
@@ -54,6 +54,26 @@ public unsafe partial struct Int4
     public static Int4 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="Int4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int4 UnitX => new(1, 0, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Int4"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int4 UnitY => new(0, 1, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Int4"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int4 UnitZ => new(0, 0, 1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="Int4"/> value with the <see cref="W"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static Int4 UnitW => new(0, 0, 0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref int X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
@@ -4276,6 +4276,106 @@ public unsafe partial struct Int4
     public static Bool4 operator <=(Int4 left, Int4 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="xyzw"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator ~(Int4 xyzw) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator >>(Int4 xyzw, Int4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator >>(Int4 xyzw, UInt4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator <<(Int4 xyzw, Int4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator <<(Int4 xyzw, UInt4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator &(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator &(Int4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator |(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator |(Int4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator ^(Int4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator ^(Int4 left, UInt4 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="Int4"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="Int4"/> value to compare.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -171,6 +171,106 @@ public unsafe partial struct Int1x1
     public static Bool1x1 operator <=(Int1x1 left, Int1x1 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator ~(Int1x1 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator >>(Int1x1 matrix, Int1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator >>(Int1x1 matrix, UInt1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator <<(Int1x1 matrix, Int1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator <<(Int1x1 matrix, UInt1x1 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator &(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator &(Int1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator |(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator |(Int1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator ^(Int1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator ^(Int1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="Int1x1"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="Int1x1"/> value to compare.</param>
@@ -360,6 +460,106 @@ public unsafe partial struct Int1x2
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool1x2 operator <=(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator ~(Int1x2 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator >>(Int1x2 matrix, Int1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator >>(Int1x2 matrix, UInt1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator <<(Int1x2 matrix, Int1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator <<(Int1x2 matrix, UInt1x2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator &(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator &(Int1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator |(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator |(Int1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator ^(Int1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator ^(Int1x2 left, UInt1x2 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int1x2"/> values to see if they are equal.
@@ -568,6 +768,106 @@ public unsafe partial struct Int1x3
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool1x3 operator <=(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator ~(Int1x3 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator >>(Int1x3 matrix, Int1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator >>(Int1x3 matrix, UInt1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator <<(Int1x3 matrix, Int1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator <<(Int1x3 matrix, UInt1x3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator &(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator &(Int1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator |(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator |(Int1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator ^(Int1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator ^(Int1x3 left, UInt1x3 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int1x3"/> values to see if they are equal.
@@ -789,6 +1089,106 @@ public unsafe partial struct Int1x4
     public static Bool1x4 operator <=(Int1x4 left, Int1x4 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator ~(Int1x4 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator >>(Int1x4 matrix, Int1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator >>(Int1x4 matrix, UInt1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator <<(Int1x4 matrix, Int1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator <<(Int1x4 matrix, UInt1x4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator &(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator &(Int1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator |(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator |(Int1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator ^(Int1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator ^(Int1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="Int1x4"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="Int1x4"/> value to compare.</param>
@@ -984,6 +1384,106 @@ public unsafe partial struct Int2x1
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x1 operator <=(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator ~(Int2x1 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator >>(Int2x1 matrix, Int2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator >>(Int2x1 matrix, UInt2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator <<(Int2x1 matrix, Int2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator <<(Int2x1 matrix, UInt2x1 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator &(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator &(Int2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator |(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator |(Int2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator ^(Int2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator ^(Int2x1 left, UInt2x1 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int2x1"/> values to see if they are equal.
@@ -1216,6 +1716,106 @@ public unsafe partial struct Int2x2
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x2 operator <=(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator ~(Int2x2 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator >>(Int2x2 matrix, Int2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator >>(Int2x2 matrix, UInt2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator <<(Int2x2 matrix, Int2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator <<(Int2x2 matrix, UInt2x2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator &(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator &(Int2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator |(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator |(Int2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator ^(Int2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator ^(Int2x2 left, UInt2x2 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int2x2"/> values to see if they are equal.
@@ -1466,6 +2066,106 @@ public unsafe partial struct Int2x3
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x3 operator <=(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator ~(Int2x3 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator >>(Int2x3 matrix, Int2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator >>(Int2x3 matrix, UInt2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator <<(Int2x3 matrix, Int2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator <<(Int2x3 matrix, UInt2x3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator &(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator &(Int2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator |(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator |(Int2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator ^(Int2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator ^(Int2x3 left, UInt2x3 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int2x3"/> values to see if they are equal.
@@ -1742,6 +2442,106 @@ public unsafe partial struct Int2x4
     public static Bool2x4 operator <=(Int2x4 left, Int2x4 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator ~(Int2x4 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator >>(Int2x4 matrix, Int2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator >>(Int2x4 matrix, UInt2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator <<(Int2x4 matrix, Int2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator <<(Int2x4 matrix, UInt2x4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator &(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator &(Int2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator |(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator |(Int2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator ^(Int2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator ^(Int2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="Int2x4"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="Int2x4"/> value to compare.</param>
@@ -1942,6 +2742,106 @@ public unsafe partial struct Int3x1
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x1 operator <=(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator ~(Int3x1 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator >>(Int3x1 matrix, Int3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator >>(Int3x1 matrix, UInt3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator <<(Int3x1 matrix, Int3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator <<(Int3x1 matrix, UInt3x1 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator &(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator &(Int3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator |(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator |(Int3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator ^(Int3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator ^(Int3x1 left, UInt3x1 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int3x1"/> values to see if they are equal.
@@ -2199,6 +3099,106 @@ public unsafe partial struct Int3x2
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x2 operator <=(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator ~(Int3x2 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator >>(Int3x2 matrix, Int3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator >>(Int3x2 matrix, UInt3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator <<(Int3x2 matrix, Int3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator <<(Int3x2 matrix, UInt3x2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator &(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator &(Int3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator |(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator |(Int3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator ^(Int3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator ^(Int3x2 left, UInt3x2 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int3x2"/> values to see if they are equal.
@@ -2486,6 +3486,106 @@ public unsafe partial struct Int3x3
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x3 operator <=(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator ~(Int3x3 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator >>(Int3x3 matrix, Int3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator >>(Int3x3 matrix, UInt3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator <<(Int3x3 matrix, Int3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator <<(Int3x3 matrix, UInt3x3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator &(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator &(Int3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator |(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator |(Int3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator ^(Int3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator ^(Int3x3 left, UInt3x3 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int3x3"/> values to see if they are equal.
@@ -2811,6 +3911,106 @@ public unsafe partial struct Int3x4
     public static Bool3x4 operator <=(Int3x4 left, Int3x4 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator ~(Int3x4 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator >>(Int3x4 matrix, Int3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator >>(Int3x4 matrix, UInt3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator <<(Int3x4 matrix, Int3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator <<(Int3x4 matrix, UInt3x4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator &(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator &(Int3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator |(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator |(Int3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator ^(Int3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator ^(Int3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="Int3x4"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="Int3x4"/> value to compare.</param>
@@ -3022,6 +4222,106 @@ public unsafe partial struct Int4x1
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x1 operator <=(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator ~(Int4x1 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator >>(Int4x1 matrix, Int4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator >>(Int4x1 matrix, UInt4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator <<(Int4x1 matrix, Int4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator <<(Int4x1 matrix, UInt4x1 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator &(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator &(Int4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator |(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator |(Int4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator ^(Int4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator ^(Int4x1 left, UInt4x1 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int4x1"/> values to see if they are equal.
@@ -3304,6 +4604,106 @@ public unsafe partial struct Int4x2
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x2 operator <=(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator ~(Int4x2 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator >>(Int4x2 matrix, Int4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator >>(Int4x2 matrix, UInt4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator <<(Int4x2 matrix, Int4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator <<(Int4x2 matrix, UInt4x2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator &(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator &(Int4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator |(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator |(Int4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator ^(Int4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator ^(Int4x2 left, UInt4x2 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int4x2"/> values to see if they are equal.
@@ -3628,6 +5028,106 @@ public unsafe partial struct Int4x3
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x3 operator <=(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator ~(Int4x3 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator >>(Int4x3 matrix, Int4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator >>(Int4x3 matrix, UInt4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator <<(Int4x3 matrix, Int4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator <<(Int4x3 matrix, UInt4x3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator &(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator &(Int4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator |(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator |(Int4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator ^(Int4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator ^(Int4x3 left, UInt4x3 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int4x3"/> values to see if they are equal.
@@ -4000,6 +5500,106 @@ public unsafe partial struct Int4x4
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x4 operator <=(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator ~(Int4x4 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator >>(Int4x4 matrix, Int4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator >>(Int4x4 matrix, UInt4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator <<(Int4x4 matrix, Int4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator <<(Int4x4 matrix, UInt4x4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator &(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator &(Int4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator |(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator |(Int4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator ^(Int4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator ^(Int4x4 left, UInt4x4 right) => default;
 
     /// <summary>
     /// Compares two <see cref="Int4x4"/> values to see if they are equal.

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -301,6 +301,113 @@ public unsafe partial struct <#=fullTypeName#>
 <#
     }
 
+    // Generate the bitwise operators
+    if (typeName == "Int" || typeName == "UInt")
+    {
+        WriteLine("");
+#>
+    /// <summary>
+    /// Bitwise negates a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator ~(<#=fullTypeName#> matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator >>(<#=fullTypeName#> matrix, Int<#=rows#>x<#=columns#> amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator >>(<#=fullTypeName#> matrix, UInt<#=rows#>x<#=columns#> amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator <<(<#=fullTypeName#> matrix, Int<#=rows#>x<#=columns#> amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator <<(<#=fullTypeName#> matrix, UInt<#=rows#>x<#=columns#> amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int<#=rows#>x<#=columns#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator &(<#=fullTypeName#> left, Int<#=rows#>x<#=columns#> right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt<#=rows#>x<#=columns#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator &(<#=fullTypeName#> left, UInt<#=rows#>x<#=columns#> right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int<#=rows#>x<#=columns#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator |(<#=fullTypeName#> left, Int<#=rows#>x<#=columns#> right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt<#=rows#>x<#=columns#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator |(<#=fullTypeName#> left, UInt<#=rows#>x<#=columns#> right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int<#=rows#>x<#=columns#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator ^(<#=fullTypeName#> left, Int<#=rows#>x<#=columns#> right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt<#=rows#>x<#=columns#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator ^(<#=fullTypeName#> left, UInt<#=rows#>x<#=columns#> right) => default;
+<#
+    }
+
     WriteLine("");
 #>
     /// <summary>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct UInt2
 {
     /// <summary>
-    /// Gets an <see cref="UInt2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt2 UnitX => new(1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="UInt2"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt2 UnitY => new(0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="UInt2"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct UInt2
 {
     /// <summary>
-    /// Gets an <see cref="UInt2"/> value with all components set to 0.
-    /// </summary>
-    public static UInt2 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="UInt2"/> value with all components set to 1.
-    /// </summary>
-    public static UInt2 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="UInt2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static UInt2 UnitX => new(1, 0);

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
@@ -536,6 +536,106 @@ public unsafe partial struct UInt2
     public static Bool2 operator <=(UInt2 left, UInt2 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="xy"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator ~(UInt2 xy) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator >>(UInt2 xy, Int2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator >>(UInt2 xy, UInt2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator <<(UInt2 xy, Int2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator <<(UInt2 xy, UInt2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator &(UInt2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator &(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator |(UInt2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator |(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator ^(UInt2 left, Int2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator ^(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="UInt2"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="UInt2"/> value to compare.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
@@ -38,6 +38,16 @@ public unsafe partial struct UInt2
     public readonly ref uint this[int i] => ref *(uint*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="UInt2"/> value with all components set to 0.
+    /// </summary>
+    public static UInt2 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="UInt2"/> value with all components set to 1.
+    /// </summary>
+    public static UInt2 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref uint X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
@@ -48,6 +48,16 @@ public unsafe partial struct UInt2
     public static UInt2 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="UInt2"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt2 UnitX => new(1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="UInt2"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt2 UnitY => new(0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref uint X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct UInt3
 {
     /// <summary>
-    /// Gets an <see cref="UInt3"/> value with all components set to 0.
-    /// </summary>
-    public static UInt3 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="UInt3"/> value with all components set to 1.
-    /// </summary>
-    public static UInt3 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="UInt3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static UInt3 UnitX => new(1, 0, 0);

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.cs
@@ -8,21 +8,6 @@ namespace ComputeSharp;
 public partial struct UInt3
 {
     /// <summary>
-    /// Gets an <see cref="UInt3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt3 UnitX => new(1, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="UInt3"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt3 UnitY => new(0, 1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="UInt3"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt3 UnitZ => new(0, 0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="UInt3"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
@@ -51,6 +51,21 @@ public unsafe partial struct UInt3
     public static UInt3 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="UInt3"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt3 UnitX => new(1, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="UInt3"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt3 UnitY => new(0, 1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="UInt3"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt3 UnitZ => new(0, 0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref uint X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
@@ -1622,6 +1622,106 @@ public unsafe partial struct UInt3
     public static Bool3 operator <=(UInt3 left, UInt3 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="xyz"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator ~(UInt3 xyz) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator >>(UInt3 xyz, Int3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator >>(UInt3 xyz, UInt3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator <<(UInt3 xyz, Int3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator <<(UInt3 xyz, UInt3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator &(UInt3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator &(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator |(UInt3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator |(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator ^(UInt3 left, Int3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator ^(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="UInt3"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="UInt3"/> value to compare.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
@@ -41,6 +41,16 @@ public unsafe partial struct UInt3
     public readonly ref uint this[int i] => ref *(uint*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="UInt3"/> value with all components set to 0.
+    /// </summary>
+    public static UInt3 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="UInt3"/> value with all components set to 1.
+    /// </summary>
+    public static UInt3 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref uint X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.cs
@@ -8,16 +8,6 @@ namespace ComputeSharp;
 public partial struct UInt4
 {
     /// <summary>
-    /// Gets an <see cref="UInt4"/> value with all components set to 0.
-    /// </summary>
-    public static UInt4 Zero => 0;
-
-    /// <summary>
-    /// Gets an <see cref="UInt4"/> value with all components set to 1.
-    /// </summary>
-    public static UInt4 One => 1;
-
-    /// <summary>
     /// Gets an <see cref="UInt4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
     /// </summary>
     public static UInt4 UnitX => new(1, 0, 0, 0);

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.cs
@@ -8,26 +8,6 @@ namespace ComputeSharp;
 public partial struct UInt4
 {
     /// <summary>
-    /// Gets an <see cref="UInt4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt4 UnitX => new(1, 0, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="UInt4"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt4 UnitY => new(0, 1, 0, 0);
-
-    /// <summary>
-    /// Gets an <see cref="UInt4"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt4 UnitZ => new(0, 0, 1, 0);
-
-    /// <summary>
-    /// Gets an <see cref="UInt4"/> value with the <see cref="W"/> component set to 1, and the others to 0.
-    /// </summary>
-    public static UInt4 UnitW => new(0, 0, 0, 1);
-
-    /// <summary>
     /// Creates a new <see cref="UInt4"/> instance with the specified parameters.
     /// </summary>
     /// <param name="x">The value to assign to the first vector component.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
@@ -44,6 +44,16 @@ public unsafe partial struct UInt4
     public readonly ref uint this[int i] => ref *(uint*)UndefinedData;
 
     /// <summary>
+    /// Gets a <see cref="UInt4"/> value with all components set to 0.
+    /// </summary>
+    public static UInt4 Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="UInt4"/> value with all components set to 1.
+    /// </summary>
+    public static UInt4 One => 1;
+
+    /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref uint X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
@@ -4268,6 +4268,106 @@ public unsafe partial struct UInt4
     public static Bool4 operator <=(UInt4 left, UInt4 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="xyzw"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator ~(UInt4 xyzw) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator >>(UInt4 xyzw, Int4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator >>(UInt4 xyzw, UInt4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator <<(UInt4 xyzw, Int4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator <<(UInt4 xyzw, UInt4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator &(UInt4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator &(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator |(UInt4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator |(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator ^(UInt4 left, Int4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator ^(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="UInt4"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="UInt4"/> value to compare.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
@@ -54,6 +54,26 @@ public unsafe partial struct UInt4
     public static UInt4 One => 1;
 
     /// <summary>
+    /// Gets a <see cref="UInt4"/> value with the <see cref="X"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt4 UnitX => new(1, 0, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="UInt4"/> value with the <see cref="Y"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt4 UnitY => new(0, 1, 0, 0);
+
+    /// <summary>
+    /// Gets a <see cref="UInt4"/> value with the <see cref="Z"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt4 UnitZ => new(0, 0, 1, 0);
+
+    /// <summary>
+    /// Gets a <see cref="UInt4"/> value with the <see cref="W"/> component set to 1, and the others to 0.
+    /// </summary>
+    public static UInt4 UnitW => new(0, 0, 0, 1);
+
+    /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>X</c> component.
     /// </summary>
     public readonly ref uint X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -164,6 +164,106 @@ public unsafe partial struct UInt1x1
     public static Bool1x1 operator <=(UInt1x1 left, UInt1x1 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator ~(UInt1x1 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator >>(UInt1x1 matrix, Int1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator >>(UInt1x1 matrix, UInt1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator <<(UInt1x1 matrix, Int1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator <<(UInt1x1 matrix, UInt1x1 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator &(UInt1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator &(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator |(UInt1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator |(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator ^(UInt1x1 left, Int1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt1x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator ^(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="UInt1x1"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x1"/> value to compare.</param>
@@ -346,6 +446,106 @@ public unsafe partial struct UInt1x2
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool1x2 operator <=(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator ~(UInt1x2 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator >>(UInt1x2 matrix, Int1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator >>(UInt1x2 matrix, UInt1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator <<(UInt1x2 matrix, Int1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator <<(UInt1x2 matrix, UInt1x2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator &(UInt1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator &(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator |(UInt1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator |(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator ^(UInt1x2 left, Int1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt1x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator ^(UInt1x2 left, UInt1x2 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt1x2"/> values to see if they are equal.
@@ -547,6 +747,106 @@ public unsafe partial struct UInt1x3
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool1x3 operator <=(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator ~(UInt1x3 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator >>(UInt1x3 matrix, Int1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator >>(UInt1x3 matrix, UInt1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator <<(UInt1x3 matrix, Int1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator <<(UInt1x3 matrix, UInt1x3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator &(UInt1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator &(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator |(UInt1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator |(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator ^(UInt1x3 left, Int1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt1x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator ^(UInt1x3 left, UInt1x3 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt1x3"/> values to see if they are equal.
@@ -761,6 +1061,106 @@ public unsafe partial struct UInt1x4
     public static Bool1x4 operator <=(UInt1x4 left, UInt1x4 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator ~(UInt1x4 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator >>(UInt1x4 matrix, Int1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator >>(UInt1x4 matrix, UInt1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator <<(UInt1x4 matrix, Int1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator <<(UInt1x4 matrix, UInt1x4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator &(UInt1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator &(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator |(UInt1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator |(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator ^(UInt1x4 left, Int1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt1x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator ^(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="UInt1x4"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x4"/> value to compare.</param>
@@ -949,6 +1349,106 @@ public unsafe partial struct UInt2x1
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x1 operator <=(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator ~(UInt2x1 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator >>(UInt2x1 matrix, Int2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator >>(UInt2x1 matrix, UInt2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator <<(UInt2x1 matrix, Int2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator <<(UInt2x1 matrix, UInt2x1 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator &(UInt2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator &(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator |(UInt2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator |(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator ^(UInt2x1 left, Int2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator ^(UInt2x1 left, UInt2x1 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt2x1"/> values to see if they are equal.
@@ -1174,6 +1674,106 @@ public unsafe partial struct UInt2x2
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x2 operator <=(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator ~(UInt2x2 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator >>(UInt2x2 matrix, Int2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator >>(UInt2x2 matrix, UInt2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator <<(UInt2x2 matrix, Int2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator <<(UInt2x2 matrix, UInt2x2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator &(UInt2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator &(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator |(UInt2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator |(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator ^(UInt2x2 left, Int2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator ^(UInt2x2 left, UInt2x2 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt2x2"/> values to see if they are equal.
@@ -1417,6 +2017,106 @@ public unsafe partial struct UInt2x3
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool2x3 operator <=(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator ~(UInt2x3 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator >>(UInt2x3 matrix, Int2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator >>(UInt2x3 matrix, UInt2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator <<(UInt2x3 matrix, Int2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator <<(UInt2x3 matrix, UInt2x3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator &(UInt2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator &(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator |(UInt2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator |(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator ^(UInt2x3 left, Int2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator ^(UInt2x3 left, UInt2x3 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt2x3"/> values to see if they are equal.
@@ -1686,6 +2386,106 @@ public unsafe partial struct UInt2x4
     public static Bool2x4 operator <=(UInt2x4 left, UInt2x4 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator ~(UInt2x4 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator >>(UInt2x4 matrix, Int2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator >>(UInt2x4 matrix, UInt2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator <<(UInt2x4 matrix, Int2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator <<(UInt2x4 matrix, UInt2x4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator &(UInt2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator &(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator |(UInt2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator |(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator ^(UInt2x4 left, Int2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt2x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator ^(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="UInt2x4"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x4"/> value to compare.</param>
@@ -1879,6 +2679,106 @@ public unsafe partial struct UInt3x1
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x1 operator <=(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator ~(UInt3x1 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator >>(UInt3x1 matrix, Int3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator >>(UInt3x1 matrix, UInt3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator <<(UInt3x1 matrix, Int3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator <<(UInt3x1 matrix, UInt3x1 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator &(UInt3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator &(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator |(UInt3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator |(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator ^(UInt3x1 left, Int3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator ^(UInt3x1 left, UInt3x1 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt3x1"/> values to see if they are equal.
@@ -2129,6 +3029,106 @@ public unsafe partial struct UInt3x2
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x2 operator <=(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator ~(UInt3x2 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator >>(UInt3x2 matrix, Int3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator >>(UInt3x2 matrix, UInt3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator <<(UInt3x2 matrix, Int3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator <<(UInt3x2 matrix, UInt3x2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator &(UInt3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator &(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator |(UInt3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator |(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator ^(UInt3x2 left, Int3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator ^(UInt3x2 left, UInt3x2 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt3x2"/> values to see if they are equal.
@@ -2409,6 +3409,106 @@ public unsafe partial struct UInt3x3
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool3x3 operator <=(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator ~(UInt3x3 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator >>(UInt3x3 matrix, Int3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator >>(UInt3x3 matrix, UInt3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator <<(UInt3x3 matrix, Int3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator <<(UInt3x3 matrix, UInt3x3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator &(UInt3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator &(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator |(UInt3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator |(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator ^(UInt3x3 left, Int3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator ^(UInt3x3 left, UInt3x3 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt3x3"/> values to see if they are equal.
@@ -2727,6 +3827,106 @@ public unsafe partial struct UInt3x4
     public static Bool3x4 operator <=(UInt3x4 left, UInt3x4 right) => default;
 
     /// <summary>
+    /// Bitwise negates a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator ~(UInt3x4 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator >>(UInt3x4 matrix, Int3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator >>(UInt3x4 matrix, UInt3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator <<(UInt3x4 matrix, Int3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator <<(UInt3x4 matrix, UInt3x4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator &(UInt3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator &(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator |(UInt3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator |(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator ^(UInt3x4 left, Int3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt3x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator ^(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
     /// Compares two <see cref="UInt3x4"/> values to see if they are equal.
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x4"/> value to compare.</param>
@@ -2931,6 +4131,106 @@ public unsafe partial struct UInt4x1
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x1 operator <=(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator ~(UInt4x1 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator >>(UInt4x1 matrix, Int4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator >>(UInt4x1 matrix, UInt4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator <<(UInt4x1 matrix, Int4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator <<(UInt4x1 matrix, UInt4x1 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator &(UInt4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator &(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator |(UInt4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator |(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator ^(UInt4x1 left, Int4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4x1"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator ^(UInt4x1 left, UInt4x1 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt4x1"/> values to see if they are equal.
@@ -3206,6 +4506,106 @@ public unsafe partial struct UInt4x2
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x2 operator <=(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator ~(UInt4x2 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator >>(UInt4x2 matrix, Int4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator >>(UInt4x2 matrix, UInt4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator <<(UInt4x2 matrix, Int4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator <<(UInt4x2 matrix, UInt4x2 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator &(UInt4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator &(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator |(UInt4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator |(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator ^(UInt4x2 left, Int4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4x2"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator ^(UInt4x2 left, UInt4x2 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt4x2"/> values to see if they are equal.
@@ -3523,6 +4923,106 @@ public unsafe partial struct UInt4x3
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x3 operator <=(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator ~(UInt4x3 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator >>(UInt4x3 matrix, Int4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator >>(UInt4x3 matrix, UInt4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator <<(UInt4x3 matrix, Int4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator <<(UInt4x3 matrix, UInt4x3 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator &(UInt4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator &(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator |(UInt4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator |(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator ^(UInt4x3 left, Int4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4x3"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator ^(UInt4x3 left, UInt4x3 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt4x3"/> values to see if they are equal.
@@ -3888,6 +5388,106 @@ public unsafe partial struct UInt4x4
     /// <returns>The result of comparing <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Bool4x4 operator <=(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise negates a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="matrix"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator ~(UInt4x4 matrix) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator >>(UInt4x4 matrix, Int4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator >>(UInt4x4 matrix, UInt4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator <<(UInt4x4 matrix, Int4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator <<(UInt4x4 matrix, UInt4x4 amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator &(UInt4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator &(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator |(UInt4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator |(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator ^(UInt4x4 left, Int4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt4x4"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator ^(UInt4x4 left, UInt4x4 right) => default;
 
     /// <summary>
     /// Compares two <see cref="UInt4x4"/> values to see if they are equal.

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -392,6 +392,115 @@ public unsafe partial struct <#=typeName#>
 <#
     }
 
+    // Generate the bitwise operators
+    if (elementTypeName == "Int" || elementTypeName == "UInt")
+    {
+        string argumentName = "xyzw".Substring(0, i);
+
+        WriteLine("");
+#>
+    /// <summary>
+    /// Bitwise negates a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to bitwise negate.</param>
+    /// <returns>The bitwise negated value of <paramref name="<#=argumentName#>"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator ~(<#=typeName#> <#=argumentName#>) => default;
+
+#if NEEDS_CSHARP_11
+    /// <summary>
+    /// Shifts right a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator >>(<#=typeName#> <#=argumentName#>, Int<#=i#> amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator >>(<#=typeName#> <#=argumentName#>, UInt<#=i#> amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator <<(<#=typeName#> <#=argumentName#>, Int<#=i#> amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator <<(<#=typeName#> <#=argumentName#>, UInt<#=i#> amount) => default;
+#endif
+
+    /// <summary>
+    /// Bitwise ands a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="Int<#=i#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator &(<#=typeName#> left, Int<#=i#> right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="UInt<#=i#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator &(<#=typeName#> left, UInt<#=i#> right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="Int<#=i#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator |(<#=typeName#> left, Int<#=i#> right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="UInt<#=i#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator |(<#=typeName#> left, UInt<#=i#> right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="Int<#=i#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator ^(<#=typeName#> left, Int<#=i#> right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="UInt<#=i#>"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator ^(<#=typeName#> left, UInt<#=i#> right) => default;
+<#
+    }
+
     WriteLine("");
 #>
     /// <summary>

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -108,7 +108,38 @@ public unsafe partial struct <#=typeName#>
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public readonly ref <#=hlslElementTypeName#> this[int i] => ref *(<#=hlslElementTypeName#>*)UndefinedData;
+
 <#
+    // Generate the true/false and zero/one properties
+    if (elementTypeName == "Bool")
+    {
+#>
+    /// <summary>
+    /// Gets a <see cref="<#=typeName#>"/> value with all components set to <see langword="false"/>.
+    /// </summary>
+    public static <#=typeName#> False => false;
+
+    /// <summary>
+    /// Gets a <see cref="<#=typeName#>"/> value with all components set to <see langword="true"/>.
+    /// </summary>
+    public static <#=typeName#> True => true;
+<#
+    }
+    else
+    {
+#>
+    /// <summary>
+    /// Gets a <see cref="<#=typeName#>"/> value with all components set to 0.
+    /// </summary>
+    public static <#=typeName#> Zero => 0;
+
+    /// <summary>
+    /// Gets a <see cref="<#=typeName#>"/> value with all components set to 1.
+    /// </summary>
+    public static <#=typeName#> One => 1;
+<#
+    }
+
     PushIndent("    ");
 
     // Generate the combinatorial swizzling properties
@@ -161,7 +192,6 @@ public unsafe partial struct <#=typeName#>
 #if !SOURCE_GENERATOR
 
 <#
-
     if (elementTypeName == "Bool")
     {
 #>
@@ -222,7 +252,6 @@ public unsafe partial struct <#=typeName#>
 
 #endif
 <#
-
     // Generate the negation operator
     if (elementTypeName != "UInt")
     {

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -140,6 +140,40 @@ public unsafe partial struct <#=typeName#>
 <#
     }
 
+    string unitName, unitOne, unitZero, unitOneXmlName, unitZeroXmlName;
+
+    if (elementTypeName == "Bool")
+    {
+        unitName = "True";
+        unitOne = "true";
+        unitZero = "false";
+        unitOneXmlName = "<see langword=\"true\"/>";
+        unitZeroXmlName = "<see langword=\"false\"/>";
+    }
+    else
+    {
+        unitName = "Unit";
+        unitOne = "1";
+        unitZero = "0";
+        unitOneXmlName = "1";
+        unitZeroXmlName = "0";
+    }
+
+    // Generate the True<N> and Unit<N> properties
+    for (int j = 0; j < i; j++)
+    {
+        string unitComponentName = ("XYZW"[j]).ToString();
+        string[] unitArguments = Enumerable.Range(0, i).Select(x => x == j ? unitOne : unitZero).ToArray();
+        string unitArgumentExpression = string.Join(", ", unitArguments);
+#>
+
+    /// <summary>
+    /// Gets a <see cref="<#=typeName#>"/> value with the <see cref="<#=unitComponentName#>"/> component set to <#=unitOneXmlName#>, and the others to <#=unitZeroXmlName#>.
+    /// </summary>
+    public static <#=typeName#> <#=unitName#><#=unitComponentName#> => new(<#=unitArgumentExpression#>);
+<#
+    }
+
     PushIndent("    ");
 
     // Generate the combinatorial swizzling properties


### PR DESCRIPTION
### Closes #361

### Description

This PR adds bitwise operators for all `int` and `uint` HLSL types.

> **Note**
> The bit shift operators are disabled as they require C# 11. They will be enabled in #353.