### PR TITLE
Update .gitattributes to set line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,7 @@ indent_size = 4
 indent_style = space
 
 # New line preferences
+end_of_line = lf
 insert_final_newline = false
 trim_trailing_whitespace = true
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,16 +22,12 @@
 *.resx         text      eol=lf
 *.sh           text      eol=lf
 *.shprroj      text      eol=lf
+*.sln          text      eol=lf
 *.slnf         text      eol=lf
 *.targets      text      eol=lf
 *.xaml         text      eol=lf
 *.txt          text      eol=lf
 *.yml          text      eol=lf
-
-# Solution files
-#  - Treat as text
-#  - Force to CRLF line endings (Windows-style)
-*.sln          text      eol=crlf
 
 # Images
 *.png          binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 # All file types:
 #   - Treat as text
 #   - Normalize to LF line endings
-* text eol=lf
+*              text=auto eol=lf
 
 # Explicit settings for well known types
 *.appxmanifest text      eol=lf
@@ -31,14 +31,17 @@
 # Solution files
 #  - Treat as text
 #  - Force to CRLF line endings (Windows-style)
-*.sln  text eol=crlf
+*.sln          text      eol=crlf
 
 # Images
-*.png  binary
-*.jpg  binary
-*.gif  binary
+*.png          binary
+*.jpg          binary
+*.gif          binary
 
 # Keys
-*.snk  binary
-*.pfx  binary
-*.cer  binary
+*.snk          binary
+*.pfx          binary
+*.cer          binary
+
+# Other binary files
+*.dll          binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,13 +3,35 @@
 #   - Normalize to LF line endings
 * text eol=lf
 
-# Solution files and Windows scripts
+# Explicit settings for well known types
+*.appxmanifest text      eol=lf
+*.cmd          text      eol=lf
+*.config       text      eol=lf
+*.cs           text      eol=lf
+*.csproj       text      eol=lf
+*.fs           text      eol=lf
+*.fsproj       text      eol=lf
+*.hlsl         text      eol=lf
+*.json         text      eol=lf
+*.manifest     text      eol=lf
+*.md           text      eol=lf
+*.msbuildproj  text      eol=lf
+*.projitems    text      eol=lf
+*.props        text      eol=lf
+*.ps1          text      eol=lf
+*.resx         text      eol=lf
+*.sh           text      eol=lf
+*.shprroj      text      eol=lf
+*.slnf         text      eol=lf
+*.targets      text      eol=lf
+*.xaml         text      eol=lf
+*.txt          text      eol=lf
+*.yml          text      eol=lf
+
+# Solution files
 #  - Treat as text
 #  - Force to CRLF line endings (Windows-style)
 *.sln  text eol=crlf
-*.slnf text eol=crlf
-*.bat  text eol=crlf
-*.cmd  text eol=crlf
 
 # Images
 *.png  binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,31 +1,13 @@
-# Set default file-type attributes
+# All file types:
+#   - Treat as text
+#   - Normalize to LF line endings
+* text eol=lf
 
-# All file types
-* text=auto
-
-# Markups
-*.md   text=auto diff=markdown
-*.mdx  text=auto diff=markdown
-
-# Solutions
-*.sln   text=auto eol=crlf
-*.slnx  text=auto
-
-# Projects
-*.*proj    text=auto
-*.tasks    text=auto
-*.props    text=auto
-*.targets  text=auto
-
-# Sources
-*.cs    text=auto diff=csharp
-*.csx   text=auto diff=csharp
-*.fs    text=auto diff=fsharp
-*.resx  text=auto
-
-# Scripts
-*.in   text eol=lf
-*.sh   text eol=lf
+# Solution files and Windows scripts
+#  - Treat as text
+#  - Force to CRLF line endings (Windows-style)
+*.sln  text eol=crlf
+*.slnf text eol=crlf
 *.bat  text eol=crlf
 *.cmd  text eol=crlf
 
@@ -38,14 +20,3 @@
 *.snk  binary
 *.pfx  binary
 *.cer  binary
-
-# Others
-
-# Preserve Line endings in diff and patch files
-*.diff   -text
-*.patch  -text
-
-# Exclude git meta files from exporting
-.gitattributes export-ignore
-.gitignore     export-ignore
-.gitkeep       export-ignore

--- a/src/TerraFX.Interop.Windows.D2D1/.editorconfig
+++ b/src/TerraFX.Interop.Windows.D2D1/.editorconfig
@@ -13,6 +13,7 @@ indent_size = 4
 indent_style = space
 
 # New line preferences
+end_of_line = lf
 insert_final_newline = false
 trim_trailing_whitespace = true
 

--- a/src/TerraFX.Interop.Windows.Dynamic/.editorconfig
+++ b/src/TerraFX.Interop.Windows.Dynamic/.editorconfig
@@ -13,6 +13,7 @@ indent_size = 4
 indent_style = space
 
 # New line preferences
+end_of_line = lf
 insert_final_newline = false
 trim_trailing_whitespace = true
 

--- a/src/TerraFX.Interop.Windows/.editorconfig
+++ b/src/TerraFX.Interop.Windows/.editorconfig
@@ -13,6 +13,7 @@ indent_size = 4
 indent_style = space
 
 # New line preferences
+end_of_line = lf
 insert_final_newline = false
 trim_trailing_whitespace = true
 


### PR DESCRIPTION
### Description

This PR updates .gitattributes to switch all text files to use LF line endings instead of CRLF.