### PR TITLE
Add diagnostic suppressor for CS0649 for D2D1 resource texture fields

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2D1ResourceTextureUninitializedFieldDiagnosticSuppressor.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2D1ResourceTextureUninitializedFieldDiagnosticSuppressor.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Mappings;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.D2D1.SourceGenerators.Diagnostics.SuppressionDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// <para>
+/// A diagnostic suppressor to suppress CS0649 warnings for uninitialized D2D1 resource texture fields.
+/// </para>
+/// <para>
+/// That is, this diagnostic suppressor will suppress the following diagnostic:
+/// <code>
+/// public struct MyShader : ID2D1PixelShader
+/// {
+///     [D2DResourceTextureIndex(0)]
+///     private D2D1ResourceTexture1D&lt;float4&gt; texture;
+/// 
+///     public float4 Execute()
+///     {
+///         return texture[0];
+///     }
+/// }
+/// </code>
+/// </para>
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class D2D1ResourceTextureUninitializedFieldDiagnosticSuppressor : DiagnosticSuppressor
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(UninitializedD2D1ResourceTextureField);
+
+    /// <inheritdoc/>
+    public override void ReportSuppressions(SuppressionAnalysisContext context)
+    {
+        foreach (Diagnostic diagnostic in context.ReportedDiagnostics)
+        {
+            SyntaxNode? syntaxNode = diagnostic.Location.SourceTree?.GetRoot(context.CancellationToken).FindNode(diagnostic.Location.SourceSpan);
+
+            if (syntaxNode is not null)
+            {
+                SemanticModel semanticModel = context.GetSemanticModel(syntaxNode.SyntaxTree);
+
+                // Get the field symbol
+                ISymbol? declaredSymbol = semanticModel.GetDeclaredSymbol(syntaxNode, context.CancellationToken);
+
+                // Check if the field is in a struct and it's of a D2D1 resource texture type
+                if (declaredSymbol is IFieldSymbol fieldSymbol &&
+                    fieldSymbol.ContainingType is { TypeKind: TypeKind.Struct } structSymbol &&
+                    HlslKnownTypes.IsResourceTextureType(fieldSymbol.Type.GetFullMetadataName()))
+                {
+                    // Get the ID2D1PixelShader interface symbol to the check the containing type of the field
+                    INamedTypeSymbol? pixelShaderInterfaceSymbol = semanticModel.Compilation.GetTypeByMetadataName(typeof(ID2D1PixelShader).FullName)!;
+
+                    if (pixelShaderInterfaceSymbol is null)
+                    {
+                        continue;
+                    }
+
+                    // Also check if the containing type is in fact a D2D1 pixel shader type
+                    if (ID2D1ShaderGenerator.IsD2D1PixelShaderType(structSymbol, pixelShaderInterfaceSymbol))
+                    {
+                        context.ReportSuppression(Suppression.Create(UninitializedD2D1ResourceTextureField, diagnostic));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/SuppressionDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/SuppressionDescriptors.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.D2D1.SourceGenerators.Diagnostics;
+
+/// <summary>
+/// A container for all <see cref="SuppressionDescriptors"/> instances for suppressed diagnostics by analyzers in this project.
+/// </summary>
+internal static class SuppressionDescriptors
+{
+    /// <summary>
+    /// Gets a <see cref="SuppressionDescriptor"/> for an uninitialized D2D1 resource texture field.
+    /// </summary>
+    public static readonly SuppressionDescriptor UninitializedD2D1ResourceTextureField = new(
+        id: "CMPSD2DSPR0001",
+        suppressedDiagnosticId: "CS0649",
+        justification: "Fields of type D2D1ResourceTexture1D<T>, D2D1ResourceTexture2D<T> and D2D1ResourceTexture3D<T> are implicitly mapped to resource texture objects into the resulting D2D1 pixel shader for their containing type, and don't need to be initialized");
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.Helpers.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.Helpers.cs
@@ -16,7 +16,7 @@ partial class ID2D1ShaderGenerator
     /// <param name="typeSymbol">The input <see cref="INamedTypeSymbol"/> instance to check.</param>
     /// <param name="d2D1PixelShaderSymbol">The <see cref="INamedTypeSymbol"/> instance for <see cref="ID2D1PixelShader"/>.</param>
     /// <returns>Whether or not <paramref name="typeSymbol"/> implements <paramref name="d2D1PixelShaderSymbol"/>.</returns>
-    private static bool IsD2D1PixelShaderType(INamedTypeSymbol typeSymbol, INamedTypeSymbol d2D1PixelShaderSymbol)
+    public static bool IsD2D1PixelShaderType(INamedTypeSymbol typeSymbol, INamedTypeSymbol d2D1PixelShaderSymbol)
     {
         foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.AllInterfaces)
         {

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureUninitializedFieldDiagnosticSuppressorTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureUninitializedFieldDiagnosticSuppressorTests.cs
@@ -1,0 +1,18 @@
+﻿namespace ComputeSharp.D2D1.Tests;
+
+/// <summary>
+/// A test class for the diagnostic suppressor for D2D1 resource texture fields being left uninitialized.
+/// </summary>
+internal sealed partial class D2D1ResourceTextureUninitializedFieldDiagnosticSuppressorTests
+{
+    public readonly partial struct MyShader : ID2D1PixelShader
+    {
+        // This test just needs to validate the project builds fine with this shader.
+        // If the diagnostic suppressor wasn't working, it'd fail to build because
+        // Roslyn would emit a CS0649 warning, which would be treated as an error.
+        [D2DResourceTextureIndex(0)]
+        private readonly D2D1ResourceTexture1D<float4> texture;
+
+        public float4 Execute() => texture[0];
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a diagnostic suppressor for CS0649 warnings on D2D1 resource texture fields.