### PR TITLE
Add workaround for dotnet test missing MSBuild properties

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -70,6 +70,11 @@ jobs:
       matrix:
         framework: [net6.0, netcoreapp3.1, net472]
     runs-on: windows-2022
+
+    # Set the environment variable which is then looked up in ComputeSharp.Dynamic.
+    # This is a workaround for https://github.com/actions/runner-images/issues/6531.
+    env:
+      CI_RUNNER_DOTNET_TEST_PLATFORM: x64
     steps:
     - name: Git checkout
       uses: actions/checkout@v3

--- a/src/ComputeSharp.Dynamic/ComputeSharp.Dynamic.csproj
+++ b/src/ComputeSharp.Dynamic/ComputeSharp.Dynamic.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <OutputPath>bin\Release</OutputPath>
@@ -23,7 +23,7 @@
 
     <!-- When building locally for x64/ARM64 (using the project through a project reference),
          just copy the right native libraries to the output directory, with no subfolders. -->
-    <When Condition="'$(Platform)' == 'x64'">
+    <When Condition="'$(Platform)' == 'x64' OR '$(CI_RUNNER_DOTNET_TEST_PLATFORM)' == 'x64'">
       <ItemGroup>
         <None Include="Libraries\x64\dxcompiler.dll"
               Link="dxcompiler.dll"
@@ -35,7 +35,7 @@
               CopyToOutputDirectory="PreserveNewest" />
       </ItemGroup>
     </When>
-    <When Condition="'$(Platform)' == 'ARM64'">
+    <When Condition="'$(Platform)' == 'ARM64' OR '$(CI_RUNNER_DOTNET_TEST_PLATFORM)' == 'x64'">
       <ItemGroup>
         <None Include="Libraries\arm64\dxcompiler.dll"
               Link="dxcompiler.dll"


### PR DESCRIPTION
### Closes #437

### Description

This PR adds a temporary workaround for https://github.com/microsoft/vstest/issues/4014.
