### PR TITLE
Add new WIN2D_GET_DEVICE_ASSOCIATION_TYPE support for ICanvasImageInterop

### DIFF
--- a/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/ICanvasImageInterop.cs
+++ b/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/ICanvasImageInterop.cs
@@ -22,13 +22,14 @@ internal unsafe struct ICanvasImageInterop
     /// <summary>
     /// Gets the device that the effect is currently realized on, if any.
     /// </summary>
-    /// <param name="device">The resulting device, if available ((as a marshalled <see cref="global::Microsoft.Graphics.Canvas.CanvasDevice"/>)).</param>
+    /// <param name="device">The resulting device, if available (as a marshalled <see cref="global::Microsoft.Graphics.Canvas.CanvasDevice"/>).</param>
+    /// <param name="type">The <see cref="WIN2D_GET_DEVICE_ASSOCIATION_TYPE"/> value describing the returned instance.</param>
     /// <returns>The <see cref="HRESULT"/> for the operation.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(3)]
-    public HRESULT GetDevice(ICanvasDevice** device)
+    public HRESULT GetDevice(ICanvasDevice** device, WIN2D_GET_DEVICE_ASSOCIATION_TYPE* type)
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasImageInterop*, ICanvasDevice**, int>)this.lpVtbl[3])((ICanvasImageInterop*)Unsafe.AsPointer(ref this), device);
+        return ((delegate* unmanaged[Stdcall]<ICanvasImageInterop*, ICanvasDevice**, WIN2D_GET_DEVICE_ASSOCIATION_TYPE*, int>)this.lpVtbl[3])((ICanvasImageInterop*)Unsafe.AsPointer(ref this), device, type);
     }
 
     /// <summary>
@@ -88,7 +89,7 @@ internal unsafe struct ICanvasImageInterop
         /// <inheritdoc cref="ICanvasImageInterop.GetDevice"/>
         [PreserveSig]
         [return: NativeTypeName("HRESULT")]
-        int GetDevice(ICanvasDevice** device);
+        int GetDevice(ICanvasDevice** device, WIN2D_GET_DEVICE_ASSOCIATION_TYPE* type);
 
         /// <inheritdoc cref="ICanvasImageInterop.GetD2DImage"/>
         [PreserveSig]

--- a/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/WIN2D_GET_D2D_IMAGE_FLAGS.cs
+++ b/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/WIN2D_GET_D2D_IMAGE_FLAGS.cs
@@ -46,5 +46,5 @@ internal enum WIN2D_GET_D2D_IMAGE_FLAGS : uint
     /// <summary>
     /// Ignored.
     /// </summary>
-    WIN2D_GET_D2D_IMAGE_FLAGS_FORCE_DWORD = 0xffffffff
+    WIN2D_GET_D2D_IMAGE_FLAGS_FORCE_DWORD = 0xFFFFFFFF
 }

--- a/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/WIN2D_GET_DEVICE_ASSOCIATION_TYPE.cs
+++ b/src/ComputeSharp.D2D1.Uwp/ABI.Microsoft.Graphics.Canvas/WIN2D_GET_DEVICE_ASSOCIATION_TYPE.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace ABI.Microsoft.Graphics.Canvas;
+
+/// <summary>
+/// Options for fine-tuning the behavior of <see cref="ICanvasImageInterop.Interface.GetDevice"/>.
+/// </summary>
+[Flags]
+internal enum WIN2D_GET_DEVICE_ASSOCIATION_TYPE : uint
+{
+    /// <summary>
+    /// No device info is available, callers will handle the returned device with their own logic.
+    /// </summary>
+    WIN2D_GET_DEVICE_ASSOCIATION_TYPE_UNSPECIFIED = 0,
+
+    /// <summary>
+    /// The returned device is the one the image is currently realized on, if any.
+    /// </summary>
+    WIN2D_GET_DEVICE_ASSOCIATION_TYPE_REALIZATION_DEVICE = 1,
+
+    /// <summary>
+    /// The returned device is the one that created the image resource, and cannot change.
+    /// </summary>
+    WIN2D_GET_DEVICE_ASSOCIATION_TYPE_CREATION_DEVICE = 2,
+
+    /// <summary>
+    /// Ignored.
+    /// </summary>
+    WIN2D_GET_DEVICE_ASSOCIATION_TYPE_FORCE_DWORD = 0xFFFFFFFF
+}

--- a/src/ComputeSharp.D2D1.Uwp/CanvasEffect.Interop.cs
+++ b/src/ComputeSharp.D2D1.Uwp/CanvasEffect.Interop.cs
@@ -41,13 +41,13 @@ unsafe partial class CanvasEffect
     }
 
     /// <inheritdoc/>
-    unsafe int ICanvasImageInterop.Interface.GetDevice(ICanvasDevice** device)
+    unsafe int ICanvasImageInterop.Interface.GetDevice(ICanvasDevice** device, WIN2D_GET_DEVICE_ASSOCIATION_TYPE* type)
     {
         using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
 
         GetCanvasImageInterop(canvasImageInterop.GetAddressOf());
 
-        return canvasImageInterop.Get()->GetDevice(device);
+        return canvasImageInterop.Get()->GetDevice(device, type);
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
+++ b/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Win2D.uwp" Version="1.27.0-preview1" />
+    <PackageReference Include="Win2D.uwp" Version="1.27.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasImageInterop.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasImageInterop.cs
@@ -12,6 +12,8 @@ using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 using Windows.Graphics.Effects;
 using static ABI.Microsoft.Graphics.Canvas.WIN2D_GET_D2D_IMAGE_FLAGS;
+using static ABI.Microsoft.Graphics.Canvas.WIN2D_GET_DEVICE_ASSOCIATION_TYPE;
+using Win32 = TerraFX.Interop.Windows.Windows;
 
 namespace ComputeSharp.D2D1.Uwp;
 
@@ -19,7 +21,7 @@ namespace ComputeSharp.D2D1.Uwp;
 unsafe partial class PixelShaderEffect<T>
 {
     /// <inheritdoc/>
-    int ICanvasImageInterop.Interface.GetDevice(ICanvasDevice** device)
+    int ICanvasImageInterop.Interface.GetDevice(ICanvasDevice** device, WIN2D_GET_DEVICE_ASSOCIATION_TYPE* type)
     {
         using ReferenceTracker.Lease _0 = GetReferenceTracker().TryGetLease(out bool leaseTaken);
 
@@ -40,15 +42,25 @@ unsafe partial class PixelShaderEffect<T>
             return E.E_NOT_VALID_STATE;
         }
 
+        HRESULT hresult;
+
         try
         {
             // Copy the device over to the target
-            return this.canvasDevice.CopyTo(device);
+            hresult = this.canvasDevice.CopyTo(device);
         }
         finally
         {
             Monitor.Exit(this.lockObject);
         }
+
+        // Set the association type if the copy was successful
+        if (Win32.SUCCEEDED(hresult))
+        {
+            *type = WIN2D_GET_DEVICE_ASSOCIATION_TYPE_REALIZATION_DEVICE;
+        }
+
+        return hresult;
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasImageInterop.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasImageInterop.cs
@@ -29,6 +29,10 @@ unsafe partial class PixelShaderEffect<T>
             return E.E_POINTER;
         }
 
+        // Set parameters to default values
+        *device = null;
+        *type = WIN2D_GET_DEVICE_ASSOCIATION_TYPE_UNSPECIFIED;
+
         using ReferenceTracker.Lease _0 = GetReferenceTracker().TryGetLease(out bool leaseTaken);
 
         // Check for disposal
@@ -78,11 +82,14 @@ unsafe partial class PixelShaderEffect<T>
         float* realizeDpi,
         ID2D1Image** ppImage)
     {
-        // No input pointer can be null
+        // The device and resulting image pointers cannot be null
         if (device is null || ppImage is null)
         {
             return E.E_POINTER;
         }
+
+        // Set the resulting image to null
+        *ppImage = null;
 
         using ReferenceTracker.Lease _0 = GetReferenceTracker().TryGetLease(out bool leaseTaken);
 
@@ -148,8 +155,6 @@ unsafe partial class PixelShaderEffect<T>
                 {
                     if (!Realize(flags, targetDpi, deviceContext))
                     {
-                        *ppImage = null;
-
                         return E.E_FAIL;
                     }
                 }
@@ -169,12 +174,6 @@ unsafe partial class PixelShaderEffect<T>
 
                 return S.S_OK;
             }
-        }
-        catch (Exception e)
-        {
-            *ppImage = null;
-
-            return e.HResult;
         }
         finally
         {

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasImageInterop.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.ICanvasImageInterop.cs
@@ -23,6 +23,12 @@ unsafe partial class PixelShaderEffect<T>
     /// <inheritdoc/>
     int ICanvasImageInterop.Interface.GetDevice(ICanvasDevice** device, WIN2D_GET_DEVICE_ASSOCIATION_TYPE* type)
     {
+        // Validate all input parameters
+        if (device is null || type is null)
+        {
+            return E.E_POINTER;
+        }
+
         using ReferenceTracker.Lease _0 = GetReferenceTracker().TryGetLease(out bool leaseTaken);
 
         // Check for disposal
@@ -72,6 +78,12 @@ unsafe partial class PixelShaderEffect<T>
         float* realizeDpi,
         ID2D1Image** ppImage)
     {
+        // No input pointer can be null
+        if (device is null || ppImage is null)
+        {
+            return E.E_POINTER;
+        }
+
         using ReferenceTracker.Lease _0 = GetReferenceTracker().TryGetLease(out bool leaseTaken);
 
         // Check for disposal


### PR DESCRIPTION
### Description

This PR adds the new `WIN2D_GET_DEVICE_ASSOCIATION_TYPE` support for `ICanvasImageInterop`.