### PR TITLE
Add support for ICanvasEffect for PixelShaderEffect<T>

### DIFF
--- a/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/ICanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/ICanvasEffect.cs
@@ -6,7 +6,7 @@ using TerraFX.Interop.Windows;
 
 #pragma warning disable CS0649, IDE1006
 
-namespace ABI.Microsoft.Graphics.Canvas;
+namespace ABI.Microsoft.Graphics.Canvas.Effects;
 
 /// <summary>
 /// The native WinRT interface for <see cref="global::Microsoft.Graphics.Canvas.Effects.ICanvasEffect"/> objects.

--- a/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/ICanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/ICanvasEffect.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TerraFX.Interop;
+using TerraFX.Interop.Windows;
+
+#pragma warning disable CS0649, IDE1006
+
+namespace ABI.Microsoft.Graphics.Canvas;
+
+/// <summary>
+/// The native WinRT interface for <see cref="global::Microsoft.Graphics.Canvas.Effects.ICanvasEffect"/> objects.
+/// </summary>
+[Guid("0EF96F8C-9B5E-4BF0-A399-AAD8CE53DB55")]
+[NativeTypeName("class ICanvasEffect : IInspectable")]
+[NativeInheritance("IInspectable")]
+internal unsafe struct ICanvasEffect
+{
+    public void** lpVtbl;
+
+    /// <inheritdoc cref="IUnknown.QueryInterface"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(0)]
+    public HRESULT QueryInterface([NativeTypeName("const IID &")] Guid* riid, void** ppvObject)
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasEffect*, Guid*, void**, int>)this.lpVtbl[0])((ICanvasEffect*)Unsafe.AsPointer(ref this), riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="IUnknown.AddRef"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(1)]
+    [return: NativeTypeName("ULONG")]
+    public uint AddRef()
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasEffect*, uint>)this.lpVtbl[1])((ICanvasEffect*)Unsafe.AsPointer(ref this));
+    }
+
+    /// <inheritdoc cref="IUnknown.Release"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(2)]
+    [return: NativeTypeName("ULONG")]
+    public uint Release()
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasEffect*, uint>)this.lpVtbl[2])((ICanvasEffect*)Unsafe.AsPointer(ref this));
+    }
+}

--- a/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/ICanvasResourceCreatorWithDpi.cs
+++ b/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/ICanvasResourceCreatorWithDpi.cs
@@ -9,12 +9,12 @@ using TerraFX.Interop.Windows;
 namespace ABI.Microsoft.Graphics.Canvas;
 
 /// <summary>
-/// The native WinRT interface for <see cref="global::Microsoft.Graphics.Canvas.ICanvasResourceCreator"/> objects.
+/// The native WinRT interface for <see cref="global::Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi"/> objects.
 /// </summary>
-[Guid("8F6D8AA8-492F-4BC6-B3D0-E7F5EAE84B11")]
-[NativeTypeName("class ICanvasResourceCreator : IInspectable")]
+[Guid("1A75B512-E9FA-49E6-A876-38CAE194013E")]
+[NativeTypeName("class ICanvasResourceCreatorWithDpi : IInspectable")]
 [NativeInheritance("IInspectable")]
-internal unsafe struct ICanvasResourceCreator
+internal unsafe struct ICanvasResourceCreatorWithDpi
 {
     public void** lpVtbl;
 
@@ -23,7 +23,7 @@ internal unsafe struct ICanvasResourceCreator
     [VtblIndex(0)]
     public HRESULT QueryInterface([NativeTypeName("const IID &")] Guid* riid, void** ppvObject)
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceCreator*, Guid*, void**, int>)this.lpVtbl[0])((ICanvasResourceCreator*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        return ((delegate* unmanaged[Stdcall]<ICanvasResourceCreatorWithDpi*, Guid*, void**, int>)this.lpVtbl[0])((ICanvasResourceCreatorWithDpi*)Unsafe.AsPointer(ref this), riid, ppvObject);
     }
 
     /// <inheritdoc cref="IUnknown.AddRef"/>
@@ -32,7 +32,7 @@ internal unsafe struct ICanvasResourceCreator
     [return: NativeTypeName("ULONG")]
     public uint AddRef()
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceCreator*, uint>)this.lpVtbl[1])((ICanvasResourceCreator*)Unsafe.AsPointer(ref this));
+        return ((delegate* unmanaged[Stdcall]<ICanvasResourceCreatorWithDpi*, uint>)this.lpVtbl[1])((ICanvasResourceCreatorWithDpi*)Unsafe.AsPointer(ref this));
     }
 
     /// <inheritdoc cref="IUnknown.Release"/>
@@ -41,6 +41,6 @@ internal unsafe struct ICanvasResourceCreator
     [return: NativeTypeName("ULONG")]
     public uint Release()
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceCreator*, uint>)this.lpVtbl[2])((ICanvasResourceCreator*)Unsafe.AsPointer(ref this));
+        return ((delegate* unmanaged[Stdcall]<ICanvasResourceCreatorWithDpi*, uint>)this.lpVtbl[2])((ICanvasResourceCreatorWithDpi*)Unsafe.AsPointer(ref this));
     }
 }

--- a/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/Win2D.cs
+++ b/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/Win2D.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using System.Runtime.InteropServices;
+using ABI.Microsoft.Graphics.Canvas.Effects;
 using TerraFX.Interop;
 using Windows.Foundation;
 
@@ -19,9 +20,73 @@ internal static unsafe class Win2D
     /// <param name="rect">The resulting bounds.</param>
     /// <returns>The <see cref="TerraFX.Interop.Windows.HRESULT"/> for the operation.</returns>
     [DllImport("Microsoft.Graphics.Canvas.dll", PreserveSig = true, ExactSpelling = true)]
+    [return: NativeTypeName("HRESULT")]
     public static extern int GetBoundsForICanvasImageInterop(
         ICanvasResourceCreator* resourceCreator,
         ICanvasImageInterop* image,
         [NativeTypeName("Windows::Foundation::Numerics::Matrix3x2 const*")] Matrix3x2* transform,
         Rect* rect);
+
+    /// <summary>
+    /// Implements support for <see cref="global::Microsoft.Graphics.Canvas.Effects.ICanvasEffect.InvalidateSourceRectangle"/> for an external <see cref="ICanvasImageInterop"/> instance.
+    /// </summary>
+    /// <param name="resourceCreator">The input <see cref="ICanvasResourceCreatorWithDpi"/> instance to use to perform the operation.</param>
+    /// <param name="image">The target <see cref="ICanvasImageInterop"/> instance to execute the operation upon.</param>
+    /// <param name="sourceIndex">The input index to invalidate.</param>
+    /// <param name="invalidRectangle">The rectangle to invalidate.</param>
+    /// <returns>The <see cref="TerraFX.Interop.Windows.HRESULT"/> for the operation.</returns>
+    [DllImport("Microsoft.Graphics.Canvas.dll", PreserveSig = true, ExactSpelling = true)]
+    [return: NativeTypeName("HRESULT")]
+    public static extern int InvalidateSourceRectangleForICanvasImageInterop(
+        ICanvasResourceCreatorWithDpi* resourceCreator,
+        ICanvasImageInterop* image,
+        uint sourceIndex,
+        [NativeTypeName("Windows::Foundation::Rect const*")] Rect* invalidRectangle);
+
+    /// <summary>
+    /// Implements support for <see cref="global::Microsoft.Graphics.Canvas.Effects.ICanvasEffect.GetInvalidRectangles"/> for an external <see cref="ICanvasImageInterop"/> instance.
+    /// </summary>
+    /// <param name="resourceCreator">The input <see cref="ICanvasResourceCreatorWithDpi"/> instance to use to perform the operation.</param>
+    /// <param name="image">The target <see cref="ICanvasImageInterop"/> instance to execute the operation upon.</param>
+    /// <param name="valueCount">The resulting length of the COM array returned via <paramref name="valueElements"/>.</param>
+    /// <param name="valueElements">The COM array with the sequence of invalid rectangles for the effect.</param>
+    /// <returns>The <see cref="TerraFX.Interop.Windows.HRESULT"/> for the operation.</returns>
+    [DllImport("Microsoft.Graphics.Canvas.dll", PreserveSig = true, ExactSpelling = true)]
+    [return: NativeTypeName("HRESULT")]
+    public static extern int GetInvalidRectanglesForICanvasImageInterop(
+        ICanvasResourceCreatorWithDpi* resourceCreator,
+        ICanvasImageInterop* image,
+        uint* valueCount,
+        Rect** valueElements);
+
+    /// <summary>
+    /// Implements support for <see cref="global::Microsoft.Graphics.Canvas.Effects.ICanvasEffect.GetRequiredSourceRectangle"/> and
+    /// <see cref="global::Microsoft.Graphics.Canvas.Effects.ICanvasEffect.GetRequiredSourceRectangles"/> for an external <see cref="ICanvasImageInterop"/> instance.
+    /// </summary>
+    /// <param name="resourceCreator">The input <see cref="ICanvasResourceCreatorWithDpi"/> instance to use to perform the operation.</param>
+    /// <param name="image">The target <see cref="ICanvasImageInterop"/> instance to execute the operation upon.</param>
+    /// <param name="outputRectangle">The portion of the output image whose inputs are being inspected.</param>
+    /// <param name="sourceEffectCount">The length of the sequence of input effects.</param>
+    /// <param name="sourceEffects">The sequence of input effects whose rectangles are being queries.</param>
+    /// <param name="sourceIndexCount">The length of the sequence of indices for the input effects.</param>
+    /// <param name="sourceIndices">The sequence of indices for the input effects.</param>
+    /// <param name="sourceBoundsCount">The length of the sequence of bounds to consider.</param>
+    /// <param name="sourceBounds">The sequence of bounds to consider in the resulting output.</param>
+    /// <param name="valueCount">The number of elements provided in <paramref name="valueElements"/>.</param>
+    /// <param name="valueElements">The sequence of resulting required rectangles to compute.</param>
+    /// <returns>The <see cref="TerraFX.Interop.Windows.HRESULT"/> for the operation.</returns>
+    [DllImport("Microsoft.Graphics.Canvas.dll", PreserveSig = true, ExactSpelling = true)]
+    [return: NativeTypeName("HRESULT")]
+    public static extern int GetRequiredSourceRectanglesForICanvasImageInterop(
+        ICanvasResourceCreatorWithDpi* resourceCreator,
+        ICanvasImageInterop* image,
+        [NativeTypeName("Windows::Foundation::Rect const*")] Rect* outputRectangle,
+        uint sourceEffectCount,
+        [NativeTypeName("ABI::Microsoft::Graphics::Canvas::Effects::ICanvasEffect* const*")] ICanvasEffect** sourceEffects,
+        uint sourceIndexCount,
+        [NativeTypeName("uint32_t const*")] uint* sourceIndices,
+        uint sourceBoundsCount,
+        [NativeTypeName("Windows::Foundation::Rect const*")] Rect* sourceBounds,
+        uint valueCount,
+        Rect* valueElements);
 }

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasEffect.cs
@@ -1,44 +1,232 @@
 using System;
-using Microsoft.Graphics.Canvas;
-using Microsoft.Graphics.Canvas.Effects;
+using System.Buffers;
+using System.Runtime.InteropServices;
+using ABI.Microsoft.Graphics.Canvas;
+using ComputeSharp.D2D1.Extensions;
+using ComputeSharp.Interop;
+using TerraFX.Interop.Windows;
 using Windows.Foundation;
+using ICanvasEffect = Microsoft.Graphics.Canvas.Effects.ICanvasEffect;
+using ICanvasResourceCreatorWithDpi = Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi;
 
 namespace ComputeSharp.D2D1.Uwp;
 
 /// <inheritdoc/>
-partial class PixelShaderEffect<T>
+unsafe partial class PixelShaderEffect<T>
 {
     /// <inheritdoc/>
-    void ICanvasEffect.InvalidateSourceRectangle(ICanvasResourceCreatorWithDpi resourceCreator, uint sourceIndex, Rect invalidRectangle)
+    public void InvalidateSourceRectangle(ICanvasResourceCreatorWithDpi resourceCreator, uint sourceIndex, Rect invalidRectangle)
     {
-        throw new NotSupportedException("ICanvasEffect.InvalidateSourceRectangle is not currently supported.");
+        using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
+        using ComPtr<ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi> resourceCreatorWithDpi = default;
+        using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
+
+        GetCanvasResourceCreatorAndCanvasImageInteropUnderlyingObjects(
+            resourceCreator,
+            resourceCreatorWithDpi.GetAddressOf(),
+            canvasImageInterop.GetAddressOf());
+
+        Win2D.InvalidateSourceRectangleForICanvasImageInterop(
+            resourceCreator: resourceCreatorWithDpi.Get(),
+            image: canvasImageInterop.Get(),
+            sourceIndex: sourceIndex,
+            invalidRectangle: &invalidRectangle).Assert();
     }
 
     /// <inheritdoc/>
-    Rect[] ICanvasEffect.GetInvalidRectangles(ICanvasResourceCreatorWithDpi resourceCreator)
+    public Rect[] GetInvalidRectangles(ICanvasResourceCreatorWithDpi resourceCreator)
     {
-        throw new NotSupportedException("ICanvasEffect.GetInvalidRectangles is not currently supported.");
+        using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
+        using ComPtr<ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi> resourceCreatorWithDpi = default;
+        using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
+
+        GetCanvasResourceCreatorAndCanvasImageInteropUnderlyingObjects(
+            resourceCreator,
+            resourceCreatorWithDpi.GetAddressOf(),
+            canvasImageInterop.GetAddressOf());
+
+        uint valueCount = 0;
+        Rect* valueElements = null;
+
+        Win2D.GetInvalidRectanglesForICanvasImageInterop(
+            resourceCreator: resourceCreatorWithDpi.Get(),
+            image: canvasImageInterop.Get(),
+            valueCount: &valueCount,
+            valueElements: &valueElements).Assert();
+
+        // If no rectangles have been returned, just use an empty array
+        if (valueCount == 0 && valueElements is null)
+        {
+            return Array.Empty<Rect>();
+        }
+
+        try
+        {
+            Rect[] result = new Rect[valueCount];
+
+            // Copy the data back from the COM array that Win2D created and returned
+            fixed (Rect* pResult = result)
+            {
+                Buffer.MemoryCopy(valueElements, pResult, valueCount * sizeof(Rect), valueCount * sizeof(Rect));
+            }
+
+            return result;
+        }
+        finally
+        {
+            // Make sure to release the callee-allocated COM array
+            Marshal.FreeCoTaskMem((IntPtr)valueElements);
+        }
     }
 
     /// <inheritdoc/>
-    Rect ICanvasEffect.GetRequiredSourceRectangle(
+    public Rect GetRequiredSourceRectangle(
         ICanvasResourceCreatorWithDpi resourceCreator,
         Rect outputRectangle,
         ICanvasEffect sourceEffect,
         uint sourceIndex,
         Rect sourceBounds)
     {
-        throw new NotSupportedException("ICanvasEffect.GetRequiredSourceRectangle is not currently supported.");
+        using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
+        using ComPtr<ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi> resourceCreatorWithDpi = default;
+        using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
+
+        GetCanvasResourceCreatorAndCanvasImageInteropUnderlyingObjects(
+            resourceCreator,
+            resourceCreatorWithDpi.GetAddressOf(),
+            canvasImageInterop.GetAddressOf());
+
+        Rect result;
+
+        using ComPtr<IUnknown> canvasEffectUnknown = default;
+        using ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect> canvasEffectAbi = default;
+
+        // Get the ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect object from the input interface
+        canvasEffectUnknown.Attach((IUnknown*)Marshal.GetIUnknownForObject(sourceEffect));
+        canvasEffectUnknown.CopyTo(canvasEffectAbi.GetAddressOf()).Assert();
+
+        Win2D.GetRequiredSourceRectanglesForICanvasImageInterop(
+            resourceCreator: resourceCreatorWithDpi.Get(),
+            image: canvasImageInterop.Get(),
+            outputRectangle: &outputRectangle,
+            sourceEffectCount: 1,
+            sourceEffects: canvasEffectAbi.GetAddressOf(),
+            sourceIndexCount: 1,
+            sourceIndices: &sourceIndex,
+            sourceBoundsCount: 1,
+            sourceBounds: &sourceBounds,
+            valueCount: 1,
+            valueElements: &result).Assert();
+
+        return result;
     }
 
     /// <inheritdoc/>
-    Rect[] ICanvasEffect.GetRequiredSourceRectangles(
+    public Rect[] GetRequiredSourceRectangles(
         ICanvasResourceCreatorWithDpi resourceCreator,
         Rect outputRectangle,
         ICanvasEffect[] sourceEffects,
         uint[] sourceIndices,
         Rect[] sourceBounds)
     {
-        throw new NotSupportedException("ICanvasEffect.GetRequiredSourceRectangles is not currently supported.");
+        using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
+        using ComPtr<ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi> resourceCreatorWithDpi = default;
+        using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
+
+        GetCanvasResourceCreatorAndCanvasImageInteropUnderlyingObjects(
+            resourceCreator,
+            resourceCreatorWithDpi.GetAddressOf(),
+            canvasImageInterop.GetAddressOf());
+
+        // The array optionally rented from the pool is of IntPtr types to reduce the number of generic
+        // instantiations. This increases the chances of the pooled arrays being shared with other code.
+        IntPtr[]? canvasEffectsAbiArray = null;
+
+        // Create the span and optional array of ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect objects
+        Span<ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>> canvasEffects = sourceEffects.Length <= 16
+            ? stackalloc ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>[16]
+            : MemoryMarshal.Cast<IntPtr, ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>>(
+                canvasEffectsAbiArray = ArrayPool<IntPtr>.Shared.Rent(sourceEffects.Length));
+
+        // Clear the span to ensure no false positives are accidentally disposed
+        canvasEffects.Clear();
+
+        try
+        {
+            // Get the underlying ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect object for each input effect
+            for (int i = 0; i < sourceEffects.Length; i++)
+            {
+                using ComPtr<IUnknown> canvasEffectUnknown = default;
+
+                canvasEffectUnknown.Attach((IUnknown*)Marshal.GetIUnknownForObject(sourceEffects[i]));
+                canvasEffectUnknown.CopyTo(canvasEffects[i].GetAddressOf()).Assert();
+            }
+
+            Rect[] result = new Rect[sourceEffects.Length];
+
+            fixed (ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>* pCanvasEffects = canvasEffects)
+            fixed (uint* pSourceIndices = sourceIndices)
+            fixed (Rect* pSourceBounds = sourceBounds)
+            fixed (Rect* pResult = result)
+            {
+                Win2D.GetRequiredSourceRectanglesForICanvasImageInterop(
+                    resourceCreator: resourceCreatorWithDpi.Get(),
+                    image: canvasImageInterop.Get(),
+                    outputRectangle: &outputRectangle,
+                    sourceEffectCount: (uint)sourceEffects.Length,
+                    sourceEffects: (ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect**)pCanvasEffects,
+                    sourceIndexCount: (uint)sourceIndices.Length,
+                    sourceIndices: pSourceIndices,
+                    sourceBoundsCount: (uint)sourceBounds.Length,
+                    sourceBounds: pSourceBounds,
+                    valueCount: (uint)sourceEffects.Length,
+                    valueElements: pResult).Assert();
+            }
+
+            // Only return the array to the pool if no exceptions have been thrown
+            if (canvasEffectsAbiArray is not null)
+            {
+                ArrayPool<IntPtr>.Shared.Return(canvasEffectsAbiArray);
+            }
+
+            return result;
+        }
+        finally
+        {
+            // Release all canvas effects that have been retrieved up until the exception
+            foreach (ref ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect> canvasEffect in canvasEffects)
+            {
+                canvasEffect.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the underlying <see cref="ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi"/> and <see cref="ICanvasImageInterop"/>
+    /// objects from an input <see cref="ICanvasResourceCreatorWithDpi"/> object and the current <see cref="PixelShaderEffect{T}"/> instance.
+    /// </summary>
+    /// <param name="resourceCreator">The input <see cref="ICanvasResourceCreatorWithDpi"/> object.</param>
+    /// <param name="resourceCreatorWithDpi">The resulting <see cref="ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi"/> object for <paramref name="resourceCreator"/>.</param>
+    /// <param name="canvasImageInterop">The resulting <see cref="ICanvasImageInterop"/> object for the current <see cref="PixelShaderEffect{T}"/> instance.</param>
+    private void GetCanvasResourceCreatorAndCanvasImageInteropUnderlyingObjects(
+        ICanvasResourceCreatorWithDpi resourceCreator,
+        ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi** resourceCreatorWithDpi,
+        ICanvasImageInterop** canvasImageInterop)
+    {
+        using ComPtr<IUnknown> resourceCreatorUnknown = default;
+
+        // Get the ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi object from the input interface
+        resourceCreatorUnknown.Attach((IUnknown*)Marshal.GetIUnknownForObject(resourceCreator));
+        resourceCreatorUnknown.CopyTo(resourceCreatorWithDpi).Assert();
+
+        using ComPtr<IUnknown> canvasImageInteropUnknown = default;
+
+        // Get the ICanvasImageInterop object from the current instance
+        canvasImageInteropUnknown.Attach((IUnknown*)Marshal.GetIUnknownForObject(this));
+        canvasImageInteropUnknown.CopyTo(canvasImageInterop).Assert();
     }
 }

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasEffect.cs
@@ -47,8 +47,8 @@ unsafe partial class PixelShaderEffect<T>
             resourceCreatorWithDpi.GetAddressOf(),
             canvasImageInterop.GetAddressOf());
 
-        uint valueCount = 0;
-        Rect* valueElements = null;
+        uint valueCount;
+        Rect* valueElements;
 
         Win2D.GetInvalidRectanglesForICanvasImageInterop(
             resourceCreator: resourceCreatorWithDpi.Get(),
@@ -56,23 +56,11 @@ unsafe partial class PixelShaderEffect<T>
             valueCount: &valueCount,
             valueElements: &valueElements).Assert();
 
-        // If no rectangles have been returned, just use an empty array
-        if (valueCount == 0 && valueElements is null)
-        {
-            return Array.Empty<Rect>();
-        }
-
         try
         {
-            Rect[] result = new Rect[valueCount];
-
-            // Copy the data back from the COM array that Win2D created and returned
-            fixed (Rect* pResult = result)
-            {
-                Buffer.MemoryCopy(valueElements, pResult, valueCount * sizeof(Rect), valueCount * sizeof(Rect));
-            }
-
-            return result;
+            // Copy the data back from the COM array that Win2D created and returned.
+            // If no items were returned, this will automatically return an empty array.
+            return new Span<Rect>(valueElements, checked((int)valueCount)).ToArray();
         }
         finally
         {

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasImage.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasImage.cs
@@ -30,25 +30,25 @@ unsafe partial class PixelShaderEffect<T>
     {
         using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
 
-        using ComPtr<IUnknown> canvasResourceCreatorUnknown = default;
+        using ComPtr<IUnknown> resourceCreatorUnknown = default;
+        using ComPtr<ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreator> resourceCreatorAbi = default;
+
+        // Get the ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreator object from the input interface
+        resourceCreatorUnknown.Attach((IUnknown*)Marshal.GetIUnknownForObject(resourceCreator));
+        resourceCreatorUnknown.CopyTo(resourceCreatorAbi.GetAddressOf()).Assert();
+
         using ComPtr<IUnknown> canvasImageInteropUnknown = default;
-
-        // Get the IUnknown* references for the ICanvasResourceCreator and ICanvasImageInterop objects
-        canvasResourceCreatorUnknown.Attach((IUnknown*)Marshal.GetIUnknownForObject(resourceCreator));
-        canvasImageInteropUnknown.Attach((IUnknown*)Marshal.GetIUnknownForObject(this));
-
-        using ComPtr<ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreator> canvasResourceCreator = default;
         using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
 
-        // Get the ICanvasResourceCreator* and ICanvasImageInterop* pointers
-        canvasResourceCreatorUnknown.CopyTo(canvasResourceCreator.GetAddressOf()).Assert();
+        // Get the ICanvasImageInterop object from the current instance
+        canvasImageInteropUnknown.Attach((IUnknown*)Marshal.GetIUnknownForObject(this));
         canvasImageInteropUnknown.CopyTo(canvasImageInterop.GetAddressOf()).Assert();
 
         Rect bounds;
 
         // Forward the actual logic to Win2D to compute the image bounds (it needs the internal context)
         Win2D.GetBoundsForICanvasImageInterop(
-            resourceCreator: canvasResourceCreator.Get(),
+            resourceCreator: resourceCreatorAbi.Get(),
             image: canvasImageInterop.Get(),
             transform: transform,
             rect: &bounds).Assert();

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.cs
@@ -2,9 +2,9 @@ using ABI.Microsoft.Graphics.Canvas;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.Interop;
 using Microsoft.Graphics.Canvas;
-using Microsoft.Graphics.Canvas.Effects;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
+using ICanvasEffect = Microsoft.Graphics.Canvas.Effects.ICanvasEffect;
 
 namespace ComputeSharp.D2D1.Uwp;
 

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.cs
@@ -2,9 +2,9 @@ using ABI.Microsoft.Graphics.Canvas;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.Interop;
 using Microsoft.Graphics.Canvas;
+using Microsoft.Graphics.Canvas.Effects;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
-using ICanvasEffect = Microsoft.Graphics.Canvas.Effects.ICanvasEffect;
 
 namespace ComputeSharp.D2D1.Uwp;
 


### PR DESCRIPTION
### Contributes to https://github.com/microsoft/Win2D/issues/894 support

### Description

This PR adds `ICanvasEffect` support to `PixelShaderEffect<T>` through the new Win2D exports for `ICanvasImageInterop`.