### PR TITLE
Add .NET 7 TFM to all unit tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -135,11 +135,11 @@ jobs:
     - name: Build and run ComputeSharp.Sample.FSharp
       run: >
         dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -p:Platform=x64 -v n;
-        ${{matrix.command}} samples\ComputeSharp.Sample.FSharp\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.Sample.FSharp.exe
+        samples\ComputeSharp.Sample.FSharp\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.Sample.FSharp.exe
     - name: Build and run ComputeSharp.ImageProcessing.csproj
       run: >
         dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -p:Platform=x64 -v n;
-        ${{matrix.command}} samples\ComputeSharp.ImageProcessing\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.ImageProcessing.exe
+        samples\ComputeSharp.ImageProcessing\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.ImageProcessing.exe
       
       # Also publish the NativeAOT test when .NET 7 is used
     - if: matrix.framework == 'net7.0'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -70,7 +70,7 @@ jobs:
     needs: [build-solution]
     strategy:
       matrix:
-        framework: [net6.0, netcoreapp3.1, net472]
+        framework: [net7.0, net6.0, netcoreapp3.1, net472]
     runs-on: windows-2022
 
     # Set the environment variable which is then looked up in ComputeSharp.Dynamic.

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS0419;CA1416</NoWarn>
   </PropertyGroup>

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
@@ -22,11 +22,11 @@
     
   <!-- When the .NET Standard 2.0 version of ComputeSharp is resolved, the TerraFX APIs are internal, as they
        are referenced from the shared project. The same reference is needed here to make all tests build fine. -->
-  <Import Condition="'$(TargetFramework)' != 'net6.0'" Project="..\..\src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems" />
-  <Import Condition="'$(TargetFramework)' != 'net6.0'" Project="..\..\src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems" />
+  <Import Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0'" Project="..\..\src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems" />
+  <Import Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0'" Project="..\..\src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems" />
 
   <!-- Only when the local TerraFX is referenced, ignore warnings from there -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0'">
     <NoWarn>$(NoWarn);CS0649</NoWarn>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>

--- a/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
+++ b/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
     <NoWarn>$(NoWarn);CA1416</NoWarn>

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
@@ -30,13 +30,13 @@
 
   <!-- When the .NET Standard 2.0 version of ComputeSharp is resolved, the TerraFX APIs are internal, as they
        are referenced from the shared project. The same reference is needed here to make all tests build fine. -->
-  <Import Condition="'$(TargetFramework)' != 'net6.0'" Project="..\..\src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems" />
-  <Import Condition="'$(TargetFramework)' != 'net6.0'" Project="..\..\src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems" />
+  <Import Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0'" Project="..\..\src\TerraFX.Interop.Windows\TerraFX.Interop.Windows.projitems" />
+  <Import Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0'" Project="..\..\src\ComputeSharp.NetStandard\ComputeSharp.NetStandard.projitems" />
 
   <Import Project="..\..\samples\ComputeSharp.SwapChain.Shaders.Shared\ComputeSharp.SwapChain.Shaders.Shared.projitems" Label="Shared" />
 
   <!-- Only when the local TerraFX is referenced, ignore warnings from there -->
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'net7.0'">
     <NoWarn>$(NoWarn);CS0649</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description

This PR enables all unit tests to run on .NET 7 as well, and enables this in the CI script as well.