### PR TITLE
Add [D2DEffectId] and [D2DEffectDisplayName]

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-﻿; Shipped analyzer releases
+; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
 
 ## Release 1.0
@@ -65,3 +65,4 @@ CMPSD2D0055 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0056 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0057 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0058 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0059 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -66,3 +66,4 @@ CMPSD2D0056 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0057 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0058 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0059 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0060 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidEffectDisplayNameValueAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidEffectDisplayNameValueAnalyzer.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Immutable;
+using ComputeSharp.D2D1.SourceGenerators.Helpers;
 using ComputeSharp.SourceGeneration.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -8,13 +8,13 @@ using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 namespace ComputeSharp.D2D1.SourceGenerators;
 
 /// <summary>
-/// A diagnostic analyzer that generates an error whenever [D2DEffectId] is used with an invalid value.
+/// A diagnostic analyzer that generates an error whenever [D2DEffectName] is used with an invalid value.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class InvalidEffectIdValueAnalyzer : DiagnosticAnalyzer
+public sealed class InvalidEffectDisplayNameValueAnalyzer : DiagnosticAnalyzer
 {
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidD2DEffectIdAttributeValue);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidD2DEffectDisplayNameAttributeValue);
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -24,8 +24,8 @@ public sealed class InvalidEffectIdValueAnalyzer : DiagnosticAnalyzer
 
         context.RegisterCompilationStartAction(static context =>
         {
-            // Get the [D2DEffectId] symbol
-            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DEffectIdAttribute") is not { } d2DEffectIdAttributeSymbol)
+            // Get the [D2DEffectDisplayName] symbol
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DEffectDisplayNameAttribute") is not { } d2DEffectIdAttributeSymbol)
             {
                 return;
             }
@@ -40,18 +40,17 @@ public sealed class InvalidEffectIdValueAnalyzer : DiagnosticAnalyzer
 
                 foreach (AttributeData attributeData in typeSymbol.GetAttributes())
                 {
-                    // Look for the [D2DEffectId] use
+                    // Look for the [D2DEffectDisplayName] use
                     if (!SymbolEqualityComparer.Default.Equals(attributeData.AttributeClass, d2DEffectIdAttributeSymbol))
                     {
                         continue;
                     }
 
-                    // Validate the GUID text and emit a diagnostic if needed
-                    if (attributeData.ConstructorArguments is not [{ Value: string value }] ||
-                        !Guid.TryParse(value, out _))
+                    // Validate the effect display name
+                    if (!D2D1EffectMetadataParser.IsValidEffectDisplayName(attributeData))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(
-                            InvalidD2DEffectIdAttributeValue,
+                            InvalidD2DEffectDisplayNameAttributeValue,
                             attributeData.GetLocation()));
                     }
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidEffectIdValueAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidEffectIdValueAnalyzer.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error whenever [D2DEffectId] is used with an invalid value.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidEffectIdValueAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidD2DEffectIdAttributeValue);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the [D2DEffectId] symbol
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DEffectIdAttribute") is not { } d2DEffectIdAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only struct types are possible targets
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                foreach (AttributeData attributeDate in typeSymbol.GetAttributes())
+                {
+                    // Look for the [D2DEffectId] use
+                    if (!SymbolEqualityComparer.Default.Equals(attributeDate.AttributeClass, d2DEffectIdAttributeSymbol))
+                    {
+                        continue;
+                    }
+
+                    // Validate the GUID text and emit a diagnostic if needed
+                    if (attributeDate.ConstructorArguments is not [{ Value: string value }] ||
+                        !Guid.TryParse(value, out _))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            InvalidD2DEffectIdAttributeValue,
+                            attributeDate.GetLocation()));
+                    }
+
+                    return;
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -857,4 +857,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A D2D1 shader must be annotated with the [D2DInputCount] attribute.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[D2DEffectId]</c> attribute is being used with an invalid value.
+    /// <para>
+    /// Format: <c>"The [D2DEffectId] attribute is being used with an invalid value (the input text must be a valid GUID)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidD2DEffectIdAttributeValue = new DiagnosticDescriptor(
+        id: "CMPSD2D0059",
+        title: "Invalid [D2DEffectId] attribute value",
+        messageFormat: "The [D2DEffectId] attribute is being used with an invalid value (the input text must be a valid GUID)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [D2DEffectId] attribute must use a valid GUID expression as value.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -873,4 +873,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "The [D2DEffectId] attribute must use a valid GUID expression as value.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[D2DEffectDisplayName]</c> attribute is being used with an invalid value.
+    /// <para>
+    /// Format: <c>"The [D2DEffectDisplayName] attribute is being used with an invalid value (the input text must be a valid GUID)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidD2DEffectDisplayNameAttributeValue = new DiagnosticDescriptor(
+        id: "CMPSD2D0060",
+        title: "Invalid [D2DEffectDisplayName] attribute value",
+        messageFormat: "The [D2DEffectDisplayName] attribute is being used with an invalid value",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [D2DEffectDisplayName] attribute must contain valid text.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Helpers/D2D1EffectMetadataParser.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Helpers/D2D1EffectMetadataParser.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Security;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.D2D1.SourceGenerators.Helpers;
+
+/// <summary>
+/// A helper class to parse D2D metadata values.
+/// </summary>
+internal static class D2D1EffectMetadataParser
+{
+    /// <summary>
+    /// A <see cref="Regex"/> instance to find all newlines.
+    /// </summary>
+    private static readonly Regex NewLinesRegex = new("[\r\n\v]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Checks whether a given <see cref="AttributeData"/> value contains a valid effect display name.
+    /// </summary>
+    /// <param name="attributeData">The input <see cref="AttributeData"/> object to inspect.</param>
+    /// <returns>Whether <paramref name="attributeData"/> contains a valid effect display name.</returns>
+    public static bool IsValidEffectDisplayName(AttributeData attributeData)
+    {
+        if (attributeData.ConstructorArguments is [{ Value: string { Length: > 0 } value }])
+        {
+            // Remove new lines (the values cannot span multiple lines in XML)
+            string singleLineValue = NewLinesRegex.Replace(value, string.Empty);
+
+            // Trim directly and check that (no need to escape, as that wouldn't change things)
+            return singleLineValue.AsSpan().Trim().Length > 0;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to get the defined effect display name for a given attribute.
+    /// </summary>
+    /// <param name="attributeData">The input <see cref="AttributeData"/> object to inspect.</param>
+    /// <param name="effectDisplayName">The resulting defined effect display name, if found.</param>
+    /// <returns>Whether or not a defined effect display name could be found.</returns>
+    public static bool TryGetEffectDisplayName(AttributeData attributeData, [NotNullWhen(true)] out string? effectDisplayName)
+    {
+        // Check that the attribute is [D2DEffectDisplayName] and with a valid parameter
+        if (attributeData.ConstructorArguments is [{ Value: string { Length: > 0 } value }])
+        {
+            // Remove new lines (the values cannot span multiple lines in XML)
+            string singleLineValue = NewLinesRegex.Replace(value, string.Empty);
+
+            // Make sure to escape any invalid XML characters
+            string escapedValue = SecurityElement.Escape(singleLineValue);
+
+            // Trim the display name as well
+            if (escapedValue.AsSpan().Trim() is { Length: > 0 } trimmedValue)
+            {
+                effectDisplayName = trimmedValue.ToString();
+
+                return true;
+            }
+        }
+
+        effectDisplayName = default;
+
+        return false;
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.Syntax.cs
@@ -1,0 +1,35 @@
+using ComputeSharp.D2D1.__Internals;
+using ComputeSharp.SourceGeneration.Models;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <inheritdoc/>
+    partial class EffectDisplayName
+    {
+        /// <summary>
+        /// Creates a <see cref="PropertyDeclarationSyntax"/> instance for the <c>EffectDisplayName</c> property.
+        /// </summary>
+        /// <param name="info">The input <see cref="HierarchyInfo"/> instance.</param>
+        /// <returns>The resulting <see cref="PropertyDeclarationSyntax"/> instance for the <c>EffectDisplayName</c> property.</returns>
+        public static PropertyDeclarationSyntax GetSyntax(HierarchyInfo info)
+        {
+            // This code produces a method declaration as follows:
+            //
+            // readonly string global::ComputeSharp.D2D1.__Internals.ID2D1Shader.EffectDisplayName => "<FULLY_QUALIFIED_NAME>";
+            return
+                PropertyDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), Identifier(nameof(EffectDisplayName)))
+                .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IdentifierName($"global::ComputeSharp.D2D1.__Internals.{nameof(ID2D1Shader)}")))
+                .AddModifiers(Token(SyntaxKind.ReadOnlyKeyword))
+                .WithExpressionBody(ArrowExpressionClause(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(info.FullyQualifiedMetadataName))))
+                .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.Syntax.cs
@@ -1,5 +1,4 @@
 using ComputeSharp.D2D1.__Internals;
-using ComputeSharp.SourceGeneration.Models;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -17,18 +16,18 @@ partial class ID2D1ShaderGenerator
         /// <summary>
         /// Creates a <see cref="PropertyDeclarationSyntax"/> instance for the <c>EffectDisplayName</c> property.
         /// </summary>
-        /// <param name="info">The input <see cref="HierarchyInfo"/> instance.</param>
+        /// <param name="effectDisplayName">The input effect display name value.</param>
         /// <returns>The resulting <see cref="PropertyDeclarationSyntax"/> instance for the <c>EffectDisplayName</c> property.</returns>
-        public static PropertyDeclarationSyntax GetSyntax(HierarchyInfo info)
+        public static PropertyDeclarationSyntax GetSyntax(string effectDisplayName)
         {
             // This code produces a method declaration as follows:
             //
-            // readonly string global::ComputeSharp.D2D1.__Internals.ID2D1Shader.EffectDisplayName => "<FULLY_QUALIFIED_NAME>";
+            // readonly string global::ComputeSharp.D2D1.__Internals.ID2D1Shader.EffectDisplayName => "<EFFECT_DISPLAY_NAME>";
             return
                 PropertyDeclaration(PredefinedType(Token(SyntaxKind.StringKeyword)), Identifier(nameof(EffectDisplayName)))
                 .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IdentifierName($"global::ComputeSharp.D2D1.__Internals.{nameof(ID2D1Shader)}")))
                 .AddModifiers(Token(SyntaxKind.ReadOnlyKeyword))
-                .WithExpressionBody(ArrowExpressionClause(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(info.FullyQualifiedMetadataName))))
+                .WithExpressionBody(ArrowExpressionClause(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(effectDisplayName))))
                 .WithSemicolonToken(Token(SyntaxKind.SemicolonToken));
         }
     }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using ComputeSharp.D2D1.SourceGenerators.Helpers;
 using ComputeSharp.SourceGeneration.Extensions;
-using ComputeSharp.SourceGeneration.Helpers;
-using ComputeSharp.SourceGeneration.Models;
 using Microsoft.CodeAnalysis;
 
 namespace ComputeSharp.D2D1.SourceGenerators;
@@ -18,14 +16,10 @@ partial class ID2D1ShaderGenerator
         /// <summary>
         /// Extracts the effect display name info for the current shader.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="compilation">The input <see cref="Compilation"/> object currently in use.</param>
         /// <param name="structDeclarationSymbol">The <see cref="INamedTypeSymbol"/> for the shader type in use.</param>
         /// <returns>The resulting effect display name.</returns>
-        public static string GetInfo(
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
-            Compilation compilation,
-            INamedTypeSymbol structDeclarationSymbol)
+        public static string GetInfo(Compilation compilation, INamedTypeSymbol structDeclarationSymbol)
         {
             if (TryGetDefinedEffectDisplayName(compilation, structDeclarationSymbol, out string? effectDisplayName))
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security;
+using System.Text.RegularExpressions;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
 using ComputeSharp.SourceGeneration.Models;
@@ -16,6 +17,11 @@ partial class ID2D1ShaderGenerator
     /// </summary>
     private static partial class EffectDisplayName
     {
+        /// <summary>
+        /// A <see cref="Regex"/> instance to find all newlines.
+        /// </summary>
+        private static readonly Regex NewLinesRegex = new("[\r\n\v]", RegexOptions.Compiled);
+
         /// <summary>
         /// Extracts the effect display name info for the current shader.
         /// </summary>
@@ -53,8 +59,11 @@ partial class ID2D1ShaderGenerator
                 if (SymbolEqualityComparer.Default.Equals(attributeData.AttributeClass, effectIdAttributeSymbol) &&
                     attributeData.ConstructorArguments is [{ Value: string { Length: > 0 } value }])
                 {
+                    // Remove new lines (the values cannot span multiple lines in XML)
+                    string singleLineValue = NewLinesRegex.Replace(value, string.Empty);
+
                     // Make sure to escape any invalid XML characters
-                    string escapedValue = SecurityElement.Escape(value);
+                    string escapedValue = SecurityElement.Escape(singleLineValue);
 
                     // Trim the display name as well
                     if (escapedValue.AsSpan().Trim() is { Length: > 0 } trimmedValue)

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Security;
-using System.Text.RegularExpressions;
+using ComputeSharp.D2D1.SourceGenerators.Helpers;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
 using ComputeSharp.SourceGeneration.Models;
@@ -17,11 +15,6 @@ partial class ID2D1ShaderGenerator
     /// </summary>
     private static partial class EffectDisplayName
     {
-        /// <summary>
-        /// A <see cref="Regex"/> instance to find all newlines.
-        /// </summary>
-        private static readonly Regex NewLinesRegex = new("[\r\n\v]", RegexOptions.Compiled);
-
         /// <summary>
         /// Extracts the effect display name info for the current shader.
         /// </summary>
@@ -55,23 +48,10 @@ partial class ID2D1ShaderGenerator
 
             foreach (AttributeData attributeData in typeSymbol.GetAttributes())
             {
-                // Check that the attribute is [D2DEffectDisplayName] and with a valid parameter
-                if (SymbolEqualityComparer.Default.Equals(attributeData.AttributeClass, effectIdAttributeSymbol) &&
-                    attributeData.ConstructorArguments is [{ Value: string { Length: > 0 } value }])
+                // Check that the attribute is [D2DEffectDisplayName]
+                if (SymbolEqualityComparer.Default.Equals(attributeData.AttributeClass, effectIdAttributeSymbol))
                 {
-                    // Remove new lines (the values cannot span multiple lines in XML)
-                    string singleLineValue = NewLinesRegex.Replace(value, string.Empty);
-
-                    // Make sure to escape any invalid XML characters
-                    string escapedValue = SecurityElement.Escape(singleLineValue);
-
-                    // Trim the display name as well
-                    if (escapedValue.AsSpan().Trim() is { Length: > 0 } trimmedValue)
-                    {
-                        effectDisplayName = trimmedValue.ToString();
-
-                        return true;
-                    }
+                    return D2D1EffectMetadataParser.TryGetEffectDisplayName(attributeData, out effectDisplayName);
                 }
             }
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectDisplayNameProperty.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Security;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Helpers;
+using ComputeSharp.SourceGeneration.Models;
+using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <summary>
+    /// A helper with all logic to generate the <c>EffectDisplayName</c> property.
+    /// </summary>
+    private static partial class EffectDisplayName
+    {
+        /// <summary>
+        /// Extracts the effect display name info for the current shader.
+        /// </summary>
+        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
+        /// <param name="compilation">The input <see cref="Compilation"/> object currently in use.</param>
+        /// <param name="structDeclarationSymbol">The <see cref="INamedTypeSymbol"/> for the shader type in use.</param>
+        /// <returns>The resulting effect display name.</returns>
+        public static string GetInfo(
+            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
+            Compilation compilation,
+            INamedTypeSymbol structDeclarationSymbol)
+        {
+            if (TryGetDefinedEffectDisplayName(compilation, structDeclarationSymbol, out string? effectDisplayName))
+            {
+                return effectDisplayName;
+            }
+
+            return structDeclarationSymbol.GetFullyQualifiedMetadataName();
+        }
+
+        /// <summary>
+        /// Tries to get the defined effect display name for a given shader type.
+        /// </summary>
+        /// <param name="compilation">The input <see cref="Compilation"/> object currently in use.</param>
+        /// <param name="typeSymbol">The input <see cref="INamedTypeSymbol"/> instance.</param>
+        /// <param name="effectDisplayName">The resulting defined effect display name, if found.</param>
+        /// <returns>Whether or not a defined effect display name could be found.</returns>
+        private static bool TryGetDefinedEffectDisplayName(Compilation compilation, INamedTypeSymbol typeSymbol, [NotNullWhen(true)] out string? effectDisplayName)
+        {
+            INamedTypeSymbol effectIdAttributeSymbol = compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DEffectDisplayNameAttribute")!;
+
+            foreach (AttributeData attributeData in typeSymbol.GetAttributes())
+            {
+                // Check that the attribute is [D2DEffectDisplayName] and with a valid parameter
+                if (SymbolEqualityComparer.Default.Equals(attributeData.AttributeClass, effectIdAttributeSymbol) &&
+                    attributeData.ConstructorArguments is [{ Value: string { Length: > 0 } value }])
+                {
+                    // Make sure to escape any invalid XML characters
+                    string escapedValue = SecurityElement.Escape(value);
+
+                    // Trim the display name as well
+                    if (escapedValue.AsSpan().Trim() is { Length: > 0 } trimmedValue)
+                    {
+                        effectDisplayName = trimmedValue.ToString();
+
+                        return true;
+                    }
+                }
+            }
+
+            effectDisplayName = default;
+
+            return false;
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectIdProperty.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectIdProperty.Syntax.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Text;
 using ComputeSharp.D2D1.__Internals;
+using ComputeSharp.D2D1.SourceGenerators.Models;
 using ComputeSharp.SourceGeneration.Helpers;
-using ComputeSharp.SourceGeneration.Models;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -22,10 +22,10 @@ partial class ID2D1ShaderGenerator
         /// <summary>
         /// Creates a <see cref="PropertyDeclarationSyntax"/> instance for the <c>EffectId</c> property.
         /// </summary>
-        /// <param name="info">The input <see cref="HierarchyInfo"/> instance.</param>
+        /// <param name="info">The input <see cref="EffectIdInfo"/> instance.</param>
         /// <param name="fixup">An opaque <see cref="Func{TResult}"/> instance to transform the final tree into text.</param>
         /// <returns>The resulting <see cref="PropertyDeclarationSyntax"/> instance for the <c>EffectId</c> property.</returns>
-        public static PropertyDeclarationSyntax GetSyntax(HierarchyInfo info, out Func<SyntaxNode, SourceText> fixup)
+        public static PropertyDeclarationSyntax GetSyntax(EffectIdInfo info, out Func<SyntaxNode, SourceText> fixup)
         {
             // Create the local declaration:
             //
@@ -48,7 +48,7 @@ partial class ID2D1ShaderGenerator
                                     SingletonSeparatedList<ExpressionSyntax>(IdentifierName("__EMBEDDED_EFFECT_ID_BYTES"))))))));
 
             // Prepare the initialization text
-            string effectIdLiterals = SyntaxFormattingHelper.BuildByteArrayInitializationExpressionString(new byte[] { 1, 2, 3, 4 }.AsSpan());
+            string effectIdLiterals = SyntaxFormattingHelper.BuildByteArrayInitializationExpressionString(info.Bytes.AsSpan());
 
             // Set the fixup function
             fixup = tree => SourceText.From(tree.ToFullString().Replace("__EMBEDDED_EFFECT_ID_BYTES", effectIdLiterals), Encoding.UTF8);

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectIdProperty.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectIdProperty.Syntax.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Text;
+using ComputeSharp.D2D1.__Internals;
+using ComputeSharp.SourceGeneration.Helpers;
+using ComputeSharp.SourceGeneration.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+#pragma warning disable CS0618
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <inheritdoc/>
+    partial class EffectId
+    {
+        /// <summary>
+        /// Creates a <see cref="PropertyDeclarationSyntax"/> instance for the <c>EffectId</c> property.
+        /// </summary>
+        /// <param name="info">The input <see cref="HierarchyInfo"/> instance.</param>
+        /// <param name="fixup">An opaque <see cref="Func{TResult}"/> instance to transform the final tree into text.</param>
+        /// <returns>The resulting <see cref="PropertyDeclarationSyntax"/> instance for the <c>EffectId</c> property.</returns>
+        public static PropertyDeclarationSyntax GetSyntax(HierarchyInfo info, out Func<SyntaxNode, SourceText> fixup)
+        {
+            // Create the local declaration:
+            //
+            // global::System.ReadOnlySpan<byte> bytes = new byte[] { __EMBEDDED_EFFECT_ID_BYTES };
+            LocalDeclarationStatementSyntax guidBytesDeclaration =
+                LocalDeclarationStatement(
+                    VariableDeclaration(
+                        GenericName(Identifier("global::System.ReadOnlySpan"))
+                        .AddTypeArgumentListArguments(PredefinedType(Token(SyntaxKind.ByteKeyword))))
+                    .AddVariables(
+                        VariableDeclarator(Identifier("bytes"))
+                        .WithInitializer(
+                            EqualsValueClause(
+                                ArrayCreationExpression(
+                                ArrayType(PredefinedType(Token(SyntaxKind.ByteKeyword)))
+                                .AddRankSpecifiers(ArrayRankSpecifier(SingletonSeparatedList<ExpressionSyntax>(OmittedArraySizeExpression()))))
+                            .WithInitializer(
+                                InitializerExpression(
+                                    SyntaxKind.ArrayInitializerExpression,
+                                    SingletonSeparatedList<ExpressionSyntax>(IdentifierName("__EMBEDDED_EFFECT_ID_BYTES"))))))));
+
+            // Prepare the initialization text
+            string effectIdLiterals = SyntaxFormattingHelper.BuildByteArrayInitializationExpressionString(new byte[] { 1, 2, 3, 4 }.AsSpan());
+
+            // Set the fixup function
+            fixup = tree => SourceText.From(tree.ToFullString().Replace("__EMBEDDED_EFFECT_ID_BYTES", effectIdLiterals), Encoding.UTF8);
+
+            // Prepare the return statement:
+            //
+            // return
+            //     ref global::System.Runtime.CompilerServices.Unsafe.As<byte, global::System.Guid>(
+            //         ref global::System.Runtime.InteropServices.MemoryMarshal.GetReference(bytes));
+            ReturnStatementSyntax returnStatement =
+                ReturnStatement(
+                    RefExpression(
+                        InvocationExpression(
+                            MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                IdentifierName("global::System.Runtime.CompilerServices.Unsafe"),
+                                GenericName(Identifier("As"))
+                                .AddTypeArgumentListArguments(
+                                    PredefinedType(Token(SyntaxKind.ByteKeyword)),
+                                    IdentifierName("global::System.Guid"))))
+                        .AddArgumentListArguments(
+                            Argument(
+                                InvocationExpression(
+                                    MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("global::System.Runtime.InteropServices.MemoryMarshal"),
+                                        IdentifierName("GetReference")))
+                                .AddArgumentListArguments(Argument(IdentifierName("bytes"))))
+                            .WithRefOrOutKeyword(Token(SyntaxKind.RefKeyword)))));
+
+            // This code produces a method declaration as follows:
+            //
+            // readonly ref readonly global::System.Guid global::ComputeSharp.D2D1.__Internals.ID2D1Shader.EffectId
+            // {
+            //     [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+            //     get
+            //     {
+            //         <BYTES_DECLARATION>
+            //         <RETURN_STATEMENT>
+            //     }
+            // }
+            return
+                PropertyDeclaration(
+                    RefType(IdentifierName("global::System.Guid")).WithReadOnlyKeyword(Token(SyntaxKind.ReadOnlyKeyword)),
+                    Identifier(nameof(EffectId)))
+                .WithExplicitInterfaceSpecifier(ExplicitInterfaceSpecifier(IdentifierName($"global::ComputeSharp.D2D1.__Internals.{nameof(ID2D1Shader)}")))
+                .AddModifiers(Token(SyntaxKind.ReadOnlyKeyword))
+                .AddAccessorListAccessors(
+                    AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
+                    .AddAttributeLists(
+                        AttributeList(SingletonSeparatedList(
+                            Attribute(IdentifierName("global::System.Runtime.CompilerServices.MethodImpl"))
+                            .AddArgumentListArguments(
+                                AttributeArgument(
+                                    MemberAccessExpression(
+                                        SyntaxKind.SimpleMemberAccessExpression,
+                                        IdentifierName("global::System.Runtime.CompilerServices.MethodImplOptions"),
+                                        IdentifierName("AggressiveInlining")))))))
+                    .AddBodyStatements(guidBytesDeclaration, returnStatement));
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectIdProperty.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectIdProperty.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Helpers;
+using ComputeSharp.SourceGeneration.Models;
+using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class ID2D1ShaderGenerator
+{
+    /// <summary>
+    /// A helper with all logic to generate the <c>EffectId</c> property.
+    /// </summary>
+    private static partial class EffectId
+    {
+        /// <summary>
+        /// The <see cref="IncrementalHash"/> instance currently in use for the running thread, if any.
+        /// </summary>
+        [ThreadStatic]
+        private static IncrementalHash? incrementalHash;
+
+        /// <summary>
+        /// Extracts the effect id info for the current shader.
+        /// </summary>
+        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
+        /// <param name="structDeclarationSymbol">The <see cref="INamedTypeSymbol"/> for the shader type in use.</param>
+        /// <returns>The resulting effect id.</returns>
+        public static ImmutableArray<byte> GetInfo(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, INamedTypeSymbol structDeclarationSymbol)
+        {
+            // Initialize an instance using the MD5 algorithm. We use this for several reasons:
+            //   - We don't really need security, this is just to uniquely identify types
+            //   - The hash size is 128 bits, which is exactly the size of a GUID.
+            IncrementalHash incrementalHash = EffectId.incrementalHash ??= IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+
+            string assemblyName = structDeclarationSymbol.ContainingAssembly?.Name ?? string.Empty;
+
+            using ImmutableArrayBuilder<byte> byteBuffer = ImmutableArrayBuilder<byte>.Rent();
+            using ImmutableArrayBuilder<char> charBuffer = ImmutableArrayBuilder<char>.Rent();
+
+            // Format the fully qualified name into a pooled builder to avoid the string allocation
+            structDeclarationSymbol.AppendFullyQualifiedMetadataName(in charBuffer);
+
+            int maxTypeNameCharsLength = Encoding.UTF8.GetMaxByteCount(charBuffer.Count);
+            int maxAssemblyNameCharsLength = Encoding.UTF8.GetMaxByteCount(assemblyName.Length);
+            int maxEncodedCharsLength = Math.Max(maxTypeNameCharsLength, maxAssemblyNameCharsLength);
+
+            byteBuffer.EnsureCapacity(maxEncodedCharsLength);
+
+            // UTF8 encode the fully qualified name first
+            int typeNameCharsLength = Encoding.UTF8.GetBytes(charBuffer.WrittenSpan, byteBuffer.DangerousGetArray().AsSpan());
+
+            byteBuffer.Advance(typeNameCharsLength);
+
+            // Append the UTF8 fully qualified name to the MD5 hash
+            incrementalHash.AppendData(byteBuffer.DangerousGetArray(), 0, byteBuffer.Count);
+
+            // UTF8 encode the assembly name as well
+            int assemblyNameCharsLength = Encoding.UTF8.GetBytes(assemblyName.AsSpan(), byteBuffer.DangerousGetArray().AsSpan());
+
+            byteBuffer.Advance(assemblyNameCharsLength);
+
+            // Append the UTF8 assembly name to the MD5 hash
+            incrementalHash.AppendData(byteBuffer.DangerousGetArray(), 0, byteBuffer.Count);
+
+            // Get the resulting MD5 hash (128 bits)
+            byte[] hash = incrementalHash.GetHashAndReset();
+
+            // We own this buffer, so we can just reinterpret to an immutable array
+            return Unsafe.As<byte[], ImmutableArray<byte>>(ref hash);
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectIdProperty.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateEffectIdProperty.cs
@@ -5,7 +5,6 @@ using System.Security.Cryptography;
 using System.Text;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
-using ComputeSharp.SourceGeneration.Models;
 using Microsoft.CodeAnalysis;
 
 namespace ComputeSharp.D2D1.SourceGenerators;
@@ -27,14 +26,10 @@ partial class ID2D1ShaderGenerator
         /// <summary>
         /// Extracts the effect id info for the current shader.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="compilation">The input <see cref="Compilation"/> object currently in use.</param>
         /// <param name="structDeclarationSymbol">The <see cref="INamedTypeSymbol"/> for the shader type in use.</param>
         /// <returns>The resulting effect id.</returns>
-        public static ImmutableArray<byte> GetInfo(
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
-            Compilation compilation,
-            INamedTypeSymbol structDeclarationSymbol)
+        public static ImmutableArray<byte> GetInfo(Compilation compilation, INamedTypeSymbol structDeclarationSymbol)
         {
             if (TryGetDefinedEffectId(compilation, structDeclarationSymbol, out ImmutableArray<byte> effectId))
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.Helpers.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.Helpers.cs
@@ -38,12 +38,12 @@ partial class ID2D1ShaderGenerator
     /// Creates a <see cref="CompilationUnitSyntax"/> instance wrapping the given method.
     /// </summary>
     /// <param name="hierarchyInfo">The <see cref="HierarchyInfo"/> instance for the current type.</param>
-    /// <param name="methodDeclaration">The <see cref="MethodDeclarationSyntax"/> item to insert.</param>
+    /// <param name="memberDeclarationSyntax">The <see cref="MemberDeclarationSyntax"/> item to insert.</param>
     /// <param name="canUseSkipLocalsInit">Whether <c>[SkipLocalsInit]</c> can be used.</param>
-    /// <returns>A <see cref="CompilationUnitSyntax"/> object wrapping <paramref name="methodDeclaration"/>.</returns>
-    private static CompilationUnitSyntax GetCompilationUnitFromMethod(
+    /// <returns>A <see cref="CompilationUnitSyntax"/> object wrapping <paramref name="memberDeclarationSyntax"/>.</returns>
+    private static CompilationUnitSyntax GetCompilationUnitFromMember(
         HierarchyInfo hierarchyInfo,
-        MethodDeclarationSyntax methodDeclaration,
+        MemberDeclarationSyntax memberDeclarationSyntax,
         bool canUseSkipLocalsInit)
     {
         // Method attributes
@@ -71,6 +71,6 @@ partial class ID2D1ShaderGenerator
             attributes.Add(AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Runtime.CompilerServices.SkipLocalsInit")))));
         }
 
-        return hierarchyInfo.GetSyntax(methodDeclaration.AddAttributeLists(attributes.ToArray()));
+        return hierarchyInfo.GetSyntax(memberDeclarationSyntax.AddAttributeLists(attributes.ToArray()));
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -53,12 +53,12 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
                     using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = ImmutableArrayBuilder<DiagnosticInfo>.Rent();
 
                     // EffectId info
-                    ImmutableArray<byte> effectId = EffectId.GetInfo(diagnostics, context.SemanticModel.Compilation, typeSymbol);
+                    ImmutableArray<byte> effectId = EffectId.GetInfo(context.SemanticModel.Compilation, typeSymbol);
 
                     token.ThrowIfCancellationRequested();
 
                     // EffectDisplayName info
-                    string effectDisplayName = EffectDisplayName.GetInfo(diagnostics, context.SemanticModel.Compilation, typeSymbol);
+                    string effectDisplayName = EffectDisplayName.GetInfo(context.SemanticModel.Compilation, typeSymbol);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -53,7 +53,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
                     using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = ImmutableArrayBuilder<DiagnosticInfo>.Rent();
 
                     // EffectId info
-                    ImmutableArray<byte> effectId = EffectId.GetInfo(diagnostics, typeSymbol);
+                    ImmutableArray<byte> effectId = EffectId.GetInfo(diagnostics, context.SemanticModel.Compilation, typeSymbol);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -136,7 +136,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
             shaderInfoWithErrors
             .Select(static (item, _) => item.Diagnostcs));
 
-        // Get the EffectDisplayName info (hierarchy)
+        // Get the EffectDisplayName and EffectId info (hierarchy)
         IncrementalValuesProvider<HierarchyInfo> hierarchyInfo =
             shaderInfoWithErrors
             .Select(static (item, _) => item.Hierarchy);
@@ -148,6 +148,16 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
             CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item, effectDisplayNameProperty, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.FullyQualifiedMetadataName}.{nameof(EffectDisplayName)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
+        });
+
+        // Generate the EffectId properties
+        context.RegisterSourceOutput(hierarchyInfo, static (context, item) =>
+        {
+            PropertyDeclarationSyntax effectDisplayNameProperty = EffectId.GetSyntax(item, out Func<SyntaxNode, SourceText> fixup);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item, effectDisplayNameProperty, canUseSkipLocalsInit: false);
+            SourceText text = fixup(compilationUnit);
+
+            context.AddSource($"{item.FullyQualifiedMetadataName}.{nameof(EffectId)}.g.cs", text);
         });
 
         // Get the GetInputCount() info (hierarchy and input count)

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -136,6 +136,20 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
             shaderInfoWithErrors
             .Select(static (item, _) => item.Diagnostcs));
 
+        // Get the EffectDisplayName info (hierarchy)
+        IncrementalValuesProvider<HierarchyInfo> hierarchyInfo =
+            shaderInfoWithErrors
+            .Select(static (item, _) => item.Hierarchy);
+
+        // Generate the EffectDisplayName properties
+        context.RegisterSourceOutput(hierarchyInfo, static (context, item) =>
+        {
+            PropertyDeclarationSyntax effectDisplayNameProperty = EffectDisplayName.GetSyntax(item);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item, effectDisplayNameProperty, canUseSkipLocalsInit: false);
+
+            context.AddSource($"{item.FullyQualifiedMetadataName}.{nameof(EffectDisplayName)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
+        });
+
         // Get the GetInputCount() info (hierarchy and input count)
         IncrementalValuesProvider<(HierarchyInfo Hierarchy, int InputCount)> inputCountInfo =
             shaderInfoWithErrors
@@ -145,7 +159,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(inputCountInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getInputCountMethod = GetInputCount.GetSyntax(item.InputCount);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getInputCountMethod, canUseSkipLocalsInit: false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Hierarchy, getInputCountMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FullyQualifiedMetadataName}.{nameof(GetInputCount)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -159,7 +173,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(inputTypesInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getInputTypeMethod = GetInputType.GetSyntax(item.InputTypes.InputTypes);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getInputTypeMethod, canUseSkipLocalsInit: false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Hierarchy, getInputTypeMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FullyQualifiedMetadataName}.{nameof(GetInputType)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -173,7 +187,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(resourceTextureDescriptionsInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getInputTypeMethod = LoadResourceTextureDescriptions.GetSyntax(item.ResourceTextureDescriptions);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getInputTypeMethod, canUseSkipLocalsInit: false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Hierarchy, getInputTypeMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FullyQualifiedMetadataName}.{nameof(LoadResourceTextureDescriptions)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -187,7 +201,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(initializeFromDispatchDataInfo, static (context, item) =>
         {
             MethodDeclarationSyntax loadDispatchDataMethod = InitializeFromDispatchData.GetSyntax(item.Dispatch);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, loadDispatchDataMethod, canUseSkipLocalsInit: false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Hierarchy, loadDispatchDataMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FullyQualifiedMetadataName}.{nameof(InitializeFromDispatchData)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -201,7 +215,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(dispatchDataInfo, static (context, item) =>
         {
             MethodDeclarationSyntax loadDispatchDataMethod = LoadDispatchData.GetSyntax(item.Info.Dispatch);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Info.Hierarchy, loadDispatchDataMethod, item.CanUseSkipLocalsInit);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Info.Hierarchy, loadDispatchDataMethod, item.CanUseSkipLocalsInit);
 
             context.AddSource($"{item.Info.Hierarchy.FullyQualifiedMetadataName}.{nameof(LoadDispatchData)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -221,7 +235,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(hlslSourceInfo, static (context, item) =>
         {
             MethodDeclarationSyntax buildHlslStringMethod = BuildHlslSource.GetSyntax(item.Info.HlslSource, item.Info.Hierarchy.Hierarchy.Length, item.CanUseRawMultilineStringLiterals);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Info.Hierarchy, buildHlslStringMethod, canUseSkipLocalsInit: false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Info.Hierarchy, buildHlslStringMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Info.Hierarchy.FullyQualifiedMetadataName}.{nameof(BuildHlslSource)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -279,7 +293,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(embeddedBytecode, static (context, item) =>
         {
             MethodDeclarationSyntax loadBytecodeMethod = LoadBytecode.GetSyntax(item.BytecodeInfo, out Func<SyntaxNode, SourceText> fixup);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, loadBytecodeMethod, canUseSkipLocalsInit: false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Hierarchy, loadBytecodeMethod, canUseSkipLocalsInit: false);
             SourceText text = fixup(compilationUnit);
 
             context.AddSource($"{item.Hierarchy.FullyQualifiedMetadataName}.{nameof(LoadBytecode)}.g.cs", text);
@@ -294,7 +308,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(outputBufferInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getOutputBufferMethod = GetOutputBuffer.GetSyntax(item.OutputBuffer);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getOutputBufferMethod, canUseSkipLocalsInit: false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Hierarchy, getOutputBufferMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FullyQualifiedMetadataName}.{nameof(GetOutputBuffer)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -309,7 +323,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(inputDescriptionsInfo, static (context, item) =>
         {
             MethodDeclarationSyntax loadInputDescriptionsMethod = LoadInputDescriptions.GetSyntax(item.Info.InputDescriptions);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Info.Hierarchy, loadInputDescriptionsMethod, item.CanUseSkipLocalsInit);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Info.Hierarchy, loadInputDescriptionsMethod, item.CanUseSkipLocalsInit);
 
             context.AddSource($"{item.Info.Hierarchy.FullyQualifiedMetadataName}.{nameof(LoadInputDescriptions)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });
@@ -323,7 +337,7 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         context.RegisterSourceOutput(pixelOptionsInfo, static (context, item) =>
         {
             MethodDeclarationSyntax getPixelOptionsMethod = GetPixelOptions.GetSyntax(item.PixelOptions);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMethod(item.Hierarchy, getPixelOptionsMethod, canUseSkipLocalsInit: false);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Hierarchy, getPixelOptionsMethod, canUseSkipLocalsInit: false);
 
             context.AddSource($"{item.Hierarchy.FullyQualifiedMetadataName}.{nameof(GetPixelOptions)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/D2D1ShaderInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/D2D1ShaderInfo.cs
@@ -8,6 +8,7 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// </summary>
 /// <param name="Hierarchy">The hierarchy info for the shader type.</param>
 /// <param name="EffectId">The effect id info for the shader type.</param>
+/// <param name="EffectDisplayName">The effect display name for the shader type.</param>
 /// <param name="DispatchData">The gathered shader dispatch data.</param>
 /// <param name="InputTypes">The gathered input types for the shader.</param>
 /// <param name="ResourceTextureDescriptions">The gathered resource texture descriptions for the shader.</param>
@@ -19,6 +20,7 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 internal sealed record D2D1ShaderInfo(
     HierarchyInfo Hierarchy,
     EffectIdInfo EffectId,
+    string EffectDisplayName,
     DispatchDataInfo DispatchData,
     InputTypesInfo InputTypes,
     ResourceTextureDescriptionsInfo ResourceTextureDescriptions,

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/D2D1ShaderInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/D2D1ShaderInfo.cs
@@ -7,6 +7,7 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// A model representing all necessary info for a full generation pass for a D2D1 shader.
 /// </summary>
 /// <param name="Hierarchy">The hierarchy info for the shader type.</param>
+/// <param name="EffectId">The effect id info for the shader type.</param>
 /// <param name="DispatchData">The gathered shader dispatch data.</param>
 /// <param name="InputTypes">The gathered input types for the shader.</param>
 /// <param name="ResourceTextureDescriptions">The gathered resource texture descriptions for the shader.</param>
@@ -17,6 +18,7 @@ namespace ComputeSharp.D2D1.SourceGenerators.Models;
 /// <param name="Diagnostcs">The discovered diagnostics, if any.</param>
 internal sealed record D2D1ShaderInfo(
     HierarchyInfo Hierarchy,
+    EffectIdInfo EffectId,
     DispatchDataInfo DispatchData,
     InputTypesInfo InputTypes,
     ResourceTextureDescriptionsInfo ResourceTextureDescriptions,

--- a/src/ComputeSharp.D2D1.SourceGenerators/Models/EffectIdInfo.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Models/EffectIdInfo.cs
@@ -1,0 +1,9 @@
+using ComputeSharp.SourceGeneration.Helpers;
+
+namespace ComputeSharp.D2D1.SourceGenerators.Models;
+
+/// <summary>
+/// A model representing info to use to generate an effect id for a shader.
+/// </summary>
+/// <param name="Bytes">The bytes for the processed effect id.</param>
+internal sealed record EffectIdInfo(EquatableArray<byte> Bytes);

--- a/src/ComputeSharp.D2D1/Attributes/D2DEffectDisplayNameAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DEffectDisplayNameAttribute.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// An attribute for a D2D1 shader indicating the display name of the shader effect to create.
+/// </summary>
+/// <remarks>
+/// This only applies to effects created from <see cref="Interop.D2D1PixelShaderEffect"/>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+public sealed class D2DEffectDisplayNameAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="D2DEffectDisplayNameAttribute"/> type with the specified arguments.
+    /// </summary>
+    /// <param name="value">The value for the display name.</param>
+    public D2DEffectDisplayNameAttribute(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets the display name value.
+    /// </summary>
+    public string Value { get; }
+}

--- a/src/ComputeSharp.D2D1/Attributes/D2DEffectIdAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DEffectIdAttribute.cs
@@ -21,7 +21,7 @@ public sealed class D2DEffectIdAttribute : Attribute
     }
 
     /// <summary>
-    /// Gets the number of texture inputs for the shader.
+    /// Gets the effect id value.
     /// </summary>
     public Guid Value { get; }
 }

--- a/src/ComputeSharp.D2D1/Attributes/D2DEffectIdAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DEffectIdAttribute.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// An attribute for a D2D1 shader indicating the id of the shader effect to create.
+/// </summary>
+/// <remarks>
+/// This only applies to effects created from <see cref="Interop.D2D1PixelShaderEffect"/>.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+public sealed class D2DEffectIdAttribute : Attribute
+{
+    /// <summary>
+    /// Creates a new instance of the <see cref="D2DEffectIdAttribute"/> type with the specified arguments.
+    /// </summary>
+    /// <param name="value">The value for the effect id.</param>
+    public D2DEffectIdAttribute(string value)
+    {
+        Value = Guid.Parse(value);
+    }
+
+    /// <summary>
+    /// Gets the number of texture inputs for the shader.
+    /// </summary>
+    public Guid Value { get; }
+}

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
@@ -12,6 +12,14 @@ namespace ComputeSharp.D2D1.__Internals;
 public interface ID2D1Shader
 {
     /// <summary>
+    /// Gets the effect id of the D2D effect using this shader.
+    /// </summary>
+    /// <remarks>
+    /// This only applies to effects created from <see cref="Interop.D2D1PixelShaderEffect"/>.
+    /// </remarks>
+    ref readonly Guid EffectId { get; }
+
+    /// <summary>
     /// Gets the display name of the D2D effect using this shader.
     /// </summary>
     /// <remarks>

--- a/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/__Internals/ID2D1Shader.cs
@@ -12,6 +12,14 @@ namespace ComputeSharp.D2D1.__Internals;
 public interface ID2D1Shader
 {
     /// <summary>
+    /// Gets the display name of the D2D effect using this shader.
+    /// </summary>
+    /// <remarks>
+    /// This only applies to effects created from <see cref="Interop.D2D1PixelShaderEffect"/>.
+    /// </remarks>
+    string EffectDisplayName { get; }
+
+    /// <summary>
     /// Initializes the current shader from a buffer with the serialized dispatch data.
     /// </summary>
     /// <param name="data">The input buffer with the serialized dispatch data.</param>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
@@ -32,6 +32,19 @@ public static unsafe class D2D1PixelShaderEffect
     }
 
     /// <summary>
+    /// Gets the effect display name of the D2D effect using this shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the effect id for.</typeparam>
+    /// <returns>The effect display name of the D2D effect using <typeparamref name="T"/> shaders.</returns>
+    public static string GetEffectDisplayName<T>()
+        where T : unmanaged, ID2D1PixelShader
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.EffectDisplayName;
+    }
+
+    /// <summary>
     /// Registers an effect from an input D2D1 pixel shader, by calling <c>ID2D1Factory1::RegisterEffectFromString</c>.
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to register.</typeparam>
@@ -58,7 +71,7 @@ public static unsafe class D2D1PixelShaderEffect
             <Effect>
                 <Property name='DisplayName' type='string' value='
             """);
-        writer.WriteRaw(typeof(T).FullName!);
+        writer.WriteRaw(GetEffectDisplayName<T>());
         writer.WriteRaw("""
             '/>
                 <Property name='Author' type='string' value='ComputeSharp.D2D1'/>
@@ -298,7 +311,7 @@ public static unsafe class D2D1PixelShaderEffect
             <Effect>
                 <Property name='DisplayName' type='string' value='
             """u8);
-        writer.WriteAsUtf8(typeof(T).FullName!);
+        writer.WriteAsUtf8(GetEffectDisplayName<T>());
         writer.WriteRaw("""
             '/>
                 <Property name='Author' type='string' value='ComputeSharp.D2D1'/>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
@@ -19,6 +19,19 @@ namespace ComputeSharp.D2D1.Interop;
 public static unsafe class D2D1PixelShaderEffect
 {
     /// <summary>
+    /// Gets the effect id of the D2D effect using this shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the effect id for.</typeparam>
+    /// <returns>The effect id of the D2D effect using <typeparamref name="T"/> shaders.</returns>
+    public static ref readonly Guid GetEffectId<T>()
+        where T : unmanaged, ID2D1PixelShader
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return ref shader.EffectId;
+    }
+
+    /// <summary>
     /// Registers an effect from an input D2D1 pixel shader, by calling <c>ID2D1Factory1::RegisterEffectFromString</c>.
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to register.</typeparam>
@@ -26,7 +39,10 @@ public static unsafe class D2D1PixelShaderEffect
     /// <param name="effectId">The <see cref="Guid"/> of the registered effect, which can be used to call <c>ID2D1DeviceContext::CreateEffect</c>.</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="d2D1Factory1"/> is <see langword="null"/>.</exception>
     /// <exception cref="InvalidOperationException">Thrown if an effect is registered multiple times with different properties.</exception>
-    /// <remarks>For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1factory1-registereffectfromstring"/>.</remarks>
+    /// <remarks>
+    /// <para>The returned <paramref name="effectId"/> value is the same as that returned by <see cref="GetEffectId{T}"/>.</para>
+    /// <para>For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1factory1-registereffectfromstring"/>.</para>
+    /// </remarks>
     public static void RegisterForD2D1Factory1<T>(void* d2D1Factory1, out Guid effectId)
         where T : unmanaged, ID2D1PixelShader
     {
@@ -261,9 +277,8 @@ public static unsafe class D2D1PixelShaderEffect
     /// To make the deserialization easier, the <see cref="D2D1EffectRegistrationData"/> type can be used to read and validate the returned blob.
     /// The leading blob id will determine what subtype should be used to deserialize the blob (eg. <see cref="D2D1EffectRegistrationData.V1"/>).
     /// </para>
-    /// <para>
-    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1factory1-registereffectfromstring"/>.
-    /// </para>
+    /// <para>The returned <paramref name="effectId"/> value is the same as that returned by <see cref="GetEffectId{T}"/>.</para>
+    /// <para>For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1factory1-registereffectfromstring"/>.</para>
     /// </remarks>
     public static ReadOnlyMemory<byte> GetRegistrationBlob<T>(out Guid effectId)
         where T : unmanaged, ID2D1PixelShader

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.For{T}.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.For{T}.cs
@@ -165,7 +165,7 @@ internal unsafe partial struct PixelShaderEffect
         private static For<T> CreateInstance()
         {
             // Load all shader properties
-            Guid shaderId = typeof(T).GUID;
+            Guid shaderId = D2D1PixelShaderEffect.GetEffectId<T>();
             int constantBufferSize = D2D1PixelShader.GetConstantBufferSize<T>();
             D2D1BufferPrecision bufferPrecision = D2D1PixelShader.GetOutputBufferPrecision<T>();
             D2D1ChannelDepth channelDepth = D2D1PixelShader.GetOutputBufferChannelDepth<T>();

--- a/src/ComputeSharp.SourceGeneration/Extensions/AttributeDataExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/AttributeDataExtensions.cs
@@ -9,6 +9,21 @@ namespace ComputeSharp.SourceGeneration.Extensions;
 internal static class AttributeDataExtensions
 {
     /// <summary>
+    /// Tries to get the location of the input <see cref="AttributeData"/> instance.
+    /// </summary>
+    /// <param name="attributeData">The input <see cref="AttributeData"/> instance to get the location for.</param>
+    /// <returns>The resulting location for <paramref name="attributeData"/>, if a syntax reference is available.</returns>
+    public static Location? GetLocation(this AttributeData attributeData)
+    {
+        if (attributeData.ApplicationSyntaxReference is { } syntaxReference)
+        {
+            return syntaxReference.SyntaxTree.GetLocation(syntaxReference.Span);
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Tries to get a constructor argument at a given index from the input <see cref="AttributeData"/> instance.
     /// </summary>
     /// <typeparam name="T">The type of constructor argument to retrieve.</typeparam>

--- a/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
@@ -76,33 +76,6 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
     }
 
     /// <summary>
-    /// Advances the current writer by the specified amount.
-    /// </summary>
-    /// <param name="count">The amoutn to advance by.</param>
-    public readonly void Advance(int count)
-    {
-        this.writer!.Advance(count);
-    }
-
-    /// <summary>
-    /// Gets the array currently in use (rented from the pool).
-    /// </summary>
-    /// <returns>The array currently in use.</returns>
-    public readonly T[] DangerousGetArray()
-    {
-        return this.writer!.DangerousGetArray();
-    }
-
-    /// <summary>
-    /// Ensures that the current instance has enough free space to contain a given number of new items.
-    /// </summary>
-    /// <param name="requestedSize">The minimum number of items to ensure space for.</param>
-    public readonly void EnsureCapacity(int requestedSize)
-    {
-        this.writer!.EnsureCapacity(requestedSize);
-    }
-
-    /// <summary>
     /// Inserts an item to the builder at the specified index.
     /// </summary>
     /// <param name="index">The zero-based index at which <paramref name="item"/> should be inserted.</param>
@@ -204,23 +177,6 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index += items.Length;
         }
 
-        /// <inheritdoc cref="ImmutableArrayBuilder{T}.Advance"/>
-        public void Advance(int count)
-        {
-            if (count > this.array.Length - this.index)
-            {
-                ImmutableArrayBuilder.ThrowArgumentOutOfRangeExceptionForCount();
-            }
-
-            this.index += count;
-        }
-
-        /// <inheritdoc cref="ImmutableArrayBuilder{T}.DangerousGetArray"/>
-        public T[] DangerousGetArray()
-        {
-            return this.array;
-        }
-
         /// <inheritdoc cref="ImmutableArrayBuilder{T}.Insert"/>
         public void Insert(int index, T item)
         {
@@ -253,9 +209,12 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index = 0;
         }
 
-        /// <inheritdoc cref="ImmutableArrayBuilder{T}.EnsureCapacity"/>
+        /// <summary>
+        /// Ensures that <see cref="array"/> has enough free space to contain a given number of new items.
+        /// </summary>
+        /// <param name="requestedSize">The minimum number of items to ensure space for in <see cref="array"/>.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void EnsureCapacity(int requestedSize)
+        private void EnsureCapacity(int requestedSize)
         {
             if (requestedSize > this.array.Length - this.index)
             {
@@ -293,13 +252,5 @@ file static class ImmutableArrayBuilder
     public static void ThrowArgumentOutOfRangeExceptionForIndex()
     {
         throw new ArgumentOutOfRangeException("index");
-    }
-
-    /// <summary>
-    /// Throws an <see cref="ArgumentOutOfRangeException"/> for <c>"count"</c>.
-    /// </summary>
-    public static void ThrowArgumentOutOfRangeExceptionForCount()
-    {
-        throw new ArgumentOutOfRangeException("count");
     }
 }

--- a/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
@@ -76,6 +76,33 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
     }
 
     /// <summary>
+    /// Advances the current writer by the specified amount.
+    /// </summary>
+    /// <param name="count">The amoutn to advance by.</param>
+    public readonly void Advance(int count)
+    {
+        this.writer!.Advance(count);
+    }
+
+    /// <summary>
+    /// Gets the array currently in use (rented from the pool).
+    /// </summary>
+    /// <returns>The array currently in use.</returns>
+    public readonly T[] DangerousGetArray()
+    {
+        return this.writer!.DangerousGetArray();
+    }
+
+    /// <summary>
+    /// Ensures that the current instance has enough free space to contain a given number of new items.
+    /// </summary>
+    /// <param name="requestedSize">The minimum number of items to ensure space for.</param>
+    public readonly void EnsureCapacity(int requestedSize)
+    {
+        this.writer!.EnsureCapacity(requestedSize);
+    }
+
+    /// <summary>
     /// Inserts an item to the builder at the specified index.
     /// </summary>
     /// <param name="index">The zero-based index at which <paramref name="item"/> should be inserted.</param>
@@ -177,6 +204,23 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index += items.Length;
         }
 
+        /// <inheritdoc cref="ImmutableArrayBuilder{T}.Advance"/>
+        public void Advance(int count)
+        {
+            if (count > this.array.Length - this.index)
+            {
+                ImmutableArrayBuilder.ThrowArgumentOutOfRangeExceptionForCount();
+            }
+
+            this.index += count;
+        }
+
+        /// <inheritdoc cref="ImmutableArrayBuilder{T}.DangerousGetArray"/>
+        public T[] DangerousGetArray()
+        {
+            return this.array;
+        }
+
         /// <inheritdoc cref="ImmutableArrayBuilder{T}.Insert"/>
         public void Insert(int index, T item)
         {
@@ -209,12 +253,9 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index = 0;
         }
 
-        /// <summary>
-        /// Ensures that <see cref="array"/> has enough free space to contain a given number of new items.
-        /// </summary>
-        /// <param name="requestedSize">The minimum number of items to ensure space for in <see cref="array"/>.</param>
+        /// <inheritdoc cref="ImmutableArrayBuilder{T}.EnsureCapacity"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void EnsureCapacity(int requestedSize)
+        public void EnsureCapacity(int requestedSize)
         {
             if (requestedSize > this.array.Length - this.index)
             {
@@ -252,5 +293,13 @@ file static class ImmutableArrayBuilder
     public static void ThrowArgumentOutOfRangeExceptionForIndex()
     {
         throw new ArgumentOutOfRangeException("index");
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> for <c>"count"</c>.
+    /// </summary>
+    public static void ThrowArgumentOutOfRangeExceptionForCount()
+    {
+        throw new ArgumentOutOfRangeException("count");
     }
 }

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -174,9 +174,14 @@ public partial class D2D1PixelShaderEffectTests
         using ComPtr<ID2D1DeviceContext> d2D1DeviceContext = D2D1Helper.CreateD2D1DeviceContext(d2D1Device.Get());
 
         D2D1PixelShaderEffect.RegisterForD2D1Factory1<ShaderWithDefaultEffectId>(d2D1Factory2.Get(), out Guid effectId);
+        D2D1PixelShaderEffect.RegisterForD2D1Factory1<ShaderWithDefaultEffectId2>(d2D1Factory2.Get(), out Guid effectId2);
+
+        // Ensure that the dynamically generated GUIDs are deterministic and stable
+        Assert.AreEqual(Guid.Parse("F5287184-0EC7-0BC6-3942-8BFB70E77C4B"), effectId);
+        Assert.AreEqual(Guid.Parse("96310279-E716-D336-5097-BE516792CBF0"), effectId2);
 
         Assert.AreEqual(D2D1PixelShaderEffect.GetEffectId<ShaderWithDefaultEffectId>(), effectId);
-        Assert.AreNotEqual(D2D1PixelShaderEffect.GetEffectId<ShaderWithDefaultEffectId2>(), effectId);
+        Assert.AreEqual(D2D1PixelShaderEffect.GetEffectId<ShaderWithDefaultEffectId2>(), effectId2);
     }
 
     [D2DInputCount(0)]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -219,4 +219,57 @@ public partial class D2D1PixelShaderEffectTests
             return 0;
         }
     }
+
+    [TestMethod]
+    public unsafe void DefaultEffectDisplayName_MatchesValue()
+    {
+        Assert.AreEqual(D2D1PixelShaderEffect.GetEffectDisplayName<ShaderWithDefaultEffectDisplayName>(), typeof(ShaderWithDefaultEffectDisplayName).FullName);
+    }
+
+    [D2DInputCount(0)]
+    private partial struct ShaderWithDefaultEffectDisplayName : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            return 0;
+        }
+    }
+
+    [TestMethod]
+    public unsafe void ExplicitEffectDisplayName_MatchesValue()
+    {
+        Assert.AreEqual(D2D1PixelShaderEffect.GetEffectDisplayName<ShaderWithExplicitEffectDisplayName>(), "Fancy blur");
+        Assert.AreEqual(D2D1PixelShaderEffect.GetEffectDisplayName<ShaderWithExplicitEffectDisplayName2>(), "Fancy&quot;&lt;");
+        Assert.AreEqual(D2D1PixelShaderEffect.GetEffectDisplayName<ShaderWithExplicitEffectDisplayName3>(), "FancyBlurEffect");
+    }
+
+    [D2DInputCount(0)]
+    [D2DEffectDisplayName("Fancy blur")]
+    private partial struct ShaderWithExplicitEffectDisplayName : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            return 0;
+        }
+    }
+
+    [D2DInputCount(0)]
+    [D2DEffectDisplayName("Fancy\"<")]
+    private partial struct ShaderWithExplicitEffectDisplayName2 : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            return 0;
+        }
+    }
+
+    [D2DInputCount(0)]
+    [D2DEffectDisplayName("Fancy\r\nBlur\nEffect")]
+    private partial struct ShaderWithExplicitEffectDisplayName3 : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            return 0;
+        }
+    }
 }

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -165,4 +165,58 @@ public partial class D2D1PixelShaderEffectTests
             return this.a + this.b + this.c.X + this.d + this.e;
         }
     }
+
+    [TestMethod]
+    public unsafe void DefaultEffectId_MatchesValue()
+    {
+        using ComPtr<ID2D1Factory2> d2D1Factory2 = D2D1Helper.CreateD2D1Factory2();
+        using ComPtr<ID2D1Device> d2D1Device = D2D1Helper.CreateD2D1Device(d2D1Factory2.Get());
+        using ComPtr<ID2D1DeviceContext> d2D1DeviceContext = D2D1Helper.CreateD2D1DeviceContext(d2D1Device.Get());
+
+        D2D1PixelShaderEffect.RegisterForD2D1Factory1<ShaderWithDefaultEffectId>(d2D1Factory2.Get(), out Guid effectId);
+
+        Assert.AreEqual(D2D1PixelShaderEffect.GetEffectId<ShaderWithDefaultEffectId>(), effectId);
+        Assert.AreNotEqual(D2D1PixelShaderEffect.GetEffectId<ShaderWithDefaultEffectId2>(), effectId);
+    }
+
+    [D2DInputCount(0)]
+    private partial struct ShaderWithDefaultEffectId : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            return 0;
+        }
+    }
+
+    [D2DInputCount(0)]
+    private partial struct ShaderWithDefaultEffectId2 : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            return 0;
+        }
+    }
+
+    [TestMethod]
+    public unsafe void ExplicitEffectId_MatchesValue()
+    {
+        using ComPtr<ID2D1Factory2> d2D1Factory2 = D2D1Helper.CreateD2D1Factory2();
+        using ComPtr<ID2D1Device> d2D1Device = D2D1Helper.CreateD2D1Device(d2D1Factory2.Get());
+        using ComPtr<ID2D1DeviceContext> d2D1DeviceContext = D2D1Helper.CreateD2D1DeviceContext(d2D1Device.Get());
+
+        D2D1PixelShaderEffect.RegisterForD2D1Factory1<ShaderWithExplicitEffectId>(d2D1Factory2.Get(), out Guid effectId);
+
+        Assert.AreEqual(Guid.Parse("8E1F7F49-EF0D-4242-8912-08ADA36AB4EC"), effectId);
+        Assert.AreEqual(D2D1PixelShaderEffect.GetEffectId<ShaderWithExplicitEffectId>(), effectId);
+    }
+
+    [D2DInputCount(0)]
+    [D2DEffectId("8E1F7F49-EF0D-4242-8912-08ADA36AB4EC")]
+    private partial struct ShaderWithExplicitEffectId : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            return 0;
+        }
+    }
 }


### PR DESCRIPTION
### Contributes to #551

### Description

This PR introduces the following changes:
- Adds the new `[D2DEffectId]` and `[D2DEffectDisplayName]` attributes
- Source-generate the effect id and display name for every shader type
  - Uses the attribute values, or a deterministic GUID and fully qualified type name otherwise
  - Removes the need for `typeof(T).GUID` and `typeof(T).FullName` at runtime
  - Contributes to reducing binary size with NativeAOT
  - Also marginally faster at runtime
  - Includes two new analyzers to enforce correct attribute use

### API breakdown

```csharp
namespace ComputeSharp.D2D1;

[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
public sealed class D2DEffectIdAttribute : Attribute
{
    public D2DEffectIdAttribute(string value);

    public Guid Value { get; }
}

[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
public sealed class D2DEffectDisplayNameAttribute : Attribute
{
    public D2DEffectDisplayNameAttribute(string value);

    public string Value { get; }
}
```