### PR TITLE
Default to 60fps for dynamic resolution when using WARP

### DIFF
--- a/src/ComputeSharp.UI/Extensions/IDXGIAdapterExtensions.cs
+++ b/src/ComputeSharp.UI/Extensions/IDXGIAdapterExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using ComputeSharp.Core.Extensions;
+using ComputeSharp.Graphics.Helpers;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 using Win32 = TerraFX.Interop.Windows.Windows;
@@ -29,7 +30,30 @@ internal static unsafe class IDXGIAdapterExtensions
 
         using ComPtr<IDXGIOutput> dxgiOutput = default;
 
-        dxgiAdapter1.Get()->EnumOutputs(0, dxgiOutput.GetAddressOf()).Assert();
+        // Get the first output for the adapter (this will match the compositor output)
+        HRESULT hresult = dxgiAdapter1.Get()->EnumOutputs(0, dxgiOutput.GetAddressOf());
+
+        // There is a corner case to handle in case the WARP device is used (which will happen if running on a device
+        // that doesn't have a dedicated GPU matching the minimum requirements for ComputeSharp, or if no dedicated
+        // GPU is available at all). For WARP devices, there will never be any outputs being reported, so the call
+        // above will fail with DXGI_ERROR_NOT_FOUND. In this case, instead of throwing, we can simply default to
+        // a standard framerate of 60fps, and use that to still allow the execution to continue without crashing.
+        if (hresult == DXGI.DXGI_ERROR_NOT_FOUND)
+        {
+            DXGI_ADAPTER_DESC dxgiDescription;
+
+            // Get the adapter description, to verify the device is in fact the WARP device
+            dxgiAdapter.GetDesc(&dxgiDescription).Assert();
+
+            // Just default to 60fps if the WARP device is used
+            if (dxgiDescription.VendorId == DeviceHelper.MicrosoftVendorId &&
+                dxgiDescription.DeviceId == DeviceHelper.WarpDeviceId)
+            {
+                return 60;
+            }
+        }
+
+        hresult.Assert();
 
         using ComPtr<IDXGIOutput1> dxgiOutput1 = default;
 

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
@@ -20,12 +20,12 @@ internal static partial class DeviceHelper
     /// <summary>
     /// The vendor id for Microsoft adapters (the "Microsoft Basic Render").
     /// </summary>
-    private const uint MicrosoftVendorId = 0x1414;
+    public const uint MicrosoftVendorId = 0x1414;
 
     /// <summary>
     /// The device id for the WARP device.
     /// </summary>
-    private const uint WarpDeviceId = 0x8C;
+    public const uint WarpDeviceId = 0x8C;
 
     /// <summary>
     /// Gets the default <see cref="GraphicsDevice"/> instance.


### PR DESCRIPTION
### Closes #458

### Description

This fixes an exception in the animated shader panel when trying to render just using the WARP device.
Also resolves https://github.com/jenius-apps/ambie/issues/303.