### PR TITLE
Skip unnecessary ToString() call to check file extension

### DIFF
--- a/src/ComputeSharp/Graphics/Helpers/WICFormatHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/WICFormatHelper.cs
@@ -116,7 +116,7 @@ internal static class WICFormatHelper
     /// <exception cref="ArgumentException">Thrown when the input filename doesn't have a valid file extension.</exception>
     public static Guid GetForFilename(ReadOnlySpan<char> filename)
     {
-        return Path.GetExtension(filename).ToString() switch
+        return Path.GetExtension(filename) switch
         {
             ".bmp" => GUID.GUID_ContainerFormatBmp,
             ".png" => GUID.GUID_ContainerFormatPng,


### PR DESCRIPTION
### Description

This PR removes an unnecessary `ToString()` call, now that C# allows switching over `ReadOnlySpan<char>` values.