### PR TITLE
Enable D2D1 tests multi-targeting

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -231,15 +231,31 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v2
+    - name: Setup .NET Core 3.1 SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
     - name: Setup .NET 6 SDK
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
-    - name: Run ComputeSharp.D2D1.Tests
-      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -v n -l "console;verbosity=detailed"
+    - name: Run ComputeSharp.D2D1.Tests (.NET 6)
+      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
       shell: cmd
-    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes
-      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -v n -l "console;verbosity=detailed"
+    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes (.NET 6)
+      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.D2D1.Tests (.NET Core 3.1)
+      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes (.NET Core 3.1)
+      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.D2D1.Tests (.NET Framework 4.7.2)
+      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f net472 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes (.NET Framework 4.7.2)
+      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -f net472 -v n -l "console;verbosity=detailed"
       shell: cmd
 
   # Run all the local samples to ensure they build and run with no errors

--- a/src/ComputeSharp.D2D1/Extensions/HRESULTExtensions.cs
+++ b/src/ComputeSharp.D2D1/Extensions/HRESULTExtensions.cs
@@ -11,7 +11,7 @@ namespace ComputeSharp.D2D1.Extensions;
 /// </summary>
 /// <remarks>Trimmed down version of the same file in <c>ComputeSharp</c>.</remarks>
 [DebuggerStepThrough]
-internal static class HResultExtensions
+internal static class HRESULTExtensions
 {
     /// <summary>
     /// Throws a <see cref="Win32Exception"/> if <paramref name="result"/> represents an error.

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ResourceTextureManagerBuffer.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ResourceTextureManagerBuffer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using ComputeSharp.D2D1.Shaders.Interop.Effects.ResourceManagers;
 
 #pragma warning disable CS0649
@@ -108,16 +107,6 @@ partial struct PixelShaderEffect
 
                 return ref @this[index];
             }
-        }
-
-        /// <summary>
-        /// Gets a <see cref="Span{T}"/> with the <see cref="ID2D1ResourceTextureManager"/> items in the current instance.
-        /// </summary>
-        /// <returns>A <see cref="Span{T}"/> with the <see cref="ID2D1ResourceTextureManager"/> items in the current instance.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<ID2D1ResourceTextureManager> AsSpan()
-        {
-            return new((ID2D1ResourceTextureManager**)Unsafe.AsPointer(ref this), 16);
         }
     }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -286,8 +286,7 @@ internal unsafe partial struct PixelShaderEffect
         @this->d2D1TransformMapperHandle = GCHandle.Alloc(d2D1TransformMapper);
         @this->d2D1DrawInfo = null;
         @this->d2D1EffectContext = null;
-
-        @this->resourceTextureManagerBuffer.AsSpan().Clear();
+        @this->resourceTextureManagerBuffer = default;
 
         *effectImpl = (IUnknown*)@this;
 

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp/Graphics/Extensions/Interop/HRESULTExtensions.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp/Graphics/Extensions/Interop/HRESULTExtensions.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.Core.Extensions;
 /// Helper methods to efficiently throw exceptions.
 /// </summary>
 [DebuggerStepThrough]
-internal static class HResultExtensions
+internal static class HRESULTExtensions
 {
     /// <summary>
     /// Throws a <see cref="Win32Exception"/> if <paramref name="result"/> represents an error.

--- a/src/ComputeSharp/Graphics/Extensions/Interop/HRESULTExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/HRESULTExtensions.cs
@@ -12,7 +12,7 @@ namespace ComputeSharp.Core.Extensions;
 /// Helper methods to efficiently throw exceptions.
 /// </summary>
 [DebuggerStepThrough]
-internal static class HResultExtensions
+internal static class HRESULTExtensions
 {
     /// <summary>
     /// Throws a <see cref="Win32Exception"/> if <paramref name="result"/> represents an error.

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.20348.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="Vortice.Win32" Version="1.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS0419;CA1416</NoWarn>
   </PropertyGroup>

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -5,8 +5,8 @@ using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Tests.Effects;
 using ComputeSharp.D2D1.Tests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TerraFX.Interop.DirectX;
-using TerraFX.Interop.Windows;
+using Win32;
+using Win32.Graphics.Direct2D;
 
 namespace ComputeSharp.D2D1.Tests;
 

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
@@ -588,7 +588,9 @@ public partial class D2D1ResourceTextureManagerTests
             data: texture,
             strides: null);
 
-        byte[] data = RandomNumberGenerator.GetBytes(updateLength);
+        byte[] data = new byte[updateLength];
+
+        RandomNumberGenerator.Create().GetBytes(data);
 
         resourceTextureManager.Update(
             minimumExtents: stackalloc uint[] { (uint)startOffset },
@@ -674,7 +676,9 @@ public partial class D2D1ResourceTextureManagerTests
             data: texture,
             strides: stackalloc uint[] { (uint)width });
 
-        byte[] data = RandomNumberGenerator.GetBytes(updateLengthX * updateLengthY);
+        byte[] data = new byte[updateLengthX * updateLengthY];
+
+        RandomNumberGenerator.Create().GetBytes(data);
 
         resourceTextureManager.Update(
             minimumExtents: stackalloc uint[] { (uint)startOffsetX, (uint)startOffsetY },
@@ -775,7 +779,9 @@ public partial class D2D1ResourceTextureManagerTests
             data: texture,
             strides: stackalloc uint[] { (uint)width, (uint)(width * height) });
 
-        byte[] data = RandomNumberGenerator.GetBytes(updateLengthX * updateLengthY * updateLengthZ);
+        byte[] data = new byte[updateLengthX * updateLengthY * updateLengthZ];
+
+        RandomNumberGenerator.Create().GetBytes(data);
 
         resourceTextureManager.Update(
             minimumExtents: stackalloc uint[] { (uint)startOffsetX, (uint)startOffsetY, (uint)startOffsetZ },

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
@@ -10,12 +10,15 @@ using ComputeSharp.Tests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using TerraFX.Interop.DirectX;
-using TerraFX.Interop.Windows;
+using Win32;
+using Win32.Graphics.Direct2D;
 
 #pragma warning disable CS0649
 
 namespace ComputeSharp.D2D1.Tests;
+
+using HRESULT = Win32.HResult;
+using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
 
 [TestClass]
 [TestCategory("D2D1ResourceTextureManager")]
@@ -56,7 +59,7 @@ public partial class D2D1ResourceTextureManagerTests
         Guid uuidOfGarbage = Guid.NewGuid();
 
         // Any other random QueryInterface should fail
-        Assert.AreEqual(E.E_NOINTERFACE, (int)resourceTextureManager.AsIID(&uuidOfGarbage, &garbage));
+        Assert.AreEqual(HRESULT.NoInterface, resourceTextureManager.AsIID(&uuidOfGarbage, &garbage));
 
         Assert.IsTrue(garbage.Get() is null);
     }

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
@@ -27,8 +27,8 @@ public partial class D2D1ShaderCompilerTests
             """;
 
         ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
-            source,
-            "PSMain",
+            source.AsSpan(),
+            "PSMain".AsSpan(),
             D2D1ShaderProfile.PixelShader40Level93,
             D2D1CompileOptions.Default);
 
@@ -79,8 +79,8 @@ public partial class D2D1ShaderCompilerTests
             """;
 
         ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
-            source,
-            "PSMain",
+            source.AsSpan(),
+            "PSMain".AsSpan(),
             D2D1ShaderProfile.PixelShader40Level93,
             D2D1CompileOptions.Default | D2D1CompileOptions.EnableLinking);
 
@@ -106,8 +106,8 @@ public partial class D2D1ShaderCompilerTests
             """;
 
         ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
-            source,
-            "Execute",
+            source.AsSpan(),
+            "Execute".AsSpan(),
             D2D1ShaderProfile.PixelShader40Level93,
             D2D1CompileOptions.Default);
 
@@ -133,8 +133,8 @@ public partial class D2D1ShaderCompilerTests
             """;
 
         ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
-            source,
-            "PSMain",
+            source.AsSpan(),
+            "PSMain".AsSpan(),
             D2D1ShaderProfile.PixelShader40Level93,
             D2D1CompileOptions.Default);
 
@@ -181,8 +181,8 @@ public partial class D2D1ShaderCompilerTests
             """;
 
         ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
-            source,
-            "PSMain",
+            source.AsSpan(),
+            "PSMain".AsSpan(),
             D2D1ShaderProfile.PixelShader40,
             D2D1CompileOptions.Default);
 

--- a/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
@@ -325,9 +325,9 @@ public sealed partial class BokehBlurEffect
         using ComPtr<ID2D1Effect> compositeEffect = default;
         using ComPtr<ID2D1Effect> borderEffect = default;
 
-        Span<ComPtr<ID2D1Effect>> verticalConvolutionEffectsForReals = stackalloc ComPtr<ID2D1Effect>[numberOfComponents];
-        Span<ComPtr<ID2D1Effect>> verticalConvolutionEffectsForImaginaries = stackalloc ComPtr<ID2D1Effect>[numberOfComponents];
-        Span<ComPtr<ID2D1Effect>> horizontalConvolutionEffects = stackalloc ComPtr<ID2D1Effect>[numberOfComponents];
+        Span<ComPtr<ID2D1Effect>> verticalConvolutionEffectsForReals = new ComPtr<ID2D1Effect>[numberOfComponents];
+        Span<ComPtr<ID2D1Effect>> verticalConvolutionEffectsForImaginaries = new ComPtr<ID2D1Effect>[numberOfComponents];
+        Span<ComPtr<ID2D1Effect>> horizontalConvolutionEffects = new ComPtr<ID2D1Effect>[numberOfComponents];
 
         try
         {

--- a/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -10,10 +9,21 @@ using ComputeSharp.D2D1;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Tests.Extensions;
 using ComputeSharp.D2D1.Tests.Helpers;
-using TerraFX.Interop.DirectX;
-using TerraFX.Interop.Windows;
+using Win32;
+using Win32.Graphics.Direct2D;
 
 namespace ComputeSharp.BokehBlur.Processors;
+
+using D2D1_BORDER_EDGE_MODE = Win32.Graphics.Direct2D.BorderEdgeMode;
+using D2D1_BORDER_PROP = Win32.Graphics.Direct2D.BorderProp;
+using D2D1_BUFFER_PRECISION = Win32.Graphics.Direct2D.BufferPrecision;
+using D2D1_COMPOSITE_MODE = Win32.Graphics.Direct2D.Common.CompositeMode;
+using D2D1_COMPOSITE_PROP = Win32.Graphics.Direct2D.CompositeProp;
+using D2D1_INTERPOLATION_MODE = Win32.Graphics.Direct2D.InterpolationMode;
+using D2D1_PROPERTY = Win32.Graphics.Direct2D.Property;
+using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
+using D2D1_RENDERING_CONTROLS = Win32.Graphics.Direct2D.RenderingControls;
+using D2D1 = Win32.Graphics.Direct2D.Apis;
 
 /// <summary>
 /// A bokeh blur effect, using linearly separable convolutions in the complex space for better efficiency.
@@ -298,7 +308,7 @@ public sealed partial class BokehBlurEffect
 
         // Set the buffer precision for the whole context to 32 bits per channel. This avoids
         // color banding issues due to intermediate buffers clamping to just 8 bits per channel.
-        d2D1RenderingControls.bufferPrecision = D2D1_BUFFER_PRECISION.D2D1_BUFFER_PRECISION_32BPC_FLOAT;
+        d2D1RenderingControls.bufferPrecision = D2D1_BUFFER_PRECISION._32bpcFloat;
 
         d2D1DeviceContext.Get()->SetRenderingControls(&d2D1RenderingControls);
 
@@ -334,31 +344,31 @@ public sealed partial class BokehBlurEffect
 
             // Create the border effect to clamp the input image
             d2D1DeviceContext.Get()->CreateEffect(
-                effectId: (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in CLSID.CLSID_D2D1Border)),
+                effectId: (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in D2D1.CLSID_D2D1Border)),
                 effect: borderEffect.GetAddressOf()).Assert();
 
-            D2D1_BORDER_EDGE_MODE d2D1BorderEdgeMode = D2D1_BORDER_EDGE_MODE.D2D1_BORDER_EDGE_MODE_CLAMP;
+            D2D1_BORDER_EDGE_MODE d2D1BorderEdgeMode = D2D1_BORDER_EDGE_MODE.Clamp;
 
             // Set the border mode to clamp on both axes
-            borderEffect.Get()->SetValue((uint)D2D1_BORDER_PROP.D2D1_BORDER_PROP_EDGE_MODE_X, (byte*)&d2D1BorderEdgeMode, sizeof(D2D1_BORDER_EDGE_MODE)).Assert();
-            borderEffect.Get()->SetValue((uint)D2D1_BORDER_PROP.D2D1_BORDER_PROP_EDGE_MODE_Y, (byte*)&d2D1BorderEdgeMode, sizeof(D2D1_BORDER_EDGE_MODE)).Assert();
+            borderEffect.Get()->SetValue((uint)D2D1_BORDER_PROP.EdgeModeX, (byte*)&d2D1BorderEdgeMode, sizeof(D2D1_BORDER_EDGE_MODE)).Assert();
+            borderEffect.Get()->SetValue((uint)D2D1_BORDER_PROP.EdgeModeY, (byte*)&d2D1BorderEdgeMode, sizeof(D2D1_BORDER_EDGE_MODE)).Assert();
 
             // If partials need to be summed, also create the composite effect
             if (numberOfComponents > 1)
             {
                 d2D1DeviceContext.Get()->CreateEffect(
-                    effectId: (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in CLSID.CLSID_D2D1Composite)),
+                    effectId: (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in D2D1.CLSID_D2D1Composite)),
                     effect: compositeEffect.GetAddressOf()).Assert();
 
-                D2D1_BUFFER_PRECISION d2D1BufferPrecision = D2D1_BUFFER_PRECISION.D2D1_BUFFER_PRECISION_32BPC_FLOAT;
+                D2D1_BUFFER_PRECISION d2D1BufferPrecision = D2D1_BUFFER_PRECISION._32bpcFloat;
 
                 // Set the channel precision to 32 bits manually to avoid banding
-                compositeEffect.Get()->SetValue((uint)D2D1_PROPERTY.D2D1_PROPERTY_PRECISION, (byte*)&d2D1BufferPrecision, sizeof(D2D1_BUFFER_PRECISION)).Assert();
+                compositeEffect.Get()->SetValue((uint)D2D1_PROPERTY.Precision, (byte*)&d2D1BufferPrecision, sizeof(D2D1_BUFFER_PRECISION)).Assert();
 
-                D2D1_COMPOSITE_MODE d2D1CompositeMode = D2D1_COMPOSITE_MODE.D2D1_COMPOSITE_MODE_PLUS;
+                D2D1_COMPOSITE_MODE d2D1CompositeMode = D2D1_COMPOSITE_MODE.Plus;
 
                 // Set the mode to plus
-                compositeEffect.Get()->SetValue((uint)D2D1_COMPOSITE_PROP.D2D1_COMPOSITE_PROP_MODE, (byte*)&d2D1CompositeMode, sizeof(D2D1_COMPOSITE_MODE)).Assert();
+                compositeEffect.Get()->SetValue((uint)D2D1_COMPOSITE_PROP.Mode, (byte*)&d2D1CompositeMode, sizeof(D2D1_COMPOSITE_MODE)).Assert();
             }
 
             ReadOnlyMemory<byte> pixels = ImageHelper.LoadBitmapFromFile(sourcePath, out uint width, out uint height);
@@ -452,8 +462,8 @@ public sealed partial class BokehBlurEffect
                 effect: inverseGammaExposureEffect.Get(),
                 targetOffset: null,
                 imageRectangle: null,
-                interpolationMode: D2D1_INTERPOLATION_MODE.D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
-                compositeMode: D2D1_COMPOSITE_MODE.D2D1_COMPOSITE_MODE_SOURCE_COPY);
+                interpolationMode: D2D1_INTERPOLATION_MODE.NearestNeighbor,
+                compositeMode: D2D1_COMPOSITE_MODE.SourceCopy);
 
             d2D1DeviceContext.Get()->EndDraw().Assert();
 

--- a/tests/ComputeSharp.D2D1.Tests/Effects/ZonePlateEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/ZonePlateEffect.cs
@@ -2,6 +2,13 @@
 
 namespace ComputeSharp.D2D1.Tests.Effects;
 
+#if !NETCOREAPP3_1_OR_GREATER 
+internal static class MathF
+{
+    public const float PI = (float)Math.PI;
+}
+#endif
+
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]

--- a/tests/ComputeSharp.D2D1.Tests/Extensions/ComPtrExtensions.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Extensions/ComPtrExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
-using TerraFX.Interop.Windows;
+using Win32;
 
 namespace ComputeSharp.D2D1.Tests.Extensions;
 
@@ -17,7 +17,7 @@ internal static class ComPtrExtensions
     /// <returns>The moved <see cref="ComPtr{T}"/> instance.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe ComPtr<T> Move<T>(this in ComPtr<T> ptr)
-        where T : unmanaged, IUnknown.Interface
+        where T : unmanaged
     {
         ComPtr<T> copy = default;
 

--- a/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
@@ -2,9 +2,10 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.D2D1.Tests.Extensions;
+
+using HRESULT = Win32.HResult;
 
 /// <summary>
 /// Helper methods to efficiently throw exceptions.

--- a/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
@@ -11,7 +11,7 @@ namespace ComputeSharp.D2D1.Tests.Extensions;
 /// </summary>
 /// <remarks>Trimmed down version of the same file in <c>ComputeSharp</c>.</remarks>
 [DebuggerStepThrough]
-internal static class HResultExtensions
+internal static class HRESULTExtensions
 {
     /// <summary>
     /// Throws a <see cref="Win32Exception"/> if <paramref name="result"/> represents an error.

--- a/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System.ComponentModel;
 using System.Diagnostics;
+#if NETCOREAPP3_1_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Runtime.CompilerServices;
 
 namespace ComputeSharp.D2D1.Tests.Extensions;
@@ -46,7 +48,9 @@ internal static class HRESULTExtensions
     /// Throws a <see cref="Win32Exception"/>.
     /// </summary>
     /// <param name="result">The input return code.</param>
+#if NETCOREAPP3_1_OR_GREATER
     [DoesNotReturn]
+#endif
     private static void ThrowWin32Exception(int result)
     {
         throw new Win32Exception(result);

--- a/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1Helper.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1Helper.cs
@@ -1,9 +1,32 @@
 ﻿using System;
+using System.Drawing;
 using ComputeSharp.D2D1.Tests.Extensions;
-using TerraFX.Interop.DirectX;
-using TerraFX.Interop.Windows;
+using Win32;
+using Win32.Graphics.Direct2D;
+using Win32.Graphics.Direct3D11;
+using Win32.Graphics.Dxgi;
 
 namespace ComputeSharp.D2D1.Tests.Helpers;
+
+using D2D1_ALPHA_MODE = Win32.Graphics.Direct2D.Common.AlphaMode;
+using D2D1_BITMAP_OPTIONS = Win32.Graphics.Direct2D.BitmapOptions;
+using D2D1_DEVICE_CONTEXT_OPTIONS = Win32.Graphics.Direct2D.DeviceContextOptions;
+using D2D1_FACTORY_OPTIONS = Win32.Graphics.Direct2D.FactoryOptions;
+using D2D1_FACTORY_TYPE = Win32.Graphics.Direct2D.FactoryType;
+using D2D1_INTERPOLATION_MODE = Win32.Graphics.Direct2D.InterpolationMode;
+using D2D1_COMPOSITE_MODE = Win32.Graphics.Direct2D.Common.CompositeMode;
+using D2D1_MAP_OPTIONS = Win32.Graphics.Direct2D.MapOptions;
+using D2D_RECT_U = Win32.Graphics.Direct2D.Common.RectU;
+using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
+using D2D1_BITMAP_PROPERTIES = Win32.Graphics.Direct2D.BitmapProperties;
+using D2D1_BITMAP_PROPERTIES1 = Win32.Graphics.Direct2D.BitmapProperties1;
+using D3D_FEATURE_LEVEL = Win32.Graphics.Direct3D.FeatureLevel;
+using D3D_DRIVER_TYPE = Win32.Graphics.Direct3D.DriverType;
+using D3D11_CREATE_DEVICE_FLAG = Win32.Graphics.Direct3D11.CreateDeviceFlags;
+using DXGI_FORMAT = Win32.Graphics.Dxgi.Common.Format;
+using Win32 = Win32.Apis;
+using D2D1 = Win32.Graphics.Direct2D.Apis;
+using D3D11 = Win32.Graphics.Direct3D11.Apis;
 
 /// <summary>
 /// A <see langword="class"/> that uses the D2D1 APIs to configure and run effects.
@@ -22,9 +45,9 @@ internal static class D2D1Helper
         D2D1_FACTORY_OPTIONS d2D1FactoryOptions = default;
 
         // Create a Direct2D factory
-        DirectX.D2D1CreateFactory(
-            factoryType: singleThreaded ? D2D1_FACTORY_TYPE.D2D1_FACTORY_TYPE_SINGLE_THREADED : D2D1_FACTORY_TYPE.D2D1_FACTORY_TYPE_MULTI_THREADED,
-            riid: Windows.__uuidof<ID2D1Factory2>(),
+        D2D1.D2D1CreateFactory(
+            factoryType: singleThreaded ? D2D1_FACTORY_TYPE.SingleThreaded : D2D1_FACTORY_TYPE.MultiThreaded,
+            riid: Win32.__uuidof<ID2D1Factory2>(),
             pFactoryOptions: &d2D1FactoryOptions,
             ppIFactory: (void**)d2D1Factory2.GetAddressOf()).Assert();
 
@@ -40,25 +63,24 @@ internal static class D2D1Helper
     {
         using ComPtr<ID3D11Device> d3D11Device = default;
 
-        uint creationFlags = (uint)D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_BGRA_SUPPORT;
         D3D_FEATURE_LEVEL* featureLevels = stackalloc[]
         {
-            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_11_1,
-            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_11_0,
-            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_10_1,
-            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_10_0,
-            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_9_3,
-            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_9_2,
-            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_9_1
+            D3D_FEATURE_LEVEL.Level_11_1,
+            D3D_FEATURE_LEVEL.Level_11_0,
+            D3D_FEATURE_LEVEL.Level_10_1,
+            D3D_FEATURE_LEVEL.Level_10_0,
+            D3D_FEATURE_LEVEL.Level_9_3,
+            D3D_FEATURE_LEVEL.Level_9_2,
+            D3D_FEATURE_LEVEL.Level_9_1
         };
         D3D_FEATURE_LEVEL d3DFeatureLevel;
 
         // Create the Direct3D 11 API device and context
-        DirectX.D3D11CreateDevice(
+        D3D11.D3D11CreateDevice(
             pAdapter: null,
-            DriverType: D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_HARDWARE,
-            Software: HMODULE.NULL,
-            Flags: creationFlags,
+            DriverType: D3D_DRIVER_TYPE.Hardware,
+            Software: IntPtr.Zero,
+            Flags: D3D11_CREATE_DEVICE_FLAG.BgraSupport,
             pFeatureLevels: featureLevels,
             FeatureLevels: 7,
             SDKVersion: D3D11.D3D11_SDK_VERSION,
@@ -92,7 +114,7 @@ internal static class D2D1Helper
 
         // Create a D2D1 device context
         d2D1Device->CreateDeviceContext(
-            options: D2D1_DEVICE_CONTEXT_OPTIONS.D2D1_DEVICE_CONTEXT_OPTIONS_NONE,
+            options: D2D1_DEVICE_CONTEXT_OPTIONS.None,
             deviceContext: d2D1DeviceContext.GetAddressOf()).Assert();
 
         return d2D1DeviceContext.Move();
@@ -116,13 +138,11 @@ internal static class D2D1Helper
     {
         using ComPtr<ID2D1Bitmap> d2D1BitmapSource = default;
 
-        D2D_SIZE_U d2DSize = default;
-        d2DSize.width = width;
-        d2DSize.height = height;
+        Size d2DSize = new((int)width, (int)height);
 
         D2D1_BITMAP_PROPERTIES d2DBitmapProperties = default;
-        d2DBitmapProperties.pixelFormat.format = DXGI_FORMAT.DXGI_FORMAT_B8G8R8A8_UNORM;
-        d2DBitmapProperties.pixelFormat.alphaMode = D2D1_ALPHA_MODE.D2D1_ALPHA_MODE_PREMULTIPLIED;
+        d2DBitmapProperties.pixelFormat.format = DXGI_FORMAT.B8G8R8A8Unorm;
+        d2DBitmapProperties.pixelFormat.alphaMode = D2D1_ALPHA_MODE.Premultiplied;
         d2DBitmapProperties.dpiX = 96;
         d2DBitmapProperties.dpiY = 96;
 
@@ -151,16 +171,12 @@ internal static class D2D1Helper
     /// <returns>A new <see cref="ID2D1Bitmap"/> instance.</returns>
     public static unsafe ComPtr<ID2D1Bitmap> CreateD2D1BitmapAndSetAsTarget(ID2D1DeviceContext* d2D1DeviceContext, uint width, uint height)
     {
-        D2D_SIZE_U d2DSize;
-        d2DSize.width = width;
-        d2DSize.height = height;
+        Size d2DSize = new((int)width, (int)height);
 
         D2D1_BITMAP_PROPERTIES1 d2DBitmapProperties1Target = default;
-        d2DBitmapProperties1Target.pixelFormat.format = DXGI_FORMAT.DXGI_FORMAT_B8G8R8A8_UNORM;
-        d2DBitmapProperties1Target.pixelFormat.alphaMode = D2D1_ALPHA_MODE.D2D1_ALPHA_MODE_PREMULTIPLIED;
-        d2DBitmapProperties1Target.bitmapOptions =
-            D2D1_BITMAP_OPTIONS.D2D1_BITMAP_OPTIONS_TARGET |
-            D2D1_BITMAP_OPTIONS.D2D1_BITMAP_OPTIONS_CANNOT_DRAW;
+        d2DBitmapProperties1Target.pixelFormat.format = DXGI_FORMAT.B8G8R8A8Unorm;
+        d2DBitmapProperties1Target.pixelFormat.alphaMode = D2D1_ALPHA_MODE.Premultiplied;
+        d2DBitmapProperties1Target.bitmapOptions = D2D1_BITMAP_OPTIONS.Target | D2D1_BITMAP_OPTIONS.CannotDraw;
 
         using ComPtr<ID2D1Bitmap> d2D1Bitmap1Target = default;
 
@@ -186,12 +202,12 @@ internal static class D2D1Helper
     /// <returns>A new <see cref="ID2D1Bitmap1"/> instance.</returns>
     public static unsafe ComPtr<ID2D1Bitmap1> CreateD2D1Bitmap1Buffer(ID2D1DeviceContext* d2D1DeviceContext, ID2D1Bitmap* d2D1Bitmap, out D2D1_MAPPED_RECT d2D1MappedRect)
     {
-        D2D_SIZE_U d2DSize = d2D1Bitmap->GetPixelSize();
+        Size d2DSize = d2D1Bitmap->GetPixelSize();
 
         D2D1_BITMAP_PROPERTIES1 d2DBitmapProperties1Buffer = default;
-        d2DBitmapProperties1Buffer.pixelFormat.format = DXGI_FORMAT.DXGI_FORMAT_B8G8R8A8_UNORM;
-        d2DBitmapProperties1Buffer.pixelFormat.alphaMode = D2D1_ALPHA_MODE.D2D1_ALPHA_MODE_PREMULTIPLIED;
-        d2DBitmapProperties1Buffer.bitmapOptions = D2D1_BITMAP_OPTIONS.D2D1_BITMAP_OPTIONS_CPU_READ | D2D1_BITMAP_OPTIONS.D2D1_BITMAP_OPTIONS_CANNOT_DRAW;
+        d2DBitmapProperties1Buffer.pixelFormat.format = DXGI_FORMAT.B8G8R8A8Unorm;
+        d2DBitmapProperties1Buffer.pixelFormat.alphaMode = D2D1_ALPHA_MODE.Premultiplied;
+        d2DBitmapProperties1Buffer.bitmapOptions = D2D1_BITMAP_OPTIONS.CpuRead | D2D1_BITMAP_OPTIONS.CannotDraw;
 
         using ComPtr<ID2D1Bitmap1> d2D1Bitmap1Buffer = default;
 
@@ -203,8 +219,12 @@ internal static class D2D1Helper
             bitmapProperties: &d2DBitmapProperties1Buffer,
             bitmap: d2D1Bitmap1Buffer.GetAddressOf()).Assert();
 
-        D2D_POINT_2U d2DPointDestination = default;
-        D2D_RECT_U d2DRectSource = new(0, 0, d2DSize.width, d2DSize.height);
+        Point d2DPointDestination = default;
+        D2D_RECT_U d2DRectSource = default;
+        d2DRectSource.top = 0;
+        d2DRectSource.left = 0;
+        d2DRectSource.right = (uint)d2DSize.Width;
+        d2DRectSource.bottom = (uint)d2DSize.Height;
 
         // Copy the image from the target to the readback bitmap
         d2D1Bitmap1Buffer.Get()->CopyFromBitmap(
@@ -216,7 +236,7 @@ internal static class D2D1Helper
         {
             // Map the buffer bitmap
             d2D1Bitmap1Buffer.Get()->Map(
-                options: D2D1_MAP_OPTIONS.D2D1_MAP_OPTIONS_READ,
+                options: D2D1_MAP_OPTIONS.Read,
                 mappedRect: d2D1MappedRectPtr).Assert();
         }
 
@@ -237,8 +257,8 @@ internal static class D2D1Helper
             effect: d2D1Effect,
             targetOffset: null,
             imageRectangle: null,
-            interpolationMode: D2D1_INTERPOLATION_MODE.D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
-            compositeMode: D2D1_COMPOSITE_MODE.D2D1_COMPOSITE_MODE_SOURCE_COPY);
+            interpolationMode: D2D1_INTERPOLATION_MODE.NearestNeighbor,
+            compositeMode: D2D1_COMPOSITE_MODE.SourceCopy);
 
         d2D1DeviceContext->EndDraw().Assert();
     }

--- a/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1TestRunner.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1TestRunner.cs
@@ -4,10 +4,12 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.Tests.Helpers;
-using TerraFX.Interop.DirectX;
-using TerraFX.Interop.Windows;
+using Win32;
+using Win32.Graphics.Direct2D;
 
 namespace ComputeSharp.D2D1.Tests.Helpers;
+
+using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
 
 /// <summary>
 /// A test helper for D2D1 pixel shaders.


### PR DESCRIPTION
### Description

This PR enables multi-targeting .NET Framework 4.7.2 and .NET Core 3.1 in all D2D1 unit tests.
It also fixes some issues in ComputeSharp.D2D1 when running on the .NET Standard 2.0 target.