### PR TITLE
Add missing readonly modifiers, ignore them in HLSL

### DIFF
--- a/samples/ComputeSharp.ImageProcessing/Primitives/ComplexVector4.cs
+++ b/samples/ComputeSharp.ImageProcessing/Primitives/ComplexVector4.cs
@@ -30,5 +30,5 @@ internal struct ComplexVector4
     /// <param name="b">The 'b' parameter, for the imaginary component</param>
     /// <returns>The resulting <see cref="Vector4"/> value</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Vector4 WeightedSum(float a, float b) => (this.Real * a) + (this.Imaginary * b);
+    public readonly Vector4 WeightedSum(float a, float b) => (this.Real * a) + (this.Imaginary * b);
 }

--- a/src/ComputeSharp.D2D1.UI/Loaders/D2D1ImmutableArrayResourceTextureDescriptionsLoader.cs
+++ b/src/ComputeSharp.D2D1.UI/Loaders/D2D1ImmutableArrayResourceTextureDescriptionsLoader.cs
@@ -24,7 +24,7 @@ internal struct D2D1ImmutableArrayResourceTextureDescriptionsLoader : ID2D1Resou
     /// </summary>
     /// <returns>An array of indices for resource textures for the current effect.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ImmutableArray<int> GetResultingIndices()
+    public readonly ImmutableArray<int> GetResultingIndices()
     {
         return this.indices;
     }

--- a/src/ComputeSharp.D2D1.UI/Loaders/D2D1IndexBitmaskResourceTextureDescriptionsLoader.cs
+++ b/src/ComputeSharp.D2D1.UI/Loaders/D2D1IndexBitmaskResourceTextureDescriptionsLoader.cs
@@ -23,7 +23,7 @@ internal struct D2D1IndexBitmaskResourceTextureDescriptionsLoader : ID2D1Resourc
     /// </summary>
     /// <returns>A bitmask of indices for resource textures in the target shader.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int GetResultingIndexBitmask()
+    public readonly int GetResultingIndexBitmask()
     {
         return this.indexBitmask;
     }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
@@ -404,7 +404,7 @@ unsafe partial struct PixelShaderEffect
     /// <param name="resourceTextureIndex">The index of the resource texture to validate.</param>
     /// <param name="dimensions">The number of dimensions for the resource texture at the gven index.</param>
     /// <returns>Whether or not <paramref name="resourceTextureIndex"/> is valid for the current effect.</returns>
-    private bool IsResourceTextureManagerIndexValid(int resourceTextureIndex, out uint dimensions)
+    private readonly bool IsResourceTextureManagerIndexValid(int resourceTextureIndex, out uint dimensions)
     {
         foreach (ref readonly D2D1ResourceTextureDescription resourceTextureDescription in new ReadOnlySpan<D2D1ResourceTextureDescription>(this.resourceTextureDescriptions, this.resourceTextureDescriptionCount))
         {

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1BufferSizeDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1BufferSizeDispatchDataLoader.cs
@@ -22,7 +22,7 @@ internal unsafe struct D2D1BufferSizeDispatchDataLoader : ID2D1DispatchDataLoade
     /// </summary>
     /// <returns>The size of the constant buffer.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int GetConstantBufferSize()
+    private readonly int GetConstantBufferSize()
     {
         return this.size;
     }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayDispatchDataLoader.cs
@@ -22,7 +22,7 @@ internal struct D2D1ByteArrayDispatchDataLoader : ID2D1DispatchDataLoader
     /// </summary>
     /// <returns>A <see cref="byte"/> array with the constant buffer for the current shader.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public byte[] GetResultingDispatchData()
+    public readonly byte[] GetResultingDispatchData()
     {
         return this.data!;
     }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayInputDescriptionsLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayInputDescriptionsLoader.cs
@@ -23,7 +23,7 @@ internal struct D2D1ByteArrayInputDescriptionsLoader : ID2D1InputDescriptionsLoa
     /// </summary>
     /// <returns>A <see cref="D2D1InputDescription"/> array with the available input descriptions.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public D2D1InputDescription[] GetResultingInputDescriptions()
+    public readonly D2D1InputDescription[] GetResultingInputDescriptions()
     {
         return this.inputDescriptions!;
     }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayResourceTextureDescriptionsLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteArrayResourceTextureDescriptionsLoader.cs
@@ -23,7 +23,7 @@ internal struct D2D1ByteArrayResourceTextureDescriptionsLoader : ID2D1ResourceTe
     /// </summary>
     /// <returns>A <see cref="D2D1ResourceTextureDescription"/> array with the available resource texture descriptions.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public D2D1ResourceTextureDescription[] GetResultingResourceTextureDescriptions()
+    public readonly D2D1ResourceTextureDescription[] GetResultingResourceTextureDescriptions()
     {
         return this.resourceTextureDescriptions!;
     }

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteBufferDispatchDataLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ByteBufferDispatchDataLoader.cs
@@ -46,7 +46,7 @@ internal unsafe struct D2D1ByteBufferDispatchDataLoader : ID2D1DispatchDataLoade
     /// <param name="writtenBytes">The number of written bytes, of <c>0</c> in case of failure.</param>
     /// <returns>Whether or not the constant buffer was retrieved successfully.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryGetWrittenBytes(out int writtenBytes)
+    public readonly bool TryGetWrittenBytes(out int writtenBytes)
     {
         // If the -1 marker is present, it means copying to the target span failed.
         // In this case, the returned number of written bytes is still reported as 0.

--- a/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ShaderBytecodeLoader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Loaders/D2D1ShaderBytecodeLoader.cs
@@ -37,7 +37,7 @@ internal unsafe struct D2D1ShaderBytecodeLoader : ID2D1BytecodeLoader
     /// <returns>An <see cref="ID3DBlob"/> with the shader bytecode, if dynamically compiled.</returns>
     /// <remarks>Either <paramref name="precompiledBytecode"/> is empty, or the returned pointer is <see langword="null"/>.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ComPtr<ID3DBlob> GetResultingShaderBytecode(out ReadOnlySpan<byte> precompiledBytecode)
+    public readonly ComPtr<ID3DBlob> GetResultingShaderBytecode(out ReadOnlySpan<byte> precompiledBytecode)
     {
         precompiledBytecode = new ReadOnlySpan<byte>(this.embeddedBytecodePtr, this.embeddedBytecodeSize);
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Extensions/SyntaxNodeExtensions.cs
@@ -206,19 +206,23 @@ internal static class SyntaxNodeExtensions
     }
 
     /// <summary>
-    /// Returns a <see cref="MethodDeclarationSyntax"/> instance with no accessibility modifiers.
+    /// Returns a <see cref="MethodDeclarationSyntax"/> instance with no invalid HLSL modifiers.
     /// </summary>
     /// <param name="node">The input <see cref="MethodDeclarationSyntax"/> node.</param>
-    /// <returns>A node just like <paramref name="node"/> but with no accessibility modifiers.</returns>
-    public static MethodDeclarationSyntax WithoutAccessibilityModifiers(this MethodDeclarationSyntax node)
+    /// <returns>A node just like <paramref name="node"/> but with no invalid HLSL modifiers.</returns>
+    /// <remarks>This method will only strip modifiers that are expected and allowed on HLSL methods.</remarks>
+    public static MethodDeclarationSyntax WithoutInvalidHlslModifiers(this MethodDeclarationSyntax node)
     {
-        return node.WithModifiers(TokenList(node.Modifiers.Where(static modifier => modifier.Kind() switch
+        static bool IsAllowedHlslModifier(SyntaxToken syntaxToken)
         {
-            SyntaxKind.PublicKeyword => false,
-            SyntaxKind.PrivateKeyword => false,
-            SyntaxKind.ProtectedKeyword => false,
-            SyntaxKind.InternalKeyword => false,
-            _ => true
-        }).ToArray()));
+            return syntaxToken.Kind() is not (
+                SyntaxKind.PublicKeyword or
+                SyntaxKind.PrivateKeyword or
+                SyntaxKind.ProtectedKeyword or
+                SyntaxKind.InternalKeyword or
+                SyntaxKind.ReadOnlyKeyword);
+        }
+
+        return node.WithModifiers(TokenList(node.Modifiers.Where(IsAllowedHlslModifier)));
     }
 }

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
@@ -245,7 +245,7 @@ internal sealed partial class ShaderSourceRewriter : HlslSourceRewriter
         return
             ((MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!)
             .WithBlockBody()
-            .WithoutAccessibilityModifiers()
+            .WithoutInvalidHlslModifiers()
             .WithAttributeLists(List<AttributeListSyntax>());
     }
 

--- a/src/ComputeSharp.SourceGeneration/Helpers/HashCode.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/HashCode.cs
@@ -439,7 +439,7 @@ internal struct HashCode
     /// Gets the resulting hashcode from the current instance.
     /// </summary>
     /// <returns>The resulting hashcode from the current instance.</returns>
-    public int ToHashCode()
+    public readonly int ToHashCode()
     {
         uint length = this.length;
         uint position = length % 4;

--- a/src/ComputeSharp/Graphics/Commands/CommandList.cs
+++ b/src/ComputeSharp/Graphics/Commands/CommandList.cs
@@ -89,7 +89,7 @@ internal unsafe struct CommandList : IDisposable
     /// <summary>
     /// Gets the <see cref="GraphicsDevice"/> instance associated with the current command list.
     /// </summary>
-    public GraphicsDevice GraphicsDevice => this.device;
+    public readonly GraphicsDevice GraphicsDevice => this.device;
 
     /// <summary>
     /// Gets the command list type being used by the current instance.

--- a/src/ComputeSharp/Graphics/Commands/Interop/ID3D12DescriptorHandleAllocator.cs
+++ b/src/ComputeSharp/Graphics/Commands/Interop/ID3D12DescriptorHandleAllocator.cs
@@ -83,7 +83,7 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     /// <summary>
     /// Gets the <see cref="ID3D12DescriptorHeap"/> in use for the current <see cref="ID3D12DescriptorHandleAllocator"/> instance.
     /// </summary>
-    public ID3D12DescriptorHeap* D3D12DescriptorHeap => this.d3D12DescriptorHeap;
+    public readonly ID3D12DescriptorHeap* D3D12DescriptorHeap => this.d3D12DescriptorHeap;
 
     /// <summary>
     /// Rents a new bundle of CPU and GPU handles to use in a resource.

--- a/src/ComputeSharp/Shaders/ComputeContext.cs
+++ b/src/ComputeSharp/Shaders/ComputeContext.cs
@@ -55,7 +55,7 @@ public struct ComputeContext : IDisposable, IAsyncDisposable
     /// <summary>
     /// Gets the <see cref="ComputeSharp.GraphicsDevice"/> associated with the current instance.
     /// </summary>
-    public GraphicsDevice GraphicsDevice
+    public readonly GraphicsDevice GraphicsDevice
     {
         get
         {

--- a/src/ComputeSharp/Shaders/Dispatching/ShaderBytecodeLoader.cs
+++ b/src/ComputeSharp/Shaders/Dispatching/ShaderBytecodeLoader.cs
@@ -24,7 +24,7 @@ internal struct ShaderBytecodeLoader : IBytecodeLoader
     /// <returns>The current <see cref="ICachedShader"/> instance.</returns>
     /// <exception cref="InvalidOperationException">Thrown if the shader has not been initialized.</exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ICachedShader GetCachedShader()
+    public readonly ICachedShader GetCachedShader()
     {
         default(InvalidOperationException).ThrowIf(this.cachedShader is null);
 

--- a/src/ComputeSharp/Shaders/Dispatching/__Internals/ArrayPoolStringBuilder.cs
+++ b/src/ComputeSharp/Shaders/Dispatching/__Internals/ArrayPoolStringBuilder.cs
@@ -136,7 +136,7 @@ public ref struct ArrayPoolStringBuilder
     }
 
     /// <inheritdoc/>
-    public void Dispose()
+    public readonly void Dispose()
     {
         ArrayPool<char>.Shared.Return(this.array);
     }

--- a/src/TerraFX.Interop.Windows/DirectX/other/d3dx12/D3D12_BOX.Manual.cs
+++ b/src/TerraFX.Interop.Windows/DirectX/other/d3dx12/D3D12_BOX.Manual.cs
@@ -49,9 +49,9 @@ internal partial struct D3D12_BOX : IEquatable<D3D12_BOX>
         return !(l == r);
     }
 
-    public override bool Equals(object? obj) => (obj is D3D12_BOX other) && Equals(other);
+    public override readonly bool Equals(object? obj) => (obj is D3D12_BOX other) && Equals(other);
 
-    public bool Equals(D3D12_BOX other) => this == other;
+    public readonly bool Equals(D3D12_BOX other) => this == other;
 
-    public override int GetHashCode() => HashCode.Combine(left, top, front, right, bottom, back);
+    public override readonly int GetHashCode() => HashCode.Combine(left, top, front, right, bottom, back);
 }

--- a/src/TerraFX.Interop.Windows/DirectX/other/d3dx12/D3D12_CPU_DESCRIPTOR_HANDLE.Manual.cs
+++ b/src/TerraFX.Interop.Windows/DirectX/other/d3dx12/D3D12_CPU_DESCRIPTOR_HANDLE.Manual.cs
@@ -59,9 +59,9 @@ internal unsafe partial struct D3D12_CPU_DESCRIPTOR_HANDLE : IEquatable<D3D12_CP
         handle.ptr = (nuint)((long)@base.ptr + ((long)offsetInDescriptors * (long)descriptorIncrementSize));
     }
 
-    public override bool Equals(object? obj) => (obj is D3D12_CPU_DESCRIPTOR_HANDLE other) && Equals(other);
+    public override readonly bool Equals(object? obj) => (obj is D3D12_CPU_DESCRIPTOR_HANDLE other) && Equals(other);
 
-    public bool Equals(D3D12_CPU_DESCRIPTOR_HANDLE other) => this == other;
+    public readonly bool Equals(D3D12_CPU_DESCRIPTOR_HANDLE other) => this == other;
 
-    public override int GetHashCode() => ptr.GetHashCode();
+    public override readonly int GetHashCode() => ptr.GetHashCode();
 }

--- a/src/TerraFX.Interop.Windows/DirectX/other/d3dx12/D3D12_GPU_DESCRIPTOR_HANDLE.Manual.cs
+++ b/src/TerraFX.Interop.Windows/DirectX/other/d3dx12/D3D12_GPU_DESCRIPTOR_HANDLE.Manual.cs
@@ -59,9 +59,9 @@ internal unsafe partial struct D3D12_GPU_DESCRIPTOR_HANDLE : IEquatable<D3D12_GP
         handle.ptr = (ulong)((long)@base.ptr + ((long)offsetInDescriptors * (long)descriptorIncrementSize));
     }
 
-    public override bool Equals(object? obj) => (obj is D3D12_GPU_DESCRIPTOR_HANDLE other) && Equals(other);
+    public override readonly bool Equals(object? obj) => (obj is D3D12_GPU_DESCRIPTOR_HANDLE other) && Equals(other);
 
-    public bool Equals(D3D12_GPU_DESCRIPTOR_HANDLE other) => this == other;
+    public readonly bool Equals(D3D12_GPU_DESCRIPTOR_HANDLE other) => this == other;
 
-    public override int GetHashCode() => ptr.GetHashCode();
+    public override readonly int GetHashCode() => ptr.GetHashCode();
 }

--- a/src/TerraFX.Interop.Windows/DirectX/other/d3dx12/D3D12_RESOURCE_DESC.Manual.cs
+++ b/src/TerraFX.Interop.Windows/DirectX/other/d3dx12/D3D12_RESOURCE_DESC.Manual.cs
@@ -53,9 +53,9 @@ internal unsafe partial struct D3D12_RESOURCE_DESC : IEquatable<D3D12_RESOURCE_D
         return new D3D12_RESOURCE_DESC(D3D12_RESOURCE_DIMENSION_TEXTURE3D, alignment, width, height, depth, mipLevels, format, 1, 0, layout, flags);
     }
 
-    public ushort Depth => ((Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D) ? DepthOrArraySize : (ushort)(1));
+    public readonly ushort Depth => ((Dimension == D3D12_RESOURCE_DIMENSION_TEXTURE3D) ? DepthOrArraySize : (ushort)(1));
 
-    public ushort ArraySize => ((Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D) ? DepthOrArraySize : (ushort)(1));
+    public readonly ushort ArraySize => ((Dimension != D3D12_RESOURCE_DIMENSION_TEXTURE3D) ? DepthOrArraySize : (ushort)(1));
 
     public static bool operator ==([NativeTypeName("const D3D12_RESOURCE_DESC &")] in D3D12_RESOURCE_DESC l, [NativeTypeName("const D3D12_RESOURCE_DESC &")] in D3D12_RESOURCE_DESC r)
     {
@@ -75,11 +75,11 @@ internal unsafe partial struct D3D12_RESOURCE_DESC : IEquatable<D3D12_RESOURCE_D
     public static bool operator !=([NativeTypeName("const D3D12_RESOURCE_DESC &")] in D3D12_RESOURCE_DESC l, [NativeTypeName("const D3D12_RESOURCE_DESC &")] in D3D12_RESOURCE_DESC r)
         => !(l == r);
 
-    public override bool Equals(object? obj) => (obj is D3D12_RESOURCE_DESC other) && Equals(other);
+    public override readonly bool Equals(object? obj) => (obj is D3D12_RESOURCE_DESC other) && Equals(other);
 
-    public bool Equals(D3D12_RESOURCE_DESC other) => this == other;
+    public readonly bool Equals(D3D12_RESOURCE_DESC other) => this == other;
 
-    public override int GetHashCode()
+    public override readonly int GetHashCode()
     {
         var hashCode = new HashCode();
         {

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -20,5 +20,8 @@
 
     <!-- Unnecessary #nullable enable directives (for shared projects across UWP) -->
     <NoWarn>$(NoWarn);IDE0240</NoWarn>
+
+    <!-- Missing readonly modifier for readonly struct members (not needed in tests) -->
+    <NoWarn>$(NoWarn);IDE0251</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Closes #525

### Description

This PR adds a few missing `readonly` modifiers on readonly members of mutable `struct` types.
This should also remove some hidden copies in some types (eg. `ComputeContext`), which is nice.
It also ignores the warning in test projects, since it's a bit overkill there (eg. for test shaders).