### PR TITLE
Remove uses of Func<T, TResult> from CLI samples

### DIFF
--- a/samples/ComputeSharp.SwapChain.Cli/Program.cs
+++ b/samples/ComputeSharp.SwapChain.Cli/Program.cs
@@ -14,22 +14,39 @@ if (args is [] or [_])
         shaderName = nameof(ColorfulInfinity);
     }
 
-    // Get the requested shader, if possible
-    Win32Application? application = shaderName.ToLowerInvariant() switch
+    static HelloWorld HelloWorld(TimeSpan time) => new((float)time.TotalSeconds);
+    static ColorfulInfinity ColorfulInfinity(TimeSpan time) => new((float)time.TotalSeconds);
+    static FractalTiling FractalTiling(TimeSpan time) => new((float)time.TotalSeconds);
+    static TwoTiledTruchet TwoTiledTruchet(TimeSpan time) => new((float)time.TotalSeconds);
+    static MengerJourney MengerJourney(TimeSpan time) => new((float)time.TotalSeconds);
+    static Octagrams Octagrams(TimeSpan time) => new((float)time.TotalSeconds);
+    static ProteanClouds ProteanClouds(TimeSpan time) => new((float)time.TotalSeconds);
+    static ExtrudedTruchetPattern ExtrudedTruchetPattern(TimeSpan time) => new((float)time.TotalSeconds);
+    static PyramidPattern PyramidPattern(TimeSpan time) => new((float)time.TotalSeconds);
+    static TriangleGridContouring TriangleGridContouring(TimeSpan time) => new((float)time.TotalSeconds);
+    static TerracedHills TerracedHills(TimeSpan time) => new((float)time.TotalSeconds);
+
+    Win32Application? application;
+
+    unsafe
     {
-        "helloworld" => new SwapChainApplication<HelloWorld>(static time => new((float)time.TotalSeconds)),
-        "colorfulinfinity" => new SwapChainApplication<ColorfulInfinity>(static time => new((float)time.TotalSeconds)),
-        "fractaltiling" => new SwapChainApplication<FractalTiling>(static time => new((float)time.TotalSeconds)),
-        "twotiledtruchet" => new SwapChainApplication<TwoTiledTruchet>(static time => new((float)time.TotalSeconds)),
-        "mengerjourney" => new SwapChainApplication<MengerJourney>(static time => new((float)time.TotalSeconds)),
-        "octagrams" => new SwapChainApplication<Octagrams>(static time => new((float)time.TotalSeconds)),
-        "proteanclouds" => new SwapChainApplication<ProteanClouds>(static time => new((float)time.TotalSeconds)),
-        "extrudedtruchetpattern" => new SwapChainApplication<ExtrudedTruchetPattern>(static time => new((float)time.TotalSeconds)),
-        "pyramidpattern" => new SwapChainApplication<PyramidPattern>(static time => new((float)time.TotalSeconds)),
-        "trianglegridcontouring" => new SwapChainApplication<TriangleGridContouring>(static time => new((float)time.TotalSeconds)),
-        "terracedhills" => new SwapChainApplication<TerracedHills>(static time => new((float)time.TotalSeconds)),
-        _ => null
-    };
+        // Get the requested shader, if possible
+        application = shaderName.ToLowerInvariant() switch
+        {
+            "helloworld" => new SwapChainApplication<HelloWorld>(&HelloWorld),
+            "colorfulinfinity" => new SwapChainApplication<ColorfulInfinity>(&ColorfulInfinity),
+            "fractaltiling" => new SwapChainApplication<FractalTiling>(&FractalTiling),
+            "twotiledtruchet" => new SwapChainApplication<TwoTiledTruchet>(&TwoTiledTruchet),
+            "mengerjourney" => new SwapChainApplication<MengerJourney>(&MengerJourney),
+            "octagrams" => new SwapChainApplication<Octagrams>(&Octagrams),
+            "proteanclouds" => new SwapChainApplication<ProteanClouds>(&ProteanClouds),
+            "extrudedtruchetpattern" => new SwapChainApplication<ExtrudedTruchetPattern>(&ExtrudedTruchetPattern),
+            "pyramidpattern" => new SwapChainApplication<PyramidPattern>(&PyramidPattern),
+            "trianglegridcontouring" => new SwapChainApplication<TriangleGridContouring>(&TriangleGridContouring),
+            "terracedhills" => new SwapChainApplication<TerracedHills>(&TerracedHills),
+            _ => null
+        };
+    }
 
     // If a shader is found, run it
     if (application is not null)

--- a/samples/ComputeSharp.SwapChain/Backend/SwapChainApplication{T}.cs
+++ b/samples/ComputeSharp.SwapChain/Backend/SwapChainApplication{T}.cs
@@ -5,13 +5,17 @@ using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.SwapChain.Backend;
 
-internal sealed class SwapChainApplication<T> : Win32Application
+/// <summary>
+/// A <see cref="Win32Application"/> type that renders an animated shader on a swapchain on a target <see cref="HWND"/>.
+/// </summary>
+/// <typeparam name="T">The shader type to render.</typeparam>
+internal sealed unsafe class SwapChainApplication<T> : Win32Application
     where T : struct, IPixelShader<float4>
 {
     /// <summary>
-    /// The <see cref="Func{T1, TResult}"/> instance used to create shaders to run.
+    /// The function pointer used to create shaders to run.
     /// </summary>
-    private readonly Func<TimeSpan, T> shaderFactory;
+    private readonly delegate*<TimeSpan, T> shaderFactory;
 
     /// <summary>
     /// The <see cref="ID3D12Device"/> pointer for the device currently in use.
@@ -76,8 +80,8 @@ internal sealed class SwapChainApplication<T> : Win32Application
     /// <summary>
     /// Creates a new <see cref="SwapChainApplication{T}"/> instance with the specified parameters.
     /// </summary>
-    /// <param name="shaderFactory">The <see cref="Func{T1, TResult}"/> instance used to create shaders to run.</param>
-    public SwapChainApplication(Func<TimeSpan, T> shaderFactory)
+    /// <param name="shaderFactory">The function pointer used to create shaders to run.</param>
+    public SwapChainApplication(delegate*<TimeSpan, T> shaderFactory)
     {
         this.shaderFactory = shaderFactory;
     }

--- a/samples/ComputeSharp.SwapChain/Program.cs
+++ b/samples/ComputeSharp.SwapChain/Program.cs
@@ -13,28 +13,45 @@ class Program
     /// </summary>
     private static readonly Lazy<IReadOnlyNormalizedTexture2D<float4>> RustyMetal = new(static () => LoadTexture());
 
-    /// <summary>
-    /// The mapping of available samples to choose from.
-    /// </summary>
-    private static readonly (string ShaderName, Win32Application Application)[] Samples = new (string, Win32Application)[]
-    {
-        (nameof(HelloWorld), new SwapChainApplication<HelloWorld>(static time => new((float)time.TotalSeconds))),
-        (nameof(FourColorGradient), new SwapChainApplication<FourColorGradient>(static time => new((float)time.TotalSeconds))),
-        (nameof(ColorfulInfinity), new SwapChainApplication<ColorfulInfinity>(static time => new((float)time.TotalSeconds))),
-        (nameof(FractalTiling), new SwapChainApplication<FractalTiling>(static time => new((float)time.TotalSeconds))),
-        (nameof(TwoTiledTruchet), new SwapChainApplication<TwoTiledTruchet>(static time => new((float)time.TotalSeconds))),
-        (nameof(MengerJourney), new SwapChainApplication<MengerJourney>(static time => new((float)time.TotalSeconds))),
-        (nameof(Octagrams), new SwapChainApplication<Octagrams>(static time => new((float)time.TotalSeconds))),
-        (nameof(ProteanClouds), new SwapChainApplication<ProteanClouds>(static time => new((float)time.TotalSeconds))),
-        (nameof(ExtrudedTruchetPattern), new SwapChainApplication<ExtrudedTruchetPattern>(static time => new((float)time.TotalSeconds))),
-        (nameof(PyramidPattern), new SwapChainApplication<PyramidPattern>(static time => new((float)time.TotalSeconds))),
-        (nameof(TriangleGridContouring), new SwapChainApplication<TriangleGridContouring>(static time => new((float)time.TotalSeconds))),
-        (nameof(ContouredLayers), new SwapChainApplication<ContouredLayers>(static time => new((float)time.TotalSeconds, RustyMetal.Value))),
-        (nameof(TerracedHills), new SwapChainApplication<TerracedHills>(static time => new((float)time.TotalSeconds)))
-    };
-
     static void Main()
     {
+        static HelloWorld HelloWorld(TimeSpan time) => new((float)time.TotalSeconds);
+        static FourColorGradient FourColorGradient(TimeSpan time) => new((float)time.TotalSeconds);
+        static ColorfulInfinity ColorfulInfinity(TimeSpan time) => new((float)time.TotalSeconds);
+        static FractalTiling FractalTiling(TimeSpan time) => new((float)time.TotalSeconds);
+        static TwoTiledTruchet TwoTiledTruchet(TimeSpan time) => new((float)time.TotalSeconds);
+        static MengerJourney MengerJourney(TimeSpan time) => new((float)time.TotalSeconds);
+        static Octagrams Octagrams(TimeSpan time) => new((float)time.TotalSeconds);
+        static ProteanClouds ProteanClouds(TimeSpan time) => new((float)time.TotalSeconds);
+        static ExtrudedTruchetPattern ExtrudedTruchetPattern(TimeSpan time) => new((float)time.TotalSeconds);
+        static PyramidPattern PyramidPattern(TimeSpan time) => new((float)time.TotalSeconds);
+        static TriangleGridContouring TriangleGridContouring(TimeSpan time) => new((float)time.TotalSeconds);
+        static ContouredLayers ContouredLayers(TimeSpan time) => new((float)time.TotalSeconds, RustyMetal.Value);
+        static TerracedHills TerracedHills(TimeSpan time) => new((float)time.TotalSeconds);
+
+        (string ShaderName, Win32Application Application)[] samples;
+
+        unsafe
+        {
+            // Prepare the mapping of available samples to choose from
+            samples = new (string, Win32Application)[]
+            {
+                (nameof(HelloWorld), new SwapChainApplication<HelloWorld>(&HelloWorld)),
+                (nameof(FourColorGradient), new SwapChainApplication<FourColorGradient>(&FourColorGradient)),
+                (nameof(ColorfulInfinity), new SwapChainApplication<ColorfulInfinity>(&ColorfulInfinity)),
+                (nameof(FractalTiling), new SwapChainApplication<FractalTiling>(&FractalTiling)),
+                (nameof(TwoTiledTruchet), new SwapChainApplication<TwoTiledTruchet>(&TwoTiledTruchet)),
+                (nameof(MengerJourney), new SwapChainApplication<MengerJourney>(&MengerJourney)),
+                (nameof(Octagrams), new SwapChainApplication<Octagrams>(&Octagrams)),
+                (nameof(ProteanClouds), new SwapChainApplication<ProteanClouds>(&ProteanClouds)),
+                (nameof(ExtrudedTruchetPattern), new SwapChainApplication<ExtrudedTruchetPattern>(&ExtrudedTruchetPattern)),
+                (nameof(PyramidPattern), new SwapChainApplication<PyramidPattern>(&PyramidPattern)),
+                (nameof(TriangleGridContouring), new SwapChainApplication<TriangleGridContouring>(&TriangleGridContouring)),
+                (nameof(ContouredLayers), new SwapChainApplication<ContouredLayers>(&ContouredLayers)),
+                (nameof(TerracedHills), new SwapChainApplication<TerracedHills>(&TerracedHills))
+            };
+        }
+
         int index;
 
         do
@@ -43,12 +60,12 @@ class Program
             Console.WriteLine("Available samples:");
             Console.WriteLine();
 
-            for (int i = 0; i < Samples.Length; i++)
+            for (int i = 0; i < samples.Length; i++)
             {
-                Console.WriteLine($"{i}: {Samples[i].ShaderName}");
+                Console.WriteLine($"{i}: {samples[i].ShaderName}");
             }
 
-            Console.WriteLine($"{Samples.Length}+: Exit (Use Escape, 'Q', or Alt + F4 to exit a sample once chosen)");
+            Console.WriteLine($"{samples.Length}+: Exit (Use Escape, 'Q', or Alt + F4 to exit a sample once chosen)");
             Console.WriteLine();
 
             do
@@ -57,15 +74,15 @@ class Program
             }
             while (!int.TryParse(Console.ReadLine(), out index));
 
-            if (index >= 0 && index < Samples.Length)
+            if (index >= 0 && index < samples.Length)
             {
                 Console.WriteLine();
-                Console.WriteLine($"Starting {Samples[index].ShaderName}...");
+                Console.WriteLine($"Starting {samples[index].ShaderName}...");
 
-                _ = Win32ApplicationRunner.Run(Samples[index].Application, "ComputeSharp.SwapChain", Samples[index].ShaderName);
+                _ = Win32ApplicationRunner.Run(samples[index].Application, "ComputeSharp.SwapChain", samples[index].ShaderName);
             }
         }
-        while (index >= 0 && index < Samples.Length);
+        while (index >= 0 && index < samples.Length);
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

This PR removes the use of functions in the CLI samples. Saves ~25 KB for the NativeAOT binary.