### PR TITLE
Add unit tests for resource dimension accessors

### DIFF
--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -98,31 +98,21 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Texture2DTests.Pixels.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>Texture2DTests.Pixels.g.cs</LastGenOutput>
-    </None>
-    <None Update="Texture3DTests.Pixels.tt">
-      <Generator>TextTemplatingFileGenerator</Generator>
-      <LastGenOutput>Texture3DTests.Pixels.g.cs</LastGenOutput>
-    </None>
-  </ItemGroup>
-
+  <!-- T4 template generation service -->
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
+  <!-- Import all .tt files with their generated .g.cs files -->
   <ItemGroup>
-    <Compile Update="Texture2DTests.Pixels.g.cs">
+    <None Update="**\*.tt">
+      <LastGenOutput>%(Filename).g.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <Compile Update="**\*.g.cs">
+      <DependentUpon>$([System.IO.Path]::GetFileNameWithoutExtension('%(Filename)')).tt</DependentUpon>
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
-      <DependentUpon>Texture2DTests.Pixels.tt</DependentUpon>
-    </Compile>
-    <Compile Update="Texture3DTests.Pixels.g.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Texture3DTests.Pixels.tt</DependentUpon>
     </Compile>
   </ItemGroup>
 

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
@@ -14,38 +14,6 @@ public partial class ResourceDimensionsTests
     [Data(64)]
     [Data(128)]
     [Data(376)]
-    public void ConstantBuffer_T1_AsConstantBuffer(Device device, int axis0)
-    {
-        using ConstantBuffer<float> resource = device.Get().AllocateConstantBuffer<float>(axis0);
-        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(1);
-
-        device.Get().For(1, new ConstantBuffer_T1_AsConstantBufferShader(resource, result));
-
-        int[] dimensions = result.ToArray();
-
-        CollectionAssert.AreEqual(
-            expected: new[] { axis0 },
-            actual: dimensions);
-    }
-
-    [AutoConstructor]
-    internal readonly partial struct ConstantBuffer_T1_AsConstantBufferShader : IComputeShader
-    {
-        public readonly ConstantBuffer<float> source;
-        public readonly ReadWriteBuffer<int> result;
-
-        public void Execute()
-        {
-            result[0] = source.Length;
-        }
-    }
-
-    [CombinatorialTestMethod]
-    [AllDevices]
-    [Data(8)]
-    [Data(64)]
-    [Data(128)]
-    [Data(376)]
     public void ReadOnlyBuffer_T1_AsReadOnlyBuffer(Device device, int axis0)
     {
         using ReadOnlyBuffer<float> resource = device.Get().AllocateReadOnlyBuffer<float>(axis0);

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
@@ -1,0 +1,583 @@
+﻿using ComputeSharp.Tests.Attributes;
+using ComputeSharp.Tests.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.Tests;
+
+[TestClass]
+[TestCategory("ResourceDimensions")]
+public partial class ResourceDimensionsTests
+{
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8)]
+    [Data(64)]
+    [Data(128)]
+    [Data(376)]
+    public void ConstantBuffer_T1_AsConstantBuffer(Device device, int axis0)
+    {
+        using ConstantBuffer<float> resource = device.Get().AllocateConstantBuffer<float>(axis0);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(1);
+
+        device.Get().For(1, new ConstantBuffer_T1_AsConstantBufferShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ConstantBuffer_T1_AsConstantBufferShader : IComputeShader
+    {
+        public readonly ConstantBuffer<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Length;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8)]
+    [Data(64)]
+    [Data(128)]
+    [Data(376)]
+    public void ReadOnlyBuffer_T1_AsReadOnlyBuffer(Device device, int axis0)
+    {
+        using ReadOnlyBuffer<float> resource = device.Get().AllocateReadOnlyBuffer<float>(axis0);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(1);
+
+        device.Get().For(1, new ReadOnlyBuffer_T1_AsReadOnlyBufferShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadOnlyBuffer_T1_AsReadOnlyBufferShader : IComputeShader
+    {
+        public readonly ReadOnlyBuffer<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Length;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8)]
+    [Data(64)]
+    [Data(128)]
+    [Data(376)]
+    public void ReadWriteBuffer_T1_AsReadWriteBuffer(Device device, int axis0)
+    {
+        using ReadWriteBuffer<float> resource = device.Get().AllocateReadWriteBuffer<float>(axis0);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(1);
+
+        device.Get().For(1, new ReadWriteBuffer_T1_AsReadWriteBufferShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteBuffer_T1_AsReadWriteBufferShader : IComputeShader
+    {
+        public readonly ReadWriteBuffer<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Length;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12)]
+    [Data(64, 13)]
+    [Data(128, 32)]
+    [Data(376, 112)]
+    public void ReadOnlyTexture2D_T1_AsReadOnlyTexture2D(Device device, int axis0, int axis1)
+    {
+        using ReadOnlyTexture2D<float> resource = device.Get().AllocateReadOnlyTexture2D<float>(axis0, axis1);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(2);
+
+        device.Get().For(1, new ReadOnlyTexture2D_T1_AsReadOnlyTexture2DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadOnlyTexture2D_T1_AsReadOnlyTexture2DShader : IComputeShader
+    {
+        public readonly ReadOnlyTexture2D<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12)]
+    [Data(64, 13)]
+    [Data(128, 32)]
+    [Data(376, 112)]
+    public void ReadWriteTexture2D_T1_AsReadWriteTexture2D(Device device, int axis0, int axis1)
+    {
+        using ReadWriteTexture2D<float> resource = device.Get().AllocateReadWriteTexture2D<float>(axis0, axis1);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(2);
+
+        device.Get().For(1, new ReadWriteTexture2D_T1_AsReadWriteTexture2DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteTexture2D_T1_AsReadWriteTexture2DShader : IComputeShader
+    {
+        public readonly ReadWriteTexture2D<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12)]
+    [Data(64, 13)]
+    [Data(128, 32)]
+    [Data(376, 112)]
+    public void ReadWriteTexture2D_T1_AsIReadOnlyTexture2D(Device device, int axis0, int axis1)
+    {
+        using ReadWriteTexture2D<float> resource = device.Get().AllocateReadWriteTexture2D<float>(axis0, axis1);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(2);
+
+        using (var context = device.Get().CreateComputeContext())
+        {
+            context.Transition(resource, ResourceState.ReadOnly);
+            context.For(1, new ReadWriteTexture2D_T1_AsIReadOnlyTexture2DShader(resource.AsReadOnly(), result));
+        }
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteTexture2D_T1_AsIReadOnlyTexture2DShader : IComputeShader
+    {
+        public readonly IReadOnlyTexture2D<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12)]
+    [Data(64, 13)]
+    [Data(128, 32)]
+    [Data(376, 112)]
+    public void ReadOnlyTexture2D_T2_AsReadOnlyTexture2D(Device device, int axis0, int axis1)
+    {
+        using ReadOnlyTexture2D<Rgba32, float4> resource = device.Get().AllocateReadOnlyTexture2D<Rgba32, float4>(axis0, axis1);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(2);
+
+        device.Get().For(1, new ReadOnlyTexture2D_T2_AsReadOnlyTexture2DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadOnlyTexture2D_T2_AsReadOnlyTexture2DShader : IComputeShader
+    {
+        public readonly ReadOnlyTexture2D<Rgba32, float4> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12)]
+    [Data(64, 13)]
+    [Data(128, 32)]
+    [Data(376, 112)]
+    public void ReadOnlyTexture2D_T2_AsIReadOnlyNormalizedTexture2D(Device device, int axis0, int axis1)
+    {
+        using ReadOnlyTexture2D<Rgba32, float4> resource = device.Get().AllocateReadOnlyTexture2D<Rgba32, float4>(axis0, axis1);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(2);
+
+        device.Get().For(1, new ReadOnlyTexture2D_T2_AsIReadOnlyNormalizedTexture2DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadOnlyTexture2D_T2_AsIReadOnlyNormalizedTexture2DShader : IComputeShader
+    {
+        public readonly IReadOnlyNormalizedTexture2D<float4> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12)]
+    [Data(64, 13)]
+    [Data(128, 32)]
+    [Data(376, 112)]
+    public void ReadWriteTexture2D_T2_AsReadWriteTexture2D(Device device, int axis0, int axis1)
+    {
+        using ReadWriteTexture2D<Rgba32, float4> resource = device.Get().AllocateReadWriteTexture2D<Rgba32, float4>(axis0, axis1);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(2);
+
+        device.Get().For(1, new ReadWriteTexture2D_T2_AsReadWriteTexture2DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteTexture2D_T2_AsReadWriteTexture2DShader : IComputeShader
+    {
+        public readonly ReadWriteTexture2D<Rgba32, float4> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12)]
+    [Data(64, 13)]
+    [Data(128, 32)]
+    [Data(376, 112)]
+    public void ReadWriteTexture2D_T2_AsIReadWriteNormalizedTexture2D(Device device, int axis0, int axis1)
+    {
+        using ReadWriteTexture2D<Rgba32, float4> resource = device.Get().AllocateReadWriteTexture2D<Rgba32, float4>(axis0, axis1);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(2);
+
+        device.Get().For(1, new ReadWriteTexture2D_T2_AsIReadWriteNormalizedTexture2DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteTexture2D_T2_AsIReadWriteNormalizedTexture2DShader : IComputeShader
+    {
+        public readonly IReadWriteNormalizedTexture2D<float4> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12, 3)]
+    [Data(64, 24, 4)]
+    [Data(128, 32, 4)]
+    [Data(376, 64, 3)]
+    public void ReadOnlyTexture3D_T1_AsReadOnlyTexture3D(Device device, int axis0, int axis1, int axis2)
+    {
+        using ReadOnlyTexture3D<float> resource = device.Get().AllocateReadOnlyTexture3D<float>(axis0, axis1, axis2);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(3);
+
+        device.Get().For(1, new ReadOnlyTexture3D_T1_AsReadOnlyTexture3DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1, axis2 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadOnlyTexture3D_T1_AsReadOnlyTexture3DShader : IComputeShader
+    {
+        public readonly ReadOnlyTexture3D<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+            result[2] = source.Depth;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12, 3)]
+    [Data(64, 24, 4)]
+    [Data(128, 32, 4)]
+    [Data(376, 64, 3)]
+    public void ReadWriteTexture3D_T1_AsReadWriteTexture3D(Device device, int axis0, int axis1, int axis2)
+    {
+        using ReadWriteTexture3D<float> resource = device.Get().AllocateReadWriteTexture3D<float>(axis0, axis1, axis2);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(3);
+
+        device.Get().For(1, new ReadWriteTexture3D_T1_AsReadWriteTexture3DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1, axis2 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteTexture3D_T1_AsReadWriteTexture3DShader : IComputeShader
+    {
+        public readonly ReadWriteTexture3D<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+            result[2] = source.Depth;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12, 3)]
+    [Data(64, 24, 4)]
+    [Data(128, 32, 4)]
+    [Data(376, 64, 3)]
+    public void ReadWriteTexture3D_T1_AsIReadOnlyTexture3D(Device device, int axis0, int axis1, int axis2)
+    {
+        using ReadWriteTexture3D<float> resource = device.Get().AllocateReadWriteTexture3D<float>(axis0, axis1, axis2);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(3);
+
+        using (var context = device.Get().CreateComputeContext())
+        {
+            context.Transition(resource, ResourceState.ReadOnly);
+            context.For(1, new ReadWriteTexture3D_T1_AsIReadOnlyTexture3DShader(resource.AsReadOnly(), result));
+        }
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1, axis2 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteTexture3D_T1_AsIReadOnlyTexture3DShader : IComputeShader
+    {
+        public readonly IReadOnlyTexture3D<float> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+            result[2] = source.Depth;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12, 3)]
+    [Data(64, 24, 4)]
+    [Data(128, 32, 4)]
+    [Data(376, 64, 3)]
+    public void ReadOnlyTexture3D_T2_AsReadOnlyTexture3D(Device device, int axis0, int axis1, int axis2)
+    {
+        using ReadOnlyTexture3D<Rgba32, float4> resource = device.Get().AllocateReadOnlyTexture3D<Rgba32, float4>(axis0, axis1, axis2);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(3);
+
+        device.Get().For(1, new ReadOnlyTexture3D_T2_AsReadOnlyTexture3DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1, axis2 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadOnlyTexture3D_T2_AsReadOnlyTexture3DShader : IComputeShader
+    {
+        public readonly ReadOnlyTexture3D<Rgba32, float4> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+            result[2] = source.Depth;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12, 3)]
+    [Data(64, 24, 4)]
+    [Data(128, 32, 4)]
+    [Data(376, 64, 3)]
+    public void ReadOnlyTexture3D_T2_AsIReadOnlyNormalizedTexture3D(Device device, int axis0, int axis1, int axis2)
+    {
+        using ReadOnlyTexture3D<Rgba32, float4> resource = device.Get().AllocateReadOnlyTexture3D<Rgba32, float4>(axis0, axis1, axis2);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(3);
+
+        device.Get().For(1, new ReadOnlyTexture3D_T2_AsIReadOnlyNormalizedTexture3DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1, axis2 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadOnlyTexture3D_T2_AsIReadOnlyNormalizedTexture3DShader : IComputeShader
+    {
+        public readonly IReadOnlyNormalizedTexture3D<float4> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+            result[2] = source.Depth;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12, 3)]
+    [Data(64, 24, 4)]
+    [Data(128, 32, 4)]
+    [Data(376, 64, 3)]
+    public void ReadWriteTexture3D_T2_AsReadWriteTexture3D(Device device, int axis0, int axis1, int axis2)
+    {
+        using ReadWriteTexture3D<Rgba32, float4> resource = device.Get().AllocateReadWriteTexture3D<Rgba32, float4>(axis0, axis1, axis2);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(3);
+
+        device.Get().For(1, new ReadWriteTexture3D_T2_AsReadWriteTexture3DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1, axis2 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteTexture3D_T2_AsReadWriteTexture3DShader : IComputeShader
+    {
+        public readonly ReadWriteTexture3D<Rgba32, float4> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+            result[2] = source.Depth;
+        }
+    }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    [Data(8, 12, 3)]
+    [Data(64, 24, 4)]
+    [Data(128, 32, 4)]
+    [Data(376, 64, 3)]
+    public void ReadWriteTexture3D_T2_AsIReadWriteNormalizedTexture3D(Device device, int axis0, int axis1, int axis2)
+    {
+        using ReadWriteTexture3D<Rgba32, float4> resource = device.Get().AllocateReadWriteTexture3D<Rgba32, float4>(axis0, axis1, axis2);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(3);
+
+        device.Get().For(1, new ReadWriteTexture3D_T2_AsIReadWriteNormalizedTexture3DShader(resource, result));
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { axis0, axis1, axis2 },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct ReadWriteTexture3D_T2_AsIReadWriteNormalizedTexture3DShader : IComputeShader
+    {
+        public readonly IReadWriteNormalizedTexture3D<float4> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+            result[0] = source.Width;
+            result[1] = source.Height;
+            result[2] = source.Depth;
+        }
+    }
+}

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
@@ -1,0 +1,149 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text.RegularExpressions" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".g.cs"#>
+using ComputeSharp.Tests.Attributes;
+using ComputeSharp.Tests.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.Tests;
+
+[TestClass]
+[TestCategory("ResourceDimensions")]
+public partial class ResourceDimensionsTests
+{
+<#
+// Map of all resource types with dimensions accessors
+var typesMap = new Dictionary<string, string[]>
+{
+    ["ConstantBuffer<float>"] = new[] { "Length" },
+    ["ReadOnlyBuffer<float>"] = new[] { "Length" },
+    ["ReadWriteBuffer<float>"] = new[] { "Length" },
+    ["ReadOnlyTexture2D<float>"] = new[] { "Width", "Height" },
+    ["ReadWriteTexture2D<float>"] = new[] { "Width", "Height" },
+    ["ReadOnlyTexture2D<Rgba32, float4>"] = new[] { "Width", "Height" },
+    ["ReadWriteTexture2D<Rgba32, float4>"] = new[] { "Width", "Height" },
+    ["ReadOnlyTexture3D<float>"] = new[] { "Width", "Height", "Depth" },
+    ["ReadWriteTexture3D<float>"] = new[] { "Width", "Height", "Depth" },
+    ["ReadOnlyTexture3D<Rgba32, float4>"] = new[] { "Width", "Height", "Depth" },
+    ["ReadWriteTexture3D<Rgba32, float4>"] = new[] { "Width", "Height", "Depth" }
+};
+
+// Map of all resource types that also have a supported interface
+var interfacesMap = new Dictionary<string, string>
+{
+    ["ReadWriteTexture2D<float>"] = "IReadOnlyTexture2D<float>",
+    ["ReadOnlyTexture2D<Rgba32, float4>"] = "IReadOnlyNormalizedTexture2D<float4>",
+    ["ReadWriteTexture2D<Rgba32, float4>"] = "IReadWriteNormalizedTexture2D<float4>",
+    ["ReadWriteTexture3D<float>"] = "IReadOnlyTexture3D<float>",
+    ["ReadOnlyTexture3D<Rgba32, float4>"] = "IReadOnlyNormalizedTexture3D<float4>",
+    ["ReadWriteTexture3D<Rgba32, float4>"] = "IReadWriteNormalizedTexture3D<float4>"
+};
+
+// Map of all resource that need a readonly wrapper
+var readonlyWrappersMap = new HashSet<string>
+{
+    "IReadOnlyTexture2D<float>",
+    "IReadOnlyTexture3D<float>"
+};
+
+// Map of data row items to test multiple dimension combinations
+var dataRows = new Dictionary<int, int[][]>
+{
+    [1] = new[] { new[] { 8 }, new[] { 64 }, new[] { 128 }, new[] { 376 } },
+    [2] = new[] { new[] { 8, 12 }, new[] { 64, 13 }, new[] { 128, 32 }, new[] { 376, 112 } },
+    [3] = new[] { new[] { 8, 12, 3 }, new[] { 64, 24, 4 }, new[] { 128, 32, 4 }, new[] { 376, 64, 3 } }
+};
+
+int index = 0;
+
+foreach (var pair in typesMap)
+{
+    var numberOfDimensions = pair.Value.Length;
+    var numberOfTypeParameters = Regex.Match(pair.Key, @"<([\w, ]+)>").Groups[1].Value.Split(',').Length;
+    var resourceName = Regex.Match(pair.Key, @"\w+").Value;
+    var shaderResourceTypes = new List<string> { pair.Key };
+
+    if (interfacesMap.TryGetValue(pair.Key, out var interfaceType)) shaderResourceTypes.Add(interfaceType);
+
+    foreach (var shaderResourceType in shaderResourceTypes)
+    {
+        if (index++ != 0) WriteLine("");
+
+        var shaderResourceName = Regex.Match(shaderResourceType, @"\w+").Value;
+        var testMethodName = $"{resourceName}_T{numberOfTypeParameters}_As{shaderResourceName}";
+#>
+    [CombinatorialTestMethod]
+    [AllDevices]
+<#
+        foreach (var dataRow in dataRows[numberOfDimensions])
+        {
+            WriteLine($"    [Data({string.Join(", ", dataRow)})]");
+        }
+
+        string parameters = string.Join(", ", Enumerable
+            .Range(0, numberOfDimensions)
+            .Select(x => $"int axis{x}"));
+
+        string arguments = string.Join(", ", Enumerable
+            .Range(0, numberOfDimensions)
+            .Select(x => $"axis{x}"));
+
+        bool needsReadonlyWrapper = readonlyWrappersMap.Contains(shaderResourceType);
+#>
+    public void <#=testMethodName#>(Device device, <#=parameters#>)
+    {
+        using <#=pair.Key#> resource = device.Get().Allocate<#=pair.Key#>(<#=arguments#>);
+        using ReadWriteBuffer<int> result = device.Get().AllocateReadWriteBuffer<int>(<#=numberOfDimensions#>);
+
+<#
+        if (needsReadonlyWrapper)
+        {
+#>
+        using (var context = device.Get().CreateComputeContext())
+        {
+            context.Transition(resource, ResourceState.ReadOnly);
+            context.For(1, new <#=testMethodName#>Shader(resource.AsReadOnly(), result));
+        }
+<#
+        }
+        else
+        {
+#>
+        device.Get().For(1, new <#=testMethodName#>Shader(resource, result));
+<#
+        }
+#>
+
+        int[] dimensions = result.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new[] { <#=arguments#> },
+            actual: dimensions);
+    }
+
+    [AutoConstructor]
+    internal readonly partial struct <#=testMethodName#>Shader : IComputeShader
+    {
+        public readonly <#=shaderResourceType#> source;
+        public readonly ReadWriteBuffer<int> result;
+
+        public void Execute()
+        {
+<#
+        for (int i = 0; i < pair.Value.Length; i++)
+        {
+#>
+            result[<#=i#>] = source.<#=pair.Value[i]#>;
+<#
+        }
+#>
+        }
+    }
+<#
+    }
+}
+#>
+}

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
@@ -18,7 +18,6 @@ public partial class ResourceDimensionsTests
 // Map of all resource types with dimensions accessors
 var typesMap = new Dictionary<string, string[]>
 {
-    ["ConstantBuffer<float>"] = new[] { "Length" },
     ["ReadOnlyBuffer<float>"] = new[] { "Length" },
     ["ReadWriteBuffer<float>"] = new[] { "Length" },
     ["ReadOnlyTexture2D<float>"] = new[] { "Width", "Height" },


### PR DESCRIPTION
### Description

This PR just adds unit tests for all resource dimension accessors. Needed to prepare for the new 1D textures too.