### PR TITLE
Update NuGet dependencies

### DIFF
--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -185,7 +185,7 @@
       <Version>2.8.2</Version>
     </PackageReference>
     <PackageReference Include="PolySharp">
-      <Version>1.11.0</Version>
+      <Version>1.12.1</Version>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
+++ b/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
@@ -6,6 +6,7 @@
     <TargetPlatformMinRevision>17763</TargetPlatformMinRevision>
     <TargetPlatformVersion>$(TargetPlatformBaseVersion).$(TargetPlatformRevision).0</TargetPlatformVersion>
     <TargetPlatformMinVersion>$(TargetPlatformBaseVersion).$(TargetPlatformMinRevision).0</TargetPlatformMinVersion>
+    <ExtrasUwpMetaPackageVersion>6.2.14</ExtrasUwpMetaPackageVersion>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>
@@ -34,7 +35,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.14" />
     <PackageReference Include="Win2D.uwp" Version="1.27.0-preview1" />
   </ItemGroup>
 

--- a/src/ComputeSharp.Uwp/ComputeSharp.Uwp.csproj
+++ b/src/ComputeSharp.Uwp/ComputeSharp.Uwp.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>uap10.0.17763</TargetFrameworks>
     <TargetPlatformBaseVersion>10.0</TargetPlatformBaseVersion>
@@ -6,6 +6,7 @@
     <TargetPlatformMinRevision>17763</TargetPlatformMinRevision>
     <TargetPlatformVersion>$(TargetPlatformBaseVersion).$(TargetPlatformRevision).0</TargetPlatformVersion>
     <TargetPlatformMinVersion>$(TargetPlatformBaseVersion).$(TargetPlatformMinRevision).0</TargetPlatformMinVersion>
+    <ExtrasUwpMetaPackageVersion>6.2.14</ExtrasUwpMetaPackageVersion>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>
@@ -26,10 +27,6 @@
 
   <ItemGroup>
     <None Include="..\ComputeSharp.Core.Package\icon.png" Pack="true" PackagePath="\icon.png" Visible="False" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     Only needed for the .Core project and all source generators.
   -->
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ComputeSharp.Core' OR $(MSBuildProjectName.EndsWith('.SourceGenerators'))">
-    <PackageReference Include="PolySharp" Version="1.11.0">
+    <PackageReference Include="PolySharp" Version="1.12.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build;analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### Description

This PR bumps .NET Native to 6.2.14 in the UWP projects, and updates PolySharp to the latest version.