### PR TITLE
Optimize and simplify CI pipeline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -217,5 +217,10 @@ jobs:
       with:
         name: nuget_packages
         path: artifacts
-    - run: dotnet nuget push "artifacts\*.nupkg" --source "https://sergio0694.pkgs.visualstudio.com/ComputeSharp/_packaging/ComputeSharp/nuget/v3/index.json" --api-key ${{secrets.ADO_FEED_PERSONAL_ACCESS_TOKEN}} --skip-duplicate
+    - uses: actions/setup-dotnet@v3
+      with:
+        source-url: "https://sergio0694.pkgs.visualstudio.com/ComputeSharp/_packaging/ComputeSharp/nuget/v3/index.json"
+      env:
+        NUGET_AUTH_TOKEN: ${{ secrets.ADO_FEED_PERSONAL_ACCESS_TOKEN }}
+    - run: dotnet nuget push "artifacts\*.nupkg" --api-key AzureDevOps --skip-duplicate
       shell: cmd

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -175,12 +175,6 @@ jobs:
     - name: Run ComputeSharp.ImageProcessing.csproj (.NET Framework 4.7.2)
       run: samples\ComputeSharp.ImageProcessing\bin\x64\Release\net472\ComputeSharp.ImageProcessing.exe
       shell: cmd
-    - name: Build ComputeSharp.Benchmark.csproj
-      run: dotnet build samples\ComputeSharp.Benchmark\ComputeSharp.Benchmark.csproj -c Release
-      shell: cmd
-    - name: Build ComputeSharp.SwapChain.csproj
-      run: dotnet build samples\ComputeSharp.SwapChain\ComputeSharp.SwapChain.csproj -c Release
-      shell: cmd
 
   # Download the NuGet packages generated in the previous job and use them
   # to build and run the sample project referencing them. This is used as

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,10 +16,6 @@ jobs:
       uses: actions/checkout@v3
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
-    - name: Setup .NET Core 3.1 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 3.1.x
     - name: Setup .NET 6 SDK
       uses: actions/setup-dotnet@v3
       with:
@@ -42,10 +38,6 @@ jobs:
       uses: actions/checkout@v3
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
-    - name: Setup .NET Core 3.1 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 3.1.x
     - name: Setup .NET 6 SDK
       uses: actions/setup-dotnet@v3
       with:
@@ -62,10 +54,6 @@ jobs:
       uses: actions/checkout@v3
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
-    - name: Setup .NET Core 3.1 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 3.1.x
     - name: Setup .NET 6 SDK
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -135,14 +135,17 @@ jobs:
         include:
           - framework: net6.0
             options: ''
+            command: dotnet
             path: Release\net6.0
             extension: dll
           - framework: netcoreapp3.1
-            options: -r win-x64
+            options: /p:Platform=x64 -r win-x64
+            command: ''
             path: Release\netcoreapp3.1\win-x64
             extension: exe
           - framework: net472
             options: /p:Platform=x64
+            command: ''
             path: x64\Release\net472
             extension: exe
     runs-on: windows-2022
@@ -153,19 +156,19 @@ jobs:
       run: dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
     - name: Run ComputeSharp.Sample
-      run: dotnet samples\ComputeSharp.Sample\bin\${{matrix.path}}\ComputeSharp.Sample.${{matrix.extension}}
+      run: ${{matrix.command}} samples\ComputeSharp.Sample\bin\${{matrix.path}}\ComputeSharp.Sample.${{matrix.extension}}
       shell: cmd
     - name: Build ComputeSharp.Sample.FSharp
-      run: dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release ${{matrix.framework}} ${{matrix.options}}
+      run: dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
     - name: Run ComputeSharp.Sample.FSharp
-      run: dotnet samples\ComputeSharp.Sample.FSharp\bin\${{matrix.path}}\ComputeSharp.Sample.FSharp.${{matrix.extension}}
+      run: ${{matrix.command}} samples\ComputeSharp.Sample.FSharp\bin\${{matrix.path}}\ComputeSharp.Sample.FSharp.${{matrix.extension}}
       shell: cmd
     - name: Build ComputeSharp.ImageProcessing.csproj
       run: dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
     - name: Run ComputeSharp.ImageProcessing.csproj
-      run: dotnet samples\ComputeSharp.ImageProcessing\bin\${{matrix.path}}\ComputeSharp.ImageProcessing.${{matrix.extension}}
+      run: ${{matrix.command}} samples\ComputeSharp.ImageProcessing\bin\${{matrix.path}}\ComputeSharp.ImageProcessing.${{matrix.extension}}
       shell: cmd
 
   # Download the NuGet packages generated in the previous job and use them
@@ -179,13 +182,16 @@ jobs:
         include:
           - framework: net6.0
             options: ''
+            command: dotnet
             path: Release\net6.0
             extension: dll
           - framework: netcoreapp3.1
             options: -r win-x64
+            command: ''
             path: Release\netcoreapp3.1\win-x64
             extension: exe
           - framework: net472
+            command: ''
             options: /p:Platform=x64
             path: x64\Release\net472
             extension: exe
@@ -205,19 +211,19 @@ jobs:
       run: dotnet build tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
     - name: Run ComputeSharp.NuGet
-      run: dotnet tests\ComputeSharp.NuGet\bin\${{matrix.path}}\ComputeSharp.NuGet.${{matrix.extension}}
+      run: ${{matrix.command}} tests\ComputeSharp.NuGet\bin\${{matrix.path}}\ComputeSharp.NuGet.${{matrix.extension}}
       shell: cmd
     - name: Build ComputeSharp.Dynamic.NuGet
       run: dotnet build tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
     - name: Run ComputeSharp.Dynamic.NuGet
-      run: dotnet tests\ComputeSharp.Dynamic.NuGet\bin\${{matrix.path}}\ComputeSharp.Dynamic.NuGet.${{matrix.extension}}
+      run: ${{matrix.command}} tests\ComputeSharp.Dynamic.NuGet\bin\${{matrix.path}}\ComputeSharp.Dynamic.NuGet.${{matrix.extension}}
       shell: cmd
     - name: Build ComputeSharp.Pix.NuGet
       run: dotnet build tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
     - name: Run ComputeSharp.Pix.NuGet
-      run: dotnet tests\ComputeSharp.Pix.NuGet\bin\${{matrix.path}}\ComputeSharp.Pix.NuGet.${{matrix.extension}}
+      run: ${{matrix.command}} tests\ComputeSharp.Pix.NuGet\bin\${{matrix.path}}\ComputeSharp.Pix.NuGet.${{matrix.extension}}
       shell: cmd
 
   # Run the extra tests to validate a number of build and publishing configurations.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -127,53 +127,45 @@ jobs:
       shell: cmd
 
   # Run all the local samples to ensure they build and run with no errors
-  run-dx12-samples:
+  run-samples:
     needs: [build-solution]
+    strategy:
+      matrix:
+        framework: [net6.0, netcoreapp3.1, net472]
+        include:
+          - framework: net6.0
+            options: ''
+            path: Release\net6.0
+            extension: dll
+          - framework: netcoreapp3.1
+            options: -r win-x64
+            path: Release\netcoreapp3.1\win-x64
+            extension: exe
+          - framework: net472
+            options: /p:Platform=x64
+            path: x64\Release\net472
+            extension: exe
     runs-on: windows-2022
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Build ComputeSharp.Sample (.NET 6)
-      run: dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f net6.0
+    - name: Build ComputeSharp.Sample
+      run: dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
-    - name: Run ComputeSharp.Sample (.NET 6)
-      run: dotnet samples\ComputeSharp.Sample\bin\Release\net6.0\ComputeSharp.Sample.dll
-      shell: cmd
-    - name: Build ComputeSharp.Sample (.NET Core 3.1)
-      run: dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -r win-x64
-      shell: cmd
-    - name: Run ComputeSharp.Sample (.NET Core 3.1)
-      run: samples\ComputeSharp.Sample\bin\x64\Release\netcoreapp3.1\win-x64\ComputeSharp.Sample.exe
-      shell: cmd
-    - name: Build ComputeSharp.Sample (.NET Framework 4.7.2)
-      run: dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f net472 /p:Platform=x64
-      shell: cmd
-    - name: Run ComputeSharp.Sample (.NET Framework 4.7.2)
-      run: samples\ComputeSharp.Sample\bin\x64\Release\net472\ComputeSharp.Sample.exe
+    - name: Run ComputeSharp.Sample
+      run: dotnet samples\ComputeSharp.Sample\bin\${{matrix.path}}\ComputeSharp.Sample.${{matrix.extension}}
       shell: cmd
     - name: Build ComputeSharp.Sample.FSharp
-      run: dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release
+      run: dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
     - name: Run ComputeSharp.Sample.FSharp
-      run: dotnet samples\ComputeSharp.Sample.FSharp\bin\Release\net6.0\ComputeSharp.Sample.FSharp.dll
+      run: dotnet samples\ComputeSharp.Sample.FSharp\bin\${{matrix.path}}\ComputeSharp.Sample.FSharp.${{matrix.extension}}
       shell: cmd
-    - name: Build ComputeSharp.ImageProcessing.csproj (.NET 6)
-      run: dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f net6.0
+    - name: Build ComputeSharp.ImageProcessing.csproj
+      run: dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
-    - name: Run ComputeSharp.ImageProcessing.csproj (.NET 6)
-      run: dotnet samples\ComputeSharp.ImageProcessing\bin\Release\net6.0\ComputeSharp.ImageProcessing.dll
-      shell: cmd
-    - name: Build ComputeSharp.ImageProcessing.csproj (.NET Core 3.1)
-      run: dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -r win-x64
-      shell: cmd
-    - name: Run ComputeSharp.ImageProcessing.csproj (.NET Core 3.1)
-      run: samples\ComputeSharp.ImageProcessing\bin\x64\Release\netcoreapp3.1\win-x64\ComputeSharp.ImageProcessing.exe
-      shell: cmd
-    - name: Build ComputeSharp.ImageProcessing.csproj (.NET Framework 4.7.2)
-      run: dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f net472 /p:Platform=x64
-      shell: cmd
-    - name: Run ComputeSharp.ImageProcessing.csproj (.NET Framework 4.7.2)
-      run: samples\ComputeSharp.ImageProcessing\bin\x64\Release\net472\ComputeSharp.ImageProcessing.exe
+    - name: Run ComputeSharp.ImageProcessing.csproj
+      run: dotnet samples\ComputeSharp.ImageProcessing\bin\${{matrix.path}}\ComputeSharp.ImageProcessing.${{matrix.extension}}
       shell: cmd
 
   # Download the NuGet packages generated in the previous job and use them
@@ -243,7 +235,7 @@ jobs:
 
   # Publish the packages to GitHub packages
   publish-nightlies-github:
-    needs: [run-tests, run-dx12-samples, verify-packages, verify-package-native-libs]
+    needs: [run-tests, run-samples, verify-packages, verify-package-native-libs]
     runs-on: windows-2022
     if: ${{github.event_name == 'push'}}
     steps:
@@ -256,7 +248,7 @@ jobs:
 
   # Publish the packages to Azure DevOps
   publish-nightlies-azure-devops:
-    needs: [run-tests, run-dx12-samples, verify-packages, verify-package-native-libs]
+    needs: [run-tests, run-samples, verify-packages, verify-package-native-libs]
     runs-on: windows-2022
     if: ${{github.event_name == 'push'}}
     steps:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -70,125 +70,62 @@ jobs:
         path: artifacts\*.nupkg
         if-no-files-found: error
 
-  # Run all the DX12 unit tests referencing the ComputeSharp project directly
-  run-dx12-tests:
-    if: success()
+  # Run all unit tests referencing the ComputeSharp project directly
+  run-tests:
     needs: [build-solution]
+    strategy:
+      matrix:
+        framework: [net6.0, netcoreapp3.1, net472]
     runs-on: windows-2022
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Run ComputeSharp.Tests (.NET 6)
-      run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET 6)
-      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.GlobalStatements (.NET 6)
-      run: dotnet test tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.Internals (.NET 6)
-      run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.GlobalStatements (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.Internals (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f netcoreapp3.1 /p:Platform=x64 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests (.NET Framework 4.7.2)
-      run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f net472 /p:Platform=x64 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DisableDynamicCompilation (.NET Framework 4.7.2)
-      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f net472 /p:Platform=x64 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.GlobalStatements (.NET Framework 4.7.2)
-      run: dotnet test tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f net472 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.Internals (.NET Framework 4.7.2)
-      run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f net472 /p:Platform=x64 -v n -l "console;verbosity=detailed"
-      shell: cmd
 
-    - name: Run ComputeSharp.Tests.SourceGenerators
+      # DirectX 12 unit tests
+    - name: Run ComputeSharp.Tests
+      run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.Tests.DisableDynamicCompilation
+      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.Tests.GlobalStatements
+      run: dotnet test tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - name: Run ComputeSharp.Tests.Internals
+      run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - if: matrix.framework == 'net6.0'
+      name: Run ComputeSharp.Tests.SourceGenerators
       run: dotnet test tests\ComputeSharp.Tests.SourceGenerators\ComputeSharp.Tests.SourceGenerators.csproj -v n -l "console;verbosity=detailed"
       shell: cmd
-
-  # Run all the DX12 device lost unit tests (run the separately to minimize issues).
-  # These tests are run one class at a time to ensure there's no accidental conflicts between any of them. This is because
-  # the code paths being tested in this project are heavily dependent on process-wide mutable state (ie. DirectX 12 devices).
-  run-dx12-device-lost-tests:
-    if: success()
-    needs: [build-solution]
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-    - name: Run ComputeSharp.Tests.DeviceLost "DeviceDisposal" (.NET 6)
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release -f net6.0 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DeviceLost "DeviceLost" (.NET 6)
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceLost" -c Release -f net6.0 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DeviceLost "GetDefaultDevice" (.NET 6)
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=GetDefaultDevice" -c Release -f net6.0 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DeviceLost "DeviceDisposal" (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DeviceLost "DeviceLost" (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceLost" -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DeviceLost "GetDefaultDevice" (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=GetDefaultDevice" -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.Tests.DeviceLost "DeviceDisposal" (.NET Framework 4.7.2)
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release -f net472 -v n -l "console;verbosity=detailed"
+    
+    # DirectX 12 device lost unit tests.
+    # These tests are run one class at a time to ensure there's no accidental conflicts between any of them. This is because
+    # the code paths being tested in this project are heavily dependent on process-wide mutable state (ie. DirectX 12 devices).
+    - name: Run ComputeSharp.Tests.DeviceLost "DeviceDisposal"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
       shell: cmd
 
-    # These tests are failing randomly in the CI, disabling them just for now
-    # - name: Run ComputeSharp.Tests.DeviceLost "DeviceLost" (.NET Framework 4.7.2)
-    #   run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceLost" -c Release -f net472 -v n -l "console;verbosity=detailed"
-    #   shell: cmd
-    # - name: Run ComputeSharp.Tests.DeviceLost "GetDefaultDevice" (.NET Framework 4.7.2)
-    #   run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=GetDefaultDevice" -c Release -f net472 -v n -l "console;verbosity=detailed"
-    #   shell: cmd
+    # These tests are failing randomly in the CI on .NET Framework, disabling them just for now
+    - if: matrix.framework != 'net472'
+      name: Run ComputeSharp.Tests.DeviceLost "DeviceLost"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceLost" -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
+      shell: cmd
+    - if: matrix.framework != 'net472'
+      name: Run ComputeSharp.Tests.DeviceLost "GetDefaultDevice"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=GetDefaultDevice" -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
+      shell: cmd
 
-  # Run all the D2D1 unit tests (referencing ComputeSharp.D2D1)
-  run-d2d1-tests:
-    if: success()
-    needs: [build-solution]
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-    - name: Run ComputeSharp.D2D1.Tests (.NET 6)
-      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
+    # D2D1 unit tests
+    - name: Run ComputeSharp.D2D1.Tests
+      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
       shell: cmd
-    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes (.NET 6)
-      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.D2D1.Tests (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes (.NET Core 3.1)
-      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -f netcoreapp3.1 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.D2D1.Tests (.NET Framework 4.7.2)
-      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f net472 -v n -l "console;verbosity=detailed"
-      shell: cmd
-    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes (.NET Framework 4.7.2)
-      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -f net472 -v n -l "console;verbosity=detailed"
+    - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes
+      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
       shell: cmd
 
   # Run all the local samples to ensure they build and run with no errors
   run-dx12-samples:
-    if: success()
     needs: [build-solution]
     runs-on: windows-2022
     steps:
@@ -247,7 +184,6 @@ jobs:
   # to build and run the sample project referencing them. This is used as
   # a test to ensure the NuGet packages work in a consuming project.
   verify-packages:
-    if: success()
     needs: [build-packages]
     runs-on: windows-2022
     steps:
@@ -282,7 +218,6 @@ jobs:
 
   # Download the NuGet packages and test the ComputeSharp.Dynamic dependency
   verify-packages-dynamic:
-    if: success()
     needs: [build-packages]
     runs-on: windows-2022
     steps:
@@ -317,7 +252,6 @@ jobs:
 
   # Download the NuGet packages and test the ComputeSharp.Pix dependency
   verify-packages-pix:
-    if: success()
     needs: [build-packages]
     runs-on: windows-2022
     steps:
@@ -354,7 +288,6 @@ jobs:
   # This is used to ensure the native dependencies can always be loaded correctly
   # regardless of whether the app is shipping with R2R, self-contained, etc.
   verify-package-native-libs:
-    if: success()
     needs: [build-packages]
     runs-on: windows-2022
     steps:
@@ -366,7 +299,7 @@ jobs:
 
   # Publish the packages to GitHub packages
   publish-nightlies-github:
-    needs: [run-dx12-tests, run-dx12-device-lost-tests, run-d2d1-tests, run-dx12-samples, verify-packages, verify-packages-dynamic, verify-packages-pix, verify-package-native-libs]
+    needs: [run-tests, run-dx12-samples, verify-packages, verify-packages-dynamic, verify-packages-pix, verify-package-native-libs]
     runs-on: windows-2022
     if: ${{github.event_name == 'push'}}
     steps:
@@ -379,7 +312,7 @@ jobs:
 
   # Publish the packages to Azure DevOps
   publish-nightlies-azure-devops:
-    needs: [run-dx12-tests, run-dx12-device-lost-tests, run-d2d1-tests, run-dx12-samples, verify-packages, verify-packages-dynamic, verify-packages-pix, verify-package-native-libs]
+    needs: [run-tests, run-dx12-samples, verify-packages, verify-packages-dynamic, verify-packages-pix, verify-package-native-libs]
     runs-on: windows-2022
     if: ${{github.event_name == 'push'}}
     steps:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,8 +8,12 @@ env:
 
 jobs:
 
-  # Build the whole ComputeSharp solution, in Debug
-  build-solution-debug-x64:
+  # Build the whole ComputeSharp solution
+  build-solution:
+    strategy:
+      matrix:
+        configuration: [Debug, Release]
+        platform: [x64, arm64]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -21,46 +25,14 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Build
-      run: msbuild -t:restore,build /p:Configuration=Debug /p:Platform=x64 /bl
+      run: msbuild -t:restore,build /p:Configuration=${{matrix.configuration}} /p:Platform=${{matrix.platform}} /bl
       shell: cmd
     - name: Upload MSBuild binary log
       uses: actions/upload-artifact@v3
       with:
-        name: msbuild_log
+        name: msbuild_log_${{matrix.configuration}}_${{matrix.platform}}
         path: msbuild.binlog
         if-no-files-found: error
-
-  # Build the whole ComputeSharp solution, in Release
-  build-solution-release-x64:
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    - name: Build
-      run: msbuild -t:restore,build /p:Configuration=Release /p:Platform=x64
-      shell: cmd
-
-  # Build the solution in Release Arm64 too to double-check that target
-  build-solution-release-arm64:
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-    - name: Build
-      run: msbuild -t:restore,build /p:Configuration=Release /p:Platform=arm64
-      shell: cmd
 
   # Build the .msbuildproj projects and the UWP/WinUI projects to generate all the NuGet packages.
   # This workflow also uploads the resulting packages as artifacts.
@@ -102,14 +74,14 @@ jobs:
     - name: Upload package artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: nuget_preview
+        name: nuget_packages
         path: artifacts\*.nupkg
         if-no-files-found: error
 
   # Run all the DX12 unit tests referencing the ComputeSharp project directly
   run-dx12-tests:
     if: success()
-    needs: [build-solution-debug-x64, build-solution-release-x64, build-solution-release-arm64]
+    needs: [build-solution]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -168,7 +140,7 @@ jobs:
   # the code paths being tested in this project are heavily dependent on process-wide mutable state (ie. DirectX 12 devices).
   run-dx12-device-lost-tests:
     if: success()
-    needs: [build-solution-debug-x64, build-solution-release-x64, build-solution-release-arm64]
+    needs: [build-solution]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -214,7 +186,7 @@ jobs:
   # Run all the D2D1 unit tests (referencing ComputeSharp.D2D1)
   run-d2d1-tests:
     if: success()
-    needs: [build-solution-debug-x64, build-solution-release-x64, build-solution-release-arm64]
+    needs: [build-solution]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -249,7 +221,7 @@ jobs:
   # Run all the local samples to ensure they build and run with no errors
   run-dx12-samples:
     if: success()
-    needs: [build-solution-debug-x64, build-solution-release-x64, build-solution-release-arm64]
+    needs: [build-solution]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -331,7 +303,7 @@ jobs:
     - name: Download package artifacts
       uses: actions/download-artifact@v3
       with:
-        name: nuget_preview
+        name: nuget_packages
         path: artifacts
     - name: Build ComputeSharp.NuGet (.NET 6)
       run: dotnet build tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f net6.0
@@ -370,7 +342,7 @@ jobs:
     - name: Download package artifacts
       uses: actions/download-artifact@v3
       with:
-        name: nuget_preview
+        name: nuget_packages
         path: artifacts
     - name: Build ComputeSharp.Dynamic.NuGet (.NET 6)
       run: dotnet build tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f net6.0
@@ -409,7 +381,7 @@ jobs:
     - name: Download package artifacts
       uses: actions/download-artifact@v3
       with:
-        name: nuget_preview
+        name: nuget_packages
         path: artifacts
     - name: Build ComputeSharp.Pix.NuGet (.NET 6)
       run: dotnet build tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f net6.0
@@ -456,7 +428,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: nuget_preview
+        name: nuget_packages
         path: artifacts
     - uses: actions/setup-dotnet@v3
       with:
@@ -472,7 +444,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: nuget_preview
+        name: nuget_packages
         path: artifacts
     - uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -179,22 +179,6 @@ jobs:
     strategy:
       matrix:
         framework: [net6.0, netcoreapp3.1, net472]
-        include:
-          - framework: net6.0
-            options: ''
-            command: dotnet
-            path: Release\net6.0
-            extension: dll
-          - framework: netcoreapp3.1
-            options: -r win-x64
-            command: ''
-            path: Release\netcoreapp3.1\win-x64
-            extension: exe
-          - framework: net472
-            command: ''
-            options: /p:Platform=x64
-            path: x64\Release\net472
-            extension: exe
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -207,23 +191,14 @@ jobs:
       with:
         name: nuget_packages
         path: artifacts
-    - name: Build ComputeSharp.NuGet
-      run: dotnet build tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
+    - name: Build and run ComputeSharp.NuGet
+      run: dotnet run --project tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -v n
       shell: cmd
-    - name: Run ComputeSharp.NuGet
-      run: ${{matrix.command}} tests\ComputeSharp.NuGet\bin\${{matrix.path}}\ComputeSharp.NuGet.${{matrix.extension}}
+    - name: Build and run ComputeSharp.Dynamic.NuGet
+      run: dotnet run --project tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -v n
       shell: cmd
-    - name: Build ComputeSharp.Dynamic.NuGet
-      run: dotnet build tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
-      shell: cmd
-    - name: Run ComputeSharp.Dynamic.NuGet
-      run: ${{matrix.command}} tests\ComputeSharp.Dynamic.NuGet\bin\${{matrix.path}}\ComputeSharp.Dynamic.NuGet.${{matrix.extension}}
-      shell: cmd
-    - name: Build ComputeSharp.Pix.NuGet
-      run: dotnet build tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
-      shell: cmd
-    - name: Run ComputeSharp.Pix.NuGet
-      run: ${{matrix.command}} tests\ComputeSharp.Pix.NuGet\bin\${{matrix.path}}\ComputeSharp.Pix.NuGet.${{matrix.extension}}
+    - name: Build and run ComputeSharp.Pix.NuGet
+      run: dotnet run --project tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -v n
       shell: cmd
 
   # Run the extra tests to validate a number of build and publishing configurations.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -200,23 +200,19 @@ jobs:
     - name: Build and run ComputeSharp.Pix.NuGet
       run: dotnet run --project tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -v n
       shell: cmd
-
-  # Run the extra tests to validate a number of build and publishing configurations.
-  # This is used to ensure the native dependencies can always be loaded correctly
-  # regardless of whether the app is shipping with R2R, self-contained, etc.
-  verify-package-native-libs:
-    needs: [build-packages]
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-    - name: Run ComputeSharp.Tests.NativeLibrariesResolver
+    
+      # Run the extra tests to validate a number of build and publishing configurations.
+      # This is used to ensure the native dependencies can always be loaded correctly
+      # regardless of whether the app is shipping with R2R, self-contained, etc.
+      # Like with the source generator tests, only run these once on the .NET 6 target.
+    - if: matrix.framework == 'net6.0'
+      name: Run ComputeSharp.Tests.NativeLibrariesResolver
       run: dotnet test tests\ComputeSharp.Tests.NativeLibrariesResolver\ComputeSharp.Tests.NativeLibrariesResolver.csproj -v n -l "console;verbosity=detailed"
       shell: cmd
 
   # Publish the packages to GitHub packages
   publish-nightlies-github:
-    needs: [run-tests, run-samples, verify-packages, verify-package-native-libs]
+    needs: [run-tests, run-samples, verify-packages]
     runs-on: windows-2022
     if: ${{github.event_name == 'push'}}
     steps:
@@ -229,7 +225,7 @@ jobs:
 
   # Publish the packages to Azure DevOps
   publish-nightlies-azure-devops:
-    needs: [run-tests, run-samples, verify-packages, verify-package-native-libs]
+    needs: [run-tests, run-samples, verify-packages]
     runs-on: windows-2022
     if: ${{github.event_name == 'push'}}
     steps:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -94,6 +94,8 @@ jobs:
     - name: Run ComputeSharp.Tests.Internals
       run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
       shell: cmd
+
+      # Only run the source generators tests once, as they're not runtime specific
     - if: matrix.framework == 'net6.0'
       name: Run ComputeSharp.Tests.SourceGenerators
       run: dotnet test tests\ComputeSharp.Tests.SourceGenerators\ComputeSharp.Tests.SourceGenerators.csproj -v n -l "console;verbosity=detailed"
@@ -185,6 +187,22 @@ jobs:
   # a test to ensure the NuGet packages work in a consuming project.
   verify-packages:
     needs: [build-packages]
+    strategy:
+      matrix:
+        framework: [net6.0, netcoreapp3.1, net472]
+        include:
+          - framework: net6.0
+            options: ''
+            path: Release\net6.0
+            extension: dll
+          - framework: netcoreapp3.1
+            options: -r win-x64
+            path: Release\netcoreapp3.1\win-x64
+            extension: exe
+          - framework: net472
+            options: /p:Platform=x64
+            path: x64\Release\net472
+            extension: exe
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -197,91 +215,23 @@ jobs:
       with:
         name: nuget_packages
         path: artifacts
-    - name: Build ComputeSharp.NuGet (.NET 6)
-      run: dotnet build tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f net6.0
+    - name: Build ComputeSharp.NuGet
+      run: dotnet build tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
-    - name: Run ComputeSharp.NuGet (.NET 6)
-      run: dotnet tests\ComputeSharp.NuGet\bin\Release\net6.0\ComputeSharp.NuGet.dll
+    - name: Run ComputeSharp.NuGet
+      run: dotnet tests\ComputeSharp.NuGet\bin\${{matrix.path}}\ComputeSharp.NuGet.${{matrix.extension}}
       shell: cmd
-    - name: Build ComputeSharp.NuGet (.NET Core 3.1)
-      run: dotnet build tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f netcoreapp3.1 -r win-x64
+    - name: Build ComputeSharp.Dynamic.NuGet
+      run: dotnet build tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
-    - name: Run ComputeSharp.NuGet (.NET Core 3.1)
-      run: tests\ComputeSharp.NuGet\bin\Release\netcoreapp3.1\win-x64\ComputeSharp.NuGet.exe
+    - name: Run ComputeSharp.Dynamic.NuGet
+      run: dotnet tests\ComputeSharp.Dynamic.NuGet\bin\${{matrix.path}}\ComputeSharp.Dynamic.NuGet.${{matrix.extension}}
       shell: cmd
-    - name: Build ComputeSharp.NuGet (.NET Framework 4.7.2)
-      run: dotnet build tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f net472 /p:Platform=x64
+    - name: Build ComputeSharp.Pix.NuGet
+      run: dotnet build tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
       shell: cmd
-    - name: Run ComputeSharp.NuGet (.NET Framework 4.7.2)
-      run: tests\ComputeSharp.NuGet\bin\x64\Release\net472\ComputeSharp.NuGet.exe
-      shell: cmd
-
-  # Download the NuGet packages and test the ComputeSharp.Dynamic dependency
-  verify-packages-dynamic:
-    needs: [build-packages]
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-    - name: Create local NuGet feed
-      run: mkdir artifacts
-      shell: cmd
-    - name: Download package artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: nuget_packages
-        path: artifacts
-    - name: Build ComputeSharp.Dynamic.NuGet (.NET 6)
-      run: dotnet build tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f net6.0
-      shell: cmd
-    - name: Run ComputeSharp.Dynamic.NuGet (.NET 6)
-      run: dotnet tests\ComputeSharp.Dynamic.NuGet\bin\Release\net6.0\ComputeSharp.Dynamic.NuGet.dll
-      shell: cmd
-    - name: Build ComputeSharp.Dynamic.NuGet (.NET Core 3.1)
-      run: dotnet build tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f netcoreapp3.1 -r win-x64
-      shell: cmd
-    - name: Run ComputeSharp.Dynamic.NuGet (.NET Core 3.1)
-      run: tests\ComputeSharp.Dynamic.NuGet\bin\Release\netcoreapp3.1\win-x64\ComputeSharp.Dynamic.NuGet.exe
-      shell: cmd
-    - name: Build ComputeSharp.Dynamic.NuGet (.NET Framework 4.7.2)
-      run: dotnet build tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f net472 /p:Platform=x64
-      shell: cmd
-    - name: Run ComputeSharp.Dynamic.NuGet (.NET Framework 4.7.2)
-      run: tests\ComputeSharp.Dynamic.NuGet\bin\x64\Release\net472\ComputeSharp.Dynamic.NuGet.exe
-      shell: cmd
-
-  # Download the NuGet packages and test the ComputeSharp.Pix dependency
-  verify-packages-pix:
-    needs: [build-packages]
-    runs-on: windows-2022
-    steps:
-    - name: Git checkout
-      uses: actions/checkout@v3
-    - name: Create local NuGet feed
-      run: mkdir artifacts
-      shell: cmd
-    - name: Download package artifacts
-      uses: actions/download-artifact@v3
-      with:
-        name: nuget_packages
-        path: artifacts
-    - name: Build ComputeSharp.Pix.NuGet (.NET 6)
-      run: dotnet build tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f net6.0
-      shell: cmd
-    - name: Run ComputeSharp.Pix.NuGet (.NET 6)
-      run: dotnet tests\ComputeSharp.Pix.NuGet\bin\Release\net6.0\ComputeSharp.Pix.NuGet.dll
-      shell: cmd
-    - name: Build ComputeSharp.Pix.NuGet (.NET Core 3.1)
-      run: dotnet build tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f netcoreapp3.1 -r win-x64
-      shell: cmd
-    - name: Run ComputeSharp.Pix.NuGet (.NET Core 3.1)
-      run: tests\ComputeSharp.Pix.NuGet\bin\Release\netcoreapp3.1\win-x64\ComputeSharp.Pix.NuGet.exe
-      shell: cmd
-    - name: Build ComputeSharp.Pix.NuGet (.NET Framework 4.7.2)
-      run: dotnet build tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f net472 /p:Platform=x64
-      shell: cmd
-    - name: Run ComputeSharp.Pix.NuGet (.NET Framework 4.7.2)
-      run: tests\ComputeSharp.Pix.NuGet\bin\x64\Release\net472\ComputeSharp.Pix.NuGet.exe
+    - name: Run ComputeSharp.Pix.NuGet
+      run: dotnet tests\ComputeSharp.Pix.NuGet\bin\${{matrix.path}}\ComputeSharp.Pix.NuGet.${{matrix.extension}}
       shell: cmd
 
   # Run the extra tests to validate a number of build and publishing configurations.
@@ -299,7 +249,7 @@ jobs:
 
   # Publish the packages to GitHub packages
   publish-nightlies-github:
-    needs: [run-tests, run-dx12-samples, verify-packages, verify-packages-dynamic, verify-packages-pix, verify-package-native-libs]
+    needs: [run-tests, run-dx12-samples, verify-packages, verify-package-native-libs]
     runs-on: windows-2022
     if: ${{github.event_name == 'push'}}
     steps:
@@ -312,7 +262,7 @@ jobs:
 
   # Publish the packages to Azure DevOps
   publish-nightlies-azure-devops:
-    needs: [run-tests, run-dx12-samples, verify-packages, verify-packages-dynamic, verify-packages-pix, verify-package-native-libs]
+    needs: [run-tests, run-dx12-samples, verify-packages, verify-package-native-libs]
     runs-on: windows-2022
     if: ${{github.event_name == 'push'}}
     steps:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -132,43 +132,27 @@ jobs:
     strategy:
       matrix:
         framework: [net6.0, netcoreapp3.1, net472]
-        include:
-          - framework: net6.0
-            options: ''
-            command: dotnet
-            path: Release\net6.0
-            extension: dll
-          - framework: netcoreapp3.1
-            options: /p:Platform=x64 -r win-x64
-            command: ''
-            path: Release\netcoreapp3.1\win-x64
-            extension: exe
-          - framework: net472
-            options: /p:Platform=x64
-            command: ''
-            path: x64\Release\net472
-            extension: exe
     runs-on: windows-2022
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
     - name: Build ComputeSharp.Sample
-      run: dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
+      run: dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -p:Platform=x64 -v n
       shell: cmd
     - name: Run ComputeSharp.Sample
-      run: ${{matrix.command}} samples\ComputeSharp.Sample\bin\${{matrix.path}}\ComputeSharp.Sample.${{matrix.extension}}
+      run: samples\ComputeSharp.Sample\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.Sample.exe
       shell: cmd
     - name: Build ComputeSharp.Sample.FSharp
-      run: dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
+      run: dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -p:Platform=x64 -v n
       shell: cmd
     - name: Run ComputeSharp.Sample.FSharp
-      run: ${{matrix.command}} samples\ComputeSharp.Sample.FSharp\bin\${{matrix.path}}\ComputeSharp.Sample.FSharp.${{matrix.extension}}
+      run: ${{matrix.command}} samples\ComputeSharp.Sample.FSharp\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.Sample.FSharp.exe
       shell: cmd
     - name: Build ComputeSharp.ImageProcessing.csproj
-      run: dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f ${{matrix.framework}} ${{matrix.options}}
+      run: dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -p:Platform=x64 -v n
       shell: cmd
     - name: Run ComputeSharp.ImageProcessing.csproj
-      run: ${{matrix.command}} samples\ComputeSharp.ImageProcessing\bin\${{matrix.path}}\ComputeSharp.ImageProcessing.${{matrix.extension}}
+      run: ${{matrix.command}} samples\ComputeSharp.ImageProcessing\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.ImageProcessing.exe
       shell: cmd
 
   # Download the NuGet packages generated in the previous job and use them

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,10 +20,6 @@ jobs:
       uses: actions/checkout@v3
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Build
       run: msbuild -t:restore,build /p:Configuration=${{matrix.configuration}} /p:Platform=${{matrix.platform}} /bl
       shell: cmd
@@ -43,10 +39,6 @@ jobs:
       uses: actions/checkout@v3
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Build ComputeSharp.Core package
       run: dotnet build src\ComputeSharp.Core.Package\ComputeSharp.Core.Package.msbuildproj -c Release
       shell: cmd
@@ -86,14 +78,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Setup .NET Core 3.1 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 3.1.x
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Run ComputeSharp.Tests (.NET 6)
       run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
       shell: cmd
@@ -145,14 +129,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Setup .NET Core 3.1 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 3.1.x
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Run ComputeSharp.Tests.DeviceLost "DeviceDisposal" (.NET 6)
       run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release -f net6.0 -v n -l "console;verbosity=detailed"
       shell: cmd
@@ -191,14 +167,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Setup .NET Core 3.1 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 3.1.x
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Run ComputeSharp.D2D1.Tests (.NET 6)
       run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f net6.0 -v n -l "console;verbosity=detailed"
       shell: cmd
@@ -226,14 +194,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Setup .NET Core 3.1 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 3.1.x
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Build ComputeSharp.Sample (.NET 6)
       run: dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f net6.0
       shell: cmd
@@ -293,10 +253,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Create local NuGet feed
       run: mkdir artifacts
       shell: cmd
@@ -332,10 +288,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Create local NuGet feed
       run: mkdir artifacts
       shell: cmd
@@ -371,10 +323,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Create local NuGet feed
       run: mkdir artifacts
       shell: cmd
@@ -412,10 +360,6 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
-    - name: Setup .NET 6 SDK
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - name: Run ComputeSharp.Tests.NativeLibrariesResolver
       run: dotnet test tests\ComputeSharp.Tests.NativeLibrariesResolver\ComputeSharp.Tests.NativeLibrariesResolver.csproj -v n -l "console;verbosity=detailed"
       shell: cmd
@@ -430,9 +374,6 @@ jobs:
       with:
         name: nuget_packages
         path: artifacts
-    - uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
     - run: dotnet nuget push "artifacts\*.nupkg" --source "https://nuget.pkg.github.com/${{github.repository_owner}}/index.json" --api-key ${{secrets.GITHUB_TOKEN}} --skip-duplicate
       shell: cmd
 
@@ -446,11 +387,5 @@ jobs:
       with:
         name: nuget_packages
         path: artifacts
-    - uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
-        source-url: "https://sergio0694.pkgs.visualstudio.com/ComputeSharp/_packaging/ComputeSharp/nuget/v3/index.json"
-      env:
-        NUGET_AUTH_TOKEN: ${{ secrets.ADO_FEED_PERSONAL_ACCESS_TOKEN }}
-    - run: dotnet nuget push "artifacts\*.nupkg" --api-key AzureDevOps --skip-duplicate
+    - run: dotnet nuget push "artifacts\*.nupkg" --source "https://sergio0694.pkgs.visualstudio.com/ComputeSharp/_packaging/ComputeSharp/nuget/v3/index.json" --api-key ${{secrets.ADO_FEED_PERSONAL_ACCESS_TOKEN}} --skip-duplicate
       shell: cmd

--- a/samples/ComputeSharp.Sample.FSharp.Shaders/ComputeSharp.Sample.FSharp.Shaders.csproj
+++ b/samples/ComputeSharp.Sample.FSharp.Shaders/ComputeSharp.Sample.FSharp.Shaders.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <Platforms>AnyCPU;x64;ARM64</Platforms>
     <LangVersion>5.0</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description

This PR includes the following improvements:
- Reduce the YAML script from 496 LOC to 226 (less than 50%)
- Speedup the pipeline a bit
- Visually group jobs together with matrices
- Reduce code duplication for steps over multiple frameworks
- Skipped installing SDKs that are built-in in the VM image
- Enable F# tests on .NET Core 3.1 and .NET Framework 4.7.2 as well