### PR TITLE
Enable GenerateDocumentationFile everywhere

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Run ComputeSharp.Tests.DisableDynamicCompilation
       run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.GlobalStatements
-      run: dotnet test tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      run: dotnet run --project tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.Internals
       run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
 

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -109,6 +109,16 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageIconUrl>https://user-images.githubusercontent.com/10199417/110238403-b8811080-7f41-11eb-8cfe-e47e7e58f05b.png</PackageIconUrl>
     <PackageTags>dotnet net netcore netstandard csharp library graphics directx shader hlsl compute gpu performance parallel windows</PackageTags>
+
+    <!--
+      Generate documentation files. In theory this should only be abled for published, non source generator projects.
+      However, this is always enabled to work around https://github.com/dotnet/roslyn/issues/41640. Until that's fixed,
+      source generators will also produce an .xml file with their documentation. Note that this doesn't really impact
+      NuGet packages, since the analyzer binaries are packed manually after build, so the .xml files aren't included.
+      When this workaround is no longer needed, the same property should also removed for the \samples directory.
+      Once that issue is fixed, this should be moved down to the src\ specific .props file again, and otherwise disabled.
+    -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -3,9 +3,6 @@
 
   <PropertyGroup>
 
-    <!-- Workaround for https://github.com/dotnet/roslyn/issues/41640 (see notes in \src .props file) -->
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-
     <!-- Samples don't need public XML docs for all APIs -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -45,16 +45,6 @@
   <!-- Additional properties for all source projects-->
   <PropertyGroup>
 
-    <!--
-      Generate documentation files. In theory this should only be abled for published, non source generator projects.
-      However, this is always enabled to work around https://github.com/dotnet/roslyn/issues/41640. Until that's fixed,
-      source generators will also produce an .xml file with their documentation. Note that this doesn't really impact
-      NuGet packages, since the analyzer binaries are packed manually after build, so the .xml files aren't included.
-      When this workaround is no longer needed, the same property should also removed for the \samples directory.
-    -->
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DocumentationFile>$(MSBuildProjectName).xml</DocumentationFile>
-
     <!-- Disable packing symbols for source generators -->
     <PackSymbols Condition="$(IsSourceGeneratorProject)">false</PackSymbols>
 

--- a/tests/ComputeSharp.D2D1.UI.Tests/Helpers/Win2DHelper.cs
+++ b/tests/ComputeSharp.D2D1.UI.Tests/Helpers/Win2DHelper.cs
@@ -155,7 +155,7 @@ internal static class Win2DHelper
     public interface ICanvasFactoryNative
     {
         /// <summary>
-        /// The vtable type for <see cref="Interface"/>.
+        /// The vtable type for <see cref="ICanvasFactoryNative"/>.
         /// </summary>
         [Guid("695C440D-04B3-4EDD-BFD9-63E51E9F7202")]
         public readonly struct Vftbl

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -11,6 +11,12 @@
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>
 
+  <PropertyGroup>
+
+    <!-- Ignore some warnings about ambiguous cref attribute references (same as in ComputeSharp.D2D1.WinUI) -->
+    <NoWarn>$(NoWarn);CS0419</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="..\ComputeSharp.Tests\Assets\ColorfulInfinity.png">
       <Link>Assets\Shaders\ColorfulInfinity.png</Link>

--- a/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
+++ b/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
@@ -5,10 +5,6 @@
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-    
-  <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ComputeSharp.Core\ComputeSharp.Core.csproj" />

--- a/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
+++ b/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
@@ -1,5 +1,4 @@
 using ComputeSharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 float[] numbers = Enumerable.Range(0, 128).Select(i => (float)i).ToArray();
 
@@ -15,11 +14,12 @@ foreach (ref float number in numbers.AsSpan())
 
 float[] result = buffer.ToArray();
 
-CollectionAssert.AreEqual(
-    expected: numbers,
-    actual: result);
+if (!numbers.SequenceEqual(result))
+{
+    throw new Exception("The processed buffer does not match the expected results.");
+}
 
-Console.WriteLine("Test passed successfully");
+Console.WriteLine("Test passed successfully!");
 
 // See https://github.com/Sergio0694/ComputeSharp/issues/374
 [ShaderMethod]


### PR DESCRIPTION
### Description

This PR temporarily enables `GenerateDocumentationFile` everywhere to work around https://github.com/dotnet/roslyn/issues/41640.

It also fixes a CI failure in some tests, due to some MSBuild nonsense.
