### PR TITLE
Add "official" Disposable pattern to CanvasEffect

### DIFF
--- a/src/ComputeSharp.D2D1.Uwp/CanvasEffect.Interop.cs
+++ b/src/ComputeSharp.D2D1.Uwp/CanvasEffect.Interop.cs
@@ -9,8 +9,6 @@ using TerraFX.Interop.Windows;
 using Windows.Foundation;
 using ICanvasResourceCreator = Microsoft.Graphics.Canvas.ICanvasResourceCreator;
 
-#pragma warning disable CA1063
-
 namespace ComputeSharp.D2D1.Uwp;
 
 /// <inheritdoc/>
@@ -29,17 +27,6 @@ unsafe partial class CanvasEffect
     }
 
     /// <inheritdoc/>
-    public void Dispose()
-    {
-        lock (this.lockObject)
-        {
-            this.canvasImage?.Dispose();
-            this.canvasImage = null;
-            this.isDisposed = true;
-        }
-    }
-
-    /// <inheritdoc/>
     unsafe int ICanvasImageInterop.Interface.GetDevice(ICanvasDevice** device, WIN2D_GET_DEVICE_ASSOCIATION_TYPE* type)
     {
         using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
@@ -50,7 +37,13 @@ unsafe partial class CanvasEffect
     }
 
     /// <inheritdoc/>
-    unsafe int ICanvasImageInterop.Interface.GetD2DImage(ICanvasDevice* device, ID2D1DeviceContext* deviceContext, WIN2D_GET_D2D_IMAGE_FLAGS flags, float targetDpi, float* realizeDpi, ID2D1Image** ppImage)
+    unsafe int ICanvasImageInterop.Interface.GetD2DImage(
+        ICanvasDevice* device,
+        ID2D1DeviceContext* deviceContext,
+        WIN2D_GET_D2D_IMAGE_FLAGS flags,
+        float targetDpi,
+        float* realizeDpi,
+        ID2D1Image** ppImage)
     {
         using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
 

--- a/src/ComputeSharp.D2D1.Uwp/CanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.Uwp/CanvasEffect.cs
@@ -25,7 +25,11 @@ public abstract partial class CanvasEffect : ICanvasImage, ICanvasImageInterop.I
     /// <summary>
     /// Indicates whether the current state has been invalidated (requiring <see cref="ConfigureCanvasImage"/> to be called).
     /// </summary>
-    private bool isInvalidated;
+    /// <remarks>
+    /// This is initially <see langword="true"/> so that <see cref="ConfigureCanvasImage"/> will always be called when
+    /// first creating the image, even if the effect has not bee invalidated. This ensures default parameters are set.
+    /// </remarks>
+    private bool isInvalidated = true;
 
     /// <summary>
     /// Indicates whether the effect is disposed.


### PR DESCRIPTION
### Description

This PR includes a couple tweaks to `CanvasEffect`:
- Set the invalidation state to `true` by default, so that `ConfigureCanvasImage` will always be called at least once.
- Add the official `IDisposable` pattern, with the `Dispose(bool)` method, so that derived types can hook into it.