### PR TITLE
Add diagnostic for missing [D2DInputCount] attribute

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -64,3 +64,4 @@ CMPSD2D0054 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0055 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0056 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0057 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0058 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -737,7 +737,7 @@ partial class DiagnosticDescriptors
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidResourceTextureElementType = new DiagnosticDescriptor(
         id: "CMPSD2D0051",
-        title: "Missing [D2DResourceTextureIndex] attribute",
+        title: "Invalid D2D1 resource texture element type",
         messageFormat: "The field \"{0}\" (in type {1}) using a D2D1 resource texture of type {2} has an invalid element type (only float and float4 type arguments are supported)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
@@ -839,5 +839,21 @@ partial class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Methods using using [D2DPixelShaderSource] must use ReadOnlySpan<byte> as the return type.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[D2DInputCount]</c> attribute is missing.
+    /// <para>
+    /// Format: <c>"The D2D1 shader of type {0} is not annotated with the [D2DInputCount] attribute (it is mandatory for all D2D1 shader types)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor MissingD2DInputCountAttribute = new DiagnosticDescriptor(
+        id: "CMPSD2D0058",
+        title: "Missing [D2DResourceTextureIndex] attribute",
+        messageFormat: "The D2D1 shader of type {0} is not annotated with the [D2DInputCount] attribute (it is mandatory for all D2D1 shader types)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A D2D1 shader must be annotated with the [D2DInputCount] attribute.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetInputTypeMethod.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateGetInputTypeMethod.cs
@@ -37,6 +37,7 @@ partial class ID2D1ShaderGenerator
             // diagnostics to, but without returning invalid values to the caller which
             // might cause generator errors (eg. -1 would cause other code to just throw).
             int rawInputCount = 0;
+            bool isInputCountPresent = false;
 
             inputCount = 0;
 
@@ -50,6 +51,7 @@ partial class ID2D1ShaderGenerator
                     case "ComputeSharp.D2D1.D2DInputCountAttribute":
                         rawInputCount = (int)attributeData.ConstructorArguments[0].Value!;
                         inputCount = Math.Max(rawInputCount, 0);
+                        isInputCountPresent = true;
                         break;
                     case "ComputeSharp.D2D1.D2DInputSimpleAttribute":
                         inputSimpleIndicesBuilder.Add((int)attributeData.ConstructorArguments[0].Value!);
@@ -65,6 +67,14 @@ partial class ID2D1ShaderGenerator
             inputSimpleIndices = inputSimpleIndicesBuilder.ToImmutable();
             inputComplexIndices = inputComplexIndicesBuilder.ToImmutable();
             combinedInputTypes = ImmutableArray<uint>.Empty;
+
+            // Ensure that the input count is present
+            if (!isInputCountPresent)
+            {
+                diagnostics.Add(MissingD2DInputCountAttribute, structDeclarationSymbol, structDeclarationSymbol);
+
+                return;
+            }
 
             // Validate the input count
             if (rawInputCount is not (>= 0 and <= 8))

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -45,6 +45,7 @@ public partial class D2D1PixelShaderEffectTests
         {
         }
 
+        [D2DInputCount(0)]
         public partial struct Shader : ID2D1PixelShader
         {
             public float4 Execute() => default;

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureUninitializedFieldDiagnosticSuppressorTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureUninitializedFieldDiagnosticSuppressorTests.cs
@@ -5,6 +5,7 @@
 /// </summary>
 internal sealed partial class D2D1ResourceTextureUninitializedFieldDiagnosticSuppressorTests
 {
+    [D2DInputCount(0)]
     public readonly partial struct MyShader : ID2D1PixelShader
     {
         // This test just needs to validate the project builds fine with this shader.


### PR DESCRIPTION
### Description

This PR adds a new diagnostic error when a D2D shader isn't annotated with `[D2DInputCount]`