### PR TITLE
Remove .NET Core 3.1 TFMs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -76,7 +76,7 @@ jobs:
     needs: [build-solution]
     strategy:
       matrix:
-        framework: [net7.0, net6.0, netcoreapp3.1, net472]
+        framework: [net7.0, net6.0, net472]
     runs-on: windows-2022
 
     # Set the environment variable which is then looked up in ComputeSharp.Dynamic.
@@ -171,7 +171,7 @@ jobs:
     needs: [build-solution]
     strategy:
       matrix:
-        framework: [net7.0, net6.0, netcoreapp3.1, net472]
+        framework: [net7.0, net6.0, net472]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -253,7 +253,7 @@ jobs:
     needs: [build-packages]
     strategy:
       matrix:
-        framework: [net7.0, net6.0, netcoreapp3.1, net472]
+        framework: [net7.0, net6.0, net472]
     runs-on: windows-2022
     steps:
     - name: Git checkout

--- a/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
+++ b/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/samples/ComputeSharp.Sample.FSharp.Shaders/ComputeSharp.Sample.FSharp.Shaders.csproj
+++ b/samples/ComputeSharp.Sample.FSharp.Shaders/ComputeSharp.Sample.FSharp.Shaders.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <LangVersion>5.0</LangVersion>
   </PropertyGroup>

--- a/samples/ComputeSharp.Sample/ComputeSharp.Sample.csproj
+++ b/samples/ComputeSharp.Sample/ComputeSharp.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests/Effects/ZonePlateEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/ZonePlateEffect.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace ComputeSharp.D2D1.Tests.Effects;
 
-#if !NETCOREAPP3_1_OR_GREATER 
+#if !NET6_0_OR_GREATER 
 internal static class MathF
 {
     public const float PI = (float)Math.PI;

--- a/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.Runtime.CompilerServices;
@@ -47,7 +47,7 @@ internal static class HRESULTExtensions
     /// Throws a <see cref="Win32Exception"/>.
     /// </summary>
     /// <param name="result">The input return code.</param>
-#if NETCOREAPP3_1_OR_GREATER
+#if NET6_0_OR_GREATER
     [DoesNotReturn]
 #endif
     private static void ThrowWin32Exception(int result)

--- a/tests/ComputeSharp.Dynamic.NuGet/ComputeSharp.Dynamic.NuGet.csproj
+++ b/tests/ComputeSharp.Dynamic.NuGet/ComputeSharp.Dynamic.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;

--- a/tests/ComputeSharp.NuGet/ComputeSharp.NuGet.csproj
+++ b/tests/ComputeSharp.NuGet/ComputeSharp.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;

--- a/tests/ComputeSharp.Pix.NuGet/ComputeSharp.Pix.NuGet.csproj
+++ b/tests/ComputeSharp.Pix.NuGet/ComputeSharp.Pix.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
+++ b/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests/Polyfills/RandomExtensions.cs
+++ b/tests/ComputeSharp.Tests/Polyfills/RandomExtensions.cs
@@ -1,4 +1,4 @@
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET6_0_OR_GREATER
 
 namespace System;
 


### PR DESCRIPTION
### Description

This PR removes all .NET Core 3.1 TFMs, since .NET Core 3.1 is unsupported as of December 2022.