### PR TITLE
Add support for Win2D resource cache manager wrapper registration

### DIFF
--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasEffectFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasEffectFactoryNative.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TerraFX.Interop;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
+using TerraFX.Interop.WinRT;
+
+#pragma warning disable CS0649, IDE1006
+
+namespace ABI.Microsoft.Graphics.Canvas;
+
+/// <summary>
+/// The interop Win2D interface for factories of external effects.
+/// </summary>
+[Guid("29BA1A1F-1CFE-44C3-984D-426D61B51427")]
+[NativeTypeName("class ICanvasEffectFactoryNative : IUnknown")]
+[NativeInheritance("IUnknown")]
+internal unsafe struct ICanvasEffectFactoryNative
+{
+    public void** lpVtbl;
+
+    /// <inheritdoc cref="IUnknown.QueryInterface"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(0)]
+    public HRESULT QueryInterface([NativeTypeName("const IID &")] Guid* riid, void** ppvObject)
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasEffectFactoryNative*, Guid*, void**, int>)this.lpVtbl[0])((ICanvasEffectFactoryNative*)Unsafe.AsPointer(ref this), riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="IUnknown.AddRef"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(1)]
+    [return: NativeTypeName("ULONG")]
+    public uint AddRef()
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasEffectFactoryNative*, uint>)this.lpVtbl[1])((ICanvasEffectFactoryNative*)Unsafe.AsPointer(ref this));
+    }
+
+    /// <inheritdoc cref="IUnknown.Release"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(2)]
+    [return: NativeTypeName("ULONG")]
+    public uint Release()
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasEffectFactoryNative*, uint>)this.lpVtbl[2])((ICanvasEffectFactoryNative*)Unsafe.AsPointer(ref this));
+    }
+
+    /// <summary>
+    /// Creates a new inspectable wrapper for an inpute D2D effect previosly registered through <see cref="ICanvasFactoryNative.RegisterEffectFactory"/>.
+    /// </summary>
+    /// <param name="device">The input canvas device.</param>
+    /// <param name="resource">The input native effect to create a wrapper for.</param>
+    /// <param name="dpi">The realization DPIs for <paramref name="resource"/>.</param>
+    /// <param name="wrapper">The resulting wrapper for <paramref name="resource"/>.</param>
+    /// <returns>The <see cref="HRESULT"/> for the operation.</returns>
+    /// <remarks>
+    /// All parameters are directly forwarded from the ones the caller passed to <see cref="ICanvasFactoryNative.GetOrCreate"/>. The returned
+    /// wrapper should implement <see cref="global::Microsoft.Graphics.Canvas.ICanvasImage"/> to be returned correctly from Win2D after this call.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(3)]
+    public HRESULT CreateWrapper(ICanvasDevice* device, ID2D1Effect* resource, float dpi, IInspectable** wrapper)
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasEffectFactoryNative*, ICanvasDevice*, ID2D1Effect*, float, IInspectable**, int>)this.lpVtbl[3])(
+            (ICanvasEffectFactoryNative*)Unsafe.AsPointer(ref this),
+            device,
+            resource,
+            dpi,
+            wrapper);
+    }
+}

--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasFactoryNative.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using TerraFX.Interop;
 using TerraFX.Interop.Windows;
+using TerraFX.Interop.WinRT;
 
 #pragma warning disable CS0649, IDE1006
 
@@ -55,9 +56,9 @@ internal unsafe struct ICanvasFactoryNative
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(6)]
     [return: NativeTypeName("ULONG")]
-    public HRESULT GetOrCreate(ICanvasDevice* device, IUnknown* resource, float dpi, [NativeTypeName("IInspectable**")] void** wrapper)
+    public HRESULT GetOrCreate(ICanvasDevice* device, IUnknown* resource, float dpi, IInspectable** wrapper)
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, ICanvasDevice*, IUnknown*, float, void**, int>)this.lpVtbl[6])(
+        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, ICanvasDevice*, IUnknown*, float, IInspectable**, int>)this.lpVtbl[6])(
             (ICanvasFactoryNative*)Unsafe.AsPointer(ref this),
             device,
             resource,

--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasFactoryNative.cs
@@ -3,7 +3,13 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using TerraFX.Interop;
 using TerraFX.Interop.Windows;
+#if WINDOWS_UWP
 using TerraFX.Interop.WinRT;
+#else
+using WinRT;
+using WinRT.Interop;
+using IInspectable = TerraFX.Interop.WinRT.IInspectable;
+#endif
 
 #pragma warning disable CS0649, IDE1006
 
@@ -142,4 +148,27 @@ internal unsafe struct ICanvasFactoryNative
         return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, int>)this.lpVtbl[10])(
             (ICanvasFactoryNative*)Unsafe.AsPointer(ref this));
     }
+
+#if !WINDOWS_UWP
+    /// <summary>
+    /// The managed interface for <see cref="ICanvasFactoryNative"/>.
+    /// </summary>
+    [Guid("695C440D-04B3-4EDD-BFD9-63E51E9F7202")]
+    [WindowsRuntimeType]
+    [WindowsRuntimeHelperType(typeof(Interface))]
+    public interface Interface
+    {
+        /// <summary>
+        /// The vtable type for <see cref="Interface"/>.
+        /// </summary>
+        [Guid("695C440D-04B3-4EDD-BFD9-63E51E9F7202")]
+        public readonly struct Vftbl
+        {
+            /// <summary>
+            /// Allows CsWinRT to retrieve a pointer to the projection vtable (the name is hardcoded by convention).
+            /// </summary>
+            public static readonly IntPtr AbiToProjectionVftablePtr = IUnknownVftbl.AbiToProjectionVftblPtr;
+        }
+    }
+#endif
 }

--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasFactoryNative.cs
@@ -50,12 +50,11 @@ internal unsafe struct ICanvasFactoryNative
     /// </summary>
     /// <param name="device">The input canvas device (as a marshalled <see cref="global::Microsoft.Graphics.Canvas.CanvasDevice"/>).</param>
     /// <param name="resource">The input native resource to create a wrapper for.</param>
-    /// <param name="dpi">The realization DPIs for <paramref name="resource"/></param>
+    /// <param name="dpi">The realization DPIs for <paramref name="resource"/>.</param>
     /// <param name="wrapper">The resulting wrapper for <paramref name="resource"/>.</param>
     /// <returns>The <see cref="HRESULT"/> for the operation.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [VtblIndex(6)]
-    [return: NativeTypeName("ULONG")]
     public HRESULT GetOrCreate(ICanvasDevice* device, IUnknown* resource, float dpi, IInspectable** wrapper)
     {
         return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, ICanvasDevice*, IUnknown*, float, IInspectable**, int>)this.lpVtbl[6])(
@@ -64,5 +63,83 @@ internal unsafe struct ICanvasFactoryNative
             resource,
             dpi,
             wrapper);
+    }
+
+    /// <summary>
+    /// Registers an <c>IInspectable</c> wrapper for a given native D2D resource.
+    /// </summary>
+    /// <param name="resource">The input native resource to register a wrapper for.</param>
+    /// <param name="wrapper">The wrapper to register for <paramref name="resource"/>.</param>
+    /// <returns>
+    /// The <see cref="HRESULT"/> for the operation. In case of success, it will be <see cref="S.S_OK"/> if the wrapper
+    /// was not previously registered, or <see cref="S.S_FALSE"/> if <paramref name="resource"/> was already registered.
+    /// </returns>
+    /// <remarks>
+    /// The method validates at runtime that <paramref name="resource"/> is an <see cref="TerraFX.Interop.DirectX.ID2D1Image"/>
+    /// and that <paramref name="wrapper"/> is an <see cref="global::Microsoft.Graphics.Canvas.ICanvasImage"/>. Additionally,
+    /// <paramref name="wrapper"/> has to implement <c>IWeakReferenceSource</c> for this method to be successful.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(7)]
+    public HRESULT RegisterWrapper(IUnknown* resource, IInspectable* wrapper)
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, IUnknown*, IInspectable*, int>)this.lpVtbl[7])(
+            (ICanvasFactoryNative*)Unsafe.AsPointer(ref this),
+            resource,
+            wrapper);
+    }
+
+    /// <summary>
+    /// Unregisters a native D2D resource previously registered with <see cref="RegisterWrapper"/>.
+    /// </summary>
+    /// <param name="resource">The input native resource to unregister.</param>
+    /// <returns>
+    /// The <see cref="HRESULT"/> for the operation. In case of success, it will be <see cref="S.S_OK"/> if the
+    /// resource was previously registered and could be correctly unregistered, <see cref="S.S_FALSE"/> otherwise.
+    /// </returns>
+    /// <remarks>
+    /// The method validates at runtime that <paramref name="resource"/> is an <see cref="TerraFX.Interop.DirectX.ID2D1Image"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(8)]
+    public HRESULT UnregisterWrapper(IUnknown* resource)
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, IUnknown*, int>)this.lpVtbl[8])(
+            (ICanvasFactoryNative*)Unsafe.AsPointer(ref this),
+            resource);
+    }
+
+    /// <summary>
+    /// Registers a factory of wrappers for custom effects.
+    /// </summary>
+    /// <param name="effectId">The id of the effects to register a factory for.</param>
+    /// <param name="factory">The input factory to create wrappers of native effects.</param>
+    /// <returns>
+    /// The <see cref="HRESULT"/> for the operation. In case of success, it will be <see cref="S.S_OK"/> if the factory
+    /// was not previously registered, or <see cref="S.S_FALSE"/> if <paramref name="effectId"/> was already registered.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(9)]
+    public HRESULT RegisterEffectFactory([NativeTypeName("const IID &")] Guid* effectId, ICanvasEffectFactoryNative* factory)
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, ICanvasEffectFactoryNative*, int>)this.lpVtbl[9])(
+            (ICanvasFactoryNative*)Unsafe.AsPointer(ref this),
+            factory);
+    }
+
+    /// <summary>
+    /// Unregisters an effect factory that was previosuly registered with <see cref="RegisterEffectFactory"/>.
+    /// </summary>
+    /// <param name="effectId">The id of the effects to unregister the factory for.</param>
+    /// <returns>
+    /// The <see cref="HRESULT"/> for the operation. In case of success, it will be <see cref="S.S_OK"/> if the
+    /// factory was previously registered and could be correctly unregistered, <see cref="S.S_FALSE"/> otherwise.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(10)]
+    public HRESULT UnregisterEffectFactory([NativeTypeName("const IID &")] Guid* effectId)
+    {
+        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, int>)this.lpVtbl[10])(
+            (ICanvasFactoryNative*)Unsafe.AsPointer(ref this));
     }
 }

--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/Inspectable/IInspectable.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/Inspectable/IInspectable.cs
@@ -1,0 +1,50 @@
+// Copyright © Tanner Gooding and Contributors. Licensed under the MIT License (MIT). See License.md in the repository root for more information.
+
+// Ported from winrt/inspectable.h in the Windows SDK for Windows 10.0.22621.0
+// Original source is Copyright © Microsoft. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using TerraFX.Interop.Windows;
+
+#pragma warning disable CS0649, IDE1006
+
+namespace TerraFX.Interop.WinRT;
+
+/// <summary>
+/// The native WinRT interface for <see href="https://learn.microsoft.com/windows/win32/api/inspectable/nn-inspectable-iinspectable"><c>IInspectable</c></see> objects.
+/// </summary>
+[Guid("AF86E2E0-B12D-4C6A-9C5A-D7AA65101E90")]
+[NativeTypeName("struct IInspectable : IUnknown")]
+[NativeInheritance("IUnknown")]
+internal unsafe struct IInspectable
+{
+    public void** lpVtbl;
+
+    /// <inheritdoc cref="IUnknown.QueryInterface" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(0)]
+    public HRESULT QueryInterface([NativeTypeName("const IID &")] Guid* riid, void** ppvObject)
+    {
+        return ((delegate* unmanaged[Stdcall]<IInspectable*, Guid*, void**, int>)this.lpVtbl[0])((IInspectable*)Unsafe.AsPointer(ref this), riid, ppvObject);
+    }
+
+    /// <inheritdoc cref="IUnknown.AddRef" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(1)]
+    [return: NativeTypeName("ULONG")]
+    public uint AddRef()
+    {
+        return ((delegate* unmanaged[Stdcall]<IInspectable*, uint>)this.lpVtbl[1])((IInspectable*)Unsafe.AsPointer(ref this));
+    }
+
+    /// <inheritdoc cref="IUnknown.Release" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [VtblIndex(2)]
+    [return: NativeTypeName("ULONG")]
+    public uint Release()
+    {
+        return ((delegate* unmanaged[Stdcall]<IInspectable*, uint>)this.lpVtbl[2])((IInspectable*)Unsafe.AsPointer(ref this));
+    }
+}

--- a/src/ComputeSharp.D2D1.UI/ComputeSharp.D2D1.UI.projitems
+++ b/src/ComputeSharp.D2D1.UI/ComputeSharp.D2D1.UI.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\ICanvasResourceWrapperNative.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\ID2D1DeviceContextLease.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\ID2D1DeviceContextPool.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\Inspectable\IInspectable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\Win2D.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\WIN2D_GET_D2D_IMAGE_FLAGS.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\WIN2D_GET_DEVICE_ASSOCIATION_TYPE.cs" />

--- a/src/ComputeSharp.D2D1.UI/ComputeSharp.D2D1.UI.projitems
+++ b/src/ComputeSharp.D2D1.UI/ComputeSharp.D2D1.UI.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\ICanvasDevice.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\ICanvasEffectFactoryNative.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\ICanvasEffect.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\ICanvasFactoryNative.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ABI.Microsoft.Graphics.Canvas\ICanvasImageInterop.cs" />

--- a/src/ComputeSharp.D2D1.UI/Helpers/ResourceManager.cs
+++ b/src/ComputeSharp.D2D1.UI/Helpers/ResourceManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using ABI.Microsoft.Graphics.Canvas;
 using ComputeSharp.D2D1.Extensions;
 using TerraFX.Interop.Windows;
@@ -19,7 +20,7 @@ using WinRT = TerraFX.Interop.WinRT.WinRT;
 /// <remarks>
 /// This type provides an entry point to use the Win2D <see cref="ICanvasFactoryNative"/> activation factory.
 /// </remarks>
-internal static class ResourceManager
+internal static unsafe class ResourceManager
 {
     /// <summary>
     /// Gets or creates an <see cref="IGraphicsEffectSource"/> instance for a native resource.
@@ -29,10 +30,66 @@ internal static class ResourceManager
     /// <param name="dpi">The realization DPIs for <paramref name="resource"/></param>
     /// <returns>The resulting <see cref="IGraphicsEffectSource"/> wrapper instance.</returns>
     /// <exception cref="Exception">Thrown if the managed wrapper could not be retrieved.</exception>
-    public static unsafe IGraphicsEffectSource GetOrCreate(ICanvasDevice* device, IUnknown* resource, float dpi)
+    public static IGraphicsEffectSource GetOrCreate(ICanvasDevice* device, IUnknown* resource, float dpi)
     {
         using ComPtr<ICanvasFactoryNative> canvasFactoryNative = default;
 
+        GetActivationFactory(canvasFactoryNative.GetAddressOf());
+
+        using ComPtr<IInspectable> wrapperInspectable = default;
+
+        // Get or create a WinRT wrapper for the resource
+        canvasFactoryNative.Get()->GetOrCreate(
+            device: device,
+            resource: resource,
+            dpi: dpi,
+            wrapper: wrapperInspectable.GetAddressOf()).Assert();
+
+        // Get the runtime-provided RCW for the resulting WinRT wrapper
+        return RcwMarshaller.GetOrCreateManagedObject<IGraphicsEffectSource>((IUnknown*)wrapperInspectable.Get());
+    }
+
+    /// <summary>
+    /// Registers a managed wrapper for a given native resource.
+    /// </summary>
+    /// <param name="resource">The input native resource to register a wrapper for.</param>
+    /// <param name="wrapper">The wrapper to register for <paramref name="resource"/>.</param>
+    public static void RegisterWrapper<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.NonPublicConstructors | DynamicallyAccessedMemberTypes.Interfaces)] T>(IUnknown* resource, T wrapper)
+        where T : class
+    {
+        using ComPtr<ICanvasFactoryNative> canvasFactoryNative = default;
+
+        GetActivationFactory(canvasFactoryNative.GetAddressOf());
+
+        using ComPtr<IInspectable> wrapperInspectable = default;
+
+        // Unwrap the input wrapper and get an IInspectable* object
+        RcwMarshaller.GetNativeObject(wrapper, wrapperInspectable.GetAddressOf()).Assert();
+
+        // Register this pair of native resource and inspectable wrapper
+        canvasFactoryNative.Get()->RegisterWrapper(resource, wrapperInspectable.Get()).Assert();
+    }
+
+    /// <summary>
+    /// Unregisters a native resource from Win2D's internal cache.
+    /// </summary>
+    /// <param name="resource">The input native resource to unregister a wrapper for.</param>
+    public static void UnregisterWrapper(IUnknown* resource)
+    {
+        using ComPtr<ICanvasFactoryNative> canvasFactoryNative = default;
+
+        GetActivationFactory(canvasFactoryNative.GetAddressOf());
+
+        // Unregister the previously registered native resource
+        canvasFactoryNative.Get()->UnregisterWrapper(resource).Assert();
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ICanvasFactoryNative"/> activation factory.
+    /// </summary>
+    /// <param name="factoryNative">A pointer to the resulting activation factory.</param>
+    private static void GetActivationFactory(ICanvasFactoryNative** factoryNative)
+    {
         const string activatableClassId = "Microsoft.Graphics.Canvas.CanvasDevice";
 
         fixed (char* pActivatableClassId = activatableClassId)
@@ -53,19 +110,7 @@ internal static class ResourceManager
             WinRT.RoGetActivationFactory(
                 activatableClassId: hStringActivatableClass,
                 iid: &canvasFactoryNativeId,
-                factory: canvasFactoryNative.GetVoidAddressOf()).Assert();
+                factory: (void**)factoryNative).Assert();
         }
-
-        using ComPtr<IInspectable> wrapperInspectable = default;
-
-        // Get or create a WinRT wrapper for the resource
-        canvasFactoryNative.Get()->GetOrCreate(
-            device: device,
-            resource: resource,
-            dpi: dpi,
-            wrapper: wrapperInspectable.GetAddressOf()).Assert();
-
-        // Get the runtime-provided RCW for the resulting WinRT wrapper
-        return RcwMarshaller.GetOrCreateManagedObject<IGraphicsEffectSource>((IUnknown*)wrapperInspectable.Get());
     }
 }

--- a/src/ComputeSharp.D2D1.UI/Helpers/ResourceManager.cs
+++ b/src/ComputeSharp.D2D1.UI/Helpers/ResourceManager.cs
@@ -56,16 +56,16 @@ internal static class ResourceManager
                 factory: canvasFactoryNative.GetVoidAddressOf()).Assert();
         }
 
-        using ComPtr<IUnknown> wrapperUnknown = default;
+        using ComPtr<IInspectable> wrapperInspectable = default;
 
         // Get or create a WinRT wrapper for the resource
         canvasFactoryNative.Get()->GetOrCreate(
             device: device,
             resource: resource,
             dpi: dpi,
-            wrapper: wrapperUnknown.GetVoidAddressOf()).Assert();
+            wrapper: wrapperInspectable.GetAddressOf()).Assert();
 
         // Get the runtime-provided RCW for the resulting WinRT wrapper
-        return RcwMarshaller.GetOrCreateManagedObject<IGraphicsEffectSource>(wrapperUnknown.Get());
+        return RcwMarshaller.GetOrCreateManagedObject<IGraphicsEffectSource>((IUnknown*)wrapperInspectable.Get());
     }
 }

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasImageInterop.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasImageInterop.cs
@@ -243,6 +243,10 @@ unsafe partial class PixelShaderEffect<T>
             }
         }
 
+        // Unregister the wrapper for the effect. In case someone is still holding a reference
+        // to it, the effect is now "orphaned" and without a registered inspectable wrapper.
+        ResourceManager.UnregisterWrapper((IUnknown*)this.d2D1Effect.Get());
+
         // Finally release the effect as well
         this.d2D1Effect.Dispose();
     }
@@ -339,6 +343,9 @@ unsafe partial class PixelShaderEffect<T>
                 D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(this.d2D1Effect.Get(), resourceTextureManager, index);
             }
         }
+
+        // Register the new realized effect
+        ResourceManager.RegisterWrapper((IUnknown*)this.d2D1Effect.Get(), this);
 
         return true;
     }


### PR DESCRIPTION
### Description

This PR supports the new APIs in https://github.com/microsoft/Win2D/issues/910 to register effect wrappers.
Support for registering effect factories will be implemented in a separate follow up PR.