### PR TITLE
Bump D3D12MA to 2.0.1.1

### DIFF
--- a/src/ComputeSharp/ComputeSharp.csproj
+++ b/src/ComputeSharp/ComputeSharp.csproj
@@ -24,7 +24,7 @@
 
   <!-- .NET 6 uses the NuGet packages for TerraFX -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="TerraFX.Interop.D3D12MemoryAllocator" Version="2.0.1" />
+    <PackageReference Include="TerraFX.Interop.D3D12MemoryAllocator" Version="2.0.1.1" />
   </ItemGroup>
 
   <!-- .NET Standard 2.0 uses a local fork -->

--- a/src/ComputeSharp/Graphics/Extensions/Interop/IWICStreamExtensions.IBufferWriter.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/IWICStreamExtensions.IBufferWriter.cs
@@ -3,6 +3,10 @@ using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+#if NET6_0_OR_GREATER
+using CommunityToolkit.Diagnostics;
+using TerraFX.Interop;
+#endif
 using TerraFX.Interop.Windows;
 using static TerraFX.Interop.Windows.E;
 using static TerraFX.Interop.Windows.IID;
@@ -46,7 +50,10 @@ unsafe partial class IWICStreamExtensions
         : IUnknown.Interface
 #endif
     {
-#if !NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
+        /// <inheritdoc/>
+        static Guid* INativeGuid.NativeGuid => (Guid*)ThrowHelper.ThrowNotSupportedException<nint>();
+#else
         /// <inheritdoc cref="QueryInterface"/>
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate int QueryInterfaceDelegate(IBufferWriterWrapper* @this, Guid* riid, void** ppvObject);

--- a/src/ComputeSharp/Graphics/Extensions/Interop/IWICStreamExtensions.Stream.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/IWICStreamExtensions.Stream.cs
@@ -4,6 +4,9 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using CommunityToolkit.Diagnostics;
+#if NET6_0_OR_GREATER
+using TerraFX.Interop;
+#endif
 using TerraFX.Interop.Windows;
 using static TerraFX.Interop.Windows.E;
 using static TerraFX.Interop.Windows.IID;
@@ -49,7 +52,10 @@ internal static unsafe partial class IWICStreamExtensions
         : IUnknown.Interface
 #endif
     {
-#if !NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
+        /// <inheritdoc/>
+        static Guid* INativeGuid.NativeGuid => (Guid*)ThrowHelper.ThrowNotSupportedException<nint>();
+#else
         /// <inheritdoc cref="QueryInterface"/>
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         private delegate int QueryInterfaceDelegate(IStreamWrapper* @this, Guid* riid, void** ppvObject);


### PR DESCRIPTION
### Description

This PR bumps D3D12MA to 2.0.1.1 and includes some fixups for new TerraFX changes.