### PR TITLE
Fix [ShaderMethod] support for global methods

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -140,6 +140,9 @@ jobs:
     - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET 6)
       run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
       shell: cmd
+    - name: Run ComputeSharp.Tests.GlobalStatements (.NET 6)
+      run: dotnet test tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
+      shell: cmd
     - name: Run ComputeSharp.Tests.Internals (.NET 6)
       run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
       shell: cmd
@@ -149,6 +152,9 @@ jobs:
     - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET Core 3.1)
       run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -v n -l "console;verbosity=detailed"
       shell: cmd
+    - name: Run ComputeSharp.Tests.GlobalStatements (.NET Core 3.1)
+      run: dotnet test tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
+      shell: cmd
     - name: Run ComputeSharp.Tests.Internals (.NET Core 3.1)
       run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -v n -l "console;verbosity=detailed"
       shell: cmd
@@ -157,6 +163,9 @@ jobs:
       shell: cmd
     - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET Framework 4.7.2)
       run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f net472 /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.Tests.GlobalStatements (.NET Framework 4.7.2)
+      run: dotnet test tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f net472 -v n -l "console;verbosity=detailed"
       shell: cmd
     - name: Run ComputeSharp.Tests.Internals (.NET Framework 4.7.2)
       run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f net472 /p:Platform=x64 -v n -l "console;verbosity=detailed"

--- a/ComputeSharp.sln
+++ b/ComputeSharp.sln
@@ -124,6 +124,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ComputeSharp.NuGet", "Compu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComputeSharp.Tests.DeviceLost", "tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj", "{5DE90C85-ED26-4B5A-A0D7-2FF966A210AC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ComputeSharp.Tests.GlobalStatements", "tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj", "{669A414F-3B46-4B55-B587-061AF63C3067}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -348,6 +350,14 @@ Global
 		{5DE90C85-ED26-4B5A-A0D7-2FF966A210AC}.Release|ARM64.Build.0 = Release|Any CPU
 		{5DE90C85-ED26-4B5A-A0D7-2FF966A210AC}.Release|x64.ActiveCfg = Release|Any CPU
 		{5DE90C85-ED26-4B5A-A0D7-2FF966A210AC}.Release|x64.Build.0 = Release|Any CPU
+		{669A414F-3B46-4B55-B587-061AF63C3067}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{669A414F-3B46-4B55-B587-061AF63C3067}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{669A414F-3B46-4B55-B587-061AF63C3067}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{669A414F-3B46-4B55-B587-061AF63C3067}.Debug|x64.Build.0 = Debug|Any CPU
+		{669A414F-3B46-4B55-B587-061AF63C3067}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{669A414F-3B46-4B55-B587-061AF63C3067}.Release|ARM64.Build.0 = Release|Any CPU
+		{669A414F-3B46-4B55-B587-061AF63C3067}.Release|x64.ActiveCfg = Release|Any CPU
+		{669A414F-3B46-4B55-B587-061AF63C3067}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -380,6 +390,7 @@ Global
 		{C0B903AA-F32C-4760-B4B6-199AC4FE1C5A} = {F8EFBB27-4EE2-4463-A75B-7EFDFB55D0F7}
 		{E3403F19-A0D8-4317-8A54-322C7A13F2A2} = {F8EFBB27-4EE2-4463-A75B-7EFDFB55D0F7}
 		{5DE90C85-ED26-4B5A-A0D7-2FF966A210AC} = {F8EFBB27-4EE2-4463-A75B-7EFDFB55D0F7}
+		{669A414F-3B46-4B55-B587-061AF63C3067} = {F8EFBB27-4EE2-4463-A75B-7EFDFB55D0F7}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4664C5E3-0340-4E22-BCFD-98AAEDF5F2DC}

--- a/src/ComputeSharp.Dynamic/Attributes/__Internals/ShaderMethodSourceAttribute.cs
+++ b/src/ComputeSharp.Dynamic/Attributes/__Internals/ShaderMethodSourceAttribute.cs
@@ -77,10 +77,10 @@ public sealed partial class ShaderMethodSourceAttribute : Attribute
             return ThrowArgumentExceptionForNonStaticMethod(name);
         }
 
-        var attributes = function.Method.DeclaringType!.Assembly.GetCustomAttributes<ShaderMethodSourceAttribute>();
+        IEnumerable<ShaderMethodSourceAttribute> attributes = function.Method.DeclaringType!.Assembly.GetCustomAttributes<ShaderMethodSourceAttribute>();
         string methodName = function.Method.GetFullyQualifiedName();
 
-        foreach (var attribute in attributes)
+        foreach (ShaderMethodSourceAttribute attribute in attributes)
         {
             if (attribute.methodName.Equals(methodName))
             {

--- a/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
+++ b/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
@@ -6,6 +6,10 @@
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+    
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ComputeSharp.Core\ComputeSharp.Core.csproj" />

--- a/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
+++ b/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Platforms>AnyCPU;x64;ARM64</Platforms>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ComputeSharp.Core\ComputeSharp.Core.csproj" />
+    <ProjectReference Include="..\..\src\ComputeSharp.Core.SourceGenerators\ComputeSharp.Core.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+    <ProjectReference Include="..\..\src\ComputeSharp\ComputeSharp.csproj" />
+    <ProjectReference Include="..\..\src\ComputeSharp.Dynamic\ComputeSharp.Dynamic.csproj" />
+    <ProjectReference Include="..\..\src\ComputeSharp.SourceGenerators\ComputeSharp.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+</Project>

--- a/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
+++ b/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
+++ b/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
@@ -1,2 +1,38 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+﻿using ComputeSharp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+float[] numbers = Enumerable.Range(0, 128).Select(i => (float)i).ToArray();
+
+using GraphicsDevice device = GraphicsDevice.GetDefault();
+using ReadWriteBuffer<float> buffer = device.AllocateReadWriteBuffer(numbers);
+
+device.For(buffer.Length, new ApplyFunctionShader(buffer, AddHalf));
+
+foreach (ref float number in numbers.AsSpan())
+{
+    number = AddHalf(number);
+}
+
+float[] result = buffer.ToArray();
+
+CollectionAssert.AreEqual(
+    expected: numbers,
+    actual: result);
+
+Console.WriteLine("Test passed successfully");
+
+// See https://github.com/Sergio0694/ComputeSharp/issues/374
+[ShaderMethod]
+static float AddHalf(float input) => input + 0.5f;
+
+[AutoConstructor]
+public readonly partial struct ApplyFunctionShader : IComputeShader
+{
+    private readonly ReadWriteBuffer<float> sourceTexture;
+    private readonly Func<float, float> func;
+
+    public void Execute()
+    {
+        this.sourceTexture[ThreadIds.X] = this.func(this.sourceTexture[ThreadIds.X]);
+    }
+}


### PR DESCRIPTION
### Closes #374

### Description

This PR fixes `[ShaderMethod]` uses on static global method declarations.