### PR TITLE
Remove matrix types row accessors for generated code

### DIFF
--- a/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
@@ -36,10 +36,10 @@ public unsafe partial struct Bool1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref Unsafe.As<int, bool>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(bool) * row)));
+    public ref bool this[int row] => ref *(bool*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x1"/> instance.
@@ -184,10 +184,10 @@ public unsafe partial struct Bool1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref Unsafe.As<int, Bool2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool2) * row)));
+    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x2"/> instance.
@@ -350,10 +350,10 @@ public unsafe partial struct Bool1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref Unsafe.As<int, Bool3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool3) * row)));
+    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x3"/> instance.
@@ -528,10 +528,10 @@ public unsafe partial struct Bool1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref Unsafe.As<int, Bool4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool4) * row)));
+    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x4"/> instance.
@@ -703,10 +703,10 @@ public unsafe partial struct Bool2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref Unsafe.As<int, bool>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(bool) * row)));
+    public ref bool this[int row] => ref *(bool*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x1"/> instance.
@@ -887,10 +887,10 @@ public unsafe partial struct Bool2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref Unsafe.As<int, Bool2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool2) * row)));
+    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x2"/> instance.
@@ -1091,10 +1091,10 @@ public unsafe partial struct Bool2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref Unsafe.As<int, Bool3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool3) * row)));
+    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x3"/> instance.
@@ -1321,10 +1321,10 @@ public unsafe partial struct Bool2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref Unsafe.As<int, Bool4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool4) * row)));
+    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x4"/> instance.
@@ -1523,10 +1523,10 @@ public unsafe partial struct Bool3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref Unsafe.As<int, bool>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(bool) * row)));
+    public ref bool this[int row] => ref *(bool*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x1"/> instance.
@@ -1727,10 +1727,10 @@ public unsafe partial struct Bool3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref Unsafe.As<int, Bool2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool2) * row)));
+    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x2"/> instance.
@@ -1964,10 +1964,10 @@ public unsafe partial struct Bool3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref Unsafe.As<int, Bool3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool3) * row)));
+    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x3"/> instance.
@@ -2240,10 +2240,10 @@ public unsafe partial struct Bool3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref Unsafe.As<int, Bool4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool4) * row)));
+    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x4"/> instance.
@@ -2475,10 +2475,10 @@ public unsafe partial struct Bool4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref Unsafe.As<int, bool>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(bool) * row)));
+    public ref bool this[int row] => ref *(bool*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x1"/> instance.
@@ -2699,10 +2699,10 @@ public unsafe partial struct Bool4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref Unsafe.As<int, Bool2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool2) * row)));
+    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x2"/> instance.
@@ -2969,10 +2969,10 @@ public unsafe partial struct Bool4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref Unsafe.As<int, Bool3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool3) * row)));
+    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x3"/> instance.
@@ -3291,10 +3291,10 @@ public unsafe partial struct Bool4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref Unsafe.As<int, Bool4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Bool4) * row)));
+    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
@@ -36,10 +36,10 @@ public unsafe partial struct Double1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref Unsafe.As<double, double>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(double) * row)));
+    public ref double this[int row] => ref *(double*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x1"/> instance.
@@ -238,10 +238,10 @@ public unsafe partial struct Double1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref Unsafe.As<double, Double2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double2) * row)));
+    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x2"/> instance.
@@ -458,10 +458,10 @@ public unsafe partial struct Double1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref Unsafe.As<double, Double3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double3) * row)));
+    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x3"/> instance.
@@ -690,10 +690,10 @@ public unsafe partial struct Double1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref Unsafe.As<double, Double4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double4) * row)));
+    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x4"/> instance.
@@ -919,10 +919,10 @@ public unsafe partial struct Double2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref Unsafe.As<double, double>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(double) * row)));
+    public ref double this[int row] => ref *(double*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x1"/> instance.
@@ -1157,10 +1157,10 @@ public unsafe partial struct Double2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref Unsafe.As<double, Double2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double2) * row)));
+    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x2"/> instance.
@@ -1415,10 +1415,10 @@ public unsafe partial struct Double2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref Unsafe.As<double, Double3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double3) * row)));
+    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x3"/> instance.
@@ -1699,10 +1699,10 @@ public unsafe partial struct Double2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref Unsafe.As<double, Double4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double4) * row)));
+    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x4"/> instance.
@@ -1955,10 +1955,10 @@ public unsafe partial struct Double3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref Unsafe.As<double, double>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(double) * row)));
+    public ref double this[int row] => ref *(double*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x1"/> instance.
@@ -2213,10 +2213,10 @@ public unsafe partial struct Double3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref Unsafe.As<double, Double2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double2) * row)));
+    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x2"/> instance.
@@ -2504,10 +2504,10 @@ public unsafe partial struct Double3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref Unsafe.As<double, Double3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double3) * row)));
+    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x3"/> instance.
@@ -2834,10 +2834,10 @@ public unsafe partial struct Double3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref Unsafe.As<double, Double4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double4) * row)));
+    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x4"/> instance.
@@ -3123,10 +3123,10 @@ public unsafe partial struct Double4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref Unsafe.As<double, double>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(double) * row)));
+    public ref double this[int row] => ref *(double*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x1"/> instance.
@@ -3401,10 +3401,10 @@ public unsafe partial struct Double4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref Unsafe.As<double, Double2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double2) * row)));
+    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x2"/> instance.
@@ -3725,10 +3725,10 @@ public unsafe partial struct Double4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref Unsafe.As<double, Double3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double3) * row)));
+    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x3"/> instance.
@@ -4101,10 +4101,10 @@ public unsafe partial struct Double4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref Unsafe.As<double, Double4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Double4) * row)));
+    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
@@ -37,10 +37,10 @@ public unsafe partial struct Float1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref Unsafe.As<float, float>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(float) * row)));
+    public ref float this[int row] => ref *(float*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x1"/> instance.
@@ -257,10 +257,10 @@ public unsafe partial struct Float1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref Unsafe.As<float, Float2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float2) * row)));
+    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x2"/> instance.
@@ -579,10 +579,10 @@ public unsafe partial struct Float1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref Unsafe.As<float, Float3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float3) * row)));
+    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x3"/> instance.
@@ -913,10 +913,10 @@ public unsafe partial struct Float1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref Unsafe.As<float, Float4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float4) * row)));
+    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x4"/> instance.
@@ -1244,10 +1244,10 @@ public unsafe partial struct Float2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref Unsafe.As<float, float>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(float) * row)));
+    public ref float this[int row] => ref *(float*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x1"/> instance.
@@ -1570,10 +1570,10 @@ public unsafe partial struct Float2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref Unsafe.As<float, Float2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float2) * row)));
+    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x2"/> instance.
@@ -1846,10 +1846,10 @@ public unsafe partial struct Float2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref Unsafe.As<float, Float3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float3) * row)));
+    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x3"/> instance.
@@ -2232,10 +2232,10 @@ public unsafe partial struct Float2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref Unsafe.As<float, Float4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float4) * row)));
+    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x4"/> instance.
@@ -2590,10 +2590,10 @@ public unsafe partial struct Float3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref Unsafe.As<float, float>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(float) * row)));
+    public ref float this[int row] => ref *(float*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x1"/> instance.
@@ -2936,10 +2936,10 @@ public unsafe partial struct Float3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref Unsafe.As<float, Float2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float2) * row)));
+    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x2"/> instance.
@@ -3329,10 +3329,10 @@ public unsafe partial struct Float3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref Unsafe.As<float, Float3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float3) * row)));
+    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x3"/> instance.
@@ -3677,10 +3677,10 @@ public unsafe partial struct Float3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref Unsafe.As<float, Float4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float4) * row)));
+    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x4"/> instance.
@@ -4068,10 +4068,10 @@ public unsafe partial struct Float4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref Unsafe.As<float, float>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(float) * row)));
+    public ref float this[int row] => ref *(float*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x1"/> instance.
@@ -4434,10 +4434,10 @@ public unsafe partial struct Float4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref Unsafe.As<float, Float2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float2) * row)));
+    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x2"/> instance.
@@ -4860,10 +4860,10 @@ public unsafe partial struct Float4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref Unsafe.As<float, Float3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float3) * row)));
+    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x3"/> instance.
@@ -5338,10 +5338,10 @@ public unsafe partial struct Float4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref Unsafe.As<float, Float4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Float4) * row)));
+    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -37,10 +37,10 @@ public unsafe partial struct Int1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref Unsafe.As<int, int>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(int) * row)));
+    public ref int this[int row] => ref *(int*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x1"/> instance.
@@ -355,10 +355,10 @@ public unsafe partial struct Int1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref Unsafe.As<int, Int2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int2) * row)));
+    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x2"/> instance.
@@ -775,10 +775,10 @@ public unsafe partial struct Int1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref Unsafe.As<int, Int3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int3) * row)));
+    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x3"/> instance.
@@ -1207,10 +1207,10 @@ public unsafe partial struct Int1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref Unsafe.As<int, Int4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int4) * row)));
+    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x4"/> instance.
@@ -1636,10 +1636,10 @@ public unsafe partial struct Int2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref Unsafe.As<int, int>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(int) * row)));
+    public ref int this[int row] => ref *(int*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x1"/> instance.
@@ -2060,10 +2060,10 @@ public unsafe partial struct Int2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref Unsafe.As<int, Int2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int2) * row)));
+    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x2"/> instance.
@@ -2434,10 +2434,10 @@ public unsafe partial struct Int2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref Unsafe.As<int, Int3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int3) * row)));
+    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x3"/> instance.
@@ -2918,10 +2918,10 @@ public unsafe partial struct Int2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref Unsafe.As<int, Int4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int4) * row)));
+    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x4"/> instance.
@@ -3374,10 +3374,10 @@ public unsafe partial struct Int3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref Unsafe.As<int, int>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(int) * row)));
+    public ref int this[int row] => ref *(int*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x1"/> instance.
@@ -3818,10 +3818,10 @@ public unsafe partial struct Int3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref Unsafe.As<int, Int2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int2) * row)));
+    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x2"/> instance.
@@ -4309,10 +4309,10 @@ public unsafe partial struct Int3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref Unsafe.As<int, Int3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int3) * row)));
+    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x3"/> instance.
@@ -4755,10 +4755,10 @@ public unsafe partial struct Int3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref Unsafe.As<int, Int4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int4) * row)));
+    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x4"/> instance.
@@ -5244,10 +5244,10 @@ public unsafe partial struct Int4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref Unsafe.As<int, int>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(int) * row)));
+    public ref int this[int row] => ref *(int*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x1"/> instance.
@@ -5708,10 +5708,10 @@ public unsafe partial struct Int4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref Unsafe.As<int, Int2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int2) * row)));
+    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x2"/> instance.
@@ -6232,10 +6232,10 @@ public unsafe partial struct Int4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref Unsafe.As<int, Int3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int3) * row)));
+    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x3"/> instance.
@@ -6808,10 +6808,10 @@ public unsafe partial struct Int4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref Unsafe.As<int, Int4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(Int4) * row)));
+    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x4"/> instance.

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -152,10 +152,10 @@ public unsafe partial struct <#=fullTypeName#>
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref <#=rowTypeName#> this[int row] => ref Unsafe.As<<#=fieldElementTypeName#>, <#=rowTypeName#>>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(<#=rowTypeName#>) * row)));
+    public ref <#=rowTypeName#> this[int row] => ref *(<#=rowTypeName#>*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="<#=fullTypeName#>"/> instance.

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -36,10 +36,10 @@ public unsafe partial struct UInt1x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref Unsafe.As<uint, uint>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(uint) * row)));
+    public ref uint this[int row] => ref *(uint*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x1"/> instance.
@@ -329,10 +329,10 @@ public unsafe partial struct UInt1x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref Unsafe.As<uint, UInt2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt2) * row)));
+    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x2"/> instance.
@@ -640,10 +640,10 @@ public unsafe partial struct UInt1x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref Unsafe.As<uint, UInt3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt3) * row)));
+    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x3"/> instance.
@@ -963,10 +963,10 @@ public unsafe partial struct UInt1x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref Unsafe.As<uint, UInt4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt4) * row)));
+    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x4"/> instance.
@@ -1283,10 +1283,10 @@ public unsafe partial struct UInt2x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref Unsafe.As<uint, uint>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(uint) * row)));
+    public ref uint this[int row] => ref *(uint*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x1"/> instance.
@@ -1612,10 +1612,10 @@ public unsafe partial struct UInt2x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref Unsafe.As<uint, UInt2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt2) * row)));
+    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x2"/> instance.
@@ -1961,10 +1961,10 @@ public unsafe partial struct UInt2x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref Unsafe.As<uint, UInt3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt3) * row)));
+    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x3"/> instance.
@@ -2336,10 +2336,10 @@ public unsafe partial struct UInt2x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref Unsafe.As<uint, UInt4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt4) * row)));
+    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x4"/> instance.
@@ -2683,10 +2683,10 @@ public unsafe partial struct UInt3x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref Unsafe.As<uint, uint>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(uint) * row)));
+    public ref uint this[int row] => ref *(uint*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x1"/> instance.
@@ -3032,10 +3032,10 @@ public unsafe partial struct UInt3x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref Unsafe.As<uint, UInt2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt2) * row)));
+    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x2"/> instance.
@@ -3414,10 +3414,10 @@ public unsafe partial struct UInt3x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref Unsafe.As<uint, UInt3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt3) * row)));
+    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x3"/> instance.
@@ -3835,10 +3835,10 @@ public unsafe partial struct UInt3x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref Unsafe.As<uint, UInt4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt4) * row)));
+    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x4"/> instance.
@@ -4215,10 +4215,10 @@ public unsafe partial struct UInt4x1
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref Unsafe.As<uint, uint>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(uint) * row)));
+    public ref uint this[int row] => ref *(uint*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x1"/> instance.
@@ -4584,10 +4584,10 @@ public unsafe partial struct UInt4x2
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref Unsafe.As<uint, UInt2>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt2) * row)));
+    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x2"/> instance.
@@ -4999,10 +4999,10 @@ public unsafe partial struct UInt4x3
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref Unsafe.As<uint, UInt3>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt3) * row)));
+    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x3"/> instance.
@@ -5466,10 +5466,10 @@ public unsafe partial struct UInt4x4
     /// <param name="row">The row to access.</param>
     /// <remarks>
     /// <para>Unlike with vector types, these properties cannot validate in advance which combinations are writeable, so callers should ensure proper use.</para>
-    /// <para>Invoking this method with an invalid row argument results in undefined behavior.</para>
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref Unsafe.As<uint, UInt4>(ref Unsafe.AddByteOffset(ref this.m11, (nint)(uint)(sizeof(UInt4) * row)));
+    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x4"/> instance.

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
@@ -14,6 +14,123 @@ namespace ComputeSharp.D2D1.Interop;
 public static class D2D1PixelShader
 {
     /// <summary>
+    /// Gets the size of the constant buffer for a D2D1 pixel shader of a specified type.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to retrieve info for.</typeparam>
+    /// <returns>The size of the constant buffer for a D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static int GetConstantBufferSize<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.ConstantBufferSize;
+    }
+
+    /// <summary>
+    /// Gets the number of inputs from an input D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the input count for.</typeparam>
+    /// <returns>The number of inputs for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static int GetInputCount<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.InputCount;
+    }
+
+    /// <summary>
+    /// Gets the number of resource textures for a D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the resource texture count for.</typeparam>
+    /// <returns>The number of resource texture for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static int GetResourceTextureCount<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.ResourceTextureCount;
+    }
+
+    /// <summary>
+    /// Gets the input types for a D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the input types for.</typeparam>
+    /// <returns>The input types of the target D2D1 pixel shader.</returns>
+    public static ReadOnlyMemory<D2D1PixelShaderInputType> GetInputTypes<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.InputTypes;
+    }
+
+    /// <summary>
+    /// Gets the available input descriptions for a D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the input descriptions for.</typeparam>
+    /// <returns>A <see cref="ReadOnlyMemory{T}"/> with the available input descriptions for the shader.</returns>
+    public static ReadOnlyMemory<D2D1InputDescription> GetInputDescriptions<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.InputDescriptions;
+    }
+
+    /// <summary>
+    /// Gets the available resource texture descriptions for a D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the resource texture descriptions for.</typeparam>
+    /// <returns>A <see cref="ReadOnlyMemory{T}"/> with the available resource texture descriptions for the shader.</returns>
+    public static ReadOnlyMemory<D2D1ResourceTextureDescription> GetResourceTextureDescriptions<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.ResourceTextureDescriptions;
+    }
+
+    /// <summary>
+    /// Gets the pixel options from an input D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the pixel options for.</typeparam>
+    /// <returns>The pixel options for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static D2D1PixelOptions GetPixelOptions<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.PixelOptions;
+    }
+
+    /// <summary>
+    /// Gets the buffer precision for the output buffer of a D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the output buffer precision for.</typeparam>
+    /// <returns>The output buffer precision for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static D2D1BufferPrecision GetOutputBufferPrecision<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.BufferPrecision;
+    }
+
+    /// <summary>
+    /// Gets the channel depth for the output buffer of a D2D1 pixel shader.
+    /// </summary>
+    /// <typeparam name="T">The type of D2D1 pixel shader to get the output buffer channel depth for.</typeparam>
+    /// <returns>The output buffer channel depth for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
+    public static D2D1ChannelDepth GetOutputBufferChannelDepth<T>()
+        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
+    {
+        Unsafe.SkipInit(out T shader);
+
+        return shader.ChannelDepth;
+    }
+
+    /// <summary>
     /// Loads the bytecode from an input D2D1 pixel shader.
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to load the bytecode for.</typeparam>
@@ -269,110 +386,6 @@ public static class D2D1PixelShader
     }
 
     /// <summary>
-    /// Gets the pixel options from an input D2D1 pixel shader.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to get the pixel options for.</typeparam>
-    /// <returns>The pixel options for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
-    public static D2D1PixelOptions GetPixelOptions<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.PixelOptions;
-    }
-
-    /// <summary>
-    /// Gets the number of inputs from an input D2D1 pixel shader.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to get the input count for.</typeparam>
-    /// <returns>The number of inputs for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
-    public static int GetInputCount<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.InputCount;
-    }
-
-    /// <summary>
-    /// Gets the number of resource textures for a D2D1 pixel shader.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to get the resource texture count for.</typeparam>
-    /// <returns>The number of resource texture for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
-    public static int GetResourceTextureCount<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.ResourceTextureCount;
-    }
-
-    /// <summary>
-    /// Gets the input types for a D2D1 pixel shader.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to get the input types for.</typeparam>
-    /// <returns>The input types of the target D2D1 pixel shader.</returns>
-    public static ReadOnlyMemory<D2D1PixelShaderInputType> GetInputTypes<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.InputTypes;
-    }
-
-    /// <summary>
-    /// Gets the available input descriptions for a D2D1 pixel shader.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to get the input descriptions for.</typeparam>
-    /// <returns>A <see cref="ReadOnlyMemory{T}"/> with the available input descriptions for the shader.</returns>
-    public static ReadOnlyMemory<D2D1InputDescription> GetInputDescriptions<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.InputDescriptions;
-    }
-
-    /// <summary>
-    /// Gets the available resource texture descriptions for a D2D1 pixel shader.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to get the resource texture descriptions for.</typeparam>
-    /// <returns>A <see cref="ReadOnlyMemory{T}"/> with the available resource texture descriptions for the shader.</returns>
-    public static ReadOnlyMemory<D2D1ResourceTextureDescription> GetResourceTextureDescriptions<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.ResourceTextureDescriptions;
-    }
-
-    /// <summary>
-    /// Gets the buffer precision for the output buffer of a D2D1 pixel shader.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to get the output buffer precision for.</typeparam>
-    /// <returns>The output buffer precision for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
-    public static D2D1BufferPrecision GetOutputBufferPrecision<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.BufferPrecision;
-    }
-
-    /// <summary>
-    /// Gets the channel depth for the output buffer of a D2D1 pixel shader.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to get the output buffer channel depth for.</typeparam>
-    /// <returns>The output buffer channel depth for the D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
-    public static D2D1ChannelDepth GetOutputBufferChannelDepth<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.ChannelDepth;
-    }
-
-    /// <summary>
     /// Gets the constant buffer from an input D2D1 pixel shader.
     /// </summary>
     /// <typeparam name="T">The type of D2D1 pixel shader to retrieve info for.</typeparam>
@@ -389,19 +402,6 @@ public static class D2D1PixelShader
         Unsafe.AsRef(in shader).LoadConstantBuffer(in shader, ref dataLoader);
 
         return dataLoader.GetResultingDispatchData();
-    }
-
-    /// <summary>
-    /// Gets the size of the constant buffer for a D2D1 pixel shader of a specified type.
-    /// </summary>
-    /// <typeparam name="T">The type of D2D1 pixel shader to retrieve info for.</typeparam>
-    /// <returns>The size of the constant buffer for a D2D1 pixel shader of type <typeparamref name="T"/>.</returns>
-    public static int GetConstantBufferSize<T>()
-        where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
-    {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.ConstantBufferSize;
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

This PR removes the row accessor for matrix types and refactors the generated code to manually access rows.