### PR TITLE
Add D2D1ShaderInfo.D3DFeatureLevel property, unit tests

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -97,6 +97,6 @@ public static class D2D1ReflectionServices
             MovInstructionCount: d3D11ShaderReflection.Get()->GetMovInstructionCount(),
             InterfaceSlotCount: d3D11ShaderReflection.Get()->GetNumInterfaceSlots(),
             RequiresDoublePrecisionSupport: (d3D11ShaderReflection.Get()->GetRequiresFlags() & (D3D.D3D_SHADER_REQUIRES_DOUBLES | D3D.D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS)) != 0,
-            FeatureLevel: (D3DFeatureLevel)d3DFeatureLevel);
+            MinimumFeatureLevel: (D3DFeatureLevel)d3DFeatureLevel);
     }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -67,6 +67,10 @@ public static class D2D1ReflectionServices
 
         d3D11ShaderReflection.Get()->GetDesc(&d3D11ShaderDescription).Assert();
 
+        D3D_FEATURE_LEVEL d3DFeatureLevel = default;
+
+        d3D11ShaderReflection.Get()->GetMinFeatureLevel(&d3DFeatureLevel).Assert();
+
         return new(
             CompilerVersion: new string(d3D11ShaderDescription.Creator),
             HlslSource: hlslSource,
@@ -92,6 +96,7 @@ public static class D2D1ReflectionServices
             MovcInstructionCount: d3D11ShaderReflection.Get()->GetMovcInstructionCount(),
             MovInstructionCount: d3D11ShaderReflection.Get()->GetMovInstructionCount(),
             InterfaceSlotCount: d3D11ShaderReflection.Get()->GetNumInterfaceSlots(),
-            RequiresDoublePrecisionSupport: (d3D11ShaderReflection.Get()->GetRequiresFlags() & (D3D.D3D_SHADER_REQUIRES_DOUBLES | D3D.D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS)) != 0);
+            RequiresDoublePrecisionSupport: (d3D11ShaderReflection.Get()->GetRequiresFlags() & (D3D.D3D_SHADER_REQUIRES_DOUBLES | D3D.D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS)) != 0,
+            FeatureLevel: (D3DFeatureLevel)d3DFeatureLevel);
     }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderInfo.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderInfo.cs
@@ -28,7 +28,7 @@ namespace ComputeSharp.D2D1.Interop;
 /// <param name="MovInstructionCount">The number of <c>mov</c> instructions used.</param>
 /// <param name="InterfaceSlotCount">The number of interface slots used.</param>
 /// <param name="RequiresDoublePrecisionSupport">Indicates whether support for double precision floating point numbers is required.</param>
-/// <param name="FeatureLevel">The feature level for the shader.</param>
+/// <param name="MinimumFeatureLevel">The minimum feature level for the shader.</param>
 public sealed record D2D1ShaderInfo(
     string CompilerVersion,
     string HlslSource,
@@ -55,4 +55,4 @@ public sealed record D2D1ShaderInfo(
     uint MovInstructionCount,
     uint InterfaceSlotCount,
     bool RequiresDoublePrecisionSupport,
-    D3DFeatureLevel FeatureLevel);
+    D3DFeatureLevel MinimumFeatureLevel);

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderInfo.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ShaderInfo.cs
@@ -28,6 +28,7 @@ namespace ComputeSharp.D2D1.Interop;
 /// <param name="MovInstructionCount">The number of <c>mov</c> instructions used.</param>
 /// <param name="InterfaceSlotCount">The number of interface slots used.</param>
 /// <param name="RequiresDoublePrecisionSupport">Indicates whether support for double precision floating point numbers is required.</param>
+/// <param name="FeatureLevel">The feature level for the shader.</param>
 public sealed record D2D1ShaderInfo(
     string CompilerVersion,
     string HlslSource,
@@ -53,4 +54,5 @@ public sealed record D2D1ShaderInfo(
     uint MovcInstructionCount,
     uint MovInstructionCount,
     uint InterfaceSlotCount,
-    bool RequiresDoublePrecisionSupport);
+    bool RequiresDoublePrecisionSupport,
+    D3DFeatureLevel FeatureLevel);

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D3DFeatureLevel.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D3DFeatureLevel.cs
@@ -1,0 +1,69 @@
+using static TerraFX.Interop.DirectX.D3D_FEATURE_LEVEL;
+
+namespace ComputeSharp.D2D1.Interop;
+
+/// <summary>
+/// Describes the set of features targeted by a Direct3D device.
+/// </summary>
+public enum D3DFeatureLevel
+{
+    /// <summary>
+    /// Allows Microsoft Compute Driver Model (MCDM) devices to be used, or more feature-rich devices (such as
+    /// traditional GPUs) that support a superset of the functionality. MCDM is the overall driver model for
+    /// compute-only; it's a scaled-down peer of the larger scoped Windows Device Driver Model (WDDM).
+    /// </summary>
+    FeatureLevel1_0Core = D3D_FEATURE_LEVEL_1_0_CORE,
+
+    /// <summary>
+    /// Targets features supported by <see href="https://learn.microsoft.com/windows/win32/direct3d11/overviews-direct3d-11-devices-downlevel-intro">feature level</see> 9.1, including shader model 2.
+    /// </summary>
+    FeatureLevel9_1 = D3D_FEATURE_LEVEL_9_1,
+
+    /// <summary>
+    /// Targets features supported by <see href="https://learn.microsoft.com/windows/win32/direct3d11/overviews-direct3d-11-devices-downlevel-intro">feature level</see> 9.2, including shader model 2.
+    /// </summary>
+    FeatureLevel9_2 = D3D_FEATURE_LEVEL_9_2,
+
+    /// <summary>
+    /// Targets features supported by <see href="https://learn.microsoft.com/windows/win32/direct3d11/overviews-direct3d-11-devices-downlevel-intro">feature level</see> 9.3, including shader model 2.
+    /// </summary>
+    FeatureLevel9_3 = D3D_FEATURE_LEVEL_9_3,
+
+    /// <summary>
+    /// Targets features supported by Direct3D 10.0, including shader model 4.
+    /// </summary>
+    FeatureLevel10 = D3D_FEATURE_LEVEL_10_0,
+
+    /// <summary>
+    /// Targets features supported by Direct3D 10.1, including shader model 4.
+    /// </summary>
+    FeatureLevel10_1 = D3D_FEATURE_LEVEL_10_1,
+
+    /// <summary>
+    /// Targets features supported by Direct3D 11.0, including shader model 5.
+    /// </summary>
+    FeatureLevel11_0 = D3D_FEATURE_LEVEL_11_0,
+
+    /// <summary>
+    /// Targets features supported by Direct3D 11.1, including shader model 5 and logical blend operations. This
+    /// feature level requires a display driver that is at least implemented to WDDM for Windows 8 (WDDM 1.2).
+    /// </summary>
+    FeatureLevel11_1 = D3D_FEATURE_LEVEL_11_1,
+
+    /// <summary>
+    /// Targets features supported by Direct3D 12.0, including shader model 5.
+    /// </summary>
+    FeatureLevel12 = D3D_FEATURE_LEVEL_12_0,
+
+    /// <summary>
+    /// Targets features supported by Direct3D 12.1, including shader model 5.
+    /// </summary>
+    FeatureLevel12_1 = D3D_FEATURE_LEVEL_12_1,
+
+    /// <summary>
+    /// Targets features supported by Direct3D 12.2, including shader model 6.5. For more information about feature
+    /// level 12_2, see its <see href="https://microsoft.github.io/DirectX-Specs/d3d/D3D12_FeatureLevel12_2.html">specification page</see>.
+    /// Feature level 12_2 is available in Windows SDK builds 20170 and later.
+    /// </summary>
+    FeatureLevel12_2 = D3D_FEATURE_LEVEL_12_2
+}

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D3DFeatureLevel.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D3DFeatureLevel.cs
@@ -12,7 +12,7 @@ public enum D3DFeatureLevel
     /// traditional GPUs) that support a superset of the functionality. MCDM is the overall driver model for
     /// compute-only; it's a scaled-down peer of the larger scoped Windows Device Driver Model (WDDM).
     /// </summary>
-    FeatureLevel1_0Core = D3D_FEATURE_LEVEL_1_0_CORE,
+    FeatureLevel1_0_Core = D3D_FEATURE_LEVEL_1_0_CORE,
 
     /// <summary>
     /// Targets features supported by <see href="https://learn.microsoft.com/windows/win32/direct3d11/overviews-direct3d-11-devices-downlevel-intro">feature level</see> 9.1, including shader model 2.
@@ -32,7 +32,7 @@ public enum D3DFeatureLevel
     /// <summary>
     /// Targets features supported by Direct3D 10.0, including shader model 4.
     /// </summary>
-    FeatureLevel10 = D3D_FEATURE_LEVEL_10_0,
+    FeatureLevel10_0 = D3D_FEATURE_LEVEL_10_0,
 
     /// <summary>
     /// Targets features supported by Direct3D 10.1, including shader model 4.
@@ -53,7 +53,7 @@ public enum D3DFeatureLevel
     /// <summary>
     /// Targets features supported by Direct3D 12.0, including shader model 5.
     /// </summary>
-    FeatureLevel12 = D3D_FEATURE_LEVEL_12_0,
+    FeatureLevel12_0 = D3D_FEATURE_LEVEL_12_0,
 
     /// <summary>
     /// Targets features supported by Direct3D 12.1, including shader model 5.

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
@@ -96,7 +96,8 @@ internal unsafe partial struct PixelShaderEffect
 
             // If E_INVALIDARG was returned, try to check whether double precision support was requested when not available. This
             // is only done to provide a more helpful error message to callers. If no error was returned, the behavior is the same.
-            if (hresult == E.E_INVALIDARG && !effectContext->IsShaderNotSupported(@this->bytecode, @this->bytecodeSize))
+            // If any error is detected while trying to check for shader support, ignore the value and propagate the current HRESULT.
+            if (hresult == E.E_INVALIDARG && effectContext->IsShaderSupported(@this->bytecode, @this->bytecodeSize) == S.S_FALSE)
             {
                 hresult = D2DERR.D2DERR_INSUFFICIENT_DEVICE_CAPABILITIES;
             }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.ID2D1ResourceTextureManagerInternal.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.ID2D1ResourceTextureManagerInternal.cs
@@ -113,7 +113,7 @@ partial struct D2D1ResourceTextureManagerImpl
                 {
                     using ComPtr<ID2D1Multithread> d2D1Multithread = default;
 
-                    int hresult = effectContext->GetD2D1Multithread(d2D1Multithread.GetAddressOf());
+                    HRESULT hresult = effectContext->GetD2D1Multithread(d2D1Multithread.GetAddressOf());
 
                     // If an ID2D1Multithread object is available, we can safely store the context. That
                     // is, under the condition that the required multithread support is also available.

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Extensions/ID2D1EffectContextExtensions.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Extensions/ID2D1EffectContextExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using ComputeSharp.D2D1.Extensions;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 
@@ -8,7 +9,7 @@ namespace ComputeSharp.D2D1.Shaders.Interop.Extensions;
 /// <summary>
 /// Extensions for the <see cref="ID2D1Multithread"/> type.
 /// </summary>
-internal static class ID2D1EffectContextExtensions
+internal static unsafe class ID2D1EffectContextExtensions
 {
     /// <summary>
     /// Gets an <see cref="ID2D1Multithread"/> from an input <see cref="ID2D1EffectContext"/> object.
@@ -37,7 +38,7 @@ internal static class ID2D1EffectContextExtensions
     /// be cast to <see cref="ID2D1Multithread"/>, which can then be kept and used to synchronize later calls.
     /// </para>
     /// </remarks>
-    public static unsafe int GetD2D1Multithread(this ref ID2D1EffectContext effectContext, ID2D1Multithread** multithread)
+    public static int GetD2D1Multithread(this ref ID2D1EffectContext effectContext, ID2D1Multithread** multithread)
     {
         using ComPtr<ID2D1Effect> floodEffect = default;
 
@@ -62,5 +63,76 @@ internal static class ID2D1EffectContextExtensions
         }
 
         return hresult;
+    }
+
+    /// <summary>
+    /// Checks whether the input shader is not supported by the target <see cref="ID2D1EffectContext"/> instance.
+    /// </summary>
+    /// <param name="effectContext">The input <see cref="ID2D1EffectContext"/> instance.</param>
+    /// <param name="bytecode">The shader bytecode.</param>
+    /// <param name="bytecodeSize">The size of <paramref name="bytecode"/>.</param>
+    /// <returns>Whether the shader is not supported.</returns>
+    /// <remarks>If any calls needed to check support fail, the method will also return <see langword="false"/>.</remarks>
+    public static bool IsShaderNotSupported(this ref ID2D1EffectContext effectContext, byte* bytecode, int bytecodeSize)
+    {
+        using ComPtr<ID3D11ShaderReflection> d3D11ShaderReflection = default;
+
+        // Create the reflection instance, and in case of error just return the previous error like above
+        if (!Windows.SUCCEEDED(DirectX.D3DReflect(
+            pSrcData: bytecode,
+            SrcDataSize: (uint)bytecodeSize,
+            pInterface: Windows.__uuidof<ID3D11ShaderReflection>(),
+            ppReflector: d3D11ShaderReflection.GetVoidAddressOf())))
+        {
+            return false;
+        }
+
+        D3D_FEATURE_LEVEL d3DMinFeatureLevel;
+
+        // Get the minimum feature level for the shader (in case of errors, just return the previous result again)
+        if (!Windows.SUCCEEDED(d3D11ShaderReflection.Get()->GetMinFeatureLevel(&d3DMinFeatureLevel)))
+        {
+            return false;
+        }
+
+        D3D_FEATURE_LEVEL d3DMaxFeatureLevel;
+
+        // Check whether the current context supports the minimum feature level
+        HRESULT hresultMaximumSupportedFeatureLevel = effectContext.GetMaximumSupportedFeatureLevel(
+            featureLevels: &d3DMinFeatureLevel,
+            featureLevelsCount: 1,
+            maximumSupportedFeatureLevel: &d3DMaxFeatureLevel);
+
+        // If the context doesn't match the required feature level, return that as an error
+        if (hresultMaximumSupportedFeatureLevel == D2DERR.D2DERR_INSUFFICIENT_DEVICE_CAPABILITIES)
+        {
+            return true;
+        }
+
+        // If the call failed for another reason, also just stop here and return the previous result
+        if (!Windows.SUCCEEDED(hresultMaximumSupportedFeatureLevel))
+        {
+            return false;
+        }
+
+        D2D1_FEATURE_DATA_DOUBLES d2D1FeatureDataDoubles = default;
+
+        // If the call failed, just do nothing and return the previous result
+        if (!Windows.SUCCEEDED(effectContext.CheckFeatureSupport(D2D1_FEATURE.D2D1_FEATURE_DOUBLES, &d2D1FeatureDataDoubles, (uint)sizeof(D2D1_FEATURE_DATA_DOUBLES))))
+        {
+            return false;
+        }
+
+        // If the context does not support double precision values, check whether the shader requested them
+        if (d2D1FeatureDataDoubles.doublePrecisionFloatShaderOps == 0)
+        {
+            // If the shader requires double precision support, return a more descriptive error
+            if ((d3D11ShaderReflection.Get()->GetRequiresFlags() & (D3D.D3D_SHADER_REQUIRES_DOUBLES | D3D.D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS)) != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/TerraFX.Interop.Windows.D2D1/DirectX/headers/d3dcommon/D3D_FEATURE_LEVEL.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/DirectX/headers/d3dcommon/D3D_FEATURE_LEVEL.cs
@@ -1,0 +1,21 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from d3dcommon.h in microsoft/DirectX-Headers tag v1.606.4
+// Original source is Copyright © Microsoft. Licensed under the MIT license
+
+namespace TerraFX.Interop.DirectX;
+
+internal enum D3D_FEATURE_LEVEL
+{
+    D3D_FEATURE_LEVEL_1_0_CORE = 0x1000,
+    D3D_FEATURE_LEVEL_9_1 = 0x9100,
+    D3D_FEATURE_LEVEL_9_2 = 0x9200,
+    D3D_FEATURE_LEVEL_9_3 = 0x9300,
+    D3D_FEATURE_LEVEL_10_0 = 0xa000,
+    D3D_FEATURE_LEVEL_10_1 = 0xa100,
+    D3D_FEATURE_LEVEL_11_0 = 0xb000,
+    D3D_FEATURE_LEVEL_11_1 = 0xb100,
+    D3D_FEATURE_LEVEL_12_0 = 0xc000,
+    D3D_FEATURE_LEVEL_12_1 = 0xc100,
+    D3D_FEATURE_LEVEL_12_2 = 0xc200
+}

--- a/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/ID2D1EffectContext.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d2d1effectauthor/ID2D1EffectContext.cs
@@ -50,6 +50,13 @@ namespace TerraFX.Interop.DirectX
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [VtblIndex(5)]
+        public HRESULT GetMaximumSupportedFeatureLevel([NativeTypeName("const D3D_FEATURE_LEVEL *")] D3D_FEATURE_LEVEL* featureLevels, [NativeTypeName("UINT32")] uint featureLevelsCount, D3D_FEATURE_LEVEL* maximumSupportedFeatureLevel)
+        {
+            return ((delegate* unmanaged[Stdcall]<ID2D1EffectContext*, D3D_FEATURE_LEVEL*, uint, D3D_FEATURE_LEVEL*, int>)(lpVtbl[5]))((ID2D1EffectContext*)Unsafe.AsPointer(ref this), featureLevels, featureLevelsCount, maximumSupportedFeatureLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [VtblIndex(11)]
         public HRESULT LoadPixelShader([NativeTypeName("const GUID &")] Guid* shaderId, [NativeTypeName("const BYTE *")] byte* shaderBuffer, [NativeTypeName("UINT32")] uint shaderBufferCount)
         {

--- a/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d3d11shader/ID3D11ShaderReflection.cs
+++ b/src/TerraFX.Interop.Windows.D2D1/DirectX/um/d3d11shader/ID3D11ShaderReflection.cs
@@ -95,6 +95,13 @@ namespace TerraFX.Interop.DirectX
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [VtblIndex(19)]
+        public HRESULT GetMinFeatureLevel([NativeTypeName("enum D3D_FEATURE_LEVEL *")] D3D_FEATURE_LEVEL* pLevel)
+        {
+            return ((delegate* unmanaged[Stdcall]<ID3D11ShaderReflection*, D3D_FEATURE_LEVEL*, int>)(lpVtbl[19]))((ID3D11ShaderReflection*)Unsafe.AsPointer(ref this), pLevel);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [VtblIndex(20)]
         public uint GetThreadGroupSize(uint* pSizeX, uint* pSizeY, uint* pSizeZ)
         {

--- a/src/TerraFX.Interop.Windows.D2D1/TerraFX.Interop.Windows.D2D1.projitems
+++ b/src/TerraFX.Interop.Windows.D2D1/TerraFX.Interop.Windows.D2D1.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\TerraFX.Interop.Windows\DirectX\um\d3d11shader\D3D.cs" Link="DirectX\um\d3d11shader\D3D.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DirectX\headers\d3dcommon\D3D_FEATURE_LEVEL.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_CHANGE_TYPE.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_FEATURE.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectX\um\d2d1effectauthor\D2D1_FEATURE_DATA_DOUBLES.cs" />

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
@@ -16,7 +16,7 @@ public partial class D2D1ReflectionServicesTests
         Assert.AreEqual(10u, shaderInfo.BoundResourceCount);
         Assert.AreEqual(5u, shaderInfo.DeclarationCount);
         Assert.IsFalse(shaderInfo.RequiresDoublePrecisionSupport);
-        Assert.AreEqual(D3DFeatureLevel.FeatureLevel10_1, shaderInfo.FeatureLevel);
+        Assert.AreEqual(D3DFeatureLevel.FeatureLevel10_1, shaderInfo.MinimumFeatureLevel);
         Assert.IsNotNull(shaderInfo.CompilerVersion);
         Assert.AreEqual("""
             // ================================================
@@ -95,7 +95,7 @@ public partial class D2D1ReflectionServicesTests
         Assert.AreEqual(1u, shaderInfo.ConstantBufferCount);
         Assert.AreEqual(2u, shaderInfo.DeclarationCount);
         Assert.IsTrue(shaderInfo.RequiresDoublePrecisionSupport);
-        Assert.AreEqual(D3DFeatureLevel.FeatureLevel11_0, shaderInfo.FeatureLevel);
+        Assert.AreEqual(D3DFeatureLevel.FeatureLevel11_0, shaderInfo.MinimumFeatureLevel);
         Assert.IsNotNull(shaderInfo.CompilerVersion);
         Assert.AreEqual("""
             // ================================================

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
@@ -1,0 +1,131 @@
+using ComputeSharp.D2D1.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.D2D1.Tests;
+
+[TestClass]
+[TestCategory("D2D1ReflectionServices")]
+public partial class D2D1ReflectionServicesTests
+{
+    [TestMethod]
+    public void GetShaderInfo()
+    {
+        D2D1ShaderInfo shaderInfo = D2D1ReflectionServices.GetShaderInfo<ReflectedShader>();
+
+        Assert.IsNotNull(shaderInfo);
+        Assert.AreEqual(10u, shaderInfo.BoundResourceCount);
+        Assert.AreEqual(5u, shaderInfo.DeclarationCount);
+        Assert.IsFalse(shaderInfo.RequiresDoublePrecisionSupport);
+        Assert.AreEqual(D3DFeatureLevel.FeatureLevel10_1, shaderInfo.FeatureLevel);
+        Assert.IsNotNull(shaderInfo.CompilerVersion);
+        Assert.AreEqual("""
+            // ================================================
+            //                  AUTO GENERATED
+            // ================================================
+            // This shader was created by ComputeSharp.
+            // See: https://github.com/Sergio0694/ComputeSharp.
+
+            #define D2D_INPUT_COUNT 3
+            #define D2D_INPUT0_SIMPLE
+            #define D2D_INPUT1_COMPLEX
+            #define D2D_INPUT2_COMPLEX
+            #define D2D_REQUIRES_SCENE_POSITION
+
+            #include "d2d1effecthelpers.hlsli"
+
+            float2 offset;
+
+            Texture1D<float> __reserved__buffer : register(t3);
+            SamplerState __sampler____reserved__buffer : register(s3);
+
+            Texture2D<float4> __reserved__texture : register(t4);
+            SamplerState __sampler____reserved__texture : register(s4);
+
+            D2D_PS_ENTRY(Execute)
+            {
+                int2 xy = (int2)D2DGetScenePosition().xy;
+                float4 input0 = D2DGetInput(0);
+                float4 input1 = D2DGetInput(1);
+                float4 input2 = D2DSampleInputAtPosition(2, xy + offset);
+                float value3 = __reserved__buffer[0];
+                float4 value4 = __reserved__texture.Sample(__sampler____reserved__texture, float2(0, 0.5));
+                return input0 + input1 + input2 + value3 + value4;
+            }
+            """.Replace("\r\n", "\n"), shaderInfo.HlslSource);
+    }
+
+    [D2DInputCount(3)]
+    [D2DInputSimple(0)]
+    [D2DInputComplex(1)]
+    [D2DInputComplex(2)]
+    [D2DRequiresScenePosition]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader41)]
+    private readonly partial struct ReflectedShader : ID2D1PixelShader
+    {
+        private readonly float2 offset;
+
+        [D2DResourceTextureIndex(3)]
+        private readonly D2D1ResourceTexture1D<float> buffer;
+
+        [D2DResourceTextureIndex(4)]
+        private readonly D2D1ResourceTexture2D<float4> texture;
+
+        public float4 Execute()
+        {
+            int2 xy = (int2)D2D.GetScenePosition().XY;
+
+            float4 input0 = D2D.GetInput(0);
+            float4 input1 = D2D.GetInput(1);
+            float4 input2 = D2D.SampleInputAtPosition(2, xy + this.offset);
+
+            float value3 = this.buffer[0];
+            float4 value4 = this.texture.Sample(0, 0.5f);
+
+            return input0 + input1 + input2 + value3 + value4;
+        }
+    }
+
+    [TestMethod]
+    public void GetShaderInfoWithDoublePrecisionFeature()
+    {
+        D2D1ShaderInfo shaderInfo = D2D1ReflectionServices.GetShaderInfo<ReflectedShaderWithDoubleOperations>();
+
+        Assert.IsNotNull(shaderInfo);
+        Assert.AreEqual(3u, shaderInfo.BoundResourceCount);
+        Assert.AreEqual(1u, shaderInfo.ConstantBufferCount);
+        Assert.AreEqual(2u, shaderInfo.DeclarationCount);
+        Assert.IsTrue(shaderInfo.RequiresDoublePrecisionSupport);
+        Assert.AreEqual(D3DFeatureLevel.FeatureLevel11_0, shaderInfo.FeatureLevel);
+        Assert.IsNotNull(shaderInfo.CompilerVersion);
+        Assert.AreEqual("""
+            // ================================================
+            //                  AUTO GENERATED
+            // ================================================
+            // This shader was created by ComputeSharp.
+            // See: https://github.com/Sergio0694/ComputeSharp.
+
+            #define D2D_INPUT_COUNT 1
+
+            #include "d2d1effecthelpers.hlsli"
+
+            double amount;
+
+            D2D_PS_ENTRY(Execute)
+            {
+                return (float4)(D2DGetInput(0) + (double4)amount);
+            }
+            """.Replace("\r\n", "\n"), shaderInfo.HlslSource);
+    }
+
+    [D2DInputCount(1)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+    private readonly partial struct ReflectedShaderWithDoubleOperations : ID2D1PixelShader
+    {
+        private readonly double amount;
+
+        public float4 Execute()
+        {
+            return (float4)(D2D.GetInput(0) + (double4)this.amount);
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR adds the new `D3DFeatureLevel` type and property into `D2D1ShaderInfo`, and new unit tests.

### API breakdown

```csharp
namespace ComputeSharp.D2D1.Interop;

public enum D3DFeatureLevel
{
    FeatureLevel1_0_Core = D3D_FEATURE_LEVEL_1_0_CORE,
    FeatureLevel9_1 = D3D_FEATURE_LEVEL_9_1,
    FeatureLevel9_2 = D3D_FEATURE_LEVEL_9_2,
    FeatureLevel9_3 = D3D_FEATURE_LEVEL_9_3,
    FeatureLevel10_0 = D3D_FEATURE_LEVEL_10_0,
    FeatureLevel10_1 = D3D_FEATURE_LEVEL_10_1,
    FeatureLevel11_0 = D3D_FEATURE_LEVEL_11_0,
    FeatureLevel11_1 = D3D_FEATURE_LEVEL_11_1,
    FeatureLevel12_0 = D3D_FEATURE_LEVEL_12_0,
    FeatureLevel12_1 = D3D_FEATURE_LEVEL_12_1,
    FeatureLevel12_2 = D3D_FEATURE_LEVEL_12_2
}
```
```diff
public sealed record D2D1ShaderInfo(
    string CompilerVersion,
    string HlslSource,
    uint ConstantBufferCount,
    uint BoundResourceCount,
    uint InstructionCount,
    uint TemporaryRegisterCount,
    uint TemporaryArrayCount,
    uint ConstantDefineCount,
    uint DeclarationCount,
    uint TextureNormalInstructions,
    uint TextureLoadInstructionCount,
    uint TextureStoreInstructionCount,
    uint FloatInstructionCount,
    uint IntInstructionCount,
    uint UIntInstructionCount,
    uint StaticFlowControlInstructionCount,
    uint DynamicFlowControlInstructionCount,
    uint EmitInstructionCount,
    uint BarrierInstructionCount,
    uint InterlockedInstructionCount,
    uint BitwiseInstructionCount,
    uint MovcInstructionCount,
    uint MovInstructionCount,
    uint InterfaceSlotCount,
    bool RequiresDoublePrecisionSupport,
+   D3DFeatureLevel FeatureLevel);
```