### PR TITLE
Update NuGet packages to latest stable

### DIFF
--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.200" />
+    <PackageReference Update="FSharp.Core" Version="7.0.300" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -184,10 +184,10 @@
       <Version>7.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.8.3</Version>
+      <Version>2.8.4</Version>
     </PackageReference>
     <PackageReference Include="PolySharp">
-      <Version>1.13.1</Version>
+      <Version>1.13.2</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -28,12 +28,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Media" Version="7.1.2" />
-    <PackageReference Include="PolySharp" Version="1.13.1" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="all" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
+++ b/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.1.0-preview1" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
+++ b/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -77,7 +77,7 @@
     Only needed for the .Core project and all source generators.
   -->
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ComputeSharp.Core' OR $(MSBuildProjectName.EndsWith('.SourceGenerators'))">
-    <PackageReference Include="PolySharp" Version="1.13.1">
+    <PackageReference Include="PolySharp" Version="1.13.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build;analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -12,8 +12,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
-    <PackageReference Include="Vortice.Win32.Graphics.Direct2D" Version="1.9.23" />
-    <PackageReference Include="Vortice.Win32.Graphics.Direct3D11" Version="1.9.23" />
+    <PackageReference Include="Vortice.Win32.Graphics.Direct2D" Version="1.9.24" />
+    <PackageReference Include="Vortice.Win32.Graphics.Direct3D11" Version="1.9.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Uwp.Tests/ComputeSharp.D2D1.Uwp.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Uwp.Tests/ComputeSharp.D2D1.Uwp.Tests.csproj
@@ -139,7 +139,7 @@
       <Version>3.0.2</Version>
     </PackageReference>
     <PackageReference Include="PolySharp">
-      <Version>1.13.1</Version>
+      <Version>1.13.2</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -51,7 +51,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" ExcludeAssets="build" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -9,8 +9,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="Vortice.Win32.Graphics.Direct3D12" Version="1.9.23" />
-    <PackageReference Include="Vortice.Win32.Graphics.Dxgi" Version="1.9.23" />
+    <PackageReference Include="Vortice.Win32.Graphics.Direct3D12" Version="1.9.24" />
+    <PackageReference Include="Vortice.Win32.Graphics.Dxgi" Version="1.9.24" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
-    <PackageReference Include="Vortice.Win32.Graphics.Direct3D12" Version="1.9.23" />
+    <PackageReference Include="Vortice.Win32.Graphics.Direct3D12" Version="1.9.24" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates all NuGet packages to their latest stable versions.
Except Roslyn, as GitHub Actions is still on VS 17.5.x