### PR TITLE
Fix bool types marshalling and rewriter handling

### DIFF
--- a/src/ComputeSharp.Core/Primitives/Bool/Bool.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool.cs
@@ -6,14 +6,14 @@ namespace ComputeSharp;
 /// <summary>
 /// A <see langword="struct"/> that can be used in place of the <see cref="bool"/> type in HLSL shaders.
 /// </summary>
-[StructLayout(LayoutKind.Explicit, Size = sizeof(int), Pack = 4)]
+[StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
 public readonly struct Bool
 {
     /// <summary>
-    /// The wrapped <see cref="bool"/> value for the current instance.
+    /// The wrapped <see cref="int"/> value for the current instance.
     /// </summary>
     [FieldOffset(0)]
-    private readonly bool Value;
+    private readonly int Value;
 
     /// <summary>
     /// Creates a new <see cref="Bool"/> instance for a given <see cref="bool"/> value.
@@ -21,7 +21,7 @@ public readonly struct Bool
     /// <param name="value">.</param>
     private Bool(bool value)
     {
-        Value = value;
+        Value = value ? 1 : 0;
     }
 
     /// <inheritdoc/>
@@ -39,20 +39,20 @@ public readonly struct Bool
     /// <inheritdoc/>
     public override string ToString()
     {
-        return Value.ToString();
+        return ((bool)this).ToString();
     }
 
     /// <inheritdoc cref="bool.ToString(IFormatProvider?)"/>
     public string ToString(IFormatProvider? formatProvider)
     {
-        return Value.ToString();
+        return ((bool)this).ToString(formatProvider);
     }
 
 #if NET6_0_OR_GREATER
     /// <inheritdoc cref="bool.TryFormat(Span{char}, out int)"/>
     public bool TryFormat(Span<char> destination, out int charsWritten)
     {
-        return Value.TryFormat(destination, out charsWritten);
+        return ((bool)this).TryFormat(destination, out charsWritten);
     }
 #endif
 
@@ -60,7 +60,7 @@ public readonly struct Bool
     /// Inverts the <see cref="bool"/> value represented by a given <see cref="Bool"/> instance.
     /// </summary>
     /// <param name="x">The input <see cref="Bool"/> instance.</param>
-    public static Bool operator !(Bool x) => new(!x.Value);
+    public static Bool operator !(Bool x) => new(!(bool)x);
 
     /// <summary>
     /// Ands two <see cref="Bool"/> values.
@@ -107,7 +107,7 @@ public readonly struct Bool
     /// Converts a given <see cref="Bool"/> instance to its corresponding <see cref="bool"/> value.
     /// </summary>
     /// <param name="x">The input <see cref="Bool"/> instance.</param>
-    public static implicit operator bool(Bool x) => x.Value;
+    public static implicit operator bool(Bool x) => x.Value != 0;
 
     /// <summary>
     /// Converts a <see cref="bool"/> value to a corresponding <see cref="Bool"/> instance.

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.cs
@@ -14,8 +14,8 @@ public partial struct Bool2
     /// <param name="y">The value to assign to the second vector component.</param>
     public Bool2(bool x, bool y)
     {
-        this.x = x;
-        this.y = y;
+        this.x = x ? 1 : 0;
+        this.y = y ? 1 : 0;
     }
 
     /// <summary>

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
@@ -20,10 +20,10 @@ public unsafe partial struct Bool2
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool x;
+    private int x;
 
     [FieldOffset(4)]
-    private bool y;
+    private int y;
 
     /// <summary>
     /// Gets a reference to a specific component in the current <see cref="Bool2"/> instance.
@@ -55,12 +55,12 @@ public unsafe partial struct Bool2
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
-    public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));
+    public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.x)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>Y</c> component.
     /// </summary>
-    public readonly ref bool Y => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.y), 1));
+    public readonly ref bool Y => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.y)), 1));
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="X"/>.
@@ -233,12 +233,12 @@ public unsafe partial struct Bool2
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>R</c> component.
     /// </summary>
-    public readonly ref bool R => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));
+    public readonly ref bool R => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.x)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>G</c> component.
     /// </summary>
-    public readonly ref bool G => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.y), 1));
+    public readonly ref bool G => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.y)), 1));
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="R"/>.
@@ -414,9 +414,9 @@ public unsafe partial struct Bool2
     public override readonly string ToString()
     {
 #if NET6_0_OR_GREATER
-        return string.Create(null, stackalloc char[32], $"<{this.x}, {this.y}>");
+        return string.Create(null, stackalloc char[32], $"<{this.x != 0}, {this.y != 0}>");
 #else
-        return $"<{this.x}, {this.y}>";
+        return $"<{this.x != 0}, {this.y != 0}>";
 #endif
     }
 

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.cs
@@ -15,9 +15,9 @@ public partial struct Bool3
     /// <param name="z">The value to assign to the third vector component.</param>
     public Bool3(bool x, bool y, bool z)
     {
-        this.x = x;
-        this.y = y;
-        this.z = z;
+        this.x = x ? 1 : 0;
+        this.y = y ? 1 : 0;
+        this.z = z ? 1 : 0;
     }
 
     /// <summary>
@@ -27,9 +27,9 @@ public partial struct Bool3
     /// <param name="z">The value to assign to the third vector component.</param>
     public Bool3(Bool2 xy, bool z)
     {
-        this.x = xy.X;
-        this.y = xy.Y;
-        this.z = z;
+        this.x = xy.X ? 1 : 0;
+        this.y = xy.Y ? 1 : 0;
+        this.z = z ? 1 : 0;
     }
 
     /// <summary>
@@ -39,9 +39,9 @@ public partial struct Bool3
     /// <param name="yz">The value to assign to the second and thirt vector components.</param>
     public Bool3(bool x, Bool2 yz)
     {
-        this.x = x;
-        this.y = yz.X;
-        this.z = yz.Y;
+        this.x = x ? 1 : 0;
+        this.y = yz.X ? 1 : 0;
+        this.z = yz.Y ? 1 : 0;
     }
 
     /// <summary>

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
@@ -20,13 +20,13 @@ public unsafe partial struct Bool3
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool x;
+    private int x;
 
     [FieldOffset(4)]
-    private bool y;
+    private int y;
 
     [FieldOffset(8)]
-    private bool z;
+    private int z;
 
     /// <summary>
     /// Gets a reference to a specific component in the current <see cref="Bool3"/> instance.
@@ -63,17 +63,17 @@ public unsafe partial struct Bool3
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
-    public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));
+    public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.x)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>Y</c> component.
     /// </summary>
-    public readonly ref bool Y => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.y), 1));
+    public readonly ref bool Y => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.y)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>Z</c> component.
     /// </summary>
-    public readonly ref bool Z => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.z), 1));
+    public readonly ref bool Z => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.z)), 1));
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="X"/>.
@@ -780,17 +780,17 @@ public unsafe partial struct Bool3
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>R</c> component.
     /// </summary>
-    public readonly ref bool R => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));
+    public readonly ref bool R => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.x)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>G</c> component.
     /// </summary>
-    public readonly ref bool G => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.y), 1));
+    public readonly ref bool G => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.y)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>B</c> component.
     /// </summary>
-    public readonly ref bool B => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.z), 1));
+    public readonly ref bool B => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.z)), 1));
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="R"/>.
@@ -1500,9 +1500,9 @@ public unsafe partial struct Bool3
     public override readonly string ToString()
     {
 #if NET6_0_OR_GREATER
-        return string.Create(null, stackalloc char[32], $"<{this.x}, {this.y}, {this.z}>");
+        return string.Create(null, stackalloc char[32], $"<{this.x != 0}, {this.y != 0}, {this.z != 0}>");
 #else
-        return $"<{this.x}, {this.y}, {this.z}>";
+        return $"<{this.x != 0}, {this.y != 0}, {this.z != 0}>";
 #endif
     }
 

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.cs
@@ -16,10 +16,10 @@ public partial struct Bool4
     /// <param name="w">The value to assign to the fourth vector component.</param>
     public Bool4(bool x, bool y, bool z, bool w)
     {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-        this.w = w;
+        this.x = x ? 1 : 0;
+        this.y = y ? 1 : 0;
+        this.z = z ? 1 : 0;
+        this.w = w ? 1 : 0;
     }
 
     /// <summary>
@@ -30,10 +30,10 @@ public partial struct Bool4
     /// <param name="w">The value to assign to the fourth vector component.</param>
     public Bool4(Bool2 xy, bool z, bool w)
     {
-        this.x = xy.X;
-        this.y = xy.Y;
-        this.z = z;
-        this.w = w;
+        this.x = xy.X ? 1 : 0;
+        this.y = xy.Y ? 1 : 0;
+        this.z = z ? 1 : 0;
+        this.w = w ? 1 : 0;
     }
 
     /// <summary>
@@ -44,10 +44,10 @@ public partial struct Bool4
     /// <param name="zw">The value to assign to the third and fourth vector components.</param>
     public Bool4(bool x, bool y, Bool2 zw)
     {
-        this.x = x;
-        this.y = y;
-        this.z = zw.X;
-        this.w = zw.Y;
+        this.x = x ? 1 : 0;
+        this.y = y ? 1 : 0;
+        this.z = zw.X ? 1 : 0;
+        this.w = zw.Y ? 1 : 0;
     }
 
     /// <summary>
@@ -57,10 +57,10 @@ public partial struct Bool4
     /// <param name="zw">The value to assign to the third and fourth vector components.</param>
     public Bool4(Bool2 xy, Bool2 zw)
     {
-        this.x = xy.X;
-        this.y = xy.Y;
-        this.z = zw.X;
-        this.w = zw.Y;
+        this.x = xy.X ? 1 : 0;
+        this.y = xy.Y ? 1 : 0;
+        this.z = zw.X ? 1 : 0;
+        this.w = zw.Y ? 1 : 0;
     }
 
     /// <summary>
@@ -70,10 +70,10 @@ public partial struct Bool4
     /// <param name="w">The value to assign to the fourth vector component.</param>
     public Bool4(Bool3 xyz, bool w)
     {
-        this.x = xyz.X;
-        this.y = xyz.Y;
-        this.z = xyz.Z;
-        this.w = w;
+        this.x = xyz.X ? 1 : 0;
+        this.y = xyz.Y ? 1 : 0;
+        this.z = xyz.Z ? 1 : 0;
+        this.w = w ? 1 : 0;
     }
 
     /// <summary>
@@ -83,10 +83,10 @@ public partial struct Bool4
     /// <param name="yzw">The value to assign to the second, third and fourth vector components.</param>
     public Bool4(bool x, Bool3 yzw)
     {
-        this.x = x;
-        this.y = yzw.X;
-        this.z = yzw.Y;
-        this.w = yzw.Z;
+        this.x = x ? 1 : 0;
+        this.y = yzw.X ? 1 : 0;
+        this.z = yzw.Y ? 1 : 0;
+        this.w = yzw.Z ? 1 : 0;
     }
 
     /// <summary>

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
@@ -20,16 +20,16 @@ public unsafe partial struct Bool4
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool x;
+    private int x;
 
     [FieldOffset(4)]
-    private bool y;
+    private int y;
 
     [FieldOffset(8)]
-    private bool z;
+    private int z;
 
     [FieldOffset(12)]
-    private bool w;
+    private int w;
 
     /// <summary>
     /// Gets a reference to a specific component in the current <see cref="Bool4"/> instance.
@@ -71,22 +71,22 @@ public unsafe partial struct Bool4
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>X</c> component.
     /// </summary>
-    public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));
+    public readonly ref bool X => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.x)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>Y</c> component.
     /// </summary>
-    public readonly ref bool Y => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.y), 1));
+    public readonly ref bool Y => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.y)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>Z</c> component.
     /// </summary>
-    public readonly ref bool Z => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.z), 1));
+    public readonly ref bool Z => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.z)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>W</c> component.
     /// </summary>
-    public readonly ref bool W => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.w), 1));
+    public readonly ref bool W => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.w)), 1));
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="X"/>.
@@ -2107,22 +2107,22 @@ public unsafe partial struct Bool4
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>R</c> component.
     /// </summary>
-    public readonly ref bool R => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.x), 1));
+    public readonly ref bool R => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.x)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>G</c> component.
     /// </summary>
-    public readonly ref bool G => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.y), 1));
+    public readonly ref bool G => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.y)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>B</c> component.
     /// </summary>
-    public readonly ref bool B => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.z), 1));
+    public readonly ref bool B => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.z)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>A</c> component.
     /// </summary>
-    public readonly ref bool A => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.w), 1));
+    public readonly ref bool A => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.w)), 1));
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="R"/>.
@@ -4146,9 +4146,9 @@ public unsafe partial struct Bool4
     public override readonly string ToString()
     {
 #if NET6_0_OR_GREATER
-        return string.Create(null, stackalloc char[32], $"<{this.x}, {this.y}, {this.z}, {this.w}>");
+        return string.Create(null, stackalloc char[32], $"<{this.x != 0}, {this.y != 0}, {this.z != 0}, {this.w != 0}>");
 #else
-        return $"<{this.x}, {this.y}, {this.z}, {this.w}>";
+        return $"<{this.x != 0}, {this.y != 0}, {this.z != 0}, {this.w != 0}>";
 #endif
     }
 

--- a/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
@@ -19,7 +19,7 @@ public unsafe partial struct Bool1x1
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool1x1), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     /// <summary>
     /// Creates a new <see cref="Bool1x1"/> instance with the specified parameters.
@@ -27,7 +27,7 @@ public unsafe partial struct Bool1x1
     /// <param name="m11">The value to assign to the component at position [1, 1].</param>
     public Bool1x1(bool m11)
     {
-        this.m11 = m11;
+        this.m11 = m11 ? 1 : 0;
     }
 
     /// <summary>
@@ -67,7 +67,7 @@ public unsafe partial struct Bool1x1
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool1x1"/> value with the same value for all its components.
@@ -77,7 +77,7 @@ public unsafe partial struct Bool1x1
     {
         Bool1x1 matrix;
 
-        matrix.m11 = x;
+        matrix.m11 = x ? 1 : 0;
 
         return matrix;
     }
@@ -145,10 +145,10 @@ public unsafe partial struct Bool1x2
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool1x2), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     /// <summary>
     /// Creates a new <see cref="Bool1x2"/> instance with the specified parameters.
@@ -157,8 +157,8 @@ public unsafe partial struct Bool1x2
     /// <param name="m12">The value to assign to the component at position [1, 2].</param>
     public Bool1x2(bool m11, bool m12)
     {
-        this.m11 = m11;
-        this.m12 = m12;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
     }
 
     /// <summary>
@@ -198,12 +198,12 @@ public unsafe partial struct Bool1x2
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool1x2"/> value with the same value for all its components.
@@ -213,8 +213,8 @@ public unsafe partial struct Bool1x2
     {
         Bool1x2 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
 
         return matrix;
     }
@@ -288,13 +288,13 @@ public unsafe partial struct Bool1x3
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool1x3), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m13;
+    private int m13;
 
     /// <summary>
     /// Creates a new <see cref="Bool1x3"/> instance with the specified parameters.
@@ -304,9 +304,9 @@ public unsafe partial struct Bool1x3
     /// <param name="m13">The value to assign to the component at position [1, 3].</param>
     public Bool1x3(bool m11, bool m12, bool m13)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m13 = m13;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m13 = m13 ? 1 : 0;
     }
 
     /// <summary>
@@ -346,17 +346,17 @@ public unsafe partial struct Bool1x3
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 3].
     /// </summary>
-    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m13), 1));
+    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m13)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool1x3"/> value with the same value for all its components.
@@ -366,9 +366,9 @@ public unsafe partial struct Bool1x3
     {
         Bool1x3 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m13 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m13 = x ? 1 : 0;
 
         return matrix;
     }
@@ -442,16 +442,16 @@ public unsafe partial struct Bool1x4
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool1x4), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m13;
+    private int m13;
 
     [FieldOffset(12)]
-    private bool m14;
+    private int m14;
 
     /// <summary>
     /// Creates a new <see cref="Bool1x4"/> instance with the specified parameters.
@@ -462,10 +462,10 @@ public unsafe partial struct Bool1x4
     /// <param name="m14">The value to assign to the component at position [1, 4].</param>
     public Bool1x4(bool m11, bool m12, bool m13, bool m14)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m13 = m13;
-        this.m14 = m14;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m13 = m13 ? 1 : 0;
+        this.m14 = m14 ? 1 : 0;
     }
 
     /// <summary>
@@ -505,22 +505,22 @@ public unsafe partial struct Bool1x4
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 3].
     /// </summary>
-    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m13), 1));
+    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m13)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 4].
     /// </summary>
-    public readonly ref bool M14 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m14), 1));
+    public readonly ref bool M14 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m14)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool1x4"/> value with the same value for all its components.
@@ -530,10 +530,10 @@ public unsafe partial struct Bool1x4
     {
         Bool1x4 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m13 = x;
-        matrix.m14 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m13 = x ? 1 : 0;
+        matrix.m14 = x ? 1 : 0;
 
         return matrix;
     }
@@ -607,10 +607,10 @@ public unsafe partial struct Bool2x1
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2x1), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m21;
+    private int m21;
 
     /// <summary>
     /// Creates a new <see cref="Bool2x1"/> instance with the specified parameters.
@@ -619,8 +619,8 @@ public unsafe partial struct Bool2x1
     /// <param name="m21">The value to assign to the component at position [2, 1].</param>
     public Bool2x1(bool m11, bool m21)
     {
-        this.m11 = m11;
-        this.m21 = m21;
+        this.m11 = m11 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
     }
 
     /// <summary>
@@ -660,12 +660,12 @@ public unsafe partial struct Bool2x1
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool2x1"/> value with the same value for all its components.
@@ -675,8 +675,8 @@ public unsafe partial struct Bool2x1
     {
         Bool2x1 matrix;
 
-        matrix.m11 = x;
-        matrix.m21 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
 
         return matrix;
     }
@@ -750,16 +750,16 @@ public unsafe partial struct Bool2x2
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2x2), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(12)]
-    private bool m22;
+    private int m22;
 
     /// <summary>
     /// Creates a new <see cref="Bool2x2"/> instance with the specified parameters.
@@ -770,10 +770,10 @@ public unsafe partial struct Bool2x2
     /// <param name="m22">The value to assign to the component at position [2, 2].</param>
     public Bool2x2(bool m11, bool m12, bool m21, bool m22)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m21 = m21;
-        this.m22 = m22;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
     }
 
     /// <summary>
@@ -783,10 +783,10 @@ public unsafe partial struct Bool2x2
     /// <param name="row2">The value to assign to the row at position [2].</param>
     public Bool2x2(Bool2 row1, Bool2 row2)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
     }
 
     /// <summary>
@@ -826,22 +826,22 @@ public unsafe partial struct Bool2x2
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool2x2"/> value with the same value for all its components.
@@ -851,10 +851,10 @@ public unsafe partial struct Bool2x2
     {
         Bool2x2 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
 
         return matrix;
     }
@@ -922,22 +922,22 @@ public unsafe partial struct Bool2x3
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2x3), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m13;
+    private int m13;
 
     [FieldOffset(12)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(16)]
-    private bool m22;
+    private int m22;
 
     [FieldOffset(20)]
-    private bool m23;
+    private int m23;
 
     /// <summary>
     /// Creates a new <see cref="Bool2x3"/> instance with the specified parameters.
@@ -950,12 +950,12 @@ public unsafe partial struct Bool2x3
     /// <param name="m23">The value to assign to the component at position [2, 3].</param>
     public Bool2x3(bool m11, bool m12, bool m13, bool m21, bool m22, bool m23)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m13 = m13;
-        this.m21 = m21;
-        this.m22 = m22;
-        this.m23 = m23;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m13 = m13 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
+        this.m23 = m23 ? 1 : 0;
     }
 
     /// <summary>
@@ -965,12 +965,12 @@ public unsafe partial struct Bool2x3
     /// <param name="row2">The value to assign to the row at position [2].</param>
     public Bool2x3(Bool3 row1, Bool3 row2)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m13 = row1.Z;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
-        this.m23 = row2.Z;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m13 = row1.Z ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
+        this.m23 = row2.Z ? 1 : 0;
     }
 
     /// <summary>
@@ -1010,32 +1010,32 @@ public unsafe partial struct Bool2x3
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 3].
     /// </summary>
-    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m13), 1));
+    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m13)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 3].
     /// </summary>
-    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m23), 1));
+    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m23)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool2x3"/> value with the same value for all its components.
@@ -1045,12 +1045,12 @@ public unsafe partial struct Bool2x3
     {
         Bool2x3 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m13 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
-        matrix.m23 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m13 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
+        matrix.m23 = x ? 1 : 0;
 
         return matrix;
     }
@@ -1118,28 +1118,28 @@ public unsafe partial struct Bool2x4
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2x4), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m13;
+    private int m13;
 
     [FieldOffset(12)]
-    private bool m14;
+    private int m14;
 
     [FieldOffset(16)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(20)]
-    private bool m22;
+    private int m22;
 
     [FieldOffset(24)]
-    private bool m23;
+    private int m23;
 
     [FieldOffset(28)]
-    private bool m24;
+    private int m24;
 
     /// <summary>
     /// Creates a new <see cref="Bool2x4"/> instance with the specified parameters.
@@ -1154,14 +1154,14 @@ public unsafe partial struct Bool2x4
     /// <param name="m24">The value to assign to the component at position [2, 4].</param>
     public Bool2x4(bool m11, bool m12, bool m13, bool m14, bool m21, bool m22, bool m23, bool m24)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m13 = m13;
-        this.m14 = m14;
-        this.m21 = m21;
-        this.m22 = m22;
-        this.m23 = m23;
-        this.m24 = m24;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m13 = m13 ? 1 : 0;
+        this.m14 = m14 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
+        this.m23 = m23 ? 1 : 0;
+        this.m24 = m24 ? 1 : 0;
     }
 
     /// <summary>
@@ -1171,14 +1171,14 @@ public unsafe partial struct Bool2x4
     /// <param name="row2">The value to assign to the row at position [2].</param>
     public Bool2x4(Bool4 row1, Bool4 row2)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m13 = row1.Z;
-        this.m14 = row1.W;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
-        this.m23 = row2.Z;
-        this.m24 = row2.W;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m13 = row1.Z ? 1 : 0;
+        this.m14 = row1.W ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
+        this.m23 = row2.Z ? 1 : 0;
+        this.m24 = row2.W ? 1 : 0;
     }
 
     /// <summary>
@@ -1218,42 +1218,42 @@ public unsafe partial struct Bool2x4
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 3].
     /// </summary>
-    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m13), 1));
+    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m13)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 4].
     /// </summary>
-    public readonly ref bool M14 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m14), 1));
+    public readonly ref bool M14 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m14)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 3].
     /// </summary>
-    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m23), 1));
+    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m23)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 4].
     /// </summary>
-    public readonly ref bool M24 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m24), 1));
+    public readonly ref bool M24 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m24)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool2x4"/> value with the same value for all its components.
@@ -1263,14 +1263,14 @@ public unsafe partial struct Bool2x4
     {
         Bool2x4 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m13 = x;
-        matrix.m14 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
-        matrix.m23 = x;
-        matrix.m24 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m13 = x ? 1 : 0;
+        matrix.m14 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
+        matrix.m23 = x ? 1 : 0;
+        matrix.m24 = x ? 1 : 0;
 
         return matrix;
     }
@@ -1338,13 +1338,13 @@ public unsafe partial struct Bool3x1
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3x1), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(8)]
-    private bool m31;
+    private int m31;
 
     /// <summary>
     /// Creates a new <see cref="Bool3x1"/> instance with the specified parameters.
@@ -1354,9 +1354,9 @@ public unsafe partial struct Bool3x1
     /// <param name="m31">The value to assign to the component at position [3, 1].</param>
     public Bool3x1(bool m11, bool m21, bool m31)
     {
-        this.m11 = m11;
-        this.m21 = m21;
-        this.m31 = m31;
+        this.m11 = m11 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m31 = m31 ? 1 : 0;
     }
 
     /// <summary>
@@ -1396,17 +1396,17 @@ public unsafe partial struct Bool3x1
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 1].
     /// </summary>
-    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m31), 1));
+    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m31)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool3x1"/> value with the same value for all its components.
@@ -1416,9 +1416,9 @@ public unsafe partial struct Bool3x1
     {
         Bool3x1 matrix;
 
-        matrix.m11 = x;
-        matrix.m21 = x;
-        matrix.m31 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m31 = x ? 1 : 0;
 
         return matrix;
     }
@@ -1492,22 +1492,22 @@ public unsafe partial struct Bool3x2
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3x2), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(12)]
-    private bool m22;
+    private int m22;
 
     [FieldOffset(16)]
-    private bool m31;
+    private int m31;
 
     [FieldOffset(20)]
-    private bool m32;
+    private int m32;
 
     /// <summary>
     /// Creates a new <see cref="Bool3x2"/> instance with the specified parameters.
@@ -1520,12 +1520,12 @@ public unsafe partial struct Bool3x2
     /// <param name="m32">The value to assign to the component at position [3, 2].</param>
     public Bool3x2(bool m11, bool m12, bool m21, bool m22, bool m31, bool m32)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m21 = m21;
-        this.m22 = m22;
-        this.m31 = m31;
-        this.m32 = m32;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
+        this.m31 = m31 ? 1 : 0;
+        this.m32 = m32 ? 1 : 0;
     }
 
     /// <summary>
@@ -1536,12 +1536,12 @@ public unsafe partial struct Bool3x2
     /// <param name="row3">The value to assign to the row at position [3].</param>
     public Bool3x2(Bool2 row1, Bool2 row2, Bool2 row3)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
-        this.m31 = row3.X;
-        this.m32 = row3.Y;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
+        this.m31 = row3.X ? 1 : 0;
+        this.m32 = row3.Y ? 1 : 0;
     }
 
     /// <summary>
@@ -1581,32 +1581,32 @@ public unsafe partial struct Bool3x2
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 1].
     /// </summary>
-    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m31), 1));
+    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m31)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 2].
     /// </summary>
-    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m32), 1));
+    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m32)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool3x2"/> value with the same value for all its components.
@@ -1616,12 +1616,12 @@ public unsafe partial struct Bool3x2
     {
         Bool3x2 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
-        matrix.m31 = x;
-        matrix.m32 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
+        matrix.m31 = x ? 1 : 0;
+        matrix.m32 = x ? 1 : 0;
 
         return matrix;
     }
@@ -1689,31 +1689,31 @@ public unsafe partial struct Bool3x3
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3x3), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m13;
+    private int m13;
 
     [FieldOffset(12)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(16)]
-    private bool m22;
+    private int m22;
 
     [FieldOffset(20)]
-    private bool m23;
+    private int m23;
 
     [FieldOffset(24)]
-    private bool m31;
+    private int m31;
 
     [FieldOffset(28)]
-    private bool m32;
+    private int m32;
 
     [FieldOffset(32)]
-    private bool m33;
+    private int m33;
 
     /// <summary>
     /// Creates a new <see cref="Bool3x3"/> instance with the specified parameters.
@@ -1729,15 +1729,15 @@ public unsafe partial struct Bool3x3
     /// <param name="m33">The value to assign to the component at position [3, 3].</param>
     public Bool3x3(bool m11, bool m12, bool m13, bool m21, bool m22, bool m23, bool m31, bool m32, bool m33)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m13 = m13;
-        this.m21 = m21;
-        this.m22 = m22;
-        this.m23 = m23;
-        this.m31 = m31;
-        this.m32 = m32;
-        this.m33 = m33;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m13 = m13 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
+        this.m23 = m23 ? 1 : 0;
+        this.m31 = m31 ? 1 : 0;
+        this.m32 = m32 ? 1 : 0;
+        this.m33 = m33 ? 1 : 0;
     }
 
     /// <summary>
@@ -1748,15 +1748,15 @@ public unsafe partial struct Bool3x3
     /// <param name="row3">The value to assign to the row at position [3].</param>
     public Bool3x3(Bool3 row1, Bool3 row2, Bool3 row3)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m13 = row1.Z;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
-        this.m23 = row2.Z;
-        this.m31 = row3.X;
-        this.m32 = row3.Y;
-        this.m33 = row3.Z;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m13 = row1.Z ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
+        this.m23 = row2.Z ? 1 : 0;
+        this.m31 = row3.X ? 1 : 0;
+        this.m32 = row3.Y ? 1 : 0;
+        this.m33 = row3.Z ? 1 : 0;
     }
 
     /// <summary>
@@ -1796,47 +1796,47 @@ public unsafe partial struct Bool3x3
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 3].
     /// </summary>
-    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m13), 1));
+    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m13)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 3].
     /// </summary>
-    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m23), 1));
+    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m23)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 1].
     /// </summary>
-    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m31), 1));
+    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m31)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 2].
     /// </summary>
-    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m32), 1));
+    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m32)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 3].
     /// </summary>
-    public readonly ref bool M33 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m33), 1));
+    public readonly ref bool M33 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m33)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool3x3"/> value with the same value for all its components.
@@ -1846,15 +1846,15 @@ public unsafe partial struct Bool3x3
     {
         Bool3x3 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m13 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
-        matrix.m23 = x;
-        matrix.m31 = x;
-        matrix.m32 = x;
-        matrix.m33 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m13 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
+        matrix.m23 = x ? 1 : 0;
+        matrix.m31 = x ? 1 : 0;
+        matrix.m32 = x ? 1 : 0;
+        matrix.m33 = x ? 1 : 0;
 
         return matrix;
     }
@@ -1922,40 +1922,40 @@ public unsafe partial struct Bool3x4
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3x4), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m13;
+    private int m13;
 
     [FieldOffset(12)]
-    private bool m14;
+    private int m14;
 
     [FieldOffset(16)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(20)]
-    private bool m22;
+    private int m22;
 
     [FieldOffset(24)]
-    private bool m23;
+    private int m23;
 
     [FieldOffset(28)]
-    private bool m24;
+    private int m24;
 
     [FieldOffset(32)]
-    private bool m31;
+    private int m31;
 
     [FieldOffset(36)]
-    private bool m32;
+    private int m32;
 
     [FieldOffset(40)]
-    private bool m33;
+    private int m33;
 
     [FieldOffset(44)]
-    private bool m34;
+    private int m34;
 
     /// <summary>
     /// Creates a new <see cref="Bool3x4"/> instance with the specified parameters.
@@ -1974,18 +1974,18 @@ public unsafe partial struct Bool3x4
     /// <param name="m34">The value to assign to the component at position [3, 4].</param>
     public Bool3x4(bool m11, bool m12, bool m13, bool m14, bool m21, bool m22, bool m23, bool m24, bool m31, bool m32, bool m33, bool m34)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m13 = m13;
-        this.m14 = m14;
-        this.m21 = m21;
-        this.m22 = m22;
-        this.m23 = m23;
-        this.m24 = m24;
-        this.m31 = m31;
-        this.m32 = m32;
-        this.m33 = m33;
-        this.m34 = m34;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m13 = m13 ? 1 : 0;
+        this.m14 = m14 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
+        this.m23 = m23 ? 1 : 0;
+        this.m24 = m24 ? 1 : 0;
+        this.m31 = m31 ? 1 : 0;
+        this.m32 = m32 ? 1 : 0;
+        this.m33 = m33 ? 1 : 0;
+        this.m34 = m34 ? 1 : 0;
     }
 
     /// <summary>
@@ -1996,18 +1996,18 @@ public unsafe partial struct Bool3x4
     /// <param name="row3">The value to assign to the row at position [3].</param>
     public Bool3x4(Bool4 row1, Bool4 row2, Bool4 row3)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m13 = row1.Z;
-        this.m14 = row1.W;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
-        this.m23 = row2.Z;
-        this.m24 = row2.W;
-        this.m31 = row3.X;
-        this.m32 = row3.Y;
-        this.m33 = row3.Z;
-        this.m34 = row3.W;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m13 = row1.Z ? 1 : 0;
+        this.m14 = row1.W ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
+        this.m23 = row2.Z ? 1 : 0;
+        this.m24 = row2.W ? 1 : 0;
+        this.m31 = row3.X ? 1 : 0;
+        this.m32 = row3.Y ? 1 : 0;
+        this.m33 = row3.Z ? 1 : 0;
+        this.m34 = row3.W ? 1 : 0;
     }
 
     /// <summary>
@@ -2047,62 +2047,62 @@ public unsafe partial struct Bool3x4
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 3].
     /// </summary>
-    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m13), 1));
+    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m13)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 4].
     /// </summary>
-    public readonly ref bool M14 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m14), 1));
+    public readonly ref bool M14 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m14)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 3].
     /// </summary>
-    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m23), 1));
+    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m23)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 4].
     /// </summary>
-    public readonly ref bool M24 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m24), 1));
+    public readonly ref bool M24 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m24)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 1].
     /// </summary>
-    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m31), 1));
+    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m31)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 2].
     /// </summary>
-    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m32), 1));
+    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m32)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 3].
     /// </summary>
-    public readonly ref bool M33 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m33), 1));
+    public readonly ref bool M33 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m33)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 4].
     /// </summary>
-    public readonly ref bool M34 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m34), 1));
+    public readonly ref bool M34 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m34)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool3x4"/> value with the same value for all its components.
@@ -2112,18 +2112,18 @@ public unsafe partial struct Bool3x4
     {
         Bool3x4 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m13 = x;
-        matrix.m14 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
-        matrix.m23 = x;
-        matrix.m24 = x;
-        matrix.m31 = x;
-        matrix.m32 = x;
-        matrix.m33 = x;
-        matrix.m34 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m13 = x ? 1 : 0;
+        matrix.m14 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
+        matrix.m23 = x ? 1 : 0;
+        matrix.m24 = x ? 1 : 0;
+        matrix.m31 = x ? 1 : 0;
+        matrix.m32 = x ? 1 : 0;
+        matrix.m33 = x ? 1 : 0;
+        matrix.m34 = x ? 1 : 0;
 
         return matrix;
     }
@@ -2191,16 +2191,16 @@ public unsafe partial struct Bool4x1
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4x1), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(8)]
-    private bool m31;
+    private int m31;
 
     [FieldOffset(12)]
-    private bool m41;
+    private int m41;
 
     /// <summary>
     /// Creates a new <see cref="Bool4x1"/> instance with the specified parameters.
@@ -2211,10 +2211,10 @@ public unsafe partial struct Bool4x1
     /// <param name="m41">The value to assign to the component at position [4, 1].</param>
     public Bool4x1(bool m11, bool m21, bool m31, bool m41)
     {
-        this.m11 = m11;
-        this.m21 = m21;
-        this.m31 = m31;
-        this.m41 = m41;
+        this.m11 = m11 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m31 = m31 ? 1 : 0;
+        this.m41 = m41 ? 1 : 0;
     }
 
     /// <summary>
@@ -2254,22 +2254,22 @@ public unsafe partial struct Bool4x1
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 1].
     /// </summary>
-    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m31), 1));
+    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m31)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 1].
     /// </summary>
-    public readonly ref bool M41 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m41), 1));
+    public readonly ref bool M41 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m41)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool4x1"/> value with the same value for all its components.
@@ -2279,10 +2279,10 @@ public unsafe partial struct Bool4x1
     {
         Bool4x1 matrix;
 
-        matrix.m11 = x;
-        matrix.m21 = x;
-        matrix.m31 = x;
-        matrix.m41 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m31 = x ? 1 : 0;
+        matrix.m41 = x ? 1 : 0;
 
         return matrix;
     }
@@ -2356,28 +2356,28 @@ public unsafe partial struct Bool4x2
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4x2), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(12)]
-    private bool m22;
+    private int m22;
 
     [FieldOffset(16)]
-    private bool m31;
+    private int m31;
 
     [FieldOffset(20)]
-    private bool m32;
+    private int m32;
 
     [FieldOffset(24)]
-    private bool m41;
+    private int m41;
 
     [FieldOffset(28)]
-    private bool m42;
+    private int m42;
 
     /// <summary>
     /// Creates a new <see cref="Bool4x2"/> instance with the specified parameters.
@@ -2392,14 +2392,14 @@ public unsafe partial struct Bool4x2
     /// <param name="m42">The value to assign to the component at position [4, 2].</param>
     public Bool4x2(bool m11, bool m12, bool m21, bool m22, bool m31, bool m32, bool m41, bool m42)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m21 = m21;
-        this.m22 = m22;
-        this.m31 = m31;
-        this.m32 = m32;
-        this.m41 = m41;
-        this.m42 = m42;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
+        this.m31 = m31 ? 1 : 0;
+        this.m32 = m32 ? 1 : 0;
+        this.m41 = m41 ? 1 : 0;
+        this.m42 = m42 ? 1 : 0;
     }
 
     /// <summary>
@@ -2411,14 +2411,14 @@ public unsafe partial struct Bool4x2
     /// <param name="row4">The value to assign to the row at position [4].</param>
     public Bool4x2(Bool2 row1, Bool2 row2, Bool2 row3, Bool2 row4)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
-        this.m31 = row3.X;
-        this.m32 = row3.Y;
-        this.m41 = row4.X;
-        this.m42 = row4.Y;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
+        this.m31 = row3.X ? 1 : 0;
+        this.m32 = row3.Y ? 1 : 0;
+        this.m41 = row4.X ? 1 : 0;
+        this.m42 = row4.Y ? 1 : 0;
     }
 
     /// <summary>
@@ -2458,42 +2458,42 @@ public unsafe partial struct Bool4x2
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 1].
     /// </summary>
-    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m31), 1));
+    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m31)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 2].
     /// </summary>
-    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m32), 1));
+    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m32)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 1].
     /// </summary>
-    public readonly ref bool M41 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m41), 1));
+    public readonly ref bool M41 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m41)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 2].
     /// </summary>
-    public readonly ref bool M42 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m42), 1));
+    public readonly ref bool M42 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m42)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool4x2"/> value with the same value for all its components.
@@ -2503,14 +2503,14 @@ public unsafe partial struct Bool4x2
     {
         Bool4x2 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
-        matrix.m31 = x;
-        matrix.m32 = x;
-        matrix.m41 = x;
-        matrix.m42 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
+        matrix.m31 = x ? 1 : 0;
+        matrix.m32 = x ? 1 : 0;
+        matrix.m41 = x ? 1 : 0;
+        matrix.m42 = x ? 1 : 0;
 
         return matrix;
     }
@@ -2578,40 +2578,40 @@ public unsafe partial struct Bool4x3
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4x3), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m13;
+    private int m13;
 
     [FieldOffset(12)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(16)]
-    private bool m22;
+    private int m22;
 
     [FieldOffset(20)]
-    private bool m23;
+    private int m23;
 
     [FieldOffset(24)]
-    private bool m31;
+    private int m31;
 
     [FieldOffset(28)]
-    private bool m32;
+    private int m32;
 
     [FieldOffset(32)]
-    private bool m33;
+    private int m33;
 
     [FieldOffset(36)]
-    private bool m41;
+    private int m41;
 
     [FieldOffset(40)]
-    private bool m42;
+    private int m42;
 
     [FieldOffset(44)]
-    private bool m43;
+    private int m43;
 
     /// <summary>
     /// Creates a new <see cref="Bool4x3"/> instance with the specified parameters.
@@ -2630,18 +2630,18 @@ public unsafe partial struct Bool4x3
     /// <param name="m43">The value to assign to the component at position [4, 3].</param>
     public Bool4x3(bool m11, bool m12, bool m13, bool m21, bool m22, bool m23, bool m31, bool m32, bool m33, bool m41, bool m42, bool m43)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m13 = m13;
-        this.m21 = m21;
-        this.m22 = m22;
-        this.m23 = m23;
-        this.m31 = m31;
-        this.m32 = m32;
-        this.m33 = m33;
-        this.m41 = m41;
-        this.m42 = m42;
-        this.m43 = m43;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m13 = m13 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
+        this.m23 = m23 ? 1 : 0;
+        this.m31 = m31 ? 1 : 0;
+        this.m32 = m32 ? 1 : 0;
+        this.m33 = m33 ? 1 : 0;
+        this.m41 = m41 ? 1 : 0;
+        this.m42 = m42 ? 1 : 0;
+        this.m43 = m43 ? 1 : 0;
     }
 
     /// <summary>
@@ -2653,18 +2653,18 @@ public unsafe partial struct Bool4x3
     /// <param name="row4">The value to assign to the row at position [4].</param>
     public Bool4x3(Bool3 row1, Bool3 row2, Bool3 row3, Bool3 row4)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m13 = row1.Z;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
-        this.m23 = row2.Z;
-        this.m31 = row3.X;
-        this.m32 = row3.Y;
-        this.m33 = row3.Z;
-        this.m41 = row4.X;
-        this.m42 = row4.Y;
-        this.m43 = row4.Z;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m13 = row1.Z ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
+        this.m23 = row2.Z ? 1 : 0;
+        this.m31 = row3.X ? 1 : 0;
+        this.m32 = row3.Y ? 1 : 0;
+        this.m33 = row3.Z ? 1 : 0;
+        this.m41 = row4.X ? 1 : 0;
+        this.m42 = row4.Y ? 1 : 0;
+        this.m43 = row4.Z ? 1 : 0;
     }
 
     /// <summary>
@@ -2704,62 +2704,62 @@ public unsafe partial struct Bool4x3
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 3].
     /// </summary>
-    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m13), 1));
+    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m13)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 3].
     /// </summary>
-    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m23), 1));
+    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m23)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 1].
     /// </summary>
-    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m31), 1));
+    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m31)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 2].
     /// </summary>
-    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m32), 1));
+    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m32)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 3].
     /// </summary>
-    public readonly ref bool M33 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m33), 1));
+    public readonly ref bool M33 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m33)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 1].
     /// </summary>
-    public readonly ref bool M41 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m41), 1));
+    public readonly ref bool M41 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m41)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 2].
     /// </summary>
-    public readonly ref bool M42 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m42), 1));
+    public readonly ref bool M42 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m42)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 3].
     /// </summary>
-    public readonly ref bool M43 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m43), 1));
+    public readonly ref bool M43 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m43)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool4x3"/> value with the same value for all its components.
@@ -2769,18 +2769,18 @@ public unsafe partial struct Bool4x3
     {
         Bool4x3 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m13 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
-        matrix.m23 = x;
-        matrix.m31 = x;
-        matrix.m32 = x;
-        matrix.m33 = x;
-        matrix.m41 = x;
-        matrix.m42 = x;
-        matrix.m43 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m13 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
+        matrix.m23 = x ? 1 : 0;
+        matrix.m31 = x ? 1 : 0;
+        matrix.m32 = x ? 1 : 0;
+        matrix.m33 = x ? 1 : 0;
+        matrix.m41 = x ? 1 : 0;
+        matrix.m42 = x ? 1 : 0;
+        matrix.m43 = x ? 1 : 0;
 
         return matrix;
     }
@@ -2848,52 +2848,52 @@ public unsafe partial struct Bool4x4
     private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4x4), sizeof(Bool4));
 
     [FieldOffset(0)]
-    private bool m11;
+    private int m11;
 
     [FieldOffset(4)]
-    private bool m12;
+    private int m12;
 
     [FieldOffset(8)]
-    private bool m13;
+    private int m13;
 
     [FieldOffset(12)]
-    private bool m14;
+    private int m14;
 
     [FieldOffset(16)]
-    private bool m21;
+    private int m21;
 
     [FieldOffset(20)]
-    private bool m22;
+    private int m22;
 
     [FieldOffset(24)]
-    private bool m23;
+    private int m23;
 
     [FieldOffset(28)]
-    private bool m24;
+    private int m24;
 
     [FieldOffset(32)]
-    private bool m31;
+    private int m31;
 
     [FieldOffset(36)]
-    private bool m32;
+    private int m32;
 
     [FieldOffset(40)]
-    private bool m33;
+    private int m33;
 
     [FieldOffset(44)]
-    private bool m34;
+    private int m34;
 
     [FieldOffset(48)]
-    private bool m41;
+    private int m41;
 
     [FieldOffset(52)]
-    private bool m42;
+    private int m42;
 
     [FieldOffset(56)]
-    private bool m43;
+    private int m43;
 
     [FieldOffset(60)]
-    private bool m44;
+    private int m44;
 
     /// <summary>
     /// Creates a new <see cref="Bool4x4"/> instance with the specified parameters.
@@ -2916,22 +2916,22 @@ public unsafe partial struct Bool4x4
     /// <param name="m44">The value to assign to the component at position [4, 4].</param>
     public Bool4x4(bool m11, bool m12, bool m13, bool m14, bool m21, bool m22, bool m23, bool m24, bool m31, bool m32, bool m33, bool m34, bool m41, bool m42, bool m43, bool m44)
     {
-        this.m11 = m11;
-        this.m12 = m12;
-        this.m13 = m13;
-        this.m14 = m14;
-        this.m21 = m21;
-        this.m22 = m22;
-        this.m23 = m23;
-        this.m24 = m24;
-        this.m31 = m31;
-        this.m32 = m32;
-        this.m33 = m33;
-        this.m34 = m34;
-        this.m41 = m41;
-        this.m42 = m42;
-        this.m43 = m43;
-        this.m44 = m44;
+        this.m11 = m11 ? 1 : 0;
+        this.m12 = m12 ? 1 : 0;
+        this.m13 = m13 ? 1 : 0;
+        this.m14 = m14 ? 1 : 0;
+        this.m21 = m21 ? 1 : 0;
+        this.m22 = m22 ? 1 : 0;
+        this.m23 = m23 ? 1 : 0;
+        this.m24 = m24 ? 1 : 0;
+        this.m31 = m31 ? 1 : 0;
+        this.m32 = m32 ? 1 : 0;
+        this.m33 = m33 ? 1 : 0;
+        this.m34 = m34 ? 1 : 0;
+        this.m41 = m41 ? 1 : 0;
+        this.m42 = m42 ? 1 : 0;
+        this.m43 = m43 ? 1 : 0;
+        this.m44 = m44 ? 1 : 0;
     }
 
     /// <summary>
@@ -2943,22 +2943,22 @@ public unsafe partial struct Bool4x4
     /// <param name="row4">The value to assign to the row at position [4].</param>
     public Bool4x4(Bool4 row1, Bool4 row2, Bool4 row3, Bool4 row4)
     {
-        this.m11 = row1.X;
-        this.m12 = row1.Y;
-        this.m13 = row1.Z;
-        this.m14 = row1.W;
-        this.m21 = row2.X;
-        this.m22 = row2.Y;
-        this.m23 = row2.Z;
-        this.m24 = row2.W;
-        this.m31 = row3.X;
-        this.m32 = row3.Y;
-        this.m33 = row3.Z;
-        this.m34 = row3.W;
-        this.m41 = row4.X;
-        this.m42 = row4.Y;
-        this.m43 = row4.Z;
-        this.m44 = row4.W;
+        this.m11 = row1.X ? 1 : 0;
+        this.m12 = row1.Y ? 1 : 0;
+        this.m13 = row1.Z ? 1 : 0;
+        this.m14 = row1.W ? 1 : 0;
+        this.m21 = row2.X ? 1 : 0;
+        this.m22 = row2.Y ? 1 : 0;
+        this.m23 = row2.Z ? 1 : 0;
+        this.m24 = row2.W ? 1 : 0;
+        this.m31 = row3.X ? 1 : 0;
+        this.m32 = row3.Y ? 1 : 0;
+        this.m33 = row3.Z ? 1 : 0;
+        this.m34 = row3.W ? 1 : 0;
+        this.m41 = row4.X ? 1 : 0;
+        this.m42 = row4.Y ? 1 : 0;
+        this.m43 = row4.Z ? 1 : 0;
+        this.m44 = row4.W ? 1 : 0;
     }
 
     /// <summary>
@@ -2998,82 +2998,82 @@ public unsafe partial struct Bool4x4
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
     /// </summary>
-    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m11), 1));
+    public readonly ref bool M11 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m11)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 2].
     /// </summary>
-    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m12), 1));
+    public readonly ref bool M12 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m12)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 3].
     /// </summary>
-    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m13), 1));
+    public readonly ref bool M13 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m13)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 4].
     /// </summary>
-    public readonly ref bool M14 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m14), 1));
+    public readonly ref bool M14 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m14)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 1].
     /// </summary>
-    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m21), 1));
+    public readonly ref bool M21 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m21)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 2].
     /// </summary>
-    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m22), 1));
+    public readonly ref bool M22 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m22)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 3].
     /// </summary>
-    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m23), 1));
+    public readonly ref bool M23 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m23)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [2, 4].
     /// </summary>
-    public readonly ref bool M24 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m24), 1));
+    public readonly ref bool M24 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m24)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 1].
     /// </summary>
-    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m31), 1));
+    public readonly ref bool M31 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m31)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 2].
     /// </summary>
-    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m32), 1));
+    public readonly ref bool M32 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m32)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 3].
     /// </summary>
-    public readonly ref bool M33 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m33), 1));
+    public readonly ref bool M33 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m33)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [3, 4].
     /// </summary>
-    public readonly ref bool M34 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m34), 1));
+    public readonly ref bool M34 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m34)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 1].
     /// </summary>
-    public readonly ref bool M41 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m41), 1));
+    public readonly ref bool M41 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m41)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 2].
     /// </summary>
-    public readonly ref bool M42 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m42), 1));
+    public readonly ref bool M42 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m42)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 3].
     /// </summary>
-    public readonly ref bool M43 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m43), 1));
+    public readonly ref bool M43 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m43)), 1));
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [4, 4].
     /// </summary>
-    public readonly ref bool M44 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m44), 1));
+    public readonly ref bool M44 => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m44)), 1));
 
     /// <summary>
     /// Creates a new <see cref="Bool4x4"/> value with the same value for all its components.
@@ -3083,22 +3083,22 @@ public unsafe partial struct Bool4x4
     {
         Bool4x4 matrix;
 
-        matrix.m11 = x;
-        matrix.m12 = x;
-        matrix.m13 = x;
-        matrix.m14 = x;
-        matrix.m21 = x;
-        matrix.m22 = x;
-        matrix.m23 = x;
-        matrix.m24 = x;
-        matrix.m31 = x;
-        matrix.m32 = x;
-        matrix.m33 = x;
-        matrix.m34 = x;
-        matrix.m41 = x;
-        matrix.m42 = x;
-        matrix.m43 = x;
-        matrix.m44 = x;
+        matrix.m11 = x ? 1 : 0;
+        matrix.m12 = x ? 1 : 0;
+        matrix.m13 = x ? 1 : 0;
+        matrix.m14 = x ? 1 : 0;
+        matrix.m21 = x ? 1 : 0;
+        matrix.m22 = x ? 1 : 0;
+        matrix.m23 = x ? 1 : 0;
+        matrix.m24 = x ? 1 : 0;
+        matrix.m31 = x ? 1 : 0;
+        matrix.m32 = x ? 1 : 0;
+        matrix.m33 = x ? 1 : 0;
+        matrix.m34 = x ? 1 : 0;
+        matrix.m41 = x ? 1 : 0;
+        matrix.m42 = x ? 1 : 0;
+        matrix.m43 = x ? 1 : 0;
+        matrix.m44 = x ? 1 : 0;
 
         return matrix;
     }

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -35,6 +35,8 @@ namespace ComputeSharp;
 void GenerateMatrixProperties(string typeName, int rows, int columns, int elementSize)
 {
     string elementTypeName = typeName.ToLower();
+    bool isBoolType = elementTypeName == "bool";
+    string fieldElementTypeName = isBoolType ? "int" : elementTypeName;
     string fullTypeName = $"{typeName}{rows}x{columns}";
     string rowTypeName = columns > 1 ? $"{typeName}{columns}" : elementTypeName;
     List<string> fieldNames = new List<string>();
@@ -56,7 +58,7 @@ public unsafe partial struct <#=fullTypeName#>
     for (int j = 1; j <= columns; j++)
     {
         WriteLine($"[FieldOffset({((i - 1) * columns + j - 1) * elementSize})]");
-        WriteLine($"private {elementTypeName} m{i}{j};");
+        WriteLine($"private {fieldElementTypeName} m{i}{j};");
         WriteLine("");
 
         fieldNames.Add($"m{i}{j}");
@@ -79,7 +81,15 @@ public unsafe partial struct <#=fullTypeName#>
 
     foreach (string fieldName in fieldNames)
     {
-        WriteLine($"this.{fieldName} = {fieldName};");
+        if (isBoolType)
+        {
+            // For bools, normalize from bool to int
+            WriteLine($"this.{fieldName} = {fieldName} ? 1 : 0;");
+        }
+        else
+        {
+            WriteLine($"this.{fieldName} = {fieldName};");
+        }
     }
 
     PopIndent();
@@ -113,7 +123,15 @@ public unsafe partial struct <#=fullTypeName#>
         for (int i = 1; i <= rows; i++)
         for (int j = 1; j <= columns; j++)
         {
-            WriteLine($"this.m{i}{j} = row{i}.{"XYZW"[j - 1]};");
+            if (isBoolType)
+            {
+                // Also normalize bools here as well
+                WriteLine($"this.m{i}{j} = row{i}.{"XYZW"[j - 1]} ? 1 : 0;");
+            }
+            else
+            {
+                WriteLine($"this.m{i}{j} = row{i}.{"XYZW"[j - 1]};");
+            }
         }
 
         PopIndent();
@@ -165,7 +183,20 @@ public unsafe partial struct <#=fullTypeName#>
     /// <summary>
     /// Gets a reference to the <see cref="<#=elementTypeName#>"/> value representing the component at position [<#=i#>, <#=j#>].
     /// </summary>
+<#
+    if (isBoolType)
+    {
+#>
+    public readonly ref <#=elementTypeName#> M<#=i#><#=j#> => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.m<#=i#><#=j#>)), 1));
+<#
+    }
+    else
+    {
+#>
     public readonly ref <#=elementTypeName#> M<#=i#><#=j#> => ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.m<#=i#><#=j#>), 1));
+<#
+    }
+#>
 <#
     }
 
@@ -187,7 +218,14 @@ public unsafe partial struct <#=fullTypeName#>
     for (int i = 1; i <= rows; i++)
     for (int j = 1; j <= columns; j++)
     {
-        WriteLine($"matrix.m{i}{j} = x;");
+        if (isBoolType)
+        {
+            WriteLine($"matrix.m{i}{j} = x ? 1 : 0;");
+        }
+        else
+        {
+            WriteLine($"matrix.m{i}{j} = x;");
+        }
     }
 
     WriteLine("");

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -49,6 +49,8 @@ void GenerateVectorProperties(string typeName, int elementSize)
 {
     string elementTypeName = Regex.Match(typeName, @"^[A-Za-z]+").Value;
     string hlslElementTypeName = elementTypeName.ToLower();
+    bool isBoolType = hlslElementTypeName == "bool";
+    string fieldElementTypeName = isBoolType ? "int" : hlslElementTypeName;
     int i = int.Parse(Regex.Match(typeName, @"\d+$").Value);
     string formattable = elementTypeName == "Bool" ? "" : "ISpanFormattable";
 
@@ -96,7 +98,7 @@ public unsafe partial struct <#=typeName#>
     foreach (char name in "xyzw".Substring(0, i))
     {
         WriteLine($"[FieldOffset({"xyzw".IndexOf(name) * elementSize})]");
-        WriteLine($"private {hlslElementTypeName} {name};");
+        WriteLine($"private {fieldElementTypeName} {name};");
         WriteLine("");
     }
 
@@ -201,7 +203,16 @@ public unsafe partial struct <#=typeName#>
 
             // Property
             Write($"public readonly {refType} {propertyType} {propertyName} ");
-            WriteLine($"=> ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.{fieldName}), 1));");
+
+            if (isBoolType)
+            {
+                // For bool types, also reinterpret cast from int to bool (the backing field is int to ensure all 4 bytes are initialized)
+                WriteLine($"=> ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.As<int, bool>(ref Unsafe.AsRef(in this.{fieldName})), 1));");
+            }
+            else
+            {
+                WriteLine($"=> ref MemoryMarshal.GetReference(MemoryMarshal.CreateSpan(ref Unsafe.AsRef(in this.{fieldName}), 1));");
+            }
         }
         else
         {
@@ -233,9 +244,9 @@ public unsafe partial struct <#=typeName#>
     public override readonly string ToString()
     {
 #if NET6_0_OR_GREATER
-        return string.Create(null, stackalloc char[32], $"<<#=string.Join(", ", "xyzw".Take(i).Select(c => $"{{this.{c}}}"))#>>");
+        return string.Create(null, stackalloc char[32], $"<<#=string.Join(", ", "xyzw".Take(i).Select(c => $"{{this.{c} != 0}}"))#>>");
 #else
-        return $"<<#=string.Join(", ", "xyzw".Take(i).Select(c => $"{{this.{c}}}"))#>>";
+        return $"<<#=string.Join(", ", "xyzw".Take(i).Select(c => $"{{this.{c} != 0}}"))#>>";
 #endif
     }
 <#

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -578,11 +578,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor InvalidDiscoveredType = new DiagnosticDescriptor(
         id: "CMPSD2D0041",
         title: "Invalid discovered type",
-        messageFormat: "The D2D1 shader of type {0} uses the invalid type {1} (only some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used)",
+        messageFormat: "The D2D1 shader of type {0} uses the invalid type {1} (only some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "D2D1 shaders can only use supported types (some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used).",
+        description: "D2D1 shaders can only use supported types (some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons).",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
@@ -70,6 +70,18 @@ partial class ID2D1ShaderGenerator
             {
                 switch (fieldInfo)
                 {
+                    case FieldInfo.Primitive { TypeName: "System.Boolean" } primitive:
+
+                        // Read a boolean value and cast it to Bool first, which will apply the correct size expansion. This will generate the following:
+                        //
+                        // global::System.Runtime.CompilerServices.Unsafe.As<byte, global::ComputeSharp.Bool>(
+                        //     ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint)<OFFSET>)) = (global::ComputeSharp.Bool)<FIELD_PATH>
+                        statements.Add(ExpressionStatement(
+                            AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                ParseExpression($"global::System.Runtime.CompilerServices.Unsafe.As<byte, global::ComputeSharp.Bool>(ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint){primitive.Offset}))"),
+                                ParseExpression($"(global::ComputeSharp.Bool){string.Join(".", primitive.FieldPath)}"))));
+                        break;
                     case FieldInfo.Primitive primitive:
 
                         // Read a primitive value and serialize it into the target buffer. This will generate:

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -218,6 +218,14 @@ internal static partial class HlslKnownTypes
         // Local function to recursively gather nested types
         static void ExploreTypes(INamedTypeSymbol type, HashSet<INamedTypeSymbol> customTypes, HashSet<INamedTypeSymbol> invalidTypes)
         {
+            // Explicitly prevent bool from being a field in a custom struct
+            if (type.SpecialType == SpecialType.System_Boolean)
+            {
+                invalidTypes.Add(type);
+
+                return;
+            }
+
             if (KnownHlslTypes.ContainsKey(type.GetFullMetadataName())) return;
 
             // Check if the type is unsupported

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -67,6 +67,7 @@ internal static partial class HlslKnownTypes
         Dictionary<string, string> knownTypes = new()
         {
             [typeof(bool).FullName] = "bool",
+            [typeof(Bool).FullName] = "bool",
             [typeof(int).FullName] = "int",
             [typeof(uint).FullName] = "uint",
             [typeof(float).FullName] = "float",
@@ -256,6 +257,15 @@ internal static partial class HlslKnownTypes
         // Explore all input types and their nested types
         foreach (INamedTypeSymbol type in discoveredTypes)
         {
+            // Special case for bool types. These types are blocked if they appear as fields in custom struct types,
+            // but are otherwise allowed. For instance, it is fine to use them in captured values for a shader (as
+            // the dispatch data loader will perform the correct marshalling) as well as in locals/parameters. This
+            // branch prevents crawling a processed type if it's just bool at the top level (ie. not a custom struct).
+            if (type.SpecialType == SpecialType.System_Boolean)
+            {
+                continue;
+            }
+
             ExploreTypes(type, customTypes, invalidTypes2);
         }
 

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -707,10 +707,10 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor InvalidDiscoveredType = new DiagnosticDescriptor(
         id: "CMPS0050",
         title: "Invalid discovered type",
-        messageFormat: "The compute shader or method {0} uses the invalid type {1} (only some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used)",
+        messageFormat: "The compute shader or method {0} uses the invalid type {1} (only some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons)",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Shaders and shader methods can only use supported types (some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used).",
+        description: "Shaders and shader methods can only use supported types (some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons).",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
@@ -121,6 +121,18 @@ partial class IShaderGenerator
                                 ParseExpression($"global::System.Runtime.CompilerServices.Unsafe.Add(ref r1, {resource.Offset})"),
                                 ParseExpression($"global::ComputeSharp.__Internals.GraphicsResourceHelper.ValidateAndGetGpuDescriptorHandle({resource.FieldName}, device)"))));
                         break;
+                    case FieldInfo.Primitive { TypeName: "System.Boolean" } primitive:
+
+                        // Read a boolean value and cast it to Bool first, which will apply the correct size expansion. This will generate the following:
+                        //
+                        // global::System.Runtime.CompilerServices.Unsafe.As<uint, global::ComputeSharp.Bool>(
+                        //     ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint)<OFFSET>)) = (global::ComputeSharp.Bool)<FIELD_PATH>
+                        statements.Add(ExpressionStatement(
+                            AssignmentExpression(
+                                SyntaxKind.SimpleAssignmentExpression,
+                                ParseExpression($"global::System.Runtime.CompilerServices.Unsafe.As<uint, global::ComputeSharp.Bool>(ref global::System.Runtime.CompilerServices.Unsafe.AddByteOffset(ref r0, (nint){primitive.Offset}))"),
+                                ParseExpression($"(global::ComputeSharp.Bool){string.Join(".", primitive.FieldPath)}"))));
+                        break;
                     case FieldInfo.Primitive primitive:
 
                         // Read a primitive value and serialize it into the target buffer. This will generate:

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1697,6 +1697,38 @@ public class DiagnosticsTests
         VerifyGeneratedDiagnostics<IShaderGenerator>(source, "CMPS0047", "CMPS0050");
     }
 
+    [TestMethod]
+    public void InvalidDiscoveredType_CustomType_SystemBoolean()
+    {
+        string source = @"
+        using System;
+        using ComputeSharp;
+
+        namespace ComputeSharp
+        {
+            public class ReadWriteBuffer<T> { }
+        }
+
+        namespace MyFancyApp.Sample
+        {
+            public struct Foo
+            {
+                public bool bar;
+            }
+
+            public struct MyShader : IComputeShader
+            {
+                public readonly ReadWriteBuffer<Foo> buffer;
+
+                public void Execute()
+                {
+                }
+            }
+        }";
+
+        VerifyGeneratedDiagnostics<IShaderGenerator>(source, "CMPS0047", "CMPS0050");
+    }
+
     /// <summary>
     /// Verifies the output of a source generator.
     /// </summary>

--- a/tests/ComputeSharp.Tests/ShaderMembersTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderMembersTests.cs
@@ -1,4 +1,5 @@
-﻿using ComputeSharp.Tests.Attributes;
+﻿using System.Linq;
+using ComputeSharp.Tests.Attributes;
 using ComputeSharp.Tests.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -81,6 +82,96 @@ public partial class ShaderMembersTests
             }
 
             buffer[ThreadIds.X] = total;
+        }
+    }
+
+    // See: https://github.com/Sergio0694/ComputeSharp/issues/193
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public void BoolInstanceFields(Device device)
+    {
+        using ReadWriteBuffer<int> buffer = device.Get().AllocateReadWriteBuffer<int>(13, AllocationMode.Clear);
+
+        device.Get().For(1, new BoolInstanceFieldsShader(buffer, true, false, 42, false, true, new int3(1, 2, 3), true, new bool2(false, true), 123, true));
+
+        int[] results = buffer.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { 1, 0, 42, 0, 1, 1, 2, 3, 1, 0, 1, 123, 1 },
+            actual: results);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct BoolInstanceFieldsShader : IComputeShader
+    {
+        public readonly ReadWriteBuffer<int> buffer;
+
+        public readonly bool a;
+        public readonly bool b;
+        public readonly int c;
+        public readonly bool d;
+        public readonly bool e;
+        public readonly int3 f;
+        public readonly bool g;
+        public readonly bool2 h;
+        public readonly int i;
+        public readonly bool j;
+
+        public void Execute()
+        {
+            buffer[0] = Hlsl.BoolToInt(a);
+            buffer[1] = Hlsl.BoolToInt(b);
+            buffer[2] = c;
+            buffer[3] = Hlsl.BoolToInt(d);
+            buffer[4] = Hlsl.BoolToInt(e);
+            buffer[5] = f.X;
+            buffer[6] = f.Y;
+            buffer[7] = f.Z;
+            buffer[8] = Hlsl.BoolToInt(g);
+            buffer[9] = Hlsl.BoolToInt(h.X);
+            buffer[10] = Hlsl.BoolToInt(h.Y);
+            buffer[11] = i;
+            buffer[12] = Hlsl.BoolToInt(j);
+        }
+    }
+
+    // See: https://github.com/Sergio0694/ComputeSharp/issues/193
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public void BoolInstanceFieldInCustomStruct(Device device)
+    {
+        Int2AndBoolField[] data = Enumerable.Range(1, 100).Select(i => new Int2AndBoolField { P = new Int2(i, i) }).ToArray();
+
+        using ReadWriteBuffer<Int2AndBoolField> buffer = device.Get().AllocateReadWriteBuffer(data);
+
+        device.Get().For(100, new BoolInstanceFieldInCustomStructShader(buffer));
+
+        Int2AndBoolField[] results = buffer.ToArray();
+
+        for (int i = 0; i < results.Length; i++)
+        {
+            ref Int2AndBoolField value = ref results[i];
+
+            Assert.AreEqual(i + 1, value.P.X);
+            Assert.AreEqual(i + 1, value.P.Y);
+            Assert.AreEqual(true, (bool)value.B);
+        }
+    }
+
+    public struct Int2AndBoolField
+    {
+        public Int2 P;
+        public Bool B;
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct BoolInstanceFieldInCustomStructShader : IComputeShader
+    {
+        public readonly ReadWriteBuffer<Int2AndBoolField> buffer;
+
+        public void Execute()
+        {
+            buffer[ThreadIds.X].B = true;
         }
     }
 }


### PR DESCRIPTION
### Closes #193

### Description

The way `bool` types were handled previously was incorrect and could cause issues. This PR does the following:
- Force `bool` values captures in shaders to expand to 4 bytes and be normalized first.
- Adjust the layout of all `Bool` HLSL primitives to use `int` fields. This ensures alignment with HLSL.
- Disallow `bool` fields into custom struct types, as the layout wouldn't match the one used by HLSL.