### PR TITLE
Bump Roslyn to 4.4 and use ForAttributeWithMetadataName

### DIFF
--- a/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
+++ b/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
@@ -21,16 +21,16 @@ public sealed class AutoConstructorGenerator : IIncrementalGenerator
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Get all declared struct symbols with the [AutoConstructor] attribute
-        IncrementalValuesProvider<INamedTypeSymbol> structDeclarations =
+        IncrementalValuesProvider<INamedTypeSymbol> structSymbols =
             context.SyntaxProvider
             .ForAttributeWithMetadataName(
-                "ComputeSharp.AutoConstructorAttribute",
+                typeof(AutoConstructorAttribute).FullName,
                 static (node, token) => node is StructDeclarationSyntax structDeclaration,
                 static (context, token) => (INamedTypeSymbol)context.TargetSymbol);
 
         // Get the type hierarchy and fields info
         IncrementalValuesProvider<(HierarchyInfo Left, ConstructorInfo Right)> constructorInfo =
-            structDeclarations
+            structSymbols
             .Select(static (item, token) => (Hierarchy: HierarchyInfo.From(item), Info: Ctor.GetData(item)))
             .Where(static item => !item.Info.Parameters.IsEmpty)
             .WithComparers(HierarchyInfo.Comparer.Default, ConstructorInfo.Comparer.Default);

--- a/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
+++ b/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
@@ -23,11 +23,10 @@ public sealed class AutoConstructorGenerator : IIncrementalGenerator
         // Get all declared struct symbols with the [AutoConstructor] attribute
         IncrementalValuesProvider<INamedTypeSymbol> structDeclarations =
             context.SyntaxProvider
-            .CreateSyntaxProvider(
+            .ForAttributeWithMetadataName(
+                "ComputeSharp.AutoConstructorAttribute",
                 static (node, token) => node is StructDeclarationSyntax structDeclaration,
-                static (context, token) => (INamedTypeSymbol?)context.SemanticModel.GetDeclaredSymbol(context.Node, token))
-            .Where(static symbol => symbol is not null &&
-                                    symbol.GetAttributes().Any(static a => a.AttributeClass?.ToDisplayString() == typeof(AutoConstructorAttribute).FullName))!;
+                static (context, token) => (INamedTypeSymbol)context.TargetSymbol);
 
         // Get the type hierarchy and fields info
         IncrementalValuesProvider<(HierarchyInfo Left, ConstructorInfo Right)> constructorInfo =

--- a/src/ComputeSharp.Core.SourceGenerators/ComputeSharp.Core.SourceGenerators.csproj
+++ b/src/ComputeSharp.Core.SourceGenerators/ComputeSharp.Core.SourceGenerators.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-1.final" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.Core.SourceGenerators/ComputeSharp.Core.SourceGenerators.csproj
+++ b/src/ComputeSharp.Core.SourceGenerators/ComputeSharp.Core.SourceGenerators.csproj
@@ -63,7 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.Core/ComputeSharp.Core.targets
+++ b/src/ComputeSharp.Core/ComputeSharp.Core.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.2 (ComputeSharp.Core's generators require Roslyn 4.2) -->
+  <!-- Remove the analyzer if using Roslyn < 4.3 (ComputeSharp.Core's generators require Roslyn 4.3) -->
   <Target Name="_ComputeSharpCoreRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <ComputeSharpCoreCurrentCompilerVersion>@(ComputeSharpCoreCurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpCoreCurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCoreCurrentCompilerVersion), 4.2))">true</ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCoreCurrentCompilerVersion), 4.3))">true</ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.2, disable the source generators -->
+    <!-- If the Roslyn version is < 4.3, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpCoreAnalyzer)"/>
     </ItemGroup>

--- a/src/ComputeSharp.Core/ComputeSharp.Core.targets
+++ b/src/ComputeSharp.Core/ComputeSharp.Core.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.3 (ComputeSharp.Core's generators require Roslyn 4.3) -->
+  <!-- Remove the analyzer if using Roslyn < 4.4 (ComputeSharp.Core's generators require Roslyn 4.4) -->
   <Target Name="_ComputeSharpCoreRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <ComputeSharpCoreCurrentCompilerVersion>@(ComputeSharpCoreCurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpCoreCurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCoreCurrentCompilerVersion), 4.3))">true</ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCoreCurrentCompilerVersion), 4.4))">true</ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.3, disable the source generators -->
+    <!-- If the Roslyn version is < 4.4, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpCoreAnalyzer)"/>
     </ItemGroup>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -96,7 +96,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -96,7 +96,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-1.final" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-#pragma warning disable CS0618, RS1024
+#pragma warning disable CS0618
 
 namespace ComputeSharp.D2D1.SourceGenerators;
 

--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.3 (ComputeSharp.D2D1's generators require Roslyn 4.3) -->
+  <!-- Remove the analyzer if using Roslyn < 4.4 (ComputeSharp.D2D1's generators require Roslyn 4.4) -->
   <Target Name="_ComputeSharpD2D1RemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <ComputeSharpD2D1CurrentCompilerVersion>@(ComputeSharpD2D1CurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpD2D1CurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpD2D1CurrentCompilerVersion), 4.3))">true</ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpD2D1CurrentCompilerVersion), 4.4))">true</ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.3, disable the source generators -->
+    <!-- If the Roslyn version is < 4.4, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpD2D1Analyzer)"/>
     </ItemGroup>
@@ -38,7 +38,7 @@
     <!-- If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
          emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
          disabled, and that ComputeSharp will not work at all unless a more up to date IDE or compiler version are used. -->
-    <Error Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp.D2D1 source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. ComputeSharp.D2D1 requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
+    <Error Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp.D2D1 source generators have been disabled on the current configuration, as they need Roslyn 4.4 in order to work. ComputeSharp.D2D1 requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->

--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.2 (ComputeSharp.D2D1's generators require Roslyn 4.2) -->
+  <!-- Remove the analyzer if using Roslyn < 4.3 (ComputeSharp.D2D1's generators require Roslyn 4.3) -->
   <Target Name="_ComputeSharpD2D1RemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <ComputeSharpD2D1CurrentCompilerVersion>@(ComputeSharpD2D1CurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpD2D1CurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpD2D1CurrentCompilerVersion), 4.2))">true</ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpD2D1CurrentCompilerVersion), 4.3))">true</ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.2, disable the source generators -->
+    <!-- If the Roslyn version is < 4.3, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpD2D1Analyzer)"/>
     </ItemGroup>
@@ -38,7 +38,7 @@
     <!-- If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
          emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
          disabled, and that ComputeSharp will not work at all unless a more up to date IDE or compiler version are used. -->
-    <Error Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp.D2D1 source generators have been disabled on the current configuration, as they need Roslyn 4.2 in order to work. ComputeSharp.D2D1 requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
+    <Error Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp.D2D1 source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. ComputeSharp.D2D1 requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0-1.final" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.0" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.Syntax.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-#pragma warning disable CS0618, RS1024
+#pragma warning disable CS0618
 
 namespace ComputeSharp.SourceGenerators;
 

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-#pragma warning disable CS0618, RS1024
+#pragma warning disable CS0618
 
 namespace ComputeSharp.SourceGenerators;
 

--- a/src/ComputeSharp.SourceGenerators/ShaderMethodSourceGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ShaderMethodSourceGenerator.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static ComputeSharp.SourceGenerators.Helpers.SyntaxFactoryHelper;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
-#pragma warning disable CS0618, RS1024
+#pragma warning disable CS0618
 
 namespace ComputeSharp.SourceGenerators;
 

--- a/src/ComputeSharp/ComputeSharp.targets
+++ b/src/ComputeSharp/ComputeSharp.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.3 (ComputeSharp's generators require Roslyn 4.3) -->
+  <!-- Remove the analyzer if using Roslyn < 4.4 (ComputeSharp's generators require Roslyn 4.4) -->
   <Target Name="_ComputeSharpRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <ComputeSharpCurrentCompilerVersion>@(ComputeSharpCurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpCurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCurrentCompilerVersion), 4.3))">true</ComputeSharpCurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCurrentCompilerVersion), 4.4))">true</ComputeSharpCurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.3, disable the source generators -->
+    <!-- If the Roslyn version is < 4.4, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpAnalyzer)"/>
     </ItemGroup>
@@ -38,7 +38,7 @@
     <!-- If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
          emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
          disabled, and that ComputeSharp will not work at all unless a more up to date IDE or compiler version are used. -->
-    <Error Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. ComputeSharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
+    <Error Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp source generators have been disabled on the current configuration, as they need Roslyn 4.4 in order to work. ComputeSharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->

--- a/src/ComputeSharp/ComputeSharp.targets
+++ b/src/ComputeSharp/ComputeSharp.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.2 (ComputeSharp's generators require Roslyn 4.2) -->
+  <!-- Remove the analyzer if using Roslyn < 4.3 (ComputeSharp's generators require Roslyn 4.3) -->
   <Target Name="_ComputeSharpRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -27,10 +27,10 @@
       <ComputeSharpCurrentCompilerVersion>@(ComputeSharpCurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpCurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCurrentCompilerVersion), 4.2))">true</ComputeSharpCurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCurrentCompilerVersion), 4.3))">true</ComputeSharpCurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.2, disable the source generators -->
+    <!-- If the Roslyn version is < 4.3, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpAnalyzer)"/>
     </ItemGroup>
@@ -38,7 +38,7 @@
     <!-- If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
          emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
          disabled, and that ComputeSharp will not work at all unless a more up to date IDE or compiler version are used. -->
-    <Error Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp source generators have been disabled on the current configuration, as they need Roslyn 4.2 in order to work. ComputeSharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
+    <Error Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. ComputeSharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS2022) or .NET SDK version."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->

--- a/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0-1.final" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

This PR uses the new [`ForAttributeWithMetadataName`](https://github.com/dotnet/roslyn/issues/54725) API whenever possible.
Updated generators include:
- `[AutoConstructor]` generator
- `[ShaderMethod]` generator
- `[D2DPixelShaderSource]` generator