### PR TITLE
Add ILLink file for ComputeSharp configuration

### DIFF
--- a/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
@@ -34,6 +34,17 @@
     <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
   </PropertyGroup>
 
+  <!--
+    Manually set all configuration switches to trim unused features. These are usually set automatically by the
+    .targets file included in ComputeSharp, but since this project is directly referencing the project and not
+    going through NuGet, it can't rely on that, so it's just copying those three directives here.
+  -->
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="COMPUTESHARP_DISABLE_GPU_TIMEOUT" Value="false" Trim="true" />
+  </ItemGroup>
+
   <!-- If requested, also reference the UPX compression package -->
   <ItemGroup Condition="'$(PUBLISH_AOT_COMPRESSED)' == 'true'">
     <PackageReference Include="PublishAotCompressed" Version="1.0.0" />

--- a/src/ComputeSharp/ComputeSharp.csproj
+++ b/src/ComputeSharp/ComputeSharp.csproj
@@ -28,6 +28,11 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
+  <!-- Include the ILLink file on the .NET 6 target (to properly trim configuration switches in publish builds) -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <EmbeddedResource Include="Properties\ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
+  </ItemGroup>
+
   <!-- T4 template generation service (the .tt/.g.cs files are resolved in the .targets file) -->
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />

--- a/src/ComputeSharp/ComputeSharp.targets
+++ b/src/ComputeSharp/ComputeSharp.targets
@@ -57,4 +57,26 @@
     </ItemGroup>
   </Target>
 
+  <!-- Automatically set the configuration switches -->
+  <ItemGroup>
+
+    <!-- COMPUTESHARP_ENABLE_DEBUG_OUTPUT switch -->
+    <RuntimeHostConfigurationOption Condition="'$(ComputeSharpEnableDebugOutput)' != ''"
+                                    Include="COMPUTESHARP_ENABLE_DEBUG_OUTPUT"
+                                    Value="$(ComputeSharpEnableDebugOutput)"
+                                    Trim="true" />
+
+    <!-- COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA switch -->
+    <RuntimeHostConfigurationOption Condition="'$(ComputeSharpEnableDeviceRemovedExtendedData)' != ''"
+                                    Include="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA"
+                                    Value="$(ComputeSharpEnableDeviceRemovedExtendedData)"
+                                    Trim="true" />
+
+    <!-- COMPUTESHARP_DISABLE_GPU_TIMEOUT switch -->
+    <RuntimeHostConfigurationOption Condition="'$(ComputeSharpDisableGpuTimeout)' != ''"
+                                    Include="COMPUTESHARP_DISABLE_GPU_TIMEOUT"
+                                    Value="$(ComputeSharpDisableGpuTimeout)"
+                                    Trim="true" />
+  </ItemGroup>
+
 </Project>

--- a/src/ComputeSharp/Properties/Configuration.cs
+++ b/src/ComputeSharp/Properties/Configuration.cs
@@ -24,17 +24,17 @@ internal static class Configuration
     private const string DisableGpuTimeout = "COMPUTESHARP_DISABLE_GPU_TIMEOUT";
 
     /// <summary>
-    /// Indicates whether or not the debug output is enabled.
+    /// Indicates whether or not the debug output is enabled (defaults to <see langword="false"/>).
     /// </summary>
     public static readonly bool IsDebugOutputEnabled = GetConfigurationValue(EnableDebugOutput);
 
     /// <summary>
-    /// Indicates whether or not the debug output is enabled.
+    /// Indicates whether or not the debug output is enabled (defaults to <see langword="false"/>).
     /// </summary>
     public static readonly bool IsDeviceRemovedExtendedDataEnabled = GetConfigurationValue(EnableDeviceRemovedExtendedDataInfo);
 
     /// <summary>
-    /// Indicates whether or not the GPU timeout is disabled.
+    /// Indicates whether or not the GPU timeout is disabled (defaults to <see langword="false"/>).
     /// </summary>
     public static readonly bool IsGpuTimeoutDisabled = GetConfigurationValue(DisableGpuTimeout);
 

--- a/src/ComputeSharp/Properties/Configuration.cs
+++ b/src/ComputeSharp/Properties/Configuration.cs
@@ -2,6 +2,7 @@ using System;
 #if DEBUG
 using System.Diagnostics;
 #endif
+using System.Runtime.CompilerServices;
 
 /// <summary>
 /// A container for all shared <see cref="AppContext"/> configuration switches for ComputeSharp.
@@ -11,32 +12,59 @@ internal static class Configuration
     /// <summary>
     /// The configuration property name for <see cref="IsDebugOutputEnabled"/>.
     /// </summary>
-    private const string EnableDebugOutput = "COMPUTESHARP_ENABLE_DEBUG_OUTPUT";
+    private const string IsDebugOutputEnabledPropertyName = "COMPUTESHARP_ENABLE_DEBUG_OUTPUT";
 
     /// <summary>
     /// The configuration property name for <see cref="IsDeviceRemovedExtendedDataEnabled"/>.
     /// </summary>
-    private const string EnableDeviceRemovedExtendedDataInfo = "COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA";
+    private const string IsDeviceRemovedExtendedDataEnabledPropertyName = "COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA";
 
     /// <summary>
     /// The configuration property name for <see cref="IsGpuTimeoutDisabled"/>.
     /// </summary>
-    private const string DisableGpuTimeout = "COMPUTESHARP_DISABLE_GPU_TIMEOUT";
+    private const string IsGpuTimeoutDisabledPropertyName = "COMPUTESHARP_DISABLE_GPU_TIMEOUT";
 
     /// <summary>
-    /// Indicates whether or not the debug output is enabled (defaults to <see langword="false"/>).
+    /// The backing field for <see cref="IsDebugOutputEnabled"/>.
     /// </summary>
-    public static readonly bool IsDebugOutputEnabled = GetConfigurationValue(EnableDebugOutput);
+    private static readonly bool IsDebugOutputEnabledConfigurationValue = GetConfigurationValue(IsDebugOutputEnabledPropertyName);
 
     /// <summary>
-    /// Indicates whether or not the debug output is enabled (defaults to <see langword="false"/>).
+    /// The backing field for <see cref="IsDeviceRemovedExtendedDataEnabled"/>.
     /// </summary>
-    public static readonly bool IsDeviceRemovedExtendedDataEnabled = GetConfigurationValue(EnableDeviceRemovedExtendedDataInfo);
+    private static readonly bool IsDeviceRemovedExtendedDataEnabledConfigurationValue = GetConfigurationValue(IsDeviceRemovedExtendedDataEnabledPropertyName);
 
     /// <summary>
-    /// Indicates whether or not the GPU timeout is disabled (defaults to <see langword="false"/>).
+    /// The backing field for <see cref="IsGpuTimeoutDisabled"/>.
     /// </summary>
-    public static readonly bool IsGpuTimeoutDisabled = GetConfigurationValue(DisableGpuTimeout);
+    private static readonly bool IsGpuTimeoutDisabledConfigurationValue = GetConfigurationValue(IsGpuTimeoutDisabledPropertyName);
+
+    /// <summary>
+    /// Gets a value indicating whether or not the debug output is enabled (defaults to <see langword="false"/>).
+    /// </summary>
+    public static bool IsDebugOutputEnabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => IsDebugOutputEnabledConfigurationValue;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether or not the debug output is enabled (defaults to <see langword="false"/>).
+    /// </summary>
+    public static bool IsDeviceRemovedExtendedDataEnabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => IsDeviceRemovedExtendedDataEnabledConfigurationValue;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether or not the GPU timeout is disabled (defaults to <see langword="false"/>).
+    /// </summary>
+    public static bool IsGpuTimeoutDisabled
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => IsGpuTimeoutDisabledConfigurationValue;
+    }
 
     /// <summary>
     /// Gets a configuration value for a specified property.
@@ -46,7 +74,7 @@ internal static class Configuration
     private static bool GetConfigurationValue(string propertyName)
     {
 #if DEBUG
-        if (Debugger.IsAttached && propertyName != DisableGpuTimeout)
+        if (Debugger.IsAttached && propertyName != IsGpuTimeoutDisabledPropertyName)
         {
             return true;
         }

--- a/src/ComputeSharp/Properties/ILLink.Substitutions.xml
+++ b/src/ComputeSharp/Properties/ILLink.Substitutions.xml
@@ -3,26 +3,26 @@
 
     <!-- COMPUTESHARP_ENABLE_DEBUG_OUTPUT switch -->
     <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" featurevalue="true">
-      <field name="IsDebugOutputEnabled" value="true" />
+      <field name="IsDebugOutputEnabledConfigurationValue" value="true" />
     </type>
     <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" featurevalue="false">
-      <field name="IsDebugOutputEnabled" value="false" />
+      <field name="IsDebugOutputEnabledConfigurationValue" value="false" />
     </type>
 
     <!-- COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA switch -->
     <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="true">
-      <field name="IsDeviceRemovedExtendedDataEnabled" value="true" />
+      <field name="IsDeviceRemovedExtendedDataEnabledConfigurationValue" value="true" />
     </type>
     <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="false">
-      <field name="IsDeviceRemovedExtendedDataEnabled" value="false" />
+      <field name="IsDeviceRemovedExtendedDataEnabledConfigurationValue" value="false" />
     </type>
 
     <!-- COMPUTESHARP_DISABLE_GPU_TIMEOUT switch -->
     <type fullname="Configuration" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="true">
-      <field name="IsGpuTimeoutDisabled" value="true" />
+      <field name="IsGpuTimeoutDisabledConfigurationValue" value="true" />
     </type>
     <type fullname="Configuration" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="false">
-      <field name="IsGpuTimeoutDisabled" value="false" />
+      <field name="IsGpuTimeoutDisabledConfigurationValue" value="false" />
     </type>
   </assembly>
 </linker>

--- a/src/ComputeSharp/Properties/ILLink.Substitutions.xml
+++ b/src/ComputeSharp/Properties/ILLink.Substitutions.xml
@@ -1,0 +1,28 @@
+<linker>
+  <assembly fullname="ComputeSharp">
+
+    <!-- COMPUTESHARP_ENABLE_DEBUG_OUTPUT switch -->
+    <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" featurevalue="true">
+      <field name="IsDebugOutputEnabled" value="true" />
+    </type>
+    <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" featurevalue="false">
+      <field name="IsDebugOutputEnabled" value="false" />
+    </type>
+
+    <!-- COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA switch -->
+    <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="true">
+      <field name="IsDeviceRemovedExtendedDataEnabled" value="true" />
+    </type>
+    <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="false">
+      <field name="IsDeviceRemovedExtendedDataEnabled" value="false" />
+    </type>
+
+    <!-- COMPUTESHARP_DISABLE_GPU_TIMEOUT switch -->
+    <type fullname="Configuration" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="true">
+      <field name="IsGpuTimeoutDisabled" value="true" />
+    </type>
+    <type fullname="Configuration" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="false">
+      <field name="IsGpuTimeoutDisabled" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/ComputeSharp/Properties/ILLink.Substitutions.xml
+++ b/src/ComputeSharp/Properties/ILLink.Substitutions.xml
@@ -1,28 +1,18 @@
 <linker>
   <assembly fullname="ComputeSharp">
+    <type fullname="Configuration">
 
-    <!-- COMPUTESHARP_ENABLE_DEBUG_OUTPUT switch -->
-    <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" featurevalue="true">
-      <field name="IsDebugOutputEnabledConfigurationValue" value="true" />
-    </type>
-    <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" featurevalue="false">
-      <field name="IsDebugOutputEnabledConfigurationValue" value="false" />
-    </type>
+      <!-- COMPUTESHARP_ENABLE_DEBUG_OUTPUT switch -->
+      <method signature="System.Boolean get_IsDebugOutputEnabled()" body="stub" value="false" feature="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" featurevalue="false"/>
+      <method signature="System.Boolean get_IsDebugOutputEnabled()" body="stub" value="true" feature="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" featurevalue="true"/>
 
-    <!-- COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA switch -->
-    <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="true">
-      <field name="IsDeviceRemovedExtendedDataEnabledConfigurationValue" value="true" />
-    </type>
-    <type fullname="Configuration" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="false">
-      <field name="IsDeviceRemovedExtendedDataEnabledConfigurationValue" value="false" />
-    </type>
+      <!-- COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA switch -->
+      <method signature="System.Boolean get_IsDeviceRemovedExtendedDataEnabled()" body="stub" value="false" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="false"/>
+      <method signature="System.Boolean get_IsDeviceRemovedExtendedDataEnabled()" body="stub" value="true" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="true"/>
 
-    <!-- COMPUTESHARP_DISABLE_GPU_TIMEOUT switch -->
-    <type fullname="Configuration" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="true">
-      <field name="IsGpuTimeoutDisabledConfigurationValue" value="true" />
-    </type>
-    <type fullname="Configuration" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="false">
-      <field name="IsGpuTimeoutDisabledConfigurationValue" value="false" />
+      <!-- COMPUTESHARP_DISABLE_GPU_TIMEOUT switch -->
+      <method signature="System.Boolean get_IsGpuTimeoutDisabled()" body="stub" value="false" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="false"/>
+      <method signature="System.Boolean get_IsGpuTimeoutDisabled()" body="stub" value="true" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="true"/>
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
### Description

This PR adds an ILLink configuration file to trim the configuration flags (same as https://github.com/terrafx/terrafx.interop.windows/pull/341). For some reason though this doesn't seem to be working — I'm getting the same exact 1.715 KB binary when building the CLI sample with NativeAOT on .NET 7 both with these changes, and removing that embedded resource entirely 🤔

@tannergooding @MichalStrehovsky am I missing something obvious here? 😅