### PR TITLE
Remove double uses in MengerJourney/TwoTiledTruchet

### DIFF
--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/MengerJourney.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/MengerJourney.cs
@@ -95,7 +95,7 @@ internal readonly partial struct MengerJourney : ID2D1PixelShader
 
             z = (Scale * z) - (Offset * (Scale - 1.0f));
 
-            if (z.Z < -0.5f * Offset.Z * (Scale - 1.0))
+            if (z.Z < -0.5f * Offset.Z * (Scale - 1.0f))
             {
                 z.Z += Offset.Z * (Scale - 1.0f);
             }

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TwoTiledTruchet.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TwoTiledTruchet.cs
@@ -67,7 +67,7 @@ internal readonly partial struct TwoTiledTruchet : ID2D1PixelShader
                 ang.Y *= -1.0f;
             }
 
-            if (rnd3 < .5)
+            if (rnd3 < 0.5f)
             {
                 d = d.YX;
                 ang = ang.YX;
@@ -79,7 +79,7 @@ internal readonly partial struct TwoTiledTruchet : ID2D1PixelShader
         }
         else
         {
-            if (rnd < .5)
+            if (rnd < 0.5f)
             {
                 p = p.YX * new float2(1, -1);
             }

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/MengerJourney.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/MengerJourney.cs
@@ -88,7 +88,7 @@ internal readonly partial struct MengerJourney : IPixelShader<float4>
 
             z = (Scale * z) - (Offset * (Scale - 1.0f));
 
-            if (z.Z < -0.5f * Offset.Z * (Scale - 1.0))
+            if (z.Z < -0.5f * Offset.Z * (Scale - 1.0f))
             {
                 z.Z += Offset.Z * (Scale - 1.0f);
             }

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TwoTiledTruchet.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TwoTiledTruchet.cs
@@ -60,7 +60,7 @@ internal readonly partial struct TwoTiledTruchet : IPixelShader<float4>
                 ang.Y *= -1.0f;
             }
 
-            if (rnd3 < .5)
+            if (rnd3 < 0.5f)
             {
                 d = d.YX;
                 ang = ang.YX;
@@ -72,7 +72,7 @@ internal readonly partial struct TwoTiledTruchet : IPixelShader<float4>
         }
         else
         {
-            if (rnd < .5)
+            if (rnd < 0.5f)
             {
                 p = p.YX * new float2(1, -1);
             }


### PR DESCRIPTION
### Description

This PR removes two accidental `double` uses in "MengerJourney" and "TwoTiledTruchet". This will enable older GPUs not supporting double precision operations in shaders to still run those two shaders correctly, instead of crashing on load.