### PR TITLE
Remove Console.WriteLine call for -h output

### DIFF
--- a/samples/ComputeSharp.SwapChain.Cli/Program.cs
+++ b/samples/ComputeSharp.SwapChain.Cli/Program.cs
@@ -53,28 +53,6 @@ if (args is [] or [_])
     {
         return Win32ApplicationRunner.Run(application, "ComputeSharp", "ComputeSharp");
     }
-
-    // If no shader matches, check if help was requested
-    if (shaderName is "-h")
-    {
-        Console.WriteLine($"""
-            Available shaders:
-
-            - {nameof(HelloWorld)}
-            - {nameof(ColorfulInfinity)}
-            - {nameof(FractalTiling)}
-            - {nameof(TwoTiledTruchet)}
-            - {nameof(MengerJourney)}
-            - {nameof(Octagrams)}
-            - {nameof(ProteanClouds)}
-            - {nameof(ExtrudedTruchetPattern)}
-            - {nameof(PyramidPattern)}
-            - {nameof(TriangleGridContouring)}
-            - {nameof(TerracedHills)}
-            """);
-
-        return S.S_OK;
-    }
 }
 
 return E.E_INVALIDARG;


### PR DESCRIPTION
### Description

This PR removes the `Console.WriteLine` call in the CLI sample when `-h` was passed.
Saves 65 KB on the x64 binary for NativeAOT (tested on .NET 8 Preview 7):
- baseline: 1,398 KB
- no text: **1,333 KB**