### PR TITLE
Remove workaround for lower D3D12MA SDK

### DIFF
--- a/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
@@ -327,12 +327,7 @@ internal static unsafe class ID3D12DeviceExtensions
             // readback buffer, probably due to some driver-specific behavior. This is not
             // an issue, as the initial state doesn't matter anyway and the readback buffer
             // is still correctly transitioned when needed, so it can be safely ignored.
-#if NET6_0_OR_GREATER
-            // This value is defined in the 22000 SDK, which is not currently referenced by D3D12MA
-            (D3D12_MESSAGE_ID)1328
-#else
             D3D12_MESSAGE_ID_CREATERESOURCE_STATE_IGNORED
-#endif
         };
 
         D3D12_INFO_QUEUE_FILTER d3D12InfoQueueFilter = default;


### PR DESCRIPTION
### Description

This PR removes a temporary workaround due to a missing enum value on D3D12MA.