### PR TITLE
Generate constant buffer layout type for marshalling

### DIFF
--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TriangleGridContouring.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TriangleGridContouring.cs
@@ -32,12 +32,6 @@ internal readonly partial struct TriangleGridContouring : ID2D1PixelShader
         return new(c, -s, s, c);
     }
 
-    // IQ's float2 to float hash.
-    private static float Hash21(float2 p)
-    {
-        return Hlsl.Frac(Hlsl.Sin(Hlsl.Dot(p, new float2(27.619f, 57.583f))) * 43758.5453f);
-    }
-
     // float2 to float2 hash.
     private float2 Hash22(float2 p)
     {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TriangleGridContouring.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TriangleGridContouring.cs
@@ -25,12 +25,6 @@ internal readonly partial struct TriangleGridContouring : IPixelShader<float4>
         return new(c, -s, s, c);
     }
 
-    // IQ's float2 to float hash.
-    private static float Hash21(float2 p)
-    {
-        return Hlsl.Frac(Hlsl.Sin(Hlsl.Dot(p, new float2(27.619f, 57.583f))) * 43758.5453f);
-    }
-
     // float2 to float2 hash.
     private float2 Hash22(float2 p)
     {

--- a/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
@@ -36,10 +36,10 @@ public unsafe partial struct Bool1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref *(bool*)UndefinedData;
+    public ref bool this[int row] => ref Unsafe.As<int, bool>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(bool) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x1"/> instance.
@@ -184,10 +184,10 @@ public unsafe partial struct Bool1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[int row] => ref Unsafe.As<int, Bool2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x2"/> instance.
@@ -350,10 +350,10 @@ public unsafe partial struct Bool1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[int row] => ref Unsafe.As<int, Bool3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x3"/> instance.
@@ -528,10 +528,10 @@ public unsafe partial struct Bool1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[int row] => ref Unsafe.As<int, Bool4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x4"/> instance.
@@ -703,10 +703,10 @@ public unsafe partial struct Bool2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref *(bool*)UndefinedData;
+    public ref bool this[int row] => ref Unsafe.As<int, bool>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(bool) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x1"/> instance.
@@ -887,10 +887,10 @@ public unsafe partial struct Bool2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[int row] => ref Unsafe.As<int, Bool2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x2"/> instance.
@@ -1091,10 +1091,10 @@ public unsafe partial struct Bool2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[int row] => ref Unsafe.As<int, Bool3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x3"/> instance.
@@ -1321,10 +1321,10 @@ public unsafe partial struct Bool2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[int row] => ref Unsafe.As<int, Bool4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x4"/> instance.
@@ -1523,10 +1523,10 @@ public unsafe partial struct Bool3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref *(bool*)UndefinedData;
+    public ref bool this[int row] => ref Unsafe.As<int, bool>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(bool) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x1"/> instance.
@@ -1727,10 +1727,10 @@ public unsafe partial struct Bool3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[int row] => ref Unsafe.As<int, Bool2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x2"/> instance.
@@ -1964,10 +1964,10 @@ public unsafe partial struct Bool3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[int row] => ref Unsafe.As<int, Bool3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x3"/> instance.
@@ -2240,10 +2240,10 @@ public unsafe partial struct Bool3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[int row] => ref Unsafe.As<int, Bool4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x4"/> instance.
@@ -2475,10 +2475,10 @@ public unsafe partial struct Bool4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref *(bool*)UndefinedData;
+    public ref bool this[int row] => ref Unsafe.As<int, bool>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(bool) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x1"/> instance.
@@ -2699,10 +2699,10 @@ public unsafe partial struct Bool4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[int row] => ref Unsafe.As<int, Bool2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x2"/> instance.
@@ -2969,10 +2969,10 @@ public unsafe partial struct Bool4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[int row] => ref Unsafe.As<int, Bool3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x3"/> instance.
@@ -3291,10 +3291,10 @@ public unsafe partial struct Bool4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[int row] => ref Unsafe.As<int, Bool4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.tt
+++ b/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.tt
@@ -1,4 +1,4 @@
-﻿<#@include file="..\MatrixType.ttinclude" #>
+<#@include file="..\MatrixType.ttinclude" #>
 <#
 GenerateAllMatrixProperties("Bool", sizeof(int));
 #>

--- a/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
@@ -36,10 +36,10 @@ public unsafe partial struct Double1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref *(double*)UndefinedData;
+    public ref double this[int row] => ref Unsafe.As<double, double>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(double) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x1"/> instance.
@@ -238,10 +238,10 @@ public unsafe partial struct Double1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[int row] => ref Unsafe.As<double, Double2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x2"/> instance.
@@ -458,10 +458,10 @@ public unsafe partial struct Double1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[int row] => ref Unsafe.As<double, Double3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x3"/> instance.
@@ -690,10 +690,10 @@ public unsafe partial struct Double1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[int row] => ref Unsafe.As<double, Double4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x4"/> instance.
@@ -919,10 +919,10 @@ public unsafe partial struct Double2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref *(double*)UndefinedData;
+    public ref double this[int row] => ref Unsafe.As<double, double>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(double) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x1"/> instance.
@@ -1157,10 +1157,10 @@ public unsafe partial struct Double2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[int row] => ref Unsafe.As<double, Double2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x2"/> instance.
@@ -1415,10 +1415,10 @@ public unsafe partial struct Double2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[int row] => ref Unsafe.As<double, Double3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x3"/> instance.
@@ -1699,10 +1699,10 @@ public unsafe partial struct Double2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[int row] => ref Unsafe.As<double, Double4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x4"/> instance.
@@ -1955,10 +1955,10 @@ public unsafe partial struct Double3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref *(double*)UndefinedData;
+    public ref double this[int row] => ref Unsafe.As<double, double>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(double) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x1"/> instance.
@@ -2213,10 +2213,10 @@ public unsafe partial struct Double3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[int row] => ref Unsafe.As<double, Double2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x2"/> instance.
@@ -2504,10 +2504,10 @@ public unsafe partial struct Double3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[int row] => ref Unsafe.As<double, Double3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x3"/> instance.
@@ -2834,10 +2834,10 @@ public unsafe partial struct Double3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[int row] => ref Unsafe.As<double, Double4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x4"/> instance.
@@ -3123,10 +3123,10 @@ public unsafe partial struct Double4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref *(double*)UndefinedData;
+    public ref double this[int row] => ref Unsafe.As<double, double>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(double) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x1"/> instance.
@@ -3401,10 +3401,10 @@ public unsafe partial struct Double4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[int row] => ref Unsafe.As<double, Double2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x2"/> instance.
@@ -3725,10 +3725,10 @@ public unsafe partial struct Double4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[int row] => ref Unsafe.As<double, Double3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x3"/> instance.
@@ -4101,10 +4101,10 @@ public unsafe partial struct Double4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[int row] => ref Unsafe.As<double, Double4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.tt
+++ b/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.tt
@@ -1,4 +1,4 @@
-﻿<#@include file="..\MatrixType.ttinclude" #>
+<#@include file="..\MatrixType.ttinclude" #>
 <#
 GenerateAllMatrixProperties("Double", sizeof(double));
 #>

--- a/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
@@ -37,10 +37,10 @@ public unsafe partial struct Float1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref *(float*)UndefinedData;
+    public ref float this[int row] => ref Unsafe.As<float, float>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(float) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x1"/> instance.
@@ -257,10 +257,10 @@ public unsafe partial struct Float1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[int row] => ref Unsafe.As<float, Float2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x2"/> instance.
@@ -579,10 +579,10 @@ public unsafe partial struct Float1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[int row] => ref Unsafe.As<float, Float3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x3"/> instance.
@@ -913,10 +913,10 @@ public unsafe partial struct Float1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[int row] => ref Unsafe.As<float, Float4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x4"/> instance.
@@ -1244,10 +1244,10 @@ public unsafe partial struct Float2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref *(float*)UndefinedData;
+    public ref float this[int row] => ref Unsafe.As<float, float>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(float) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x1"/> instance.
@@ -1570,10 +1570,10 @@ public unsafe partial struct Float2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[int row] => ref Unsafe.As<float, Float2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x2"/> instance.
@@ -1846,10 +1846,10 @@ public unsafe partial struct Float2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[int row] => ref Unsafe.As<float, Float3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x3"/> instance.
@@ -2232,10 +2232,10 @@ public unsafe partial struct Float2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[int row] => ref Unsafe.As<float, Float4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x4"/> instance.
@@ -2590,10 +2590,10 @@ public unsafe partial struct Float3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref *(float*)UndefinedData;
+    public ref float this[int row] => ref Unsafe.As<float, float>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(float) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x1"/> instance.
@@ -2936,10 +2936,10 @@ public unsafe partial struct Float3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[int row] => ref Unsafe.As<float, Float2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x2"/> instance.
@@ -3329,10 +3329,10 @@ public unsafe partial struct Float3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[int row] => ref Unsafe.As<float, Float3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x3"/> instance.
@@ -3677,10 +3677,10 @@ public unsafe partial struct Float3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[int row] => ref Unsafe.As<float, Float4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x4"/> instance.
@@ -4068,10 +4068,10 @@ public unsafe partial struct Float4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref *(float*)UndefinedData;
+    public ref float this[int row] => ref Unsafe.As<float, float>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(float) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x1"/> instance.
@@ -4434,10 +4434,10 @@ public unsafe partial struct Float4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[int row] => ref Unsafe.As<float, Float2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x2"/> instance.
@@ -4860,10 +4860,10 @@ public unsafe partial struct Float4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[int row] => ref Unsafe.As<float, Float3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x3"/> instance.
@@ -5338,10 +5338,10 @@ public unsafe partial struct Float4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[int row] => ref Unsafe.As<float, Float4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/Float/FloatMxN.tt
+++ b/src/ComputeSharp.Core/Primitives/Float/FloatMxN.tt
@@ -1,4 +1,4 @@
-﻿<#@include file="..\MatrixType.ttinclude" #>
+<#@include file="..\MatrixType.ttinclude" #>
 <#
 GenerateAllMatrixProperties("Float", sizeof(float));
 #>

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -37,10 +37,10 @@ public unsafe partial struct Int1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref *(int*)UndefinedData;
+    public ref int this[int row] => ref Unsafe.As<int, int>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(int) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x1"/> instance.
@@ -355,10 +355,10 @@ public unsafe partial struct Int1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[int row] => ref Unsafe.As<int, Int2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x2"/> instance.
@@ -775,10 +775,10 @@ public unsafe partial struct Int1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[int row] => ref Unsafe.As<int, Int3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x3"/> instance.
@@ -1207,10 +1207,10 @@ public unsafe partial struct Int1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[int row] => ref Unsafe.As<int, Int4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x4"/> instance.
@@ -1636,10 +1636,10 @@ public unsafe partial struct Int2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref *(int*)UndefinedData;
+    public ref int this[int row] => ref Unsafe.As<int, int>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(int) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x1"/> instance.
@@ -2060,10 +2060,10 @@ public unsafe partial struct Int2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[int row] => ref Unsafe.As<int, Int2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x2"/> instance.
@@ -2434,10 +2434,10 @@ public unsafe partial struct Int2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[int row] => ref Unsafe.As<int, Int3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x3"/> instance.
@@ -2918,10 +2918,10 @@ public unsafe partial struct Int2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[int row] => ref Unsafe.As<int, Int4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x4"/> instance.
@@ -3374,10 +3374,10 @@ public unsafe partial struct Int3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref *(int*)UndefinedData;
+    public ref int this[int row] => ref Unsafe.As<int, int>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(int) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x1"/> instance.
@@ -3818,10 +3818,10 @@ public unsafe partial struct Int3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[int row] => ref Unsafe.As<int, Int2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x2"/> instance.
@@ -4309,10 +4309,10 @@ public unsafe partial struct Int3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[int row] => ref Unsafe.As<int, Int3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x3"/> instance.
@@ -4755,10 +4755,10 @@ public unsafe partial struct Int3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[int row] => ref Unsafe.As<int, Int4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x4"/> instance.
@@ -5244,10 +5244,10 @@ public unsafe partial struct Int4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref *(int*)UndefinedData;
+    public ref int this[int row] => ref Unsafe.As<int, int>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(int) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x1"/> instance.
@@ -5708,10 +5708,10 @@ public unsafe partial struct Int4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[int row] => ref Unsafe.As<int, Int2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x2"/> instance.
@@ -6232,10 +6232,10 @@ public unsafe partial struct Int4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[int row] => ref Unsafe.As<int, Int3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x3"/> instance.
@@ -6808,10 +6808,10 @@ public unsafe partial struct Int4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[int row] => ref Unsafe.As<int, Int4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.tt
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.tt
@@ -1,4 +1,4 @@
-﻿<#@include file="..\MatrixType.ttinclude" #>
+<#@include file="..\MatrixType.ttinclude" #>
 <#
 GenerateAllMatrixProperties("Int", sizeof(int));
 #>

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -152,10 +152,10 @@ public unsafe partial struct <#=fullTypeName#>
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref <#=rowTypeName#> this[int row] => ref *(<#=rowTypeName#>*)UndefinedData;
+    public ref <#=rowTypeName#> this[int row] => ref Unsafe.As<<#=fieldElementTypeName#>, <#=rowTypeName#>>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(<#=rowTypeName#>) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="<#=fullTypeName#>"/> instance.

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -36,10 +36,10 @@ public unsafe partial struct UInt1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref *(uint*)UndefinedData;
+    public ref uint this[int row] => ref Unsafe.As<uint, uint>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(uint) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x1"/> instance.
@@ -329,10 +329,10 @@ public unsafe partial struct UInt1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[int row] => ref Unsafe.As<uint, UInt2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x2"/> instance.
@@ -640,10 +640,10 @@ public unsafe partial struct UInt1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[int row] => ref Unsafe.As<uint, UInt3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x3"/> instance.
@@ -963,10 +963,10 @@ public unsafe partial struct UInt1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[int row] => ref Unsafe.As<uint, UInt4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x4"/> instance.
@@ -1283,10 +1283,10 @@ public unsafe partial struct UInt2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref *(uint*)UndefinedData;
+    public ref uint this[int row] => ref Unsafe.As<uint, uint>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(uint) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x1"/> instance.
@@ -1612,10 +1612,10 @@ public unsafe partial struct UInt2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[int row] => ref Unsafe.As<uint, UInt2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x2"/> instance.
@@ -1961,10 +1961,10 @@ public unsafe partial struct UInt2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[int row] => ref Unsafe.As<uint, UInt3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x3"/> instance.
@@ -2336,10 +2336,10 @@ public unsafe partial struct UInt2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[int row] => ref Unsafe.As<uint, UInt4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x4"/> instance.
@@ -2683,10 +2683,10 @@ public unsafe partial struct UInt3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref *(uint*)UndefinedData;
+    public ref uint this[int row] => ref Unsafe.As<uint, uint>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(uint) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x1"/> instance.
@@ -3032,10 +3032,10 @@ public unsafe partial struct UInt3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[int row] => ref Unsafe.As<uint, UInt2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x2"/> instance.
@@ -3414,10 +3414,10 @@ public unsafe partial struct UInt3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[int row] => ref Unsafe.As<uint, UInt3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x3"/> instance.
@@ -3835,10 +3835,10 @@ public unsafe partial struct UInt3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[int row] => ref Unsafe.As<uint, UInt4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x4"/> instance.
@@ -4215,10 +4215,10 @@ public unsafe partial struct UInt4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref *(uint*)UndefinedData;
+    public ref uint this[int row] => ref Unsafe.As<uint, uint>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(uint) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x1"/> instance.
@@ -4584,10 +4584,10 @@ public unsafe partial struct UInt4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[int row] => ref Unsafe.As<uint, UInt2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt2) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x2"/> instance.
@@ -4999,10 +4999,10 @@ public unsafe partial struct UInt4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[int row] => ref Unsafe.As<uint, UInt3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt3) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x3"/> instance.
@@ -5466,10 +5466,10 @@ public unsafe partial struct UInt4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[int row] => ref Unsafe.As<uint, UInt4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt4) * row)));
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.tt
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.tt
@@ -1,4 +1,4 @@
-﻿<#@include file="..\MatrixType.ttinclude" #>
+<#@include file="..\MatrixType.ttinclude" #>
 <#
 GenerateAllMatrixProperties("UInt", sizeof(uint));
 #>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
@@ -1,7 +1,11 @@
+using System;
 using System.Collections.Immutable;
 using ComputeSharp.D2D1.__Internals;
 using ComputeSharp.D2D1.SourceGenerators.Models;
 using ComputeSharp.SourceGeneration.Helpers;
+using ComputeSharp.SourceGeneration.Mappings;
+using ComputeSharp.SourceGeneration.Models;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -19,10 +23,22 @@ partial class ID2D1ShaderGenerator
         /// <summary>
         /// Creates a <see cref="MethodDeclarationSyntax"/> instance for the <c>LoadDispatchDataMethod</c> method.
         /// </summary>
+        /// <param name="hierarchyInfo">The hiararchy info of the shader type.</param>
         /// <param name="dispatchInfo">The dispatch info gathered for the current shader.</param>
+        /// <param name="additionalTypes">Any additional <see cref="TypeDeclarationSyntax"/> instances needed by the generated code, if needed.</param>
         /// <returns>The resulting <see cref="MethodDeclarationSyntax"/> instance for the <c>LoadDispatchDataMethod</c> method.</returns>
-        public static MethodDeclarationSyntax GetSyntax(DispatchDataInfo dispatchInfo)
+        public static MethodDeclarationSyntax GetSyntax(HierarchyInfo hierarchyInfo, DispatchDataInfo dispatchInfo, out TypeDeclarationSyntax[] additionalTypes)
         {
+            // Declare the mapping constant buffer type, if needed (ie. if the shader has at least one field)
+            if (dispatchInfo.FieldInfos.Length == 0)
+            {
+                additionalTypes = Array.Empty<TypeDeclarationSyntax>();
+            }
+            else
+            {
+                additionalTypes = new[] { GetConstantBufferDeclaration(hierarchyInfo, dispatchInfo.FieldInfos, dispatchInfo.ConstantBufferSizeInBytes) };
+            }
+
             // This code produces a method declaration as follows:
             //
             // readonly void global::ComputeSharp.D2D1.__Internals.ID2D1Shader.LoadDispatchData<TLoader>(ref TLoader loader)
@@ -36,6 +52,122 @@ partial class ID2D1ShaderGenerator
                 .AddTypeParameterListParameters(TypeParameter(Identifier("TLoader")))
                 .AddParameterListParameters(Parameter(Identifier("loader")).AddModifiers(Token(SyntaxKind.RefKeyword)).WithType(IdentifierName("TLoader")))
                 .WithBody(Block(GetDispatchDataLoadingStatements(dispatchInfo.FieldInfos, dispatchInfo.ConstantBufferSizeInBytes)));
+        }
+
+        /// <summary>
+        /// Gets a type definition to map the constant buffer of a given shader type.
+        /// </summary>
+        /// <param name="hierarchyInfo">The hiararchy info of the shader type.</param>
+        /// <param name="fieldInfos">The array of <see cref="FieldInfo"/> values for all captured fields.</param>
+        /// <param name="constantBufferSizeInBytes">The size of the shader constant buffer.</param>
+        /// <returns>The <see cref="TypeDeclarationSyntax"/> object for the mapped constant buffer for the current shader type.</returns>
+        private static TypeDeclarationSyntax GetConstantBufferDeclaration(HierarchyInfo hierarchyInfo, ImmutableArray<FieldInfo> fieldInfos, int constantBufferSizeInBytes)
+        {
+            string fullyQualifiedTypeName = hierarchyInfo.GetFullyQualifiedTypeName();
+
+            using ImmutableArrayBuilder<FieldDeclarationSyntax> fieldDeclarations = ImmutableArrayBuilder<FieldDeclarationSyntax>.Rent();
+
+            // Appends a new field declaration for a constant buffer field:
+            //
+            // <COMMENT>
+            // [global::System.Runtime.InteropServices.FieldOffset(<FIELD_OFFSET>)]
+            // public <FIELD_TYPE> <FIELD_NAME>;
+            void AppendFieldDeclaration(
+                string comment,
+                TypeSyntax typeIdentifier,
+                string identifierName,
+                int fieldOffset)
+            {
+                fieldDeclarations.Add(
+                    FieldDeclaration(
+                        VariableDeclaration(typeIdentifier)
+                        .AddVariables(VariableDeclarator(Identifier(identifierName))))
+                    .AddAttributeLists(AttributeList(SingletonSeparatedList(
+                        Attribute(IdentifierName("global::System.Runtime.InteropServices.FieldOffset"))
+                        .AddArgumentListArguments(AttributeArgument(
+                            LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(fieldOffset)))))))
+                    .AddModifiers(Token(SyntaxKind.PublicKeyword))
+                    .WithLeadingTrivia(Comment(comment)));
+            }
+
+            // Declare fields for every mapped item from the shader layout
+            foreach (FieldInfo fieldInfo in fieldInfos)
+            {
+                switch (fieldInfo)
+                {
+                    case FieldInfo.Primitive { TypeName: "System.Boolean" } primitive:
+
+                        // Append a field as a global::ComputeSharp.Bool value (will use the implicit conversion from bool values)
+                        AppendFieldDeclaration(
+                            comment: $"""/// <inheritdoc cref="{fullyQualifiedTypeName}.{string.Join(".", primitive.FieldPath)}"/>""",
+                            typeIdentifier: IdentifierName("global::ComputeSharp.Bool"),
+                            identifierName: string.Join("_", primitive.FieldPath),
+                            fieldOffset: primitive.Offset);
+                        break;
+                    case FieldInfo.Primitive primitive:
+
+                        // Append primitive fields of other types with their mapped names
+                        AppendFieldDeclaration(
+                            comment: $"""/// <inheritdoc cref="{fullyQualifiedTypeName}.{string.Join(".", primitive.FieldPath)}"/>""",
+                            typeIdentifier: IdentifierName(HlslKnownTypes.GetMappedName(primitive.TypeName)),
+                            identifierName: string.Join("_", primitive.FieldPath),
+                            fieldOffset: primitive.Offset);
+                        break;
+
+                    case FieldInfo.NonLinearMatrix matrix:
+                        string rowTypeName = HlslKnownTypes.GetMappedName($"ComputeSharp.{matrix.ElementName}{matrix.Columns}");
+                        string fieldNamePrefix = string.Join("_", matrix.FieldPath);
+
+                        // Declare a field for every row of the matrix type
+                        for (int j = 0; j < matrix.Rows; j++)
+                        {
+                            AppendFieldDeclaration(
+                                comment: $"""/// <summary>Row {j} of <see cref="{fullyQualifiedTypeName}.{string.Join(".", matrix.FieldPath)}"/>.</summary>""",
+                                typeIdentifier: IdentifierName(rowTypeName),
+                                identifierName: $"{fieldNamePrefix}_{j}",
+                                fieldOffset: matrix.Offsets[j]);
+                        }
+
+                        break;
+                }
+            }
+
+            // Create the constant buffer type:
+            //
+            // /// <summary>
+            // /// A type representing the constant buffer native layout for <see cref="<SHADER_TYPE"/>.
+            // /// </summary>
+            // [global::System.CodeDom.Compiler.GeneratedCode("...", "...")]
+            // [global::System.Diagnostics.DebuggerNonUserCode]
+            // [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+            // [global::System.Runtime.InteropServices.StructLayout(global::System.Runtime.InteropServices.LayoutKind.Explicit, Size = <CONSTANT_BUFFER_SIZE>)]
+            // file struct ConstantBuffer
+            // {
+            //     <FIELD_DECLARATIONS>
+            // }
+            return
+                StructDeclaration("ConstantBuffer")
+                .AddModifiers(Token(SyntaxKind.FileKeyword))
+                .AddAttributeLists(
+                    AttributeList(SingletonSeparatedList(
+                        Attribute(IdentifierName("global::System.CodeDom.Compiler.GeneratedCode")).AddArgumentListArguments(
+                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ID2D1ShaderGenerator).FullName))),
+                            AttributeArgument(LiteralExpression(SyntaxKind.StringLiteralExpression, Literal(typeof(ID2D1ShaderGenerator).Assembly.GetName().Version.ToString())))))),
+                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.DebuggerNonUserCode")))),
+                    AttributeList(SingletonSeparatedList(Attribute(IdentifierName("global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage")))),
+                    AttributeList(SingletonSeparatedList(
+                        Attribute(IdentifierName("global::System.Runtime.InteropServices.StructLayout")).AddArgumentListArguments(
+                            AttributeArgument(MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                IdentifierName("global::System.Runtime.InteropServices.LayoutKind"),
+                                IdentifierName("Explicit"))),
+                            AttributeArgument(LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(constantBufferSizeInBytes)))
+                            .WithNameEquals(NameEquals(IdentifierName("Size")))))))
+                .AddMembers(fieldDeclarations.ToArray())
+                .WithLeadingTrivia(
+                    Comment("/// <summary>"),
+                    Comment($"""/// A type representing the constant buffer native layout for <see cref="{fullyQualifiedTypeName}"/>."""),
+                    Comment("/// </summary>"));
         }
 
         /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
@@ -199,11 +199,11 @@ partial class ID2D1ShaderGenerator
 
             using ImmutableArrayBuilder<StatementSyntax> statements = ImmutableArrayBuilder<StatementSyntax>.Rent();
 
-            // ConstantBuffer data;
+            // ConstantBuffer buffer;
             statements.Add(
                 LocalDeclarationStatement(
                     VariableDeclaration(IdentifierName("ConstantBuffer"))
-                    .AddVariables(VariableDeclarator(Identifier("data")))));
+                    .AddVariables(VariableDeclarator(Identifier("buffer")))));
 
             // Generate loading statements for each captured field
             foreach (FieldInfo fieldInfo in fieldInfos)
@@ -214,14 +214,14 @@ partial class ID2D1ShaderGenerator
 
                         // Assign a primitive value:
                         //
-                        // data.<CONSTANT_BUFFER_PATH> = this.<FIELD_PATH>;
+                        // buffer.<CONSTANT_BUFFER_PATH> = this.<FIELD_PATH>;
                         statements.Add(
                             ExpressionStatement(
                                 AssignmentExpression(
                                     SyntaxKind.SimpleAssignmentExpression,
                                     MemberAccessExpression(
                                         SyntaxKind.SimpleMemberAccessExpression,
-                                        IdentifierName("data"),
+                                        IdentifierName("buffer"),
                                         IdentifierName(string.Join("_", primitive.FieldPath))),
                                     MemberAccessExpression(
                                         SyntaxKind.SimpleMemberAccessExpression,
@@ -235,10 +235,10 @@ partial class ID2D1ShaderGenerator
 
                         // Assign all rows of a given matrix type:
                         //
-                        // data.<CONSTANT_BUFFER_ROW_0_PATH> = this.<FIELD_PATH>[0];
-                        // data.<CONSTANT_BUFFER_ROW_1_PATH> = this.<FIELD_PATH>[1];
+                        // buffer.<CONSTANT_BUFFER_ROW_0_PATH> = this.<FIELD_PATH>[0];
+                        // buffer.<CONSTANT_BUFFER_ROW_1_PATH> = this.<FIELD_PATH>[1];
                         // ...
-                        // data.<CONSTANT_BUFFER_ROW_N_PATH> = this.<FIELD_PATH>[N];
+                        // buffer.<CONSTANT_BUFFER_ROW_N_PATH> = this.<FIELD_PATH>[N];
                         for (int j = 0; j < matrix.Rows; j++)
                         {
                             statements.Add(
@@ -247,7 +247,7 @@ partial class ID2D1ShaderGenerator
                                         SyntaxKind.SimpleAssignmentExpression,
                                         MemberAccessExpression(
                                             SyntaxKind.SimpleMemberAccessExpression,
-                                            IdentifierName("data"),
+                                            IdentifierName("buffer"),
                                             IdentifierName($"{fieldNamePrefix}_{j}")),
                                         ElementAccessExpression(
                                             MemberAccessExpression(
@@ -264,7 +264,7 @@ partial class ID2D1ShaderGenerator
                 }
             }
 
-            // loader.LoadConstantBuffer(new global::System.ReadOnlySpan<byte>(&data, sizeof(ConstantBuffer)));
+            // loader.LoadConstantBuffer(new global::System.ReadOnlySpan<byte>(&buffer, sizeof(ConstantBuffer)));
             statements.Add(
                 ExpressionStatement(
                     InvocationExpression(
@@ -280,7 +280,7 @@ partial class ID2D1ShaderGenerator
                             Argument(
                                 PrefixUnaryExpression(
                                     SyntaxKind.AddressOfExpression,
-                                    IdentifierName("data"))),
+                                    IdentifierName("buffer"))),
                             Argument(SizeOfExpression(IdentifierName("ConstantBuffer"))))))));
 
             return statements.ToImmutable();

--- a/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ID2D1ShaderGenerator.cs
@@ -307,8 +307,8 @@ public sealed partial class ID2D1ShaderGenerator : IIncrementalGenerator
         // Generate the LoadDispatchData() methods
         context.RegisterSourceOutput(dispatchDataInfo, static (context, item) =>
         {
-            MethodDeclarationSyntax loadDispatchDataMethod = LoadDispatchData.GetSyntax(item.Info.Dispatch);
-            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Info.Hierarchy, loadDispatchDataMethod, item.CanUseSkipLocalsInit);
+            MethodDeclarationSyntax loadDispatchDataMethod = LoadDispatchData.GetSyntax(item.Info.Hierarchy, item.Info.Dispatch, out TypeDeclarationSyntax[] additionalTypes);
+            CompilationUnitSyntax compilationUnit = GetCompilationUnitFromMember(item.Info.Hierarchy, loadDispatchDataMethod, item.CanUseSkipLocalsInit, additionalMemberDeclarations: additionalTypes);
 
             context.AddSource($"{item.Info.Hierarchy.FullyQualifiedMetadataName}.{nameof(LoadDispatchData)}.g.cs", compilationUnit.GetText(Encoding.UTF8));
         });

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -181,8 +181,18 @@ internal static partial class HlslKnownTypes
     /// Gets the mapped HLSL-compatible type name for the input type name.
     /// </summary>
     /// <param name="originalName">The input type name to map.</param>
-    /// <param name="mappedName">The resulting mapped type name, if found.</param>
     /// <returns>The HLSL-compatible type name that can be used in an HLSL shader.</returns>
+    public static string GetMappedName(string originalName)
+    {
+        return KnownHlslTypes[originalName];
+    }
+
+    /// <summary>
+    /// Tries to get the mapped HLSL-compatible type name for the input type name.
+    /// </summary>
+    /// <param name="originalName">The input type name to map.</param>
+    /// <param name="mappedName">The resulting mapped type name, if found.</param>
+    /// <returns>Whether a mapped name was available.</returns>
     public static bool TryGetMappedName(string originalName, out string? mappedName)
     {
         return KnownHlslTypes.TryGetValue(originalName, out mappedName);

--- a/src/ComputeSharp.SourceGeneration/Models/HierarchyInfo.cs
+++ b/src/ComputeSharp.SourceGeneration/Models/HierarchyInfo.cs
@@ -43,6 +43,26 @@ internal sealed partial record HierarchyInfo(string FullyQualifiedMetadataName, 
     }
 
     /// <summary>
+    /// Gets the fully qualified type name for the current instance.
+    /// </summary>
+    /// <returns>The fully qualified type name for the current instance.</returns>
+    public string GetFullyQualifiedTypeName()
+    {
+        using ImmutableArrayBuilder<char> fullyQualifiedTypeName = ImmutableArrayBuilder<char>.Rent();
+
+        fullyQualifiedTypeName.AddRange("global::".AsSpan());
+        fullyQualifiedTypeName.AddRange(Namespace.AsSpan());
+
+        for (int i = Hierarchy.Length - 1; i >= 0; i--)
+        {
+            fullyQualifiedTypeName.Add('.');
+            fullyQualifiedTypeName.AddRange(Hierarchy[i].QualifiedName.AsSpan());
+        }
+
+        return fullyQualifiedTypeName.ToString();
+    }
+
+    /// <summary>
     /// Creates a <see cref="CompilationUnitSyntax"/> instance for the current hierarchy.
     /// </summary>
     /// <param name="memberDeclarations">The member declarations to add to the generated type.</param>


### PR DESCRIPTION
### Description

This PR updates the D2D1 shader generator to emit a type mapping the constant buffer of a shader. This is then used as local to perform marshalling back and forth between the managed instance and the native buffer. This results in much easier to read and understand generated code, and better perform (due to no stack alloc, more compact codegen, etc.).