### PR TITLE
Fix effect factory cache registration and validation logic

### DIFF
--- a/src/ComputeSharp.D2D1.UI/Extensions/IUnknownExtensions.cs
+++ b/src/ComputeSharp.D2D1.UI/Extensions/IUnknownExtensions.cs
@@ -51,7 +51,7 @@ internal static unsafe class IUnknownExtensions
     /// <typeparam name="T">The type of object being copied.</typeparam>
     /// <param name="source">The source <see cref="IUnknown"/> object.</param>
     /// <param name="destination">The destination <see cref="ComPtr{T}"/> location.</param>
-    /// <returns>The <see cref="HRESULT"/> for the operation (always <see cref="S.S_OK"/>).</returns>
+    /// <returns>The <see cref="HRESULT"/> for the operation.</returns>
     public static HRESULT CopyTo<T>(this ref T source, ref ComPtr<T> destination)
         where T : unmanaged // IUnknown
     {
@@ -64,5 +64,22 @@ internal static unsafe class IUnknownExtensions
         using ComPtr<T> temporary = new((T*)Unsafe.AsPointer(ref source));
 
         return temporary.CopyTo(ref destination);
+    }
+
+    /// <summary>
+    /// Copies the source <see cref="IUnknown"/> object onto a target <typeparamref name="U"/> location.
+    /// </summary>
+    /// <typeparam name="T">The type of object being copied.</typeparam>
+    /// <typeparam name="U">The type of destination object being copied.</typeparam>
+    /// <param name="source">The source <see cref="IUnknown"/> object.</param>
+    /// <param name="destination">The destination <typeparamref name="U"/> location.</param>
+    /// <returns>The <see cref="HRESULT"/> for the operation.</returns>
+    public static HRESULT CopyTo<T, U>(this ref T source, U** destination)
+        where T : unmanaged // IUnknown
+        where U : unmanaged // IUnknown
+    {
+        using ComPtr<T> temporary = new((T*)Unsafe.AsPointer(ref source));
+
+        return temporary.CopyTo(destination);
     }
 }

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffectFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffectFactoryNative.cs
@@ -91,12 +91,45 @@ unsafe partial class PixelShaderEffect<T>
         /// <inheritdoc/>
         int ICanvasEffectFactoryNative.Interface.CreateWrapper(ICanvasDevice* device, ID2D1Effect* resource, float dpi, IInspectable** wrapper)
         {
-            PixelShaderEffect<T> @this = new();
+            PixelShaderEffect<T> @this;
 
             using (ComPtr<ID2D1Device1> d2D1Device1 = default)
             {
                 // Get the underlying ID2D1Device1 instance for the input device
                 device->GetD2DDevice(d2D1Device1.GetAddressOf()).Assert();
+
+                // Validate that the input underlying D2D device and resource share the same D2D factory
+                using (ComPtr<ID2D1Image> d2D1ImageResource = default)
+                using (ComPtr<ID2D1Factory> d2D1FactoryFromDevice = default)
+                using (ComPtr<ID2D1Factory> d2D1FactoryFromResource = default)
+                {
+                    resource->CopyTo(d2D1ImageResource.GetAddressOf()).Assert();
+
+                    d2D1Device1.Get()->GetFactory(d2D1FactoryFromDevice.GetAddressOf());
+                    d2D1ImageResource.Get()->GetFactory(d2D1FactoryFromResource.GetAddressOf());
+
+                    // Shared logic and comments from Win2D, as this validation path is the same as that of CanvasEffect.
+                    // There is a small chance of constructing a PixelShaderEffect<T> object that is in an invalid state
+                    // when using this method to create a managed wrapper indirectly from the interop APIs exposed in the
+                    // public headers. In general, this would happen if someone did manual interop to get a managed wrapper
+                    // for an orphaned effect previously retrieved from an existing PixelShaderEffect<T> instance that has
+                    // since changed. For more info and a full example, see https://github.com/microsoft/Win2D/issues/913.
+                    // Here we're validating the D2D factories from the wrapped effect and the device to try to minimize
+                    // the chances of this happening. We can't be 100% sure since there is no way with the existing D2D
+                    // APIs to fully determine whether two resources are "compatible", short of just trying to draw with
+                    // both of them to see if that fails. But, comparing factories is at least a nice additional check
+                    // to perform, and due to the fact that Win2D creates a new D2D factory per CanvasDevice, this should
+                    // already cover most scenarios where this might potentially happen, so that's good enough.
+                    if (!d2D1FactoryFromDevice.Get()->IsSameInstance(d2D1FactoryFromResource.Get()))
+                    {
+                        *wrapper = null;
+
+                        return E.E_INVALIDARG;
+                    }
+                }
+
+                // Only initialize the effect once we're past the validation
+                @this = new PixelShaderEffect<T>();
 
                 // Initialize the effect state
                 device->CopyTo(ref @this.canvasDevice).Assert();

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffectFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffectFactoryNative.cs
@@ -104,6 +104,11 @@ unsafe partial class PixelShaderEffect<T>
                 resource->CopyTo(ref @this.d2D1Effect).Assert();
             }
 
+            // Register the new wrapper for the input resource. This has to be done manually in this
+            // case, as the effect is not being realized through the usual path from GetD2DImage.
+            ResourceManager.RegisterWrapper((IUnknown*)resource, this);
+
+            // Unwrap the PixelShaderEffect<T> and return its CCW to the caller
             RcwMarshaller.GetNativeObject(@this, wrapper);
 
             return S.S_OK;


### PR DESCRIPTION
### Description

This PR includes a couple follow up fixes for #512. Specifically:
- Adds the missing registration for created wrappers into the Win2D cache
- Ports the D2D factory validation logic from Win2D