### PR TITLE
Avoid duplicate Actions runs when PR branch is from the same repo

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,9 @@
 name: .NET
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
 
 env:
   EXCLUDE_RUN_ID_FROM_PACKAGE: false


### PR DESCRIPTION
This should *hopefully* avoid this duplication:

![image](https://user-images.githubusercontent.com/31348972/201778410-d4adee4e-f5c2-4f86-9c52-4cdea9c71092.png)
