### PR TITLE
Enable embedded PDBs for UWP libraries

### DIFF
--- a/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
+++ b/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
@@ -6,7 +6,6 @@
     <TargetPlatformMinRevision>17763</TargetPlatformMinRevision>
     <TargetPlatformVersion>$(TargetPlatformBaseVersion).$(TargetPlatformRevision).0</TargetPlatformVersion>
     <TargetPlatformMinVersion>$(TargetPlatformBaseVersion).$(TargetPlatformMinRevision).0</TargetPlatformMinVersion>
-    <DebugType>Portable</DebugType>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>

--- a/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
+++ b/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>
     <ExtrasEnableDefaultXamlItems>true</ExtrasEnableDefaultXamlItems>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <RootNamespace>ComputeSharp.D2D1.Uwp</RootNamespace>
     <Platforms>x64;ARM64</Platforms>

--- a/src/ComputeSharp.Uwp/ComputeSharp.Uwp.csproj
+++ b/src/ComputeSharp.Uwp/ComputeSharp.Uwp.csproj
@@ -10,7 +10,6 @@
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>
     <ExtrasEnableDefaultXamlItems>true</ExtrasEnableDefaultXamlItems>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <RootNamespace>ComputeSharp.Uwp</RootNamespace>
     <Platforms>x64;ARM64</Platforms>

--- a/src/ComputeSharp.Uwp/ComputeSharp.Uwp.csproj
+++ b/src/ComputeSharp.Uwp/ComputeSharp.Uwp.csproj
@@ -6,7 +6,6 @@
     <TargetPlatformMinRevision>17763</TargetPlatformMinRevision>
     <TargetPlatformVersion>$(TargetPlatformBaseVersion).$(TargetPlatformRevision).0</TargetPlatformVersion>
     <TargetPlatformMinVersion>$(TargetPlatformBaseVersion).$(TargetPlatformMinRevision).0</TargetPlatformMinVersion>
-    <DebugType>Portable</DebugType>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>


### PR DESCRIPTION
### Description

This PR switches the PDB mode for the UWP libraries to use the embedded PDB mode like all other projects.
Additionally it also removes one duplicate property that was already set in the imported .props file.