### PR TITLE
Remove string allocation in ID3DIncludeForD2DHelpers.Open

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.ID3DInclude.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.ID3DInclude.cs
@@ -1,8 +1,12 @@
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
-#if !NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
+using MemoryMarshal2 = System.Runtime.InteropServices.MemoryMarshal;
+#else
+using MemoryMarshal2 = ComputeSharp.NetStandard.MemoryMarshal;
 using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
 #endif
 
@@ -82,7 +86,9 @@ partial class D3DCompiler
         [UnmanagedCallersOnly]
         public static int Open(ID3DIncludeForD2DHelpers* @this, D3D_INCLUDE_TYPE IncludeType, sbyte* pFileName, void* pParentData, void** ppData, uint* pBytes)
         {
-            if (new string(pFileName) == "d2d1effecthelpers.hlsli")
+            ReadOnlySpan<byte> fileName = MemoryMarshal2.CreateReadOnlySpanFromNullTerminated((byte*)pFileName);
+
+            if (fileName.SequenceEqual("d2d1effecthelpers.hlsli"u8))
             {
                 *ppData = (byte*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(D2D1EffectHelpers.TextUtf8));
                 *pBytes = (uint)D2D1EffectHelpers.TextUtf8.Length;

--- a/src/ComputeSharp.NetStandard/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/ComputeSharp.NetStandard/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -18,4 +18,25 @@ internal static class MemoryMarshal
     {
         return ref global::System.Runtime.InteropServices.MemoryMarshal.GetReference(array.AsSpan());
     }
+
+    /// <summary>
+    /// Creates a new read-only span for a <see langword="null"/>-terminated UTF-8 string.
+    /// </summary>
+    /// <param name="value">The pointer to the <see langword="null"/>-terminated string of bytes.</param>
+    /// <returns>A read-only span representing the specified <see langword="null"/>-terminated string, or an empty span if the pointer is <see langword="null"/>.</returns>
+    /// <remarks>The returned span does not include the <see langword="null"/> terminator, nor does it validate the well-formedness of the UTF-8 data.</remarks>
+    /// <exception cref="ArgumentException">The string is longer than <see cref="int.MaxValue"/>.</exception>
+    public static unsafe ReadOnlySpan<byte> CreateReadOnlySpanFromNullTerminated(byte* value)
+    {
+        for (int i = 0; i < int.MaxValue; i++)
+        {
+            // Stop when the null-terminator has been found
+            if (value[i] == 0)
+            {
+                return new(value, i);
+            }
+        }
+
+        throw new ArgumentException("The string must be null-terminated.");
+    }
 }


### PR DESCRIPTION
### Description

This PR removes a `string` allocation in `ID3DIncludeForD2DHelpers` and makes it slightly faster.