### PR TITLE
Fix some incorrect signatures in Win2D ABI type bindings

### DIFF
--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasDevice.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasDevice.cs
@@ -23,7 +23,7 @@ internal unsafe struct ICanvasDevice
     [VtblIndex(0)]
     public HRESULT QueryInterface([NativeTypeName("const IID &")] Guid* riid, void** ppvObject)
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceWrapperNative*, Guid*, void**, int>)this.lpVtbl[0])((ICanvasResourceWrapperNative*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        return ((delegate* unmanaged[Stdcall]<ICanvasDevice*, Guid*, void**, int>)this.lpVtbl[0])((ICanvasDevice*)Unsafe.AsPointer(ref this), riid, ppvObject);
     }
 
     /// <inheritdoc cref="IUnknown.AddRef"/>
@@ -32,7 +32,7 @@ internal unsafe struct ICanvasDevice
     [return: NativeTypeName("ULONG")]
     public uint AddRef()
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceWrapperNative*, uint>)this.lpVtbl[1])((ICanvasResourceWrapperNative*)Unsafe.AsPointer(ref this));
+        return ((delegate* unmanaged[Stdcall]<ICanvasDevice*, uint>)this.lpVtbl[1])((ICanvasDevice*)Unsafe.AsPointer(ref this));
     }
 
     /// <inheritdoc cref="IUnknown.Release"/>
@@ -41,6 +41,6 @@ internal unsafe struct ICanvasDevice
     [return: NativeTypeName("ULONG")]
     public uint Release()
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceWrapperNative*, uint>)this.lpVtbl[2])((ICanvasResourceWrapperNative*)Unsafe.AsPointer(ref this));
+        return ((delegate* unmanaged[Stdcall]<ICanvasDevice*, uint>)this.lpVtbl[2])((ICanvasDevice*)Unsafe.AsPointer(ref this));
     }
 }

--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasFactoryNative.cs
@@ -30,7 +30,7 @@ internal unsafe struct ICanvasFactoryNative
     [VtblIndex(0)]
     public HRESULT QueryInterface([NativeTypeName("const IID &")] Guid* riid, void** ppvObject)
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceWrapperNative*, Guid*, void**, int>)this.lpVtbl[0])((ICanvasResourceWrapperNative*)Unsafe.AsPointer(ref this), riid, ppvObject);
+        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, Guid*, void**, int>)this.lpVtbl[0])((ICanvasFactoryNative*)Unsafe.AsPointer(ref this), riid, ppvObject);
     }
 
     /// <inheritdoc cref="IUnknown.AddRef"/>
@@ -39,7 +39,7 @@ internal unsafe struct ICanvasFactoryNative
     [return: NativeTypeName("ULONG")]
     public uint AddRef()
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceWrapperNative*, uint>)this.lpVtbl[1])((ICanvasResourceWrapperNative*)Unsafe.AsPointer(ref this));
+        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, uint>)this.lpVtbl[1])((ICanvasFactoryNative*)Unsafe.AsPointer(ref this));
     }
 
     /// <inheritdoc cref="IUnknown.Release"/>
@@ -48,7 +48,7 @@ internal unsafe struct ICanvasFactoryNative
     [return: NativeTypeName("ULONG")]
     public uint Release()
     {
-        return ((delegate* unmanaged[Stdcall]<ICanvasResourceWrapperNative*, uint>)this.lpVtbl[2])((ICanvasResourceWrapperNative*)Unsafe.AsPointer(ref this));
+        return ((delegate* unmanaged[Stdcall]<ICanvasFactoryNative*, uint>)this.lpVtbl[2])((ICanvasFactoryNative*)Unsafe.AsPointer(ref this));
     }
 
     /// <summary>

--- a/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
+++ b/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
@@ -9,8 +9,9 @@
   <PropertyGroup>
 
     <!--
-      Ignore some warnings about ambiguous cref attribute references.
-      This happens for ICanvasImage, but it's not really clear why.
+      Ignore some warnings about ambiguous cref attribute references. These are because the assembly defines
+      blittable bindings for several ABI types from Win2D, in the same namespace as the ABI types from the
+      CsWinRT projections that are in Win2D. They are internal, but Roslyn will still complain about them.
     -->
     <NoWarn>$(NoWarn);CS0419</NoWarn>
 


### PR DESCRIPTION
### Description

This PR fixes some incorrect function pointer signatures in `ICanvasDevice` and `ICanvasFactoryNative`.
