### PR TITLE
Invert GPU timeout feature switch, true by default

### DIFF
--- a/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
@@ -42,7 +42,7 @@
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="COMPUTESHARP_ENABLE_DEBUG_OUTPUT" Value="false" Trim="true" />
     <RuntimeHostConfigurationOption Include="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" Value="false" Trim="true" />
-    <RuntimeHostConfigurationOption Include="COMPUTESHARP_DISABLE_GPU_TIMEOUT" Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="COMPUTESHARP_ENABLE_GPU_TIMEOUT" Value="true" Trim="true" />
   </ItemGroup>
 
   <!-- If requested, also reference the UPX compression package -->

--- a/src/ComputeSharp/ComputeSharp.targets
+++ b/src/ComputeSharp/ComputeSharp.targets
@@ -72,10 +72,10 @@
                                     Value="$(ComputeSharpEnableDeviceRemovedExtendedData)"
                                     Trim="true" />
 
-    <!-- COMPUTESHARP_DISABLE_GPU_TIMEOUT switch -->
-    <RuntimeHostConfigurationOption Condition="'$(ComputeSharpDisableGpuTimeout)' != ''"
-                                    Include="COMPUTESHARP_DISABLE_GPU_TIMEOUT"
-                                    Value="$(ComputeSharpDisableGpuTimeout)"
+    <!-- COMPUTESHARP_ENABLE_GPU_TIMEOUT switch -->
+    <RuntimeHostConfigurationOption Condition="'$(ComputeSharpEnableGpuTimeout)' != ''"
+                                    Include="COMPUTESHARP_ENABLE_GPU_TIMEOUT"
+                                    Value="$(ComputeSharpEnableGpuTimeout)"
                                     Trim="true" />
   </ItemGroup>
 

--- a/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
@@ -356,7 +356,7 @@ internal static unsafe class ID3D12DeviceExtensions
         d3D12CommandQueueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
         d3D12CommandQueueDesc.NodeMask = 0;
 
-        if (Configuration.IsGpuTimeoutDisabled)
+        if (!Configuration.IsGpuTimeoutEnabled)
         {
             d3D12CommandQueueDesc.Flags |= D3D12_COMMAND_QUEUE_FLAG_DISABLE_GPU_TIMEOUT;
         }

--- a/src/ComputeSharp/Properties/Configuration.cs
+++ b/src/ComputeSharp/Properties/Configuration.cs
@@ -30,9 +30,9 @@ internal static class Configuration
     private const string IsDeviceRemovedExtendedDataEnabledPropertyName = "COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA";
 
     /// <summary>
-    /// The configuration property name for <see cref="IsGpuTimeoutDisabled"/>.
+    /// The configuration property name for <see cref="IsGpuTimeoutEnabled"/>.
     /// </summary>
-    private const string IsGpuTimeoutDisabledPropertyName = "COMPUTESHARP_DISABLE_GPU_TIMEOUT";
+    private const string IsGpuTimeoutEnabledPropertyName = "COMPUTESHARP_ENABLE_GPU_TIMEOUT";
 
     /// <summary>
     /// The backing field for <see cref="IsDebugOutputEnabled"/>.
@@ -45,9 +45,9 @@ internal static class Configuration
     private static int isDeviceRemovedExtendedDataEnabledConfigurationValue;
 
     /// <summary>
-    /// The backing field for <see cref="IsGpuTimeoutDisabled"/>.
+    /// The backing field for <see cref="IsGpuTimeoutEnabled"/>.
     /// </summary>
-    private static int isGpuTimeoutDisabledConfigurationValue;
+    private static int isGpuTimeoutEnabledConfigurationValue;
 
     /// <summary>
     /// Gets a value indicating whether or not the debug output is enabled (defaults to <see langword="false"/>).
@@ -68,12 +68,12 @@ internal static class Configuration
     }
 
     /// <summary>
-    /// Gets a value indicating whether or not the GPU timeout is disabled (defaults to <see langword="false"/>).
+    /// Gets a value indicating whether or not the GPU timeout is enabled (defaults to <see langword="true"/>).
     /// </summary>
-    public static bool IsGpuTimeoutDisabled
+    public static bool IsGpuTimeoutEnabled
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => GetConfigurationValue(IsGpuTimeoutDisabledPropertyName, ref isGpuTimeoutDisabledConfigurationValue);
+        get => GetConfigurationValue(IsGpuTimeoutEnabledPropertyName, ref isGpuTimeoutEnabledConfigurationValue);
     }
 
     /// <summary>
@@ -140,10 +140,10 @@ internal static class Configuration
 #endif
         }
 
-        // Disable GPU timeout (always false by default)
-        if (propertyName == IsGpuTimeoutDisabledPropertyName)
+        // GPU timeout (always enabled by default, disabling it is only recommended for debugging purposes)
+        if (propertyName == IsGpuTimeoutEnabledPropertyName)
         {
-            return false;
+            return true;
         }
 
         return false;

--- a/src/ComputeSharp/Properties/ILLink.Substitutions.xml
+++ b/src/ComputeSharp/Properties/ILLink.Substitutions.xml
@@ -10,9 +10,9 @@
       <method signature="System.Boolean get_IsDeviceRemovedExtendedDataEnabled()" body="stub" value="false" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="false"/>
       <method signature="System.Boolean get_IsDeviceRemovedExtendedDataEnabled()" body="stub" value="true" feature="COMPUTESHARP_ENABLE_DEVICE_REMOVED_EXTENDED_DATA" featurevalue="true"/>
 
-      <!-- COMPUTESHARP_DISABLE_GPU_TIMEOUT switch -->
-      <method signature="System.Boolean get_IsGpuTimeoutDisabled()" body="stub" value="false" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="false"/>
-      <method signature="System.Boolean get_IsGpuTimeoutDisabled()" body="stub" value="true" feature="COMPUTESHARP_DISABLE_GPU_TIMEOUT" featurevalue="true"/>
+      <!-- COMPUTESHARP_ENABLE_GPU_TIMEOUT switch -->
+      <method signature="System.Boolean get_IsGpuTimeoutEnabled()" body="stub" value="false" feature="COMPUTESHARP_ENABLE_GPU_TIMEOUT" featurevalue="false"/>
+      <method signature="System.Boolean get_IsGpuTimeoutEnabled()" body="stub" value="true" feature="COMPUTESHARP_ENABLE_GPU_TIMEOUT" featurevalue="true"/>
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
### Description

This PR inverts the GPU timeout feature switch, and makes it enabled by default.
This makes all feature switches positive, and avoids double negation confusion.