### PR TITLE
Fix WinRT projections marshalling on WASDK

### DIFF
--- a/src/ComputeSharp.D2D1.UI/CanvasEffect.Interop.cs
+++ b/src/ComputeSharp.D2D1.UI/CanvasEffect.Interop.cs
@@ -40,7 +40,7 @@ unsafe partial class CanvasEffect
     {
         using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
 
-        RcwMarshaller.GetNativeObject(GetCanvasImage(), canvasImageInterop.GetAddressOf()).Assert();
+        RcwMarshaller.GetNativeInterface(GetCanvasImage(), canvasImageInterop.GetAddressOf()).Assert();
 
         return canvasImageInterop.Get()->GetDevice(device, type);
     }
@@ -56,7 +56,7 @@ unsafe partial class CanvasEffect
     {
         using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
 
-        RcwMarshaller.GetNativeObject(GetCanvasImage(), canvasImageInterop.GetAddressOf()).Assert();
+        RcwMarshaller.GetNativeInterface(GetCanvasImage(), canvasImageInterop.GetAddressOf()).Assert();
 
         return canvasImageInterop.Get()->GetD2DImage(device, deviceContext, flags, targetDpi, realizeDpi, ppImage);
     }

--- a/src/ComputeSharp.D2D1.UI/Helpers/ResourceManager.cs
+++ b/src/ComputeSharp.D2D1.UI/Helpers/ResourceManager.cs
@@ -52,7 +52,7 @@ internal static unsafe class ResourceManager
             wrapper: wrapperInspectable.GetAddressOf()).Assert();
 
         // Get the runtime-provided RCW for the resulting WinRT wrapper
-        return RcwMarshaller.GetOrCreateManagedObject<IGraphicsEffectSource>((IUnknown*)wrapperInspectable.Get());
+        return RcwMarshaller.GetOrCreateManagedInterface<IGraphicsEffectSource>((IUnknown*)wrapperInspectable.Get());
     }
 
     /// <summary>
@@ -70,7 +70,7 @@ internal static unsafe class ResourceManager
         using ComPtr<IInspectable> wrapperInspectable = default;
 
         // Unwrap the input wrapper and get an IInspectable* object
-        RcwMarshaller.GetNativeObject(wrapper, wrapperInspectable.GetAddressOf()).Assert();
+        RcwMarshaller.GetNativeObject(wrapper, wrapperInspectable.GetAddressOf());
 
         // Register this pair of native resource and inspectable wrapper
         canvasFactoryNative.Get()->RegisterWrapper(resource, wrapperInspectable.Get()).Assert();
@@ -128,7 +128,7 @@ internal static unsafe class ResourceManager
         // For instance, this will ensure the following call will work fine in unpackaged apps.
         ICanvasFactoryNative.Interface canvasDeviceActivationFactory = CanvasDevice.As<ICanvasFactoryNative.Interface>();
 
-        *factoryNative = (ICanvasFactoryNative*)MarshalInspectable<ICanvasFactoryNative.Interface>.FromManaged(canvasDeviceActivationFactory);
+        *factoryNative = (ICanvasFactoryNative*)MarshalInterface<ICanvasFactoryNative.Interface>.FromManaged(canvasDeviceActivationFactory);
 #endif
     }
 }

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffect.cs
@@ -101,7 +101,7 @@ unsafe partial class PixelShaderEffect<T>
         using ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect> canvasEffectAbi = default;
 
         // Get the ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect object from the input interface
-        RcwMarshaller.GetNativeObject(sourceEffect, canvasEffectAbi.GetAddressOf()).Assert();
+        RcwMarshaller.GetNativeInterface(sourceEffect, canvasEffectAbi.GetAddressOf()).Assert();
 
         Win2D.GetRequiredSourceRectanglesForICanvasImageInterop(
             resourceCreator: resourceCreatorWithDpi.Get(),
@@ -155,7 +155,7 @@ unsafe partial class PixelShaderEffect<T>
             // Get the underlying ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect object for each input effect
             for (int i = 0; i < sourceEffects.Length; i++)
             {
-                RcwMarshaller.GetNativeObject(sourceEffects[i], canvasEffects[i].GetAddressOf()).Assert();
+                RcwMarshaller.GetNativeInterface(sourceEffects[i], canvasEffects[i].GetAddressOf()).Assert();
             }
 
             Rect[] result = new Rect[sourceEffects.Length];
@@ -210,9 +210,9 @@ unsafe partial class PixelShaderEffect<T>
         ICanvasImageInterop** canvasImageInterop)
     {
         // Get the ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreatorWithDpi object from the input interface
-        RcwMarshaller.GetNativeObject(resourceCreator, resourceCreatorWithDpi).Assert();
+        RcwMarshaller.GetNativeInterface(resourceCreator, resourceCreatorWithDpi).Assert();
 
         // Get the ICanvasImageInterop object from the current instance
-        RcwMarshaller.GetNativeObject(this, canvasImageInterop).Assert();
+        RcwMarshaller.GetNativeInterface(this, canvasImageInterop).Assert();
     }
 }

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasImage.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasImage.cs
@@ -40,12 +40,12 @@ unsafe partial class PixelShaderEffect<T>
         using ComPtr<ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreator> resourceCreatorAbi = default;
 
         // Get the ABI.Microsoft.Graphics.Canvas.ICanvasResourceCreator object from the input interface
-        RcwMarshaller.GetNativeObject(resourceCreator, resourceCreatorAbi.GetAddressOf()).Assert();
+        RcwMarshaller.GetNativeInterface(resourceCreator, resourceCreatorAbi.GetAddressOf()).Assert();
 
         using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
 
         // Get the ICanvasImageInterop object from the current instance
-        RcwMarshaller.GetNativeObject(this, canvasImageInterop.GetAddressOf()).Assert();
+        RcwMarshaller.GetNativeInterface(this, canvasImageInterop.GetAddressOf()).Assert();
 
         Rect bounds;
 

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasImageInterop.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasImageInterop.cs
@@ -373,7 +373,7 @@ unsafe partial class PixelShaderEffect<T>
                 using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
 
                 // Convert to ICanvasImageInterop (this must always succeed, and throws if it doesn't)
-                RcwMarshaller.GetNativeObject(source, canvasImageInterop.GetAddressOf()).Assert();
+                RcwMarshaller.GetNativeInterface(source, canvasImageInterop.GetAddressOf()).Assert();
 
                 using ComPtr<ID2D1Image> d2D1Image = default;
 

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.Properties.Interop.Sources.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.Properties.Interop.Sources.cs
@@ -141,7 +141,7 @@ unsafe partial class PixelShaderEffect<T>
             using ComPtr<ICanvasImageInterop> canvasImageInterop = default;
 
             // Try to get the ICanvasImageInterop interface from the input source
-            HRESULT hresult = RcwMarshaller.GetNativeObject(value, canvasImageInterop.GetAddressOf());
+            HRESULT hresult = RcwMarshaller.GetNativeInterface(value, canvasImageInterop.GetAddressOf());
 
             if (!Win32.SUCCEEDED(hresult))
             {


### PR DESCRIPTION
### Related to https://github.com/microsoft/CsWinRT/issues/1326

### Description

This PR fixes the marshalling of WinRT projections on the Win2D WASDK project.
Previous, this was causing invoked methods on `CanvasDevice`'s interop activation factory interface to be incorrect.