### PR TITLE
Add support for instance methods in custom struct types

### DIFF
--- a/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
+++ b/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="..\ComputeSharp.ImageProcessing\Primitives\Complex64.cs" Link="Imaging\Primitives\Complex64.cs" />
+    <Compile Include="..\ComputeSharp.ImageProcessing\Primitives\ComplexVector4.cs" Link="Imaging\Primitives\ComplexVector4.cs" />
     <Compile Include="..\ComputeSharp.ImageProcessing\Processors\HlslBokehBlurProcessor.cs" Link="Imaging\Processors\HlslBokehBlurProcessor.cs" />
     <Compile Include="..\ComputeSharp.ImageProcessing\Processors\HlslBokehBlurProcessor{TPixel}.cs" Link="Imaging\Processors\HlslBokehBlurProcessor{TPixel}.cs" />
     <Compile Include="..\ComputeSharp.ImageProcessing\Processors\HlslGaussianBlurProcessor.cs" Link="Imaging\Processors\HlslGaussianBlurProcessor.cs" />

--- a/samples/ComputeSharp.ImageProcessing/Primitives/ComplexVector4.cs
+++ b/samples/ComputeSharp.ImageProcessing/Primitives/ComplexVector4.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Six Labors.
+// Licensed under the Apache License, Version 2.0.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace SixLabors.ImageSharp;
+
+/// <summary>
+/// A vector with 4 values of type <see cref="Complex64"/>.
+/// </summary>
+internal struct ComplexVector4
+{
+    /// <summary>
+    /// The real part of the complex vector
+    /// </summary>
+    public Vector4 Real;
+
+    /// <summary>
+    /// The imaginary part of the complex number
+    /// </summary>
+    public Vector4 Imaginary;
+
+    /// <summary>
+    /// Performs a weighted sum on the current instance according to the given parameters
+    /// </summary>
+    /// <param name="a">The 'a' parameter, for the real component</param>
+    /// <param name="b">The 'b' parameter, for the imaginary component</param>
+    /// <returns>The resulting <see cref="Vector4"/> value</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Vector4 WeightedSum(float a, float b) => (this.Real * a) + (this.Imaginary * b);
+}

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor{TPixel}.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor{TPixel}.cs
@@ -363,13 +363,12 @@ public sealed partial class HlslBokehBlurProcessor
             /// <inheritdoc/>
             public void Execute()
             {
-                float4 real = float4.Zero;
-                float4 imaginary = float4.Zero;
                 int maxY = target.Height;
                 int maxX = target.Width;
                 int kernelLength = kernel.Length;
                 int radiusX = kernelLength >> 1;
                 int offsetY = Hlsl.Clamp(ThreadIds.Y, 0, maxY);
+                ComplexVector4 result = default;
 
                 for (int i = 0; i < kernelLength; i++)
                 {
@@ -378,11 +377,11 @@ public sealed partial class HlslBokehBlurProcessor
                     float4 sourceImaginary = imaginaries[offsetX, offsetY];
                     Complex64 factors = kernel[i];
 
-                    real += factors.Real * sourceReal - factors.Imaginary * sourceImaginary;
-                    imaginary += factors.Real * sourceImaginary + factors.Imaginary * sourceReal;
+                    result.Real += (Vector4)(factors.Real * sourceReal - factors.Imaginary * sourceImaginary);
+                    result.Imaginary += (Vector4)(factors.Real * sourceImaginary + factors.Imaginary * sourceReal);
                 }
 
-                target[ThreadIds.XY] += real * z + imaginary * w;
+                target[ThreadIds.XY] += (float4)result.WeightedSum(z, w);
             }
         }
 

--- a/src/ComputeSharp.SourceGenerators/ShaderMethodSourceGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ShaderMethodSourceGenerator.cs
@@ -84,11 +84,12 @@ public sealed partial class ShaderMethodSourceGenerator : IIncrementalGenerator
             // We need to sets to track all discovered custom types and static methods
             HashSet<INamedTypeSymbol> discoveredTypes = new(SymbolEqualityComparer.Default);
             Dictionary<IFieldSymbol, string> constantDefinitions = new(SymbolEqualityComparer.Default);
+            Dictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods = new(SymbolEqualityComparer.Default); // Unused in this generator
 
             // Explore the syntax tree and extract the processed info
             var semanticModel = new SemanticModelProvider(compilation);
             var (entryPoint, dependentMethods) = GetProcessedMethods(builder, methodDeclaration, semanticModel, discoveredTypes, constantDefinitions);
-            var definedTypes = IShaderGenerator.BuildHlslSource.GetDeclaredTypes(builder, methodSymbol, discoveredTypes);
+            var definedTypes = IShaderGenerator.BuildHlslSource.GetDeclaredTypes(builder, methodSymbol, discoveredTypes, instanceMethods);
             var definedConstants = IShaderGenerator.BuildHlslSource.GetDefinedConstants(constantDefinitions);
 
             diagnostics = builder.ToImmutable();
@@ -118,8 +119,9 @@ public sealed partial class ShaderMethodSourceGenerator : IIncrementalGenerator
             IDictionary<IFieldSymbol, string> constantDefinitions)
         {
             Dictionary<IMethodSymbol, MethodDeclarationSyntax> staticMethods = new(SymbolEqualityComparer.Default);
+            Dictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods = new(SymbolEqualityComparer.Default);
 
-            ShaderSourceRewriter shaderSourceRewriter = new(semanticModel, discoveredTypes, staticMethods, constantDefinitions, diagnostics);
+            ShaderSourceRewriter shaderSourceRewriter = new(semanticModel, discoveredTypes, staticMethods, instanceMethods, constantDefinitions, diagnostics);
 
             // Process the possible syntax nodes
             SyntaxNode visitedMethod = methodDeclaration switch

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -26,6 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\samples\ComputeSharp.ImageProcessing\Primitives\Complex64.cs" Link="Imaging\Primitives\Complex64.cs" />
+    <Compile Include="..\..\samples\ComputeSharp.ImageProcessing\Primitives\ComplexVector4.cs" Link="Imaging\Primitives\ComplexVector4.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="Assets\Landscape.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
@@ -9,6 +9,7 @@ using ComputeSharp.D2D1;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Tests.Extensions;
 using ComputeSharp.D2D1.Tests.Helpers;
+using SixLabors.ImageSharp;
 using Win32;
 using Win32.Graphics.Direct2D;
 
@@ -568,10 +569,9 @@ public sealed partial class BokehBlurEffect
             /// <inheritdoc/>
             public float4 Execute()
             {
-                float4 real = float4.Zero;
-                float4 imaginary = float4.Zero;
                 int length = this.kernelLength;
                 int radiusX = length >> 1;
+                ComplexVector4 result = default;
 
                 for (int i = 0; i < length; i++)
                 {
@@ -580,11 +580,11 @@ public sealed partial class BokehBlurEffect
                     float realFactor = kernelReals[i];
                     float imaginaryFactor = kernelImaginaries[i];
 
-                    real += realFactor * sourceReal - imaginaryFactor * sourceImaginary;
-                    imaginary += realFactor * sourceImaginary + imaginaryFactor * sourceReal;
+                    result.Real += (Vector4)(realFactor * sourceReal - imaginaryFactor * sourceImaginary);
+                    result.Imaginary += (Vector4)(realFactor * sourceImaginary + imaginaryFactor * sourceReal);
                 }
 
-                return real * z + imaginary * w;
+                return result.WeightedSum(z, w);
             }
         }
     }
@@ -632,41 +632,5 @@ public sealed partial class BokehBlurEffect
 
             return pixel;
         }
-    }
-
-    /// <summary>
-    /// Represents a complex number, where the real and imaginary parts are stored as <see cref="float"/> values.
-    /// </summary>
-    private readonly struct Complex64
-    {
-        /// <summary>
-        /// The real part of the complex number.
-        /// </summary>
-        public readonly float Real;
-
-        /// <summary>
-        /// The imaginary part of the complex number.
-        /// </summary>
-        public readonly float Imaginary;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Complex64"/> struct.
-        /// </summary>
-        /// <param name="real">The real part in the complex number.</param>
-        /// <param name="imaginary">The imaginary part in the complex number.</param>
-        public Complex64(float real, float imaginary)
-        {
-            this.Real = real;
-            this.Imaginary = imaginary;
-        }
-
-        /// <summary>
-        /// Performs the multiplication operation between a <see cref="Complex64"/> instance and a <see cref="float"/> scalar.
-        /// </summary>
-        /// <param name="value">The <see cref="Complex64"/> value to multiply.</param>
-        /// <param name="scalar">The <see cref="float"/> scalar to use to multiply the <see cref="Complex64"/> value.</param>
-        /// <returns>The <see cref="Complex64"/> result.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Complex64 operator *(Complex64 value, float scalar) => new(value.Real * scalar, value.Imaginary * scalar);
     }
 }

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <Compile Include="..\..\samples\ComputeSharp.ImageProcessing\Primitives\Complex64.cs" Link="Imaging\Primitives\Complex64.cs" />
+    <Compile Include="..\..\samples\ComputeSharp.ImageProcessing\Primitives\ComplexVector4.cs" Link="Imaging\Primitives\ComplexVector4.cs" />
     <Compile Include="..\..\samples\ComputeSharp.ImageProcessing\Processors\HlslBokehBlurProcessor.cs" Link="Imaging\Processors\HlslBokehBlurProcessor.cs" />
     <Compile Include="..\..\samples\ComputeSharp.ImageProcessing\Processors\HlslBokehBlurProcessor{TPixel}.cs" Link="Imaging\Processors\HlslBokehBlurProcessor{TPixel}.cs" />
     <Compile Include="..\..\samples\ComputeSharp.ImageProcessing\Processors\HlslGaussianBlurProcessor.cs" Link="Imaging\Processors\HlslGaussianBlurProcessor.cs" />

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -416,6 +416,55 @@ namespace ComputeSharp.Tests
                 return default;
             }
         }
+
+        [TestMethod]
+        public void StructInstanceMethods()
+        {
+            _ = ReflectionServices.GetShaderInfo<StructInstanceMethodsShader>();
+        }
+
+        public struct MyStructTypeA
+        {
+            public int A;
+            public float B;
+
+            public float Sum()
+            {
+                return A + Bar();
+            }
+
+            public float Bar() => this.B;
+        }
+
+        public struct MyStructTypeB
+        {
+            public MyStructTypeA A;
+            public float B;
+
+            public float Combine()
+            {
+                return A.Sum() + this.B;
+            }
+        }
+
+        [AutoConstructor]
+        internal readonly partial struct StructInstanceMethodsShader : IComputeShader
+        {
+            public readonly MyStructTypeA a;
+            public readonly MyStructTypeB b;
+            public readonly ReadWriteBuffer<MyStructTypeA> bufferA;
+            public readonly ReadWriteBuffer<MyStructTypeB> bufferB;
+            public readonly ReadWriteBuffer<float> results;
+
+            /// <inheritdoc/>
+            public void Execute()
+            {
+                float result1 = a.Sum() + a.Bar();
+                float result2 = b.Combine();
+
+                results[ThreadIds.X] = result1 + result2 + bufferA[ThreadIds.X].Sum() + bufferB[0].Combine();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Closes #390

### Description

This PR adds support for instance methods in custom struct types used in shaders. Applies both to DX12 and D2D1.

![image](https://user-images.githubusercontent.com/10199417/193462779-0f1a0f34-b4bf-4b72-baa1-6bbb3836a7de.png)