### PR TITLE
Move MethodInfoExtensions to ComputeSharp.Dynamic

### DIFF
--- a/src/ComputeSharp.Dynamic/Attributes/Extensions/MethodInfoExtensions.cs
+++ b/src/ComputeSharp.Dynamic/Attributes/Extensions/MethodInfoExtensions.cs
@@ -2,7 +2,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
-namespace ComputeSharp.Core.Extensions;
+namespace ComputeSharp.Extensions;
 
 /// <summary>
 /// A <see langword="class"/> that provides extension methods for the <see cref="MethodInfo"/> type.

--- a/src/ComputeSharp.Dynamic/Attributes/__Internals/ShaderMethodSourceAttribute.cs
+++ b/src/ComputeSharp.Dynamic/Attributes/__Internals/ShaderMethodSourceAttribute.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
-using ComputeSharp.Core.Extensions;
+using ComputeSharp.Extensions;
 
 #pragma warning disable IDE0052
 

--- a/src/ComputeSharp.Dynamic/ComputeSharp.Dynamic.csproj
+++ b/src/ComputeSharp.Dynamic/ComputeSharp.Dynamic.csproj
@@ -25,26 +25,14 @@
          just copy the right native libraries to the output directory, with no subfolders. -->
     <When Condition="'$(Platform)' == 'x64' OR '$(CI_RUNNER_DOTNET_TEST_PLATFORM)' == 'x64'">
       <ItemGroup>
-        <None Include="Libraries\x64\dxcompiler.dll"
-              Link="dxcompiler.dll"
-              Visible="False"
-              CopyToOutputDirectory="PreserveNewest" />
-        <None Include="Libraries\x64\dxil.dll"
-              Link="dxil.dll"
-              Visible="False"
-              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="Libraries\x64\dxcompiler.dll" Link="dxcompiler.dll" Visible="False" CopyToOutputDirectory="PreserveNewest" />
+        <None Include="Libraries\x64\dxil.dll" Link="dxil.dll" Visible="False" CopyToOutputDirectory="PreserveNewest" />
       </ItemGroup>
     </When>
     <When Condition="'$(Platform)' == 'ARM64' OR '$(CI_RUNNER_DOTNET_TEST_PLATFORM)' == 'x64'">
       <ItemGroup>
-        <None Include="Libraries\arm64\dxcompiler.dll"
-              Link="dxcompiler.dll"
-              Visible="False"
-              CopyToOutputDirectory="PreserveNewest" />
-        <None Include="Libraries\arm64\dxil.dll"
-              Link="dxil.dll"
-              Visible="False"
-              CopyToOutputDirectory="PreserveNewest" />
+        <None Include="Libraries\arm64\dxcompiler.dll" Link="dxcompiler.dll" Visible="False" CopyToOutputDirectory="PreserveNewest" />
+        <None Include="Libraries\arm64\dxil.dll" Link="dxil.dll" Visible="False" CopyToOutputDirectory="PreserveNewest" />
       </ItemGroup>
     </When>
 
@@ -57,26 +45,10 @@
          while still not causing any change in the final NuGet package (Link isn't looked up there). -->
     <Otherwise>
       <ItemGroup>
-        <None Include="Libraries\x64\dxcompiler.dll"
-              Link="runtimes\win-x64\native\dxcompiler.dll"
-              Visible="False"
-              CopyToOutputDirectory="PreserveNewest"
-              PackFolder="runtimes\win-x64\native" />
-        <None Include="Libraries\x64\dxil.dll"
-              Link="runtimes\win-x64\native\dxil.dll"
-              Visible="False"
-              CopyToOutputDirectory="PreserveNewest"
-              PackFolder="runtimes\win-x64\native" />
-        <None Include="Libraries\arm64\dxcompiler.dll"
-              Link="runtimes\win-arm64\native\dxcompiler.dll"
-              Visible="False"
-              CopyToOutputDirectory="PreserveNewest"
-              PackFolder="runtimes\win-arm64\native" />
-        <None Include="Libraries\arm64\dxil.dll"
-              Link="runtimes\win-arm64\native\dxil.dll"
-              Visible="False"
-              CopyToOutputDirectory="PreserveNewest"
-              PackFolder="runtimes\win-arm64\native" />
+        <None Include="Libraries\x64\dxcompiler.dll" Link="runtimes\win-x64\native\dxcompiler.dll" Visible="False" CopyToOutputDirectory="PreserveNewest" PackFolder="runtimes\win-x64\native" />
+        <None Include="Libraries\x64\dxil.dll" Link="runtimes\win-x64\native\dxil.dll" Visible="False" CopyToOutputDirectory="PreserveNewest" PackFolder="runtimes\win-x64\native" />
+        <None Include="Libraries\arm64\dxcompiler.dll" Link="runtimes\win-arm64\native\dxcompiler.dll" Visible="False" CopyToOutputDirectory="PreserveNewest" PackFolder="runtimes\win-arm64\native" />
+        <None Include="Libraries\arm64\dxil.dll" Link="runtimes\win-arm64\native\dxil.dll" Visible="False" CopyToOutputDirectory="PreserveNewest" PackFolder="runtimes\win-arm64\native" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -65,6 +65,7 @@
     <Compile Include="..\ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" Link="ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" />
     <Compile Include="..\ComputeSharp.Dynamic\Attributes\ShaderMethodAttribute.cs" Link="ComputeSharp\Core\Attributes\ShaderMethodAttribute.cs" />
     <Compile Include="..\ComputeSharp.Dynamic\Attributes\__Internals\ShaderMethodSourceAttribute.cs" Link="ComputeSharp\Core\Attributes\__Internals\ShaderMethodSourceAttribute.cs" />
+    <Compile Include="..\ComputeSharp.Dynamic\Attributes\Extensions\MethodInfoExtensions.cs" Link="ComputeSharp\Extensions\MethodInfoExtensions.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchAxis.cs" Link="ComputeSharp\Core\Dispatch\DispatchAxis.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchSize.cs" Link="ComputeSharp\Core\Dispatch\DispatchSize.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\GridIds.cs" Link="ComputeSharp\Core\Dispatch\GridIds.cs" />
@@ -72,7 +73,6 @@
     <Compile Include="..\ComputeSharp\Core\Dispatch\GroupSize.cs" Link="ComputeSharp\Core\Dispatch\GroupSize.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\ThreadIds.cs" Link="ComputeSharp\Core\Dispatch\ThreadIds.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\ThreadIds.Normalized.cs" Link="ComputeSharp\Core\Dispatch\ThreadIds.Normalized.cs" />
-    <Compile Include="..\ComputeSharp\Core\Extensions\MethodInfoExtensions.cs" Link="ComputeSharp\Core\Extensions\MethodInfoExtensions.cs" />
     <Compile Include="..\ComputeSharp\Core\Helpers\AlignmentHelper.cs" Link="ComputeSharp\Core\Helpers\AlignmentHelper.cs" />
     <Compile Include="..\ComputeSharp\Core\Interfaces\IComputeShader.cs" Link="ComputeSharp\Core\Interfaces\IComputeShader.cs" />
     <Compile Include="..\ComputeSharp\Core\Interfaces\IPixelShader{TPixel}.cs" Link="ComputeSharp\Core\Interfaces\IPixelShader{TPixel}.cs" />


### PR DESCRIPTION
### Description

This PR moves an extension only used for dynamic support out of the main ComputeSharp package.