### PR TITLE
Add more MSBuild options to DX12 CLI sample

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -229,7 +229,7 @@ jobs:
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
       
-      # Publish the NativeAOT CLI sample
+      # Publish the NativeAOT CLI sample (optimized for speed)
     - name: Publish ComputeSharp.SwapChain.Cli with NativeAOT
       run: >
         $env:COMPUTESHARP_SWAPCHAIN_CLI_PUBLISH_AOT='true';
@@ -244,13 +244,41 @@ jobs:
         $process.CloseMainWindow() | Out-Null;
         $process.WaitForExit();
         $process.ExitCode
-      
+
       # Upload the binary (to track binary size trends)
     - if: matrix.platform == 'x64'
       name: Upload NativeAOT CLI sample
       uses: actions/upload-artifact@v3
       with:
-        name: computesharp.cli.exe
+        name: computesharp.cli.opt-speed.exe
+        path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net7.0\win-x64\publish\computesharp.cli.exe
+        if-no-files-found: error
+
+      # Publish the NativeAOT CLI sample (optimized for size, and reflection-free)
+    - name: Publish ComputeSharp.SwapChain.Cli with NativeAOT
+      run: >
+        $env:COMPUTESHARP_SWAPCHAIN_CLI_PUBLISH_AOT='true';
+        $env:COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED='true';
+        $env:COMPUTESHARP_SWAPCHAIN_CLI_DISABLE_REFLECTION='true';
+        git clean -fdx;
+        dotnet publish samples\ComputeSharp.SwapChain.Cli\ComputeSharp.SwapChain.Cli.csproj -c Release -f net7.0 -r win-${{matrix.platform}} -v n
+      
+      # Again only on x64, also run the sample and validate it works correctly
+    - if: matrix.platform == 'x64'
+      name: Run ComputeSharp.SwapChain.Cli
+      run: >
+        $process = (Start-Process samples\ComputeSharp.SwapChain.Cli\bin\Release\net7.0\win-x64\publish\computesharp.cli.exe -PassThru);
+        sleep -Seconds 2;
+        $process.CloseMainWindow() | Out-Null;
+        $process.WaitForExit();
+        $process.ExitCode
+
+      # Upload the binary again (with a different name)
+    - if: matrix.platform == 'x64'
+      name: Upload NativeAOT CLI sample
+      uses: actions/upload-artifact@v3
+      with:
+        name: computesharp.cli.opt-size.exe
         path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net7.0\win-x64\publish\computesharp.cli.exe
         if-no-files-found: error
 

--- a/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
@@ -13,7 +13,9 @@
     <DefineConstants>$(DefineConstants);SAMPLE_APP</DefineConstants>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
     <AssemblyName>computesharp.cli</AssemblyName>
-    <ApplicationIcon>..\..\assets\icon.ico</ApplicationIcon>
+
+    <!-- When explicitly optimizing for size, strip the icon (which adds about 100 KB of binary size) -->
+    <ApplicationIcon Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED)' != 'true'">..\..\assets\icon.ico</ApplicationIcon>
   </PropertyGroup>
 
   <!--
@@ -30,8 +32,9 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
     <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
-    <IlcDisableReflection>true</IlcDisableReflection>
-    <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
+    <IlcDisableReflection Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_DISABLE_REFLECTION)' == 'true'">true</IlcDisableReflection>
+    <IlcOptimizationPreference Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED)' == 'true'">Size</IlcOptimizationPreference>
+    <IlcOptimizationPreference Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED)' != 'true'">Speed</IlcOptimizationPreference>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
### Description

This PR adds two new MSBuild properties to the DirectX 12 CLI sample:
- `COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED`: this will strip the icon and optimize for size
- `COMPUTESHARP_SWAPCHAIN_CLI_DISABLE_REFLECTION`: enables the NativeAOT reflection-free mode