### PR TITLE
Generate documentation files for all source and samples

### DIFF
--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/Backend/PixelShaderEffect.cs
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/Backend/PixelShaderEffect.cs
@@ -1,7 +1,6 @@
 using System;
 using ComputeSharp.D2D1;
 using ComputeSharp.D2D1.WinUI;
-using Microsoft.Graphics.Canvas;
 
 namespace ComputeSharp.SwapChain.D2D1.Backend;
 

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -3,6 +3,9 @@
 
   <PropertyGroup>
 
+    <!-- Workaround for https://github.com/dotnet/roslyn/issues/41640 (see notes in \src .props file) -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
     <!-- Samples don't need public XML docs for all APIs -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -42,9 +42,15 @@
   <!-- Additional properties for all source projects-->
   <PropertyGroup>
 
-    <!-- Generate documentation files (only for published, non source generator projects) -->
-    <GenerateDocumentationFile Condition="$(IsPackagedProject)">true</GenerateDocumentationFile>
-    <DocumentationFile Condition="'$(GenerateDocumentationFile)' == 'true'">$(MSBuildProjectName).xml</DocumentationFile>
+    <!--
+      Generate documentation files. In theory this should only be abled for published, non source generator projects.
+      However, this is always enabled to work around https://github.com/dotnet/roslyn/issues/41640. Until that's fixed,
+      source generators will also produce an .xml file with their documentation. Note that this doesn't really impact
+      NuGet packages, since the analyzer binaries are packed manually after build, so the .xml files aren't included.
+      When this workaround is no longer needed, the same property should also removed for the \samples directory.
+    -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DocumentationFile>$(MSBuildProjectName).xml</DocumentationFile>
 
     <!-- Disable packing symbols for source generators -->
     <PackSymbols Condition="$(IsSourceGeneratorProject)">false</PackSymbols>


### PR DESCRIPTION
### Description

This works around build failures from CLI builds due to https://github.com/dotnet/roslyn/issues/41640.
