### PR TITLE
Require <AllowUnsafeBlocks> for D2D1 source generator

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -70,3 +70,4 @@ CMPSD2D0060 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0061 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0062 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0063 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0064 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
@@ -1,0 +1,33 @@
+using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error if the <c>AllowUnsafeBlocks</c> compilation option is not set.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MissingAllowUnsafeBlocksCompilationOptionAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MissingAllowUnsafeBlocksOption);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationAction(static context =>
+        {
+            // Check whether unsafe blocks are available, and emit an error if they are not
+            if (!context.Compilation.IsAllowUnsafeBlocksEnabled())
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MissingAllowUnsafeBlocksOption, location: null));
+            }
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -937,4 +937,21 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "The [D2DEffectAuthor] attribute must contain valid text.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>AllowUnsafeBlocks</c> option is not set.
+    /// <para>
+    /// Format: <c>"Unsafe blocks must be enabled for the source generators to emit valid code (add &lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt; to your .csproj/.props file)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor MissingAllowUnsafeBlocksOption = new DiagnosticDescriptor(
+        id: "CMPSD2D0064",
+        title: "Missing 'AllowUnsafeBlocks' compilation option",
+        messageFormat: "Unsafe blocks must be enabled for the source generators to emit valid code (add <AllowUnsafeBlocks>true</AllowUnsafeBlocks> to your .csproj/.props file)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Unsafe blocks must be enabled for the source generators to emit valid code (the <AllowUnsafeBlocks>true</AllowUnsafeBlocks> option must be set in the .csproj/.props file).",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -36,6 +36,12 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
                 static (node, _) => node.IsTypeDeclarationWithOrPotentiallyWithBaseTypes<StructDeclarationSyntax>(),
                 static (context, token) =>
                 {
+                    // The source generator requires unsafe blocks to be enabled (eg. for pointers, [SkipLocalsInit], etc.)
+                    if (!context.SemanticModel.Compilation.IsAllowUnsafeBlocksEnabled())
+                    {
+                        return default;
+                    }
+
                     StructDeclarationSyntax typeDeclaration = (StructDeclarationSyntax)context.Node;
 
                     // If the type symbol doesn't have at least one interface, it can't possibly be a shader type

--- a/src/ComputeSharp.SourceGeneration/Extensions/CompilationExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/CompilationExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace ComputeSharp.SourceGeneration.Extensions;
 
@@ -43,6 +44,16 @@ internal static class CompilationExtensions
         typeSymbols = builder.ToImmutable();
 
         return true;
+    }
+
+    /// <summary>
+    /// Checks whether the <c>AllowUnsafeBlocks</c> option is set for a given compilation.
+    /// </summary>
+    /// <param name="compilation">The <see cref="Compilation"/> object to check.</param>
+    /// <returns>Whether the <c>AllowUnsafeBlocks</c> option is set for <paramref name="compilation"/>.</returns>
+    public static bool IsAllowUnsafeBlocksEnabled(this Compilation compilation)
+    {
+        return compilation.Options is CSharpCompilationOptions { AllowUnsafe: true };
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

This PR makes `<AllowUnsafeBlocks>` required for the D2D1 source generator.
It also adds a new diagnostic analyzer to emit an error if the option is not enabled.