### PR TITLE
Add double feature support check to TransferBuffer<T> constructor

### DIFF
--- a/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Resources.cs
+++ b/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Resources.cs
@@ -1075,6 +1075,7 @@ partial class GraphicsDeviceExtensions
     /// <param name="length">The length of the buffer to allocate.</param>
     /// <param name="allocationMode">The allocation mode to use for the new resource.</param>
     /// <returns>A <see cref="ReadOnlyBuffer{T}"/> instance of size <paramref name="length"/>.</returns>
+    [RequiresUnreferencedCode("This method reads type info of all fields of the resource element type (recursively).")]
     public static UploadBuffer<T> AllocateUploadBuffer<T>(this GraphicsDevice device, int length, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {
@@ -1126,6 +1127,7 @@ partial class GraphicsDeviceExtensions
     /// <param name="length">The length of the buffer to allocate.</param>
     /// <param name="allocationMode">The allocation mode to use for the new resource.</param>
     /// <returns>A <see cref="ReadBackBuffer{T}"/> instance of size <paramref name="length"/>.</returns>
+    [RequiresUnreferencedCode("This method reads type info of all fields of the resource element type (recursively).")]
     public static ReadBackBuffer<T> AllocateReadBackBuffer<T>(this GraphicsDevice device, int length, AllocationMode allocationMode = AllocationMode.Default)
         where T : unmanaged
     {

--- a/src/ComputeSharp/Graphics/Resources/ReadBackBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadBackBuffer{T}.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using ComputeSharp.Graphics.Resources.Enums;
 using ComputeSharp.Resources;
 using ComputeSharp.Resources.Debug;
@@ -20,6 +21,7 @@ public sealed class ReadBackBuffer<T> : TransferBuffer<T>
     /// <param name="device">The <see cref="GraphicsDevice"/> associated with the current instance.</param>
     /// <param name="length">The number of items to store in the current buffer.</param>
     /// <param name="allocationMode">The allocation mode to use for the new resource.</param>
+    [RequiresUnreferencedCode("This method reads type info of all fields of the resource element type (recursively).")]
     internal ReadBackBuffer(GraphicsDevice device, int length, AllocationMode allocationMode)
         : base(device, length, ResourceType.ReadBack, allocationMode)
     {

--- a/src/ComputeSharp/Graphics/Resources/UploadBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/UploadBuffer{T}.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using ComputeSharp.Graphics.Resources.Enums;
 using ComputeSharp.Resources;
 using ComputeSharp.Resources.Debug;
@@ -20,6 +21,7 @@ public sealed class UploadBuffer<T> : TransferBuffer<T>
     /// <param name="device">The <see cref="GraphicsDevice"/> associated with the current instance.</param>
     /// <param name="length">The number of items to store in the current buffer.</param>
     /// <param name="allocationMode">The allocation mode to use for the new resource.</param>
+    [RequiresUnreferencedCode("This method reads type info of all fields of the resource element type (recursively).")]
     internal UploadBuffer(GraphicsDevice device, int length, AllocationMode allocationMode)
         : base(device, length, ResourceType.Upload, allocationMode)
     {

--- a/tests/ComputeSharp.Tests/BufferTests.cs
+++ b/tests/ComputeSharp.Tests/BufferTests.cs
@@ -388,7 +388,7 @@ public partial class BufferTests
     [Resource(typeof(ReadOnlyBuffer<>))]
     [Resource(typeof(ReadWriteBuffer<>))]
     [ExpectedException(typeof(UnsupportedDoubleOperationException))]
-    public void Dispatch_ReadWriteBuffer_DoublePrecision_ThrowsExceptionIfUnsupported(Device device, Type resourceType)
+    public void Dispatch_Buffer_DoublePrecision_ThrowsExceptionIfUnsupported(Device device, Type resourceType)
     {
         if (device.Get().IsDoublePrecisionSupportAvailable())
         {
@@ -396,6 +396,23 @@ public partial class BufferTests
         }
 
         using Buffer<double> buffer = device.Get().AllocateBuffer<double>(resourceType, 32);
+
+        Assert.Fail();
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Resource(typeof(UploadBuffer<>))]
+    [Resource(typeof(ReadBackBuffer<>))]
+    [ExpectedException(typeof(UnsupportedDoubleOperationException))]
+    public void Dispatch_TransferBuffer_DoublePrecision_ThrowsExceptionIfUnsupported(Device device, Type resourceType)
+    {
+        if (device.Get().IsDoublePrecisionSupportAvailable())
+        {
+            Assert.Inconclusive();
+        }
+
+        using TransferBuffer<double> buffer = device.Get().AllocateTransferBuffer<double>(resourceType, 32);
 
         Assert.Fail();
     }


### PR DESCRIPTION
### Description

This PR adds the missing feature support checks when creating a `TransferBuffer<double>` instance.