### PR TITLE
Update TerraFX.Interop.D3D12MemoryAllocator reference

### DIFF
--- a/src/ComputeSharp/ComputeSharp.csproj
+++ b/src/ComputeSharp/ComputeSharp.csproj
@@ -24,7 +24,7 @@
 
   <!-- .NET 6 uses the NuGet packages for TerraFX -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="TerraFX.Interop.D3D12MemoryAllocator" Version="2.0.1.1" />
+    <PackageReference Include="TerraFX.Interop.D3D12MemoryAllocator" Version="2.0.1.2" />
   </ItemGroup>
 
   <!-- .NET Standard 2.0 uses a local fork -->


### PR DESCRIPTION
### Description

This update bumps the D3D12MA reference with the fix to work in reflection-free mode.