### PR TITLE
Only emit raw multiline string literals when possible

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateBuildHlslSourceMethod.Syntax.cs
@@ -1,5 +1,6 @@
 ﻿using ComputeSharp.D2D1.__Internals;
 using ComputeSharp.SourceGeneration.Helpers;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -19,9 +20,16 @@ partial class ID2D1ShaderGenerator
         /// </summary>
         /// <param name="hlslSource">The input HLSL source.</param>
         /// <param name="hierarchyDepth">The depth of the hierarchy for this type (used to calculate the right indentation).</param>
+        /// <param name="useRawMultiLineStringLiteralExpression">Whether to use a raw multiline string literal expression</param>
         /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the <c>BuildHlslSource</c> method.</returns>
-        public static MethodDeclarationSyntax GetSyntax(string hlslSource, int hierarchyDepth)
+        public static MethodDeclarationSyntax GetSyntax(string hlslSource, int hierarchyDepth, bool useRawMultiLineStringLiteralExpression)
         {
+            SyntaxToken hlslSourceLiteralExpression = useRawMultiLineStringLiteralExpression switch
+            {
+                true => SyntaxTokenHelper.CreateRawMultilineStringLiteral(hlslSource, hierarchyDepth),
+                false => Literal(hlslSource)
+            };
+
             // This code produces a method declaration as follows:
             //
             // readonly void global::ComputeSharp.D2D1.__Internals.ID2D1Shader.BuildHlslSource(out string hlslSource)
@@ -38,9 +46,7 @@ partial class ID2D1ShaderGenerator
                     AssignmentExpression(
                         SyntaxKind.SimpleAssignmentExpression,
                         IdentifierName("hlslSource"),
-                        LiteralExpression(
-                            SyntaxKind.StringLiteralExpression,
-                            SyntaxTokenHelper.CreateRawMultilineStringLiteral(hlslSource, hierarchyDepth))))));
+                        LiteralExpression(SyntaxKind.StringLiteralExpression, hlslSourceLiteralExpression)))));
         }
     }
 }

--- a/src/ComputeSharp.SourceGeneration/ComputeSharp.SourceGeneration.projitems
+++ b/src/ComputeSharp.SourceGeneration/ComputeSharp.SourceGeneration.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AttributeDataExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\IncrementalValueProviderExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CompilationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\DiagnosticsExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\HashCodeExtensions.cs" />

--- a/src/ComputeSharp.SourceGeneration/Extensions/IncrementalValueProviderExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/IncrementalValueProviderExtensions.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.SourceGeneration.Extensions;
+
+/// <summary>
+/// Extension methods for the <see cref="IncrementalValueProvider{TValue}"/> type.
+/// </summary>
+internal static class IncrementalValueProviderExtensions
+{
+    /// <summary>
+    /// Combines three <see cref="IncrementalValueProvider{TValue}"/> instances.
+    /// </summary>
+    /// <typeparam name="T1">The type of values produced by the first <see cref="IncrementalValueProvider{TValue}"/> input.</typeparam>
+    /// <typeparam name="T2">The type of values produced by the second <see cref="IncrementalValueProvider{TValue}"/> input.</typeparam>
+    /// <typeparam name="T3">The type of values produced by the third <see cref="IncrementalValueProvider{TValue}"/> input.</typeparam>
+    /// <param name="source1">The first <see cref="IncrementalValueProvider{TValue}"/> input.</param>
+    /// <param name="source2">The second <see cref="IncrementalValueProvider{TValue}"/> input.</param>
+    /// <param name="source3">The third <see cref="IncrementalValueProvider{TValue}"/> input.</param>
+    /// <returns>The resulting combined <see cref="IncrementalValueProvider{TValue}"/> result.</returns>
+    public static IncrementalValueProvider<(T1, T2, T3)> Combine<T1, T2, T3>(
+        this IncrementalValueProvider<T1> source1,
+        IncrementalValueProvider<T2> source2,
+        IncrementalValueProvider<T3> source3)
+    {
+        return
+            source1
+            .Combine(source2)
+            .Combine(source3)
+            .Select(static (items, _) => (items.Left.Left, items.Left.Right, items.Right));
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a check before using raw multiline string literals, making ComputeSharp usable on C# 10 as well.
