### PR TITLE
Fix constructor finalization issues with ReferenceTracker

### DIFF
--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.cs
@@ -74,7 +74,7 @@ public sealed partial class PixelShaderEffect<T> : IReferenceTrackedObject, ICan
     /// </summary>
     public PixelShaderEffect()
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         Sources = new SourceCollection(this);
         ResourceTextureManagers = new ResourceTextureManagerCollection(this);

--- a/src/ComputeSharp/Graphics/GraphicsDevice.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.cs
@@ -151,7 +151,7 @@ public sealed unsafe partial class GraphicsDevice : IReferenceTrackedObject
     /// <param name="dxgiDescription1">The available info for the new <see cref="GraphicsDevice"/> instance.</param>
     internal GraphicsDevice(ID3D12Device* d3D12Device, IDXGIAdapter* dxgiAdapter, DXGI_ADAPTER_DESC1* dxgiDescription1)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         this.d3D12Device = new ComPtr<ID3D12Device>(d3D12Device);
 

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
@@ -101,6 +101,8 @@ partial class DeviceHelper
             /// <inheritdoc/>
             public bool MoveNext()
             {
+                using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
                 if (!this.isInitialized)
                 {
                     this.isInitialized = true;

--- a/src/ComputeSharp/Graphics/Interop/ReferenceTrackedObject.cs
+++ b/src/ComputeSharp/Graphics/Interop/ReferenceTrackedObject.cs
@@ -18,7 +18,7 @@ internal abstract partial class ReferenceTrackedObject : IReferenceTrackedObject
     /// </summary>
     public ReferenceTrackedObject()
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        ReferenceTracker.DangerousCreate(this, out this.referenceTracker);
     }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
@@ -71,7 +71,7 @@ public abstract unsafe partial class Buffer<T> : IReferenceTrackedObject, IGraph
     [RequiresUnreferencedCode("This method reads type info of all fields of the resource element type (recursively).")]
     private protected Buffer(GraphicsDevice device, int length, uint elementSizeInBytes, ResourceType resourceType, AllocationMode allocationMode)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         if (resourceType == ResourceType.Constant)
         {
@@ -83,7 +83,7 @@ public abstract unsafe partial class Buffer<T> : IReferenceTrackedObject, IGraph
             default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(length, 1, (uint.MaxValue / elementSizeInBytes) & ~255);
         }
 
-        using ReferenceTracker.Lease _0 = device.GetReferenceTracker().GetLease();
+        using ReferenceTracker.Lease _1 = device.GetReferenceTracker().GetLease();
 
         device.ThrowIfDeviceLost();
 

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture1D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture1D{T}.cs
@@ -75,11 +75,11 @@ public abstract unsafe partial class Texture1D<T> : IReferenceTrackedObject, IGr
     /// <param name="d3D12FormatSupport">The format support for the current texture type.</param>
     private protected Texture1D(GraphicsDevice device, int width, ResourceType resourceType, AllocationMode allocationMode, D3D12_FORMAT_SUPPORT1 d3D12FormatSupport)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(width, 1, D3D12.D3D12_REQ_TEXTURE1D_U_DIMENSION);
 
-        using ReferenceTracker.Lease _0 = device.GetReferenceTracker().GetLease();
+        using ReferenceTracker.Lease _1 = device.GetReferenceTracker().GetLease();
 
         device.ThrowIfDeviceLost();
 

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
@@ -76,12 +76,12 @@ public abstract unsafe partial class Texture2D<T> : IReferenceTrackedObject, IGr
     /// <param name="d3D12FormatSupport">The format support for the current texture type.</param>
     private protected Texture2D(GraphicsDevice device, int width, int height, ResourceType resourceType, AllocationMode allocationMode, D3D12_FORMAT_SUPPORT1 d3D12FormatSupport)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(width, 1, D3D12.D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION);
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(height, 1, D3D12.D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION);
 
-        using ReferenceTracker.Lease _0 = device.GetReferenceTracker().GetLease();
+        using ReferenceTracker.Lease _1 = device.GetReferenceTracker().GetLease();
 
         device.ThrowIfDeviceLost();
 

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
@@ -77,13 +77,13 @@ public abstract unsafe partial class Texture3D<T> : IReferenceTrackedObject, IGr
     /// <param name="d3D12FormatSupport">The format support for the current texture type.</param>
     private protected Texture3D(GraphicsDevice device, int width, int height, int depth, ResourceType resourceType, AllocationMode allocationMode, D3D12_FORMAT_SUPPORT1 d3D12FormatSupport)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(width, 1, D3D12.D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION);
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(height, 1, D3D12.D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION);
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(depth, 1, D3D12.D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION);
 
-        using ReferenceTracker.Lease _0 = device.GetReferenceTracker().GetLease();
+        using ReferenceTracker.Lease _1 = device.GetReferenceTracker().GetLease();
 
         device.ThrowIfDeviceLost();
 

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferBuffer{T}.cs
@@ -54,12 +54,12 @@ public abstract unsafe partial class TransferBuffer<T> : IReferenceTrackedObject
     [RequiresUnreferencedCode("This method reads type info of all fields of the resource element type (recursively).")]
     private protected TransferBuffer(GraphicsDevice device, int length, ResourceType resourceType, AllocationMode allocationMode)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         // The maximum length is set such that the aligned buffer size can't exceed uint.MaxValue
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(length, 1, (uint.MaxValue / (uint)sizeof(T)) & ~255);
 
-        using ReferenceTracker.Lease _0 = device.GetReferenceTracker().GetLease();
+        using ReferenceTracker.Lease _1 = device.GetReferenceTracker().GetLease();
 
         device.ThrowIfDeviceLost();
 

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture1D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture1D{T}.cs
@@ -57,11 +57,11 @@ public abstract unsafe partial class TransferTexture1D<T> : IReferenceTrackedObj
     /// <param name="allocationMode">The allocation mode to use for the new resource.</param>
     private protected TransferTexture1D(GraphicsDevice device, int width, ResourceType resourceType, AllocationMode allocationMode)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(width, 1, D3D12.D3D12_REQ_TEXTURE1D_U_DIMENSION);
 
-        using ReferenceTracker.Lease _0 = device.GetReferenceTracker().GetLease();
+        using ReferenceTracker.Lease _1 = device.GetReferenceTracker().GetLease();
 
         device.ThrowIfDeviceLost();
 

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture2D{T}.cs
@@ -57,12 +57,12 @@ public abstract unsafe partial class TransferTexture2D<T> : IReferenceTrackedObj
     /// <param name="allocationMode">The allocation mode to use for the new resource.</param>
     private protected TransferTexture2D(GraphicsDevice device, int width, int height, ResourceType resourceType, AllocationMode allocationMode)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(width, 1, D3D12.D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION);
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(height, 1, D3D12.D3D12_REQ_TEXTURE2D_U_OR_V_DIMENSION);
 
-        using ReferenceTracker.Lease _0 = device.GetReferenceTracker().GetLease();
+        using ReferenceTracker.Lease _1 = device.GetReferenceTracker().GetLease();
 
         device.ThrowIfDeviceLost();
 

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture3D{T}.cs
@@ -58,13 +58,13 @@ public abstract unsafe partial class TransferTexture3D<T> : IReferenceTrackedObj
     /// <param name="allocationMode">The allocation mode to use for the new resource.</param>
     private protected TransferTexture3D(GraphicsDevice device, int width, int height, int depth, ResourceType resourceType, AllocationMode allocationMode)
     {
-        this.referenceTracker = new ReferenceTracker(this);
+        using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);
 
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(width, 1, D3D12.D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION);
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(height, 1, D3D12.D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION);
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(depth, 1, D3D12.D3D12_REQ_TEXTURE3D_U_V_OR_W_DIMENSION);
 
-        using ReferenceTracker.Lease _0 = device.GetReferenceTracker().GetLease();
+        using ReferenceTracker.Lease _1 = device.GetReferenceTracker().GetLease();
 
         device.ThrowIfDeviceLost();
 

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture1D{T,TPixel}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture1D{T,TPixel}.ReadOnly.cs
@@ -76,6 +76,8 @@ partial class ReadWriteTexture1D<T, TPixel>
         /// <param name="owner">The owning <see cref="ReadWriteTexture1D{T, TPixel}"/> instance to wrap.</param>
         public ReadOnly(ReadWriteTexture1D<T, TPixel> owner)
         {
+            using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
             owner.GetReferenceTracker().DangerousAddRef();
 
             this.owner = owner;

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture1D{T}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture1D{T}.ReadOnly.cs
@@ -76,6 +76,8 @@ partial class ReadWriteTexture1D<T>
         /// <param name="owner">The owning <see cref="ReadWriteTexture1D{T}"/> instance to wrap.</param>
         public ReadOnly(ReadWriteTexture1D<T> owner)
         {
+            using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
             owner.GetReferenceTracker().DangerousAddRef();
 
             this.owner = owner;

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T,TPixel}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T,TPixel}.ReadOnly.cs
@@ -76,6 +76,8 @@ partial class ReadWriteTexture2D<T, TPixel>
         /// <param name="owner">The owning <see cref="ReadWriteTexture2D{T, TPixel}"/> instance to wrap.</param>
         public ReadOnly(ReadWriteTexture2D<T, TPixel> owner)
         {
+            using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
             // This call is required to ensure the underlying resource is kept alive as long as this resource
             // is not disposed, given that the underlying native resource is the same. Additional checks are
             // still performed below so that exceptions are thrown early, but this is needed to ensure safety.

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture2D{T}.ReadOnly.cs
@@ -79,6 +79,8 @@ partial class ReadWriteTexture2D<T>
         /// <param name="owner">The owning <see cref="ReadWriteTexture2D{T}"/> instance to wrap.</param>
         public ReadOnly(ReadWriteTexture2D<T> owner)
         {
+            using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
             owner.GetReferenceTracker().DangerousAddRef();
 
             this.owner = owner;

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T,TPixel}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T,TPixel}.ReadOnly.cs
@@ -76,6 +76,8 @@ partial class ReadWriteTexture3D<T, TPixel>
         /// <param name="owner">The owning <see cref="ReadWriteTexture3D{T, TPixel}"/> instance to wrap.</param>
         public ReadOnly(ReadWriteTexture3D<T, TPixel> owner)
         {
+            using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
             owner.GetReferenceTracker().DangerousAddRef();
 
             this.owner = owner;

--- a/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T}.ReadOnly.cs
+++ b/src/ComputeSharp/Graphics/Resources/ReadWriteTexture3D{T}.ReadOnly.cs
@@ -76,6 +76,8 @@ partial class ReadWriteTexture3D<T>
         /// <param name="owner">The owning <see cref="ReadWriteTexture3D{T}"/> instance to wrap.</param>
         public ReadOnly(ReadWriteTexture3D<T> owner)
         {
+            using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
             owner.GetReferenceTracker().DangerousAddRef();
 
             this.owner = owner;

--- a/src/ComputeSharp/Shaders/Models/ICachedShader.cs
+++ b/src/ComputeSharp/Shaders/Models/ICachedShader.cs
@@ -76,6 +76,8 @@ internal interface ICachedShader
         /// <param name="dxcBlobBytecode">The <see cref="IDxcBlob"/> bytecode instance to wrap.</param>
         public Dynamic(IDxcBlob* dxcBlobBytecode)
         {
+            using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
             this.dxcBlobBytecode = new ComPtr<IDxcBlob>(dxcBlobBytecode);
         }
 

--- a/src/ComputeSharp/Shaders/Models/PipelineData.cs
+++ b/src/ComputeSharp/Shaders/Models/PipelineData.cs
@@ -26,6 +26,8 @@ internal sealed unsafe class PipelineData : ReferenceTrackedObject
     /// <param name="d3D12PipelineState">The compiled pipeline state to reuse for the current shader.</param>
     public PipelineData(ID3D12RootSignature* d3D12RootSignature, ID3D12PipelineState* d3D12PipelineState)
     {
+        using ReferenceTracker.Lease _0 = GetReferenceTracker().GetLease();
+
         this.d3D12RootSignature = new ComPtr<ID3D12RootSignature>(d3D12RootSignature);
         this.d3D12PipelineState = new ComPtr<ID3D12PipelineState>(d3D12PipelineState);
     }


### PR DESCRIPTION
### Description

This PR includes some improvements to the finalization behavior for objects wrapping native resources. Specifically, it ensures consistent behavior in cases where a finalizer could've been invoked on an object while the constructor was still running.