### PR TITLE
Add missing TFM to ComputeSharp.Tests.GlobalStatements

### DIFF
--- a/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
+++ b/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>


### PR DESCRIPTION
### Description

This PR adds the missing .NET Core 3.1 TFM to `ComputeSharp.Tests.GlobalStatements`.