### PR TITLE
Build ComputeSharp.D3D12MemoryAllocator package

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,6 +44,8 @@ jobs:
       run: dotnet pack src\ComputeSharp\ComputeSharp.csproj -c Release
     - name: Build ComputeSharp.Dynamic package
       run: dotnet pack src\ComputeSharp.Dynamic\ComputeSharp.Dynamic.csproj -c Release
+    - name: Build ComputeSharp.D3D12MemoryAllocator package
+      run: dotnet pack src\ComputeSharp.D3D12MemoryAllocator\ComputeSharp.D3D12MemoryAllocator.csproj -c Release
     - name: Build ComputeSharp.D2D1 package
       run: dotnet pack src\ComputeSharp.D2D1\ComputeSharp.D2D1.csproj -c Release
     - name: Build ComputeSharp.Pix package


### PR DESCRIPTION
### Description

Small follow up to #539 to pack the NuGet package in the CI script.