### PR TITLE
Fix trimming support for ComputeSharp.D2D1.WinUI and CI test

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -243,7 +243,8 @@ jobs:
         sleep -Seconds 2;
         $process.CloseMainWindow() | Out-Null;
         $process.WaitForExit();
-        $process.ExitCode
+        if ($process.ExitCode -lt 0) { throw $process.ExitCode; }
+        return $process.ExitCode;
 
       # Upload the binary (to track binary size trends)
     - if: matrix.platform == 'x64'
@@ -271,7 +272,8 @@ jobs:
         sleep -Seconds 2;
         $process.CloseMainWindow() | Out-Null;
         $process.WaitForExit();
-        $process.ExitCode
+        if ($process.ExitCode -lt 0) { throw $process.ExitCode; }
+        return $process.ExitCode;
 
       # Upload the binary again (with a different name)
     - if: matrix.platform == 'x64'
@@ -297,7 +299,8 @@ jobs:
         sleep -Seconds 2;
         $process.CloseMainWindow() | Out-Null;
         $process.WaitForExit();
-        $process.ExitCode
+        if ($process.ExitCode -lt 0) { throw $process.ExitCode; }
+        return $process.ExitCode;
 
   # Download the NuGet packages generated in the previous job and use them
   # to build and run the sample project referencing them. This is used as

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.cs
@@ -1,3 +1,6 @@
+#if !WINDOWS_UWP
+using System.Diagnostics.CodeAnalysis;
+#endif
 using ABI.Microsoft.Graphics.Canvas;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.Interop;
@@ -72,6 +75,16 @@ public sealed partial class PixelShaderEffect<T> : IReferenceTrackedObject, ICan
     /// <summary>
     /// Creates a new <see cref="PixelShaderEffect{T}"/> instance.
     /// </summary>
+#if !WINDOWS_UWP
+    // Workaround for trimming bug in custom COM/WinRT components with CsWinRT. Without manually preserving metadata for
+    // these types, using them will throw an InvalidCastException (see https://github.com/microsoft/CsWinRT/issues/1319).
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ICanvasImageInterop.Interface))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ICanvasImageInterop.Interface.Vftbl))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ICanvasFactoryNative.Interface))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ICanvasFactoryNative.Interface.Vftbl))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ICanvasEffectFactoryNative.Interface))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ICanvasEffectFactoryNative.Interface.Vftbl))]
+#endif
     public PixelShaderEffect()
     {
         using ReferenceTracker.Lease _0 = ReferenceTracker.Create(this, out this.referenceTracker);


### PR DESCRIPTION
### Description

This PR includes the following changes:
- Fixes the CI script to correctly fail if any of the published samples fails to run
- Adds a workaround to allow ComputeSharp.D2D1.WinUI to work fine with trimming (see https://github.com/microsoft/CsWinRT/issues/1319)