### PR TITLE
Fix visibility of interpolated string handler polyfills

### DIFF
--- a/src/ComputeSharp.Core.NetStandard/System/Runtime.CompilerServices/InterpolatedStringHandlerArgumentAttribute.cs
+++ b/src/ComputeSharp.Core.NetStandard/System/Runtime.CompilerServices/InterpolatedStringHandlerArgumentAttribute.cs
@@ -4,7 +4,7 @@ namespace System.Runtime.CompilerServices;
 /// Indicates which arguments to a method involving an interpolated string handler should be passed to that handler.
 /// </summary>
 [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-public sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
+internal sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="InterpolatedStringHandlerArgumentAttribute"/> class.

--- a/src/ComputeSharp.Core.NetStandard/System/Runtime.CompilerServices/InterpolatedStringHandlerAttribute.cs
+++ b/src/ComputeSharp.Core.NetStandard/System/Runtime.CompilerServices/InterpolatedStringHandlerAttribute.cs
@@ -4,6 +4,6 @@ namespace System.Runtime.CompilerServices;
 /// Indicates the attributed type is to be used as an interpolated string handler.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
-public sealed class InterpolatedStringHandlerAttribute : Attribute
+internal sealed class InterpolatedStringHandlerAttribute : Attribute
 {
 }


### PR DESCRIPTION
### Description

This PR fixes the `[InterpolatedStringHandler]` and `[InterpolatedStringHandlerArgument]` polyfills accidentally being public 🤦‍♂️