### PR TITLE
Add D2D1PixelShader.LoadBytecode overloads to get effective profile/options

### DIFF
--- a/src/ComputeSharp.D2D1.NetStandard/ComputeSharp.D2D1.NetStandard.projitems
+++ b/src/ComputeSharp.D2D1.NetStandard/ComputeSharp.D2D1.NetStandard.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\BitOperations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics.CodeAnalysis\DoesNotReturnAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics.CodeAnalysis\NotNullAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Math.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\RuntimeHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)..\ComputeSharp.NetStandard\System\Runtime\InteropServices\NativeMemory.cs" Link="System\Runtime\InteropServices\NativeMemory.cs" />

--- a/src/ComputeSharp.D2D1.NetStandard/System/Diagnostics.CodeAnalysis/NotNullAttribute.cs
+++ b/src/ComputeSharp.D2D1.NetStandard/System/Diagnostics.CodeAnalysis/NotNullAttribute.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// Specifies that an output will not be null even if the corresponding type allows it.
+/// Specifies that an input argument was not null when the call returns.
+/// </summary>
+/// <remarks>Internal copy from the BCL attribute.</remarks>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+internal sealed class NotNullAttribute : Attribute
+{
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -239,15 +239,16 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
                 ImmutableArray<byte> bytecode = LoadBytecode.GetBytecode(
                     item.Source,
                     token,
-                    out D2D1CompileOptions options,
+                    out D2D1ShaderProfile shaderProfile,
+                    out D2D1CompileOptions compileOptions,
                     out DeferredDiagnosticInfo? diagnostic);
 
                 token.ThrowIfCancellationRequested();
 
                 EmbeddedBytecodeInfo bytecodeInfo = new(
                     item.Source.HlslSource,
-                    item.Source.ShaderProfile,
-                    options,
+                    shaderProfile,
+                    compileOptions,
                     bytecode);
 
                 return (item.Hierarchy, bytecodeInfo, diagnostic);

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/EmbeddedBytecodeInfo.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// A model representing info on a shader that has requested to be precompiled at build time.
 /// </summary>
 /// <param name="HlslSource">The HLSL source for the shader.</param>
-/// <param name="ShaderProfile">The shader profile to use to compile the shader, if requested.</param>
-/// <param name="CompileOptions">The compile options to use to compile the shader.</param>
+/// <param name="ShaderProfile">The shader profile to use to compile the shader, or the default one.</param>
+/// <param name="CompileOptions">The compile options to use to compile the shader, or the default one.</param>
 /// <param name="Bytecode">The compiled shader bytecode, if available.</param>
-internal sealed record EmbeddedBytecodeInfo(string HlslSource, D2D1ShaderProfile? ShaderProfile, D2D1CompileOptions? CompileOptions, EquatableArray<byte> Bytecode);
+internal sealed record EmbeddedBytecodeInfo(string HlslSource, D2D1ShaderProfile ShaderProfile, D2D1CompileOptions CompileOptions, EquatableArray<byte> Bytecode);

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ComputeSharp.D2D1.__Internals;
 
@@ -98,10 +99,11 @@ public interface ID2D1Shader
     /// <typeparam name="TLoader">The type of bytecode loader being used.</typeparam>
     /// <param name="loader">The <typeparamref name="TLoader"/> instance to use to load the bytecode.</param>
     /// <param name="shaderProfile">The shader profile to use to get the shader bytecode (if <see langword="null"/>, the precompiled shader will be used).</param>
-    /// <param name="options">The compile options to use to get the shader bytecode (if <see langword="null"/>, the precompiled shader will be used).</param>
+    /// <param name="compileOptions">The compile options to use to get the shader bytecode (if <see langword="null"/>, the precompiled shader will be used).</param>
     /// <exception cref="InvalidOperationException">Thrown if a precompiled bytecode was requested (<paramref name="shaderProfile"/> is <see langword="null"/>), but it wasn't availablle.</exception>
+    /// <remarks>When this method returns, <paramref name="shaderProfile"/> and <paramref name="compileOptions"/> will be set to the effective laues used to create the shader bytecode that was loaded.</remarks>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [Obsolete("This method is not intended to be used directly by user code")]
-    void LoadBytecode<TLoader>(ref TLoader loader, D2D1ShaderProfile? shaderProfile, D2D1CompileOptions? options)
+    void LoadBytecode<TLoader>(ref TLoader loader, [NotNull] ref D2D1ShaderProfile? shaderProfile, [NotNull] ref D2D1CompileOptions? compileOptions)
         where TLoader : struct, ID2D1BytecodeLoader;
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -37,7 +37,10 @@ public static class D2D1ReflectionServices
 
         D2D1ShaderBytecodeLoader bytecodeLoader = default;
 
-        shader.LoadBytecode(ref bytecodeLoader, null, null);
+        D2D1ShaderProfile? shaderProfile = null;
+        D2D1CompileOptions? compileOptions = null;
+
+        shader.LoadBytecode(ref bytecodeLoader, ref shaderProfile, ref compileOptions);
 
         using ComPtr<ID3DBlob> dynamicBytecode = bytecodeLoader.GetResultingShaderBytecode(out ReadOnlySpan<byte> precompiledBytecode);
 

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
@@ -21,7 +21,7 @@ public partial class D2D1PixelShaderTests
 
         _ = D2D1PixelShader.LoadBytecode<ShaderWithNoCompileAttributes>(
             shaderProfile: D2D1ShaderProfile.PixelShader41,
-            options: D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.PartialPrecision);
+            compileOptions: D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.PartialPrecision);
 
         // Verify the expected options were used
         Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out manager));
@@ -55,7 +55,7 @@ public partial class D2D1PixelShaderTests
 
         _ = D2D1PixelShader.LoadBytecode<ShaderWithOverriddenProfile>(
             shaderProfile: D2D1ShaderProfile.PixelShader50,
-            options: D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.PartialPrecision);
+            compileOptions: D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.PartialPrecision);
 
         Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out manager));
         Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
@@ -89,7 +89,7 @@ public partial class D2D1PixelShaderTests
 
         _ = D2D1PixelShader.LoadBytecode<ShaderWithOverriddenOptions>(
             shaderProfile: D2D1ShaderProfile.PixelShader41,
-            options: D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision);
+            compileOptions: D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision);
 
         Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out manager));
         Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);
@@ -123,7 +123,7 @@ public partial class D2D1PixelShaderTests
 
         _ = D2D1PixelShader.LoadBytecode<ShaderWithOverriddenProfileAndOptions>(
             shaderProfile: D2D1ShaderProfile.PixelShader50,
-            options: D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision);
+            compileOptions: D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision);
 
         Assert.IsTrue(MemoryMarshal.TryGetMemoryManager(bytecode, out manager));
         Assert.AreEqual("PinnedBufferMemoryManager", manager!.GetType().Name);


### PR DESCRIPTION
### Closes #411

### Description

This PR adds new APIs to load the bytecode from D2D1 shaders and get the effective profile and options used.
It also fixes an issue where the wrong compile options were used to dynamically load shaders with default options.