### PR TITLE
Use Unsafe.As to reinterpret ImmutableArray<T> values

### DIFF
--- a/src/ComputeSharp.D2D1.Uwp/Loaders/D2D1ImmutableArrayResourceTextureDescriptionsLoader.cs
+++ b/src/ComputeSharp.D2D1.Uwp/Loaders/D2D1ImmutableArrayResourceTextureDescriptionsLoader.cs
@@ -30,7 +30,7 @@ internal struct D2D1ImmutableArrayResourceTextureDescriptionsLoader : ID2D1Resou
     }
 
     /// <inheritdoc/>
-    unsafe void ID2D1ResourceTextureDescriptionsLoader.LoadResourceTextureDescriptions(ReadOnlySpan<byte> data)
+    void ID2D1ResourceTextureDescriptionsLoader.LoadResourceTextureDescriptions(ReadOnlySpan<byte> data)
     {
         if (data.IsEmpty)
         {
@@ -47,7 +47,7 @@ internal struct D2D1ImmutableArrayResourceTextureDescriptionsLoader : ID2D1Resou
                 indices[i] = descriptions[i].Index;
             }
 
-            this.indices = *(ImmutableArray<int>*)&indices;
+            this.indices = Unsafe.As<int[], ImmutableArray<int>>(ref indices);
         }
     }
 }

--- a/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.Properties.Sources.cs
+++ b/src/ComputeSharp.D2D1.Uwp/PixelShaderEffect{T}.Properties.Sources.cs
@@ -208,7 +208,7 @@ partial class PixelShaderEffect<T>
         /// Gets the collection of valid indices for the current effect.
         /// </summary>
         /// <returns>The collection of valid indices for the current effect.</returns>
-        private static unsafe ImmutableArray<int> GetIndices()
+        private static ImmutableArray<int> GetIndices()
         {
             int inputCount = D2D1PixelShader.GetInputCount<T>();
 
@@ -224,7 +224,7 @@ partial class PixelShaderEffect<T>
                 indices[i] = i;
             }
 
-            return *(ImmutableArray<int>*)&indices;
+            return Unsafe.As<int[], ImmutableArray<int>>(ref indices);
         }
     }
 }


### PR DESCRIPTION
### Closes #490