### PR TITLE
Switch some ParseExpression calls to IdentifierName calls

### DIFF
--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
@@ -363,7 +363,7 @@ internal sealed partial class ShaderSourceRewriter : HlslSourceRewriter
                     // Allow specialized types to track the method invocation, if needed
                     TrackKnownMethodInvocation(metadataName);
 
-                    return updatedNode.WithExpression(ParseExpression(mapping!));
+                    return updatedNode.WithExpression(IdentifierName(mapping!));
                 }
 
                 // Update the name if the target is a local function. The exact schema for the
@@ -372,7 +372,7 @@ internal sealed partial class ShaderSourceRewriter : HlslSourceRewriter
                 {
                     var functionIdentifier = $"__{this.currentMethod!.Identifier.Text}__{method.Name}";
 
-                    return updatedNode.WithExpression(ParseExpression(functionIdentifier));
+                    return updatedNode.WithExpression(IdentifierName(functionIdentifier));
                 }
 
                 // If the method is an external static method, import and rewrite it as well.
@@ -398,7 +398,7 @@ internal sealed partial class ShaderSourceRewriter : HlslSourceRewriter
                         this.staticMethods.Add(method, processedMethod.WithIdentifier(Identifier(methodIdentifier)));
                     }
 
-                    return updatedNode.WithExpression(ParseExpression(methodIdentifier));
+                    return updatedNode.WithExpression(IdentifierName(methodIdentifier));
                 }
             }
             else

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/StaticFieldRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/StaticFieldRewriter.cs
@@ -106,7 +106,7 @@ internal sealed partial class StaticFieldRewriter : HlslSourceRewriter
                     mapping = HlslKnownMethods.GetMappedNameWithParameters(method.Name, method.Parameters.Select(static p => p.Type.Name));
                 }
 
-                return updatedNode.WithExpression(ParseExpression(mapping!));
+                return updatedNode.WithExpression(IdentifierName(mapping!));
             }
         }
 


### PR DESCRIPTION
### Description

This PR moves some `ParseExpression` calls to `IdentifierName`. This fixes the whitespace normalization down the line. Specifically, this was an issue for boolean cast intrinsics, which could use eg. `bool` or `int` as method names. Using `ParseExpression` resulted in Roslyn creating a `PredefinedType(Token(SyntaxKind.BoolKeyword))` tree, which would then be formatted as `"bool "` with a trailing whitespace. This PR changes that to juse `IdentifierName("<NAME>")`, which is then formatted correctly with no space.