### PR TITLE
Disable resolution scale options when dynamic resolution is enabled

### DIFF
--- a/samples/ComputeSharp.SwapChain.Core.Shared/ComputeSharp.SwapChain.Core.Shared.projitems
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/ComputeSharp.SwapChain.Core.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Constants\Error.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Constants\Event.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Converters\BoolConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\RenderingPauseConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\ResolutionScaleConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\DebugAnalyticsService.cs" />

--- a/samples/ComputeSharp.SwapChain.Core.Shared/Converters/BoolConverter.cs
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/Converters/BoolConverter.cs
@@ -1,0 +1,20 @@
+using System.Runtime.CompilerServices;
+
+namespace ComputeSharp.SwapChain.Core.Converters;
+
+/// <summary>
+/// A class with some static converters for <see cref="bool"/> values.
+/// </summary>
+public static class BoolConverter
+{
+    /// <summary>
+    /// Negates an input <see cref="bool"/> value.
+    /// </summary>
+    /// <param name="value">The <see cref="bool"/> value to negate.</param>
+    /// <returns>The negated value of <paramref name="value"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool Not(bool value)
+    {
+        return !value;
+    }
+}

--- a/samples/ComputeSharp.SwapChain.Core.Shared/Converters/RenderingPauseConverter.cs
+++ b/samples/ComputeSharp.SwapChain.Core.Shared/Converters/RenderingPauseConverter.cs
@@ -14,7 +14,7 @@ public static class RenderingPauseConverter
     /// <summary>
     /// Gets a symbol for an input rendering state.
     /// </summary>
-    /// <param name="value">Whether or not the rendering is currently paaused.</param>
+    /// <param name="value">Whether or not the rendering is currently paused.</param>
     /// <returns>A symbol representing the next action for the rendering.</returns>
     public static Symbol ConvertPausedToSymbol(bool value)
     {

--- a/samples/ComputeSharp.SwapChain.Uwp/App.xaml
+++ b/samples/ComputeSharp.SwapChain.Uwp/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application
+<Application
     x:Class="ComputeSharp.SwapChain.Uwp.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">

--- a/samples/ComputeSharp.SwapChain.Uwp/Views/MainView.xaml
+++ b/samples/ComputeSharp.SwapChain.Uwp/Views/MainView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl
+<UserControl
     x:Class="ComputeSharp.SwapChain.Uwp.Views.MainView"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -196,21 +196,25 @@
                             Command="{x:Bind ViewModel.SetResolutionScaleCommand}"
                             CommandParameter="{x:Bind ViewModel.ResolutionScaleOptions[0]}"
                             IsChecked="{x:Bind ViewModel.SelectedResolutionScale.Equals(ViewModel.ResolutionScaleOptions[0]), Mode=OneWay}"
+                            IsEnabled="{x:Bind converters:BoolConverter.Not(ViewModel.IsDynamicResolutionEnabled), Mode=OneWay}"
                             Text="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToFormattedString(ViewModel.ResolutionScaleOptions[0])}" />
                         <ToggleMenuFlyoutItem
                             Command="{x:Bind ViewModel.SetResolutionScaleCommand}"
                             CommandParameter="{x:Bind ViewModel.ResolutionScaleOptions[1]}"
                             IsChecked="{x:Bind ViewModel.SelectedResolutionScale.Equals(ViewModel.ResolutionScaleOptions[1]), Mode=OneWay}"
+                            IsEnabled="{x:Bind converters:BoolConverter.Not(ViewModel.IsDynamicResolutionEnabled), Mode=OneWay}"
                             Text="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToFormattedString(ViewModel.ResolutionScaleOptions[1])}" />
                         <ToggleMenuFlyoutItem
                             Command="{x:Bind ViewModel.SetResolutionScaleCommand}"
                             CommandParameter="{x:Bind ViewModel.ResolutionScaleOptions[2]}"
                             IsChecked="{x:Bind ViewModel.SelectedResolutionScale.Equals(ViewModel.ResolutionScaleOptions[2]), Mode=OneWay}"
+                            IsEnabled="{x:Bind converters:BoolConverter.Not(ViewModel.IsDynamicResolutionEnabled), Mode=OneWay}"
                             Text="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToFormattedString(ViewModel.ResolutionScaleOptions[2])}" />
                         <ToggleMenuFlyoutItem
                             Command="{x:Bind ViewModel.SetResolutionScaleCommand}"
                             CommandParameter="{x:Bind ViewModel.ResolutionScaleOptions[3]}"
                             IsChecked="{x:Bind ViewModel.SelectedResolutionScale.Equals(ViewModel.ResolutionScaleOptions[3]), Mode=OneWay}"
+                            IsEnabled="{x:Bind converters:BoolConverter.Not(ViewModel.IsDynamicResolutionEnabled), Mode=OneWay}"
                             Text="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToFormattedString(ViewModel.ResolutionScaleOptions[3])}" />
                     </MenuFlyout>
                 </Button.Flyout>

--- a/samples/ComputeSharp.SwapChain.WinUI/App.xaml
+++ b/samples/ComputeSharp.SwapChain.WinUI/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application
+<Application
     x:Class="ComputeSharp.SwapChain.WinUI.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
@@ -8,9 +8,9 @@
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
                 <ResourceDictionary>
 
-                    <!-- Override the title bar colors to keep it transparent -->
-                    <SolidColorBrush x:Key="WindowCaptionBackground" Color="Transparent"/>
-                    <SolidColorBrush x:Key="WindowCaptionBackgroundDisabled" Color="Transparent"/>
+                    <!--  Override the title bar colors to keep it transparent  -->
+                    <SolidColorBrush x:Key="WindowCaptionBackground" Color="Transparent" />
+                    <SolidColorBrush x:Key="WindowCaptionBackgroundDisabled" Color="Transparent" />
                 </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>

--- a/samples/ComputeSharp.SwapChain.WinUI/Views/MainWindow.xaml
+++ b/samples/ComputeSharp.SwapChain.WinUI/Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+<Window
     x:Class="ComputeSharp.SwapChain.WinUI.Views.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -150,9 +150,9 @@
         <computesharp:AnimatedComputeShaderPanel
             x:Name="ShaderPanel"
             Grid.Row="1"
-            IsVerticalSyncEnabled="{x:Bind ViewModel.IsVerticalSyncEnabled, Mode=OneWay}"
             IsDynamicResolutionEnabled="{x:Bind ViewModel.IsDynamicResolutionEnabled, Mode=OneWay}"
             IsPaused="{x:Bind ViewModel.IsRenderingPaused, Mode=OneWay}"
+            IsVerticalSyncEnabled="{x:Bind ViewModel.IsVerticalSyncEnabled, Mode=OneWay}"
             ResolutionScale="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToScale(ViewModel.SelectedResolutionScale), Mode=OneWay}"
             ShaderRunner="{x:Bind ViewModel.SelectedComputeShader.ShaderRunner, Mode=OneWay}" />
 
@@ -196,21 +196,25 @@
                             Command="{x:Bind ViewModel.SetResolutionScaleCommand}"
                             CommandParameter="{x:Bind ViewModel.ResolutionScaleOptions[0]}"
                             IsChecked="{x:Bind ViewModel.SelectedResolutionScale.Equals(ViewModel.ResolutionScaleOptions[0]), Mode=OneWay}"
+                            IsEnabled="{x:Bind converters:BoolConverter.Not(ViewModel.IsDynamicResolutionEnabled), Mode=OneWay}"
                             Text="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToFormattedString(ViewModel.ResolutionScaleOptions[0])}" />
                         <ToggleMenuFlyoutItem
                             Command="{x:Bind ViewModel.SetResolutionScaleCommand}"
                             CommandParameter="{x:Bind ViewModel.ResolutionScaleOptions[1]}"
                             IsChecked="{x:Bind ViewModel.SelectedResolutionScale.Equals(ViewModel.ResolutionScaleOptions[1]), Mode=OneWay}"
+                            IsEnabled="{x:Bind converters:BoolConverter.Not(ViewModel.IsDynamicResolutionEnabled), Mode=OneWay}"
                             Text="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToFormattedString(ViewModel.ResolutionScaleOptions[1])}" />
                         <ToggleMenuFlyoutItem
                             Command="{x:Bind ViewModel.SetResolutionScaleCommand}"
                             CommandParameter="{x:Bind ViewModel.ResolutionScaleOptions[2]}"
                             IsChecked="{x:Bind ViewModel.SelectedResolutionScale.Equals(ViewModel.ResolutionScaleOptions[2]), Mode=OneWay}"
+                            IsEnabled="{x:Bind converters:BoolConverter.Not(ViewModel.IsDynamicResolutionEnabled), Mode=OneWay}"
                             Text="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToFormattedString(ViewModel.ResolutionScaleOptions[2])}" />
                         <ToggleMenuFlyoutItem
                             Command="{x:Bind ViewModel.SetResolutionScaleCommand}"
                             CommandParameter="{x:Bind ViewModel.ResolutionScaleOptions[3]}"
                             IsChecked="{x:Bind ViewModel.SelectedResolutionScale.Equals(ViewModel.ResolutionScaleOptions[3]), Mode=OneWay}"
+                            IsEnabled="{x:Bind converters:BoolConverter.Not(ViewModel.IsDynamicResolutionEnabled), Mode=OneWay}"
                             Text="{x:Bind converters:ResolutionScaleConverter.ConvertPercentageToFormattedString(ViewModel.ResolutionScaleOptions[3])}" />
                     </MenuFlyout>
                 </Button.Flyout>


### PR DESCRIPTION
### Description

This PR disables the resolution scale options when dynamic resolution is enabled, since they don't do anything in that case.

![](https://user-images.githubusercontent.com/10199417/209437398-96e3a0cb-66b5-4677-8673-86dbed98645f.png)