### PR TITLE
Add .NET 7 SDK to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,9 @@
 {
-  "msbuild-sdks":
-  {
+  "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "3.0.38"
+  },
+  "sdk": {
+    "version": "7.0.202",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
### Description

This PR adds the .NET 7 SDK to the global.json file, to ensure the repo can still build fine if preview SDKs are installed.
For instance, currently building with the .NET 8 SDK installed fails due to some new warnings being emitted with it.