### PR TITLE
Fix dispatch [numthreads] values for ND dispatches

### DIFF
--- a/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Dispatching.cs
+++ b/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Dispatching.cs
@@ -22,7 +22,7 @@ public static partial class GraphicsDeviceExtensions
 
         using ComputeContext context = device.CreateComputeContext();
 
-        context.Run(x, 1, 1, ref Unsafe.AsRef(in shader));
+        context.Run(x, ref Unsafe.AsRef(in shader));
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public static partial class GraphicsDeviceExtensions
 
         using ComputeContext context = device.CreateComputeContext();
 
-        context.Run(x, y, 1, ref Unsafe.AsRef(in shader));
+        context.Run(x, y, ref Unsafe.AsRef(in shader));
     }
 
     /// <summary>

--- a/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
@@ -488,7 +488,7 @@ public static class ComputeContextExtensions
     public static void For<T>(this in ComputeContext context, int x, in T shader)
         where T : struct, IComputeShader
     {
-        context.Run(x, 1, 1, ref Unsafe.AsRef(in shader));
+        context.Run(x, ref Unsafe.AsRef(in shader));
     }
 
     /// <summary>
@@ -502,7 +502,7 @@ public static class ComputeContextExtensions
     public static void For<T>(this in ComputeContext context, int x, int y, in T shader)
         where T : struct, IComputeShader
     {
-        context.Run(x, y, 1, ref Unsafe.AsRef(in shader));
+        context.Run(x, y, ref Unsafe.AsRef(in shader));
     }
 
     /// <summary>


### PR DESCRIPTION
### Closes #380

### Description

This PR ensures that the `[numthreads]` values are fixed depending on the calling method doing the dispatch.