### PR TITLE
Only declare valid resource texture manager properties in effect XML

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
@@ -107,6 +107,7 @@ public static unsafe class D2D1PixelShaderEffect
 
         fixed (char* pXml = effectXml.GetBuffer())
         fixed (char* pBufferPropertyName = nameof(D2D1PixelShaderEffectProperty.ConstantBuffer))
+        fixed (char* pTransformMapperPropertyName = nameof(D2D1PixelShaderEffectProperty.TransformMapper))
         fixed (char* pResourceTextureManager0PropertyName = nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager0))
         fixed (char* pResourceTextureManager1PropertyName = nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager1))
         fixed (char* pResourceTextureManager2PropertyName = nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager2))
@@ -123,70 +124,69 @@ public static unsafe class D2D1PixelShaderEffect
         fixed (char* pResourceTextureManager13PropertyName = nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager13))
         fixed (char* pResourceTextureManager14PropertyName = nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager14))
         fixed (char* pResourceTextureManager15PropertyName = nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager15))
-        fixed (char* pTransformMapperPropertyName = nameof(D2D1PixelShaderEffectProperty.TransformMapper))
         {
             // Prepare the effect binding functions
-            D2D1_PROPERTY_BINDING* d2D1PropertyBinding = stackalloc D2D1_PROPERTY_BINDING[(int)D2D1PixelShaderEffectProperty.NumberOfProperties];
+            D2D1_PROPERTY_BINDING* d2D1PropertyBinding = stackalloc D2D1_PROPERTY_BINDING[D2D1PixelShaderEffectProperty.MaximumNumberOfAvailableProperties];
 
             // Property names
-            d2D1PropertyBinding[0].propertyName = (ushort*)pBufferPropertyName;
-            d2D1PropertyBinding[1].propertyName = (ushort*)pResourceTextureManager0PropertyName;
-            d2D1PropertyBinding[2].propertyName = (ushort*)pResourceTextureManager1PropertyName;
-            d2D1PropertyBinding[3].propertyName = (ushort*)pResourceTextureManager2PropertyName;
-            d2D1PropertyBinding[4].propertyName = (ushort*)pResourceTextureManager3PropertyName;
-            d2D1PropertyBinding[5].propertyName = (ushort*)pResourceTextureManager4PropertyName;
-            d2D1PropertyBinding[6].propertyName = (ushort*)pResourceTextureManager5PropertyName;
-            d2D1PropertyBinding[7].propertyName = (ushort*)pResourceTextureManager6PropertyName;
-            d2D1PropertyBinding[8].propertyName = (ushort*)pResourceTextureManager7PropertyName;
-            d2D1PropertyBinding[9].propertyName = (ushort*)pResourceTextureManager8PropertyName;
-            d2D1PropertyBinding[10].propertyName = (ushort*)pResourceTextureManager9PropertyName;
-            d2D1PropertyBinding[11].propertyName = (ushort*)pResourceTextureManager10PropertyName;
-            d2D1PropertyBinding[12].propertyName = (ushort*)pResourceTextureManager11PropertyName;
-            d2D1PropertyBinding[13].propertyName = (ushort*)pResourceTextureManager12PropertyName;
-            d2D1PropertyBinding[14].propertyName = (ushort*)pResourceTextureManager13PropertyName;
-            d2D1PropertyBinding[15].propertyName = (ushort*)pResourceTextureManager14PropertyName;
-            d2D1PropertyBinding[16].propertyName = (ushort*)pResourceTextureManager15PropertyName;
-            d2D1PropertyBinding[17].propertyName = (ushort*)pTransformMapperPropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ConstantBuffer].propertyName = (ushort*)pBufferPropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.TransformMapper].propertyName = (ushort*)pTransformMapperPropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager0].propertyName = (ushort*)pResourceTextureManager0PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager1].propertyName = (ushort*)pResourceTextureManager1PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager2].propertyName = (ushort*)pResourceTextureManager2PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager3].propertyName = (ushort*)pResourceTextureManager3PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager4].propertyName = (ushort*)pResourceTextureManager4PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager5].propertyName = (ushort*)pResourceTextureManager5PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager6].propertyName = (ushort*)pResourceTextureManager6PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager7].propertyName = (ushort*)pResourceTextureManager7PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager8].propertyName = (ushort*)pResourceTextureManager8PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager9].propertyName = (ushort*)pResourceTextureManager9PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager10].propertyName = (ushort*)pResourceTextureManager10PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager11].propertyName = (ushort*)pResourceTextureManager11PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager12].propertyName = (ushort*)pResourceTextureManager12PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager13].propertyName = (ushort*)pResourceTextureManager13PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager14].propertyName = (ushort*)pResourceTextureManager14PropertyName;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager15].propertyName = (ushort*)pResourceTextureManager15PropertyName;
 
             // Property getters
-            d2D1PropertyBinding[0].getFunction = PixelShaderEffect.GetConstantBuffer;
-            d2D1PropertyBinding[1].getFunction = PixelShaderEffect.GetResourceTextureManager0;
-            d2D1PropertyBinding[2].getFunction = PixelShaderEffect.GetResourceTextureManager1;
-            d2D1PropertyBinding[3].getFunction = PixelShaderEffect.GetResourceTextureManager2;
-            d2D1PropertyBinding[4].getFunction = PixelShaderEffect.GetResourceTextureManager3;
-            d2D1PropertyBinding[5].getFunction = PixelShaderEffect.GetResourceTextureManager4;
-            d2D1PropertyBinding[6].getFunction = PixelShaderEffect.GetResourceTextureManager5;
-            d2D1PropertyBinding[7].getFunction = PixelShaderEffect.GetResourceTextureManager6;
-            d2D1PropertyBinding[8].getFunction = PixelShaderEffect.GetResourceTextureManager7;
-            d2D1PropertyBinding[9].getFunction = PixelShaderEffect.GetResourceTextureManager8;
-            d2D1PropertyBinding[10].getFunction = PixelShaderEffect.GetResourceTextureManager9;
-            d2D1PropertyBinding[11].getFunction = PixelShaderEffect.GetResourceTextureManager10;
-            d2D1PropertyBinding[12].getFunction = PixelShaderEffect.GetResourceTextureManager11;
-            d2D1PropertyBinding[13].getFunction = PixelShaderEffect.GetResourceTextureManager12;
-            d2D1PropertyBinding[14].getFunction = PixelShaderEffect.GetResourceTextureManager13;
-            d2D1PropertyBinding[15].getFunction = PixelShaderEffect.GetResourceTextureManager14;
-            d2D1PropertyBinding[16].getFunction = PixelShaderEffect.GetResourceTextureManager15;
-            d2D1PropertyBinding[17].getFunction = PixelShaderEffect.GetTransformMapper;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ConstantBuffer].getFunction = PixelShaderEffect.GetConstantBuffer;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.TransformMapper].getFunction = PixelShaderEffect.GetTransformMapper;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager0].getFunction = PixelShaderEffect.GetResourceTextureManager0;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager1].getFunction = PixelShaderEffect.GetResourceTextureManager1;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager2].getFunction = PixelShaderEffect.GetResourceTextureManager2;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager3].getFunction = PixelShaderEffect.GetResourceTextureManager3;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager4].getFunction = PixelShaderEffect.GetResourceTextureManager4;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager5].getFunction = PixelShaderEffect.GetResourceTextureManager5;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager6].getFunction = PixelShaderEffect.GetResourceTextureManager6;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager7].getFunction = PixelShaderEffect.GetResourceTextureManager7;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager8].getFunction = PixelShaderEffect.GetResourceTextureManager8;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager9].getFunction = PixelShaderEffect.GetResourceTextureManager9;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager10].getFunction = PixelShaderEffect.GetResourceTextureManager10;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager11].getFunction = PixelShaderEffect.GetResourceTextureManager11;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager12].getFunction = PixelShaderEffect.GetResourceTextureManager12;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager13].getFunction = PixelShaderEffect.GetResourceTextureManager13;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager14].getFunction = PixelShaderEffect.GetResourceTextureManager14;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager15].getFunction = PixelShaderEffect.GetResourceTextureManager15;
 
             // Property setters
-            d2D1PropertyBinding[0].setFunction = PixelShaderEffect.SetConstantBuffer;
-            d2D1PropertyBinding[1].setFunction = PixelShaderEffect.SetResourceTextureManager0;
-            d2D1PropertyBinding[2].setFunction = PixelShaderEffect.SetResourceTextureManager1;
-            d2D1PropertyBinding[3].setFunction = PixelShaderEffect.SetResourceTextureManager2;
-            d2D1PropertyBinding[4].setFunction = PixelShaderEffect.SetResourceTextureManager3;
-            d2D1PropertyBinding[5].setFunction = PixelShaderEffect.SetResourceTextureManager4;
-            d2D1PropertyBinding[6].setFunction = PixelShaderEffect.SetResourceTextureManager5;
-            d2D1PropertyBinding[7].setFunction = PixelShaderEffect.SetResourceTextureManager6;
-            d2D1PropertyBinding[8].setFunction = PixelShaderEffect.SetResourceTextureManager7;
-            d2D1PropertyBinding[9].setFunction = PixelShaderEffect.SetResourceTextureManager8;
-            d2D1PropertyBinding[10].setFunction = PixelShaderEffect.SetResourceTextureManager9;
-            d2D1PropertyBinding[11].setFunction = PixelShaderEffect.SetResourceTextureManager10;
-            d2D1PropertyBinding[12].setFunction = PixelShaderEffect.SetResourceTextureManager11;
-            d2D1PropertyBinding[13].setFunction = PixelShaderEffect.SetResourceTextureManager12;
-            d2D1PropertyBinding[14].setFunction = PixelShaderEffect.SetResourceTextureManager13;
-            d2D1PropertyBinding[15].setFunction = PixelShaderEffect.SetResourceTextureManager14;
-            d2D1PropertyBinding[16].setFunction = PixelShaderEffect.SetResourceTextureManager15;
-            d2D1PropertyBinding[17].setFunction = PixelShaderEffect.SetTransformMapper;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ConstantBuffer].setFunction = PixelShaderEffect.SetConstantBuffer;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.TransformMapper].setFunction = PixelShaderEffect.SetTransformMapper;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager0].setFunction = PixelShaderEffect.SetResourceTextureManager0;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager1].setFunction = PixelShaderEffect.SetResourceTextureManager1;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager2].setFunction = PixelShaderEffect.SetResourceTextureManager2;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager3].setFunction = PixelShaderEffect.SetResourceTextureManager3;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager4].setFunction = PixelShaderEffect.SetResourceTextureManager4;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager5].setFunction = PixelShaderEffect.SetResourceTextureManager5;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager6].setFunction = PixelShaderEffect.SetResourceTextureManager6;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager7].setFunction = PixelShaderEffect.SetResourceTextureManager7;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager8].setFunction = PixelShaderEffect.SetResourceTextureManager8;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager9].setFunction = PixelShaderEffect.SetResourceTextureManager9;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager10].setFunction = PixelShaderEffect.SetResourceTextureManager10;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager11].setFunction = PixelShaderEffect.SetResourceTextureManager11;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager12].setFunction = PixelShaderEffect.SetResourceTextureManager12;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager13].setFunction = PixelShaderEffect.SetResourceTextureManager13;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager14].setFunction = PixelShaderEffect.SetResourceTextureManager14;
+            d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager15].setFunction = PixelShaderEffect.SetResourceTextureManager15;
 
             fixed (Guid* pGuid = &PixelShaderEffect.For<T>.Instance.Id)
             {
@@ -195,7 +195,7 @@ public static unsafe class D2D1PixelShaderEffect
                     classId: pGuid,
                     propertyXml: (ushort*)pXml,
                     bindings: d2D1PropertyBinding,
-                    bindingsCount: D2D1PixelShaderEffectProperty.NumberOfProperties,
+                    bindingsCount: (uint)(D2D1PixelShaderEffectProperty.NumberOfAlwaysAvailableProperties + D2D1PixelShader.GetResourceTextureCount<T>()),
                     effectFactory: PixelShaderEffect.For<T>.Instance.Factory).Assert();
             }
 
@@ -273,79 +273,119 @@ public static unsafe class D2D1PixelShaderEffect
         }
 
         // Bindings
-        writer.Write(D2D1PixelShaderEffectProperty.NumberOfProperties);
+        writer.Write(D2D1PixelShaderEffectProperty.NumberOfAlwaysAvailableProperties + D2D1PixelShader.GetResourceTextureCount<T>());
         writer.Write("ConstantBuffer"u8);
         writer.Write((byte)'\0');
         writer.Write((nint)PixelShaderEffect.GetConstantBuffer);
         writer.Write((nint)PixelShaderEffect.SetConstantBuffer);
-        writer.Write("ResourceTextureManager0"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager0);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager0);
-        writer.Write("ResourceTextureManager1"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager1);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager1);
-        writer.Write("ResourceTextureManager2"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager2);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager2);
-        writer.Write("ResourceTextureManager3"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager3);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager3);
-        writer.Write("ResourceTextureManager4"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager4);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager4);
-        writer.Write("ResourceTextureManager5"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager5);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager5);
-        writer.Write("ResourceTextureManager6"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager6);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager6);
-        writer.Write("ResourceTextureManager7"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager7);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager7);
-        writer.Write("ResourceTextureManager8"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager8);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager8);
-        writer.Write("ResourceTextureManager9"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager9);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager9);
-        writer.Write("ResourceTextureManager10"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager10);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager10);
-        writer.Write("ResourceTextureManager11"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager11);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager11);
-        writer.Write("ResourceTextureManager12"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager12);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager12);
-        writer.Write("ResourceTextureManager13"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager13);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager13);
-        writer.Write("ResourceTextureManager14"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager14);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager14);
-        writer.Write("ResourceTextureManager15"u8);
-        writer.Write((byte)'\0');
-        writer.Write((nint)PixelShaderEffect.GetResourceTextureManager15);
-        writer.Write((nint)PixelShaderEffect.SetResourceTextureManager15);
         writer.Write("TransformMapper"u8);
         writer.Write((byte)'\0');
         writer.Write((nint)PixelShaderEffect.GetTransformMapper);
         writer.Write((nint)PixelShaderEffect.SetTransformMapper);
+
+        // Add all resource texture manager property bindings
+        for (int i = 0; i < D2D1PixelShader.GetResourceTextureCount<T>(); i++)
+        {
+            switch (i)
+            {
+                case 0:
+                    writer.Write("ResourceTextureManager0"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager0);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager0);
+                    break;
+                case 1:
+                    writer.Write("ResourceTextureManager1"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager1);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager1);
+                    break;
+                case 2:
+                    writer.Write("ResourceTextureManager2"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager2);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager2);
+                    break;
+                case 3:
+                    writer.Write("ResourceTextureManager3"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager3);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager3);
+                    break;
+                case 4:
+                    writer.Write("ResourceTextureManager4"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager4);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager4);
+                    break;
+                case 5:
+                    writer.Write("ResourceTextureManager5"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager5);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager5);
+                    break;
+                case 6:
+                    writer.Write("ResourceTextureManager6"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager6);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager6);
+                    break;
+                case 7:
+                    writer.Write("ResourceTextureManager7"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager7);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager7);
+                    break;
+                case 8:
+                    writer.Write("ResourceTextureManager8"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager8);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager8);
+                    break;
+                case 9:
+                    writer.Write("ResourceTextureManager9"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager9);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager9);
+                    break;
+                case 10:
+                    writer.Write("ResourceTextureManager10"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager10);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager10);
+                    break;
+                case 11:
+                    writer.Write("ResourceTextureManager11"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager11);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager11);
+                    break;
+                case 12:
+                    writer.Write("ResourceTextureManager12"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager12);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager12);
+                    break;
+                case 13:
+                    writer.Write("ResourceTextureManager13"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager13);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager13);
+                    break;
+                case 14:
+                    writer.Write("ResourceTextureManager14"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager14);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager14);
+                    break;
+                case 15:
+                    writer.Write("ResourceTextureManager15"u8);
+                    writer.Write((byte)'\0');
+                    writer.Write((nint)PixelShaderEffect.GetResourceTextureManager15);
+                    writer.Write((nint)PixelShaderEffect.SetResourceTextureManager15);
+                    break;
+            }
+        }
 
         // Effect factory
         writer.Write((nint)PixelShaderEffect.For<T>.Instance.Factory);
@@ -410,16 +450,18 @@ public static unsafe class D2D1PixelShaderEffect
     /// </summary>
     /// <param name="d2D1Effect">A pointer to the <c>ID2D1Effect</c> instance to use.</param>
     /// <param name="resourceTextureManager">The input <c>ID2D1ResourceTextureManager</c> object (see <see cref="D2D1ResourceTextureManager"/>).</param>
-    /// <param name="resourceTextureIndex">The index of the resource texture to assign the resource texture manager to.</param>
+    /// <param name="index">The index of the resource texture manager to assign the resource texture manager to (note: this might not match the resource texture index).</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="d2D1Effect"/> or <paramref name="resourceTextureManager"/> are <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="index"/> is outside of the allowed range (ie. [0, 16]).</exception>
     /// <remarks>For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1properties-setvalue(uint32_d2d1_property_type_constbyte_uint32)"/>.</remarks>
-    public static void SetResourceTextureManagerForD2D1Effect(void* d2D1Effect, void* resourceTextureManager, int resourceTextureIndex)
+    public static void SetResourceTextureManagerForD2D1Effect(void* d2D1Effect, void* resourceTextureManager, int index)
     {
         default(ArgumentNullException).ThrowIfNull(d2D1Effect);
         default(ArgumentNullException).ThrowIfNull(resourceTextureManager);
+        default(ArgumentOutOfRangeException).ThrowIfNotInRange(index, 0, 16);
 
         ((ID2D1Effect*)d2D1Effect)->SetValue(
-            index: D2D1PixelShaderEffectProperty.ResourceTextureManager0 + (uint)resourceTextureIndex,
+            index: D2D1PixelShaderEffectProperty.ResourceTextureManager0 + (uint)index,
             type: D2D1_PROPERTY_TYPE.D2D1_PROPERTY_TYPE_IUNKNOWN,
             data: (byte*)&resourceTextureManager,
             dataSize: (uint)sizeof(void*)).Assert();
@@ -430,20 +472,22 @@ public static unsafe class D2D1PixelShaderEffect
     /// </summary>
     /// <param name="d2D1Effect">A pointer to the <c>ID2D1Effect</c> instance to use.</param>
     /// <param name="resourceTextureManager">The input <see cref="D2D1ResourceTextureManager"/> instance.</param>
-    /// <param name="resourceTextureIndex">The index of the resource texture to assign the resource texture manager to.</param>
+    /// <param name="index">The index of the resource texture manager to assign the resource texture manager to (note: this might not match the resource texture index)</param>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="d2D1Effect"/> or <paramref name="resourceTextureManager"/> are <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="index"/> is outside of the allowed range (ie. [0, 16]).</exception>
     /// <remarks>For more info, see <see href="https://docs.microsoft.com/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1properties-setvalue(uint32_d2d1_property_type_constbyte_uint32)"/>.</remarks>
-    public static void SetResourceTextureManagerForD2D1Effect(void* d2D1Effect, D2D1ResourceTextureManager resourceTextureManager, int resourceTextureIndex)
+    public static void SetResourceTextureManagerForD2D1Effect(void* d2D1Effect, D2D1ResourceTextureManager resourceTextureManager, int index)
     {
         default(ArgumentNullException).ThrowIfNull(d2D1Effect);
         default(ArgumentNullException).ThrowIfNull(resourceTextureManager);
+        default(ArgumentOutOfRangeException).ThrowIfNotInRange(index, 0, 16);
 
         using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager2 = default;
 
         resourceTextureManager.GetD2D1ResourceTextureManager(resourceTextureManager2.GetAddressOf());
 
         ((ID2D1Effect*)d2D1Effect)->SetValue(
-            index: D2D1PixelShaderEffectProperty.ResourceTextureManager0 + (uint)resourceTextureIndex,
+            index: D2D1PixelShaderEffectProperty.ResourceTextureManager0 + (uint)index,
             type: D2D1_PROPERTY_TYPE.D2D1_PROPERTY_TYPE_IUNKNOWN,
             data: (byte*)resourceTextureManager2.GetAddressOf(),
             dataSize: (uint)sizeof(void*)).Assert();

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffectProperty.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffectProperty.cs
@@ -18,102 +18,6 @@ public static class D2D1PixelShaderEffectProperty
     public const uint ConstantBuffer = 0;
 
     /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 0.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager0 = 1;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 1.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager1 = 2;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 2.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager2 = 3;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 3.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager3 = 4;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 4.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager4 = 5;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 5.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager5 = 6;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 6.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager6 = 7;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 7.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager7 = 8;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 8.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager8 = 9;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 9.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager9 = 10;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 10.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager10 = 11;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 11.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager11 = 12;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 12.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager12 = 13;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 13.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager13 = 14;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 14.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager14 = 15;
-
-    /// <summary>
-    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 15.
-    /// </summary>
-    /// <remarks>For more info, see <see cref="D2D1ResourceTextureManager"/>.</remarks>
-    public const uint ResourceTextureManager15 = 16;
-
-    /// <summary>
     /// The index for the <c>ID2D1TransformMapper</c> property of a <see cref="D2D1PixelShaderEffect"/> object.
     /// </summary>
     /// <remarks>
@@ -121,11 +25,116 @@ public static class D2D1PixelShaderEffectProperty
     /// <para>This value can be passed when calling <c>ID2D1Effect::SetValue</c>.</para>
     /// <para>For more info, see <see href="https://learn.microsoft.com/en-us/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1properties-setvalue(uint32_d2d1_property_type_constbyte_uint32)"/>.</para>
     /// </remarks>
-    public const uint TransformMapper = 17;
+    public const uint TransformMapper = 1;
 
     /// <summary>
-    /// The total number of properties.
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 0.
+    /// </summary>
+    /// <remarks>
+    /// <para>For more info, see <see cref="D2D1ResourceTextureManager"/>.</para>
+    /// <para>This property is only available if a shader declares at least N + 1 resource textures.</para>
+    /// </remarks>
+    public const uint ResourceTextureManager0 = 2;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 1.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager1 = 3;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 2.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager2 = 4;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 3.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager3 = 5;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 4.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager4 = 6;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 5.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager5 = 7;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 6.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager6 = 8;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 7.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager7 = 9;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 8.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager8 = 10;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 9.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager9 = 11;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 10.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager10 = 12;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 11.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager11 = 13;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 12.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager12 = 14;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 13.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager13 = 15;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 14.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager14 = 16;
+
+    /// <summary>
+    /// The index for the <c>ID2D1ResourceTextureManager</c> instance for the resource texture at index 15.
+    /// </summary>
+    /// <remarks><inheritdoc cref="ResourceTextureManager0" path="/remarks/node()"/></remarks>
+    public const uint ResourceTextureManager15 = 17;
+
+    /// <summary>
+    /// The maximum total number of properties.
     /// </summary>
     /// <remarks>This should always be the value of the last property above, plus 1.</remarks>
-    internal const uint NumberOfProperties = 18;
+    internal const int MaximumNumberOfAvailableProperties = 18;
+
+    /// <summary>
+    /// The number of always available properties.
+    /// </summary>
+    /// <remarks>These are <see cref="ConstantBuffer"/> and <see cref="TransformMapper"/>.</remarks>
+    internal const int NumberOfAlwaysAvailableProperties = 2;
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
@@ -146,9 +146,9 @@ internal unsafe partial struct PixelShaderEffect
 
             if (Windows.SUCCEEDED(hresult))
             {
-                foreach (ref readonly D2D1ResourceTextureDescription resourceTextureDescription in new ReadOnlySpan<D2D1ResourceTextureDescription>(@this->resourceTextureDescriptions, @this->resourceTextureDescriptionCount))
+                for (int i = 0; i < @this->resourceTextureDescriptionCount; i++)
                 {
-                    using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = @this->resourceTextureManagerBuffer[resourceTextureDescription.Index];
+                    using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = @this->resourceTextureManagerBuffer[i];
 
                     // If the current resource texture manager is not set, we cannot render, as there's an unbound resource texture
                     if (resourceTextureManager.Get() is null)
@@ -179,6 +179,8 @@ internal unsafe partial struct PixelShaderEffect
                     {
                         break;
                     }
+
+                    ref readonly D2D1ResourceTextureDescription resourceTextureDescription = ref @this->resourceTextureDescriptions[i];
 
                     // Set the ID2D1ResourceTexture object to the current index in the ID2D1DrawInfo object in use
                     hresult = @this->d2D1DrawInfo->SetResourceTexture(

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
@@ -277,14 +277,14 @@ unsafe partial struct PixelShaderEffect
     /// <summary>
     /// Gets the resource texture manager for a given index.
     /// </summary>
-    /// <param name="resourceTextureIndex">The index of the resource texture to get the manager for.</param>
+    /// <param name="index">The index of the resource texture manager to assign the resource texture manager to (this might not match the resource texture index).</param>
     /// <param name="data">A pointer to a variable that stores the data that this function retrieves on the property.</param>
     /// <param name="dataSize">The number of bytes in the property to retrieve.</param>
     /// <param name="actualSize">A optional pointer to a variable that stores the actual number of bytes retrieved on the property.</param>
     /// <returns>The <see cref="HRESULT"/> for the operation.</returns>
-    private int GetResourceTextureManagerAtIndex(int resourceTextureIndex, byte* data, uint dataSize, uint* actualSize)
+    private int GetResourceTextureManagerAtIndex(int index, byte* data, uint dataSize, uint* actualSize)
     {
-        if (!IsResourceTextureManagerIndexValid(resourceTextureIndex, out _))
+        if (index >= this.resourceTextureDescriptionCount)
         {
             return E.E_INVALIDARG;
         }
@@ -299,7 +299,7 @@ unsafe partial struct PixelShaderEffect
             return E.E_INVALIDARG;
         }
 
-        using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = this.resourceTextureManagerBuffer[resourceTextureIndex];
+        using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = this.resourceTextureManagerBuffer[index];
 
         HRESULT hresult = resourceTextureManager.CopyTo((ID2D1ResourceTextureManager**)data);
 
@@ -319,13 +319,13 @@ unsafe partial struct PixelShaderEffect
     /// <summary>
     /// Sets the resource texture manager for a given index.
     /// </summary>
-    /// <param name="resourceTextureIndex">The index of the resource texture to set the manager for.</param>
+    /// <param name="index">The index of the resource texture manager to assign the resource texture manager to (this might not match the resource texture index).</param>
     /// <param name="data">A pointer to the data to be set on the property.</param>
     /// <param name="dataSize">The number of bytes in the property set by the function.</param>
     /// <returns>The <see cref="HRESULT"/> for the operation.</returns>
-    private int SetResourceTextureManagerAtIndex(int resourceTextureIndex, byte* data, uint dataSize)
+    private int SetResourceTextureManagerAtIndex(int index, byte* data, uint dataSize)
     {
-        if (!IsResourceTextureManagerIndexValid(resourceTextureIndex, out uint dimensions))
+        if (index >= this.resourceTextureDescriptionCount)
         {
             return E.E_INVALIDARG;
         }
@@ -371,6 +371,8 @@ unsafe partial struct PixelShaderEffect
         // Initialize the resource texture manager, if an effect context is available
         if (this.d2D1EffectContext is not null)
         {
+            uint dimensions = (uint)this.resourceTextureDescriptions[index].Dimensions;
+
             result = resourceTextureManagerInternal.Get()->Initialize(this.d2D1EffectContext, &dimensions);
 
             // ID2D1ResourceTextureManager::Initialize should generally return either S_OK for first
@@ -384,7 +386,7 @@ unsafe partial struct PixelShaderEffect
             }
         }
 
-        ref ID2D1ResourceTextureManager* currentResourceTextureManager = ref this.resourceTextureManagerBuffer[resourceTextureIndex];
+        ref ID2D1ResourceTextureManager* currentResourceTextureManager = ref this.resourceTextureManagerBuffer[index];
 
         // If there's already an existing manager at this index, release it
         if (currentResourceTextureManager is not null)
@@ -396,28 +398,5 @@ unsafe partial struct PixelShaderEffect
         currentResourceTextureManager = resourceTextureManager.Detach();
 
         return S.S_OK;
-    }
-
-    /// <summary>
-    /// Checks whether a given index for a resource texture manager is valid for the current effect.
-    /// </summary>
-    /// <param name="resourceTextureIndex">The index of the resource texture to validate.</param>
-    /// <param name="dimensions">The number of dimensions for the resource texture at the gven index.</param>
-    /// <returns>Whether or not <paramref name="resourceTextureIndex"/> is valid for the current effect.</returns>
-    private readonly bool IsResourceTextureManagerIndexValid(int resourceTextureIndex, out uint dimensions)
-    {
-        foreach (ref readonly D2D1ResourceTextureDescription resourceTextureDescription in new ReadOnlySpan<D2D1ResourceTextureDescription>(this.resourceTextureDescriptions, this.resourceTextureDescriptionCount))
-        {
-            if (resourceTextureDescription.Index == resourceTextureIndex)
-            {
-                dimensions = (uint)resourceTextureDescription.Dimensions;
-
-                return true;
-            }
-        }
-
-        dimensions = 0;
-
-        return false;
     }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -351,11 +351,10 @@ internal unsafe partial struct PixelShaderEffect
                 _ = this.d2D1EffectContext->Release();
             }
 
-            // Use the list of resource texture descriptions to see the indices that might have accepted a resource texture manager.
-            // Then, retrieve all of them and release the ones that had been assigned (from one of the property bindings).
-            foreach (ref readonly D2D1ResourceTextureDescription resourceTextureDescription in new ReadOnlySpan<D2D1ResourceTextureDescription>(this.resourceTextureDescriptions, this.resourceTextureDescriptionCount))
+            // Retrieve all possible resource texture managers in use and release the ones that had been assigned (from one of the property bindings)
+            for (int i = 0; i < this.resourceTextureDescriptionCount; i++)
             {
-                ID2D1ResourceTextureManager* resourceTextureManager = this.resourceTextureManagerBuffer[resourceTextureDescription.Index];
+                ID2D1ResourceTextureManager* resourceTextureManager = this.resourceTextureManagerBuffer[i];
 
                 if (resourceTextureManager is not null)
                 {

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Helpers/D2D1EffectXmlFactory.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Helpers/D2D1EffectXmlFactory.cs
@@ -53,66 +53,32 @@ internal static unsafe class D2D1EffectXmlFactory
                 _ = builder.Append($"        <Input name='Source{i}'/>");
             }
 
-            // Close the inputs tag and add all effect properties
+            // Close the inputs tag and add the always available properties
             _ = builder.Append('\n');
             _ = builder.Append("""
                     </Inputs>
                     <Property name='ConstantBuffer' type='blob'>
                         <Property name='DisplayName' type='string' value='ConstantBuffer'/>
                     </Property>
-                    <Property name='ResourceTextureManager0' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager0'/>
-                    </Property>
-                    <Property name='ResourceTextureManager1' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager1'/>
-                    </Property>
-                    <Property name='ResourceTextureManager2' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager2'/>
-                    </Property>
-                    <Property name='ResourceTextureManager3' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager3'/>
-                    </Property>
-                    <Property name='ResourceTextureManager4' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager4'/>
-                    </Property>
-                    <Property name='ResourceTextureManager5' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager5'/>
-                    </Property>
-                    <Property name='ResourceTextureManager6' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager6'/>
-                    </Property>
-                    <Property name='ResourceTextureManager7' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager7'/>
-                    </Property>
-                    <Property name='ResourceTextureManager8' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager8'/>
-                    </Property>
-                    <Property name='ResourceTextureManager9' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager9'/>
-                    </Property>
-                    <Property name='ResourceTextureManager10' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager10'/>
-                    </Property>
-                    <Property name='ResourceTextureManager11' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager11'/>
-                    </Property>
-                    <Property name='ResourceTextureManager12' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager12'/>
-                    </Property>
-                    <Property name='ResourceTextureManager13' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager13'/>
-                    </Property>
-                    <Property name='ResourceTextureManager14' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager14'/>
-                    </Property>
-                    <Property name='ResourceTextureManager15' type='iunknown'>
-                        <Property name='DisplayName' type='string' value='ResourceTextureManager15'/>
-                    </Property>
                     <Property name='TransformMapper' type='iunknown'>
                         <Property name='DisplayName' type='string' value='TransformMapper'/>
                     </Property>
-                </Effect>
                 """);
+
+            // Add the resource texture manager nodes, if any
+            for (int i = 0; i < D2D1PixelShader.GetResourceTextureCount<T>(); i++)
+            {
+                _ = builder.Append('\n');
+                _ = builder.Append($"""
+                    <Property name='ResourceTextureManager{i}' type='iunknown'>
+                        <Property name='DisplayName' type='string' value='ResourceTextureManager{i}'/>
+                    </Property>
+                """);
+            }
+
+            // Close the effect tag
+            _ = builder.Append('\n');
+            _ = builder.Append("</Effect>");
 
             // Null terminator for the text
             _ = builder.Append('\0');

--- a/tests/ComputeSharp.D2D1.Tests/D2D1EffectRegistrationDataTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1EffectRegistrationDataTests.cs
@@ -18,25 +18,9 @@ public partial class D2D1EffectRegistrationDataTests
         Assert.AreEqual(effectId, data.ClassId);
         Assert.AreEqual(2, data.NumberOfInputs);
         Assert.IsTrue(data.EffectFactory is not null);
-        Assert.AreEqual(18, data.PropertyBindings.Length);
+        Assert.AreEqual(2, data.PropertyBindings.Length);
         Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ConstantBuffer), data.PropertyBindings.Span[0].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager0), data.PropertyBindings.Span[1].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager1), data.PropertyBindings.Span[2].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager2), data.PropertyBindings.Span[3].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager3), data.PropertyBindings.Span[4].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager4), data.PropertyBindings.Span[5].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager5), data.PropertyBindings.Span[6].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager6), data.PropertyBindings.Span[7].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager7), data.PropertyBindings.Span[8].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager8), data.PropertyBindings.Span[9].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager9), data.PropertyBindings.Span[10].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager10), data.PropertyBindings.Span[11].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager11), data.PropertyBindings.Span[12].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager12), data.PropertyBindings.Span[13].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager13), data.PropertyBindings.Span[14].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager14), data.PropertyBindings.Span[15].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager15), data.PropertyBindings.Span[16].PropertyName);
-        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.TransformMapper), data.PropertyBindings.Span[17].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.TransformMapper), data.PropertyBindings.Span[1].PropertyName);
 
         foreach (ref readonly D2D1PropertyBinding propertyBinding in data.PropertyBindings.Span)
         {
@@ -57,54 +41,6 @@ public partial class D2D1EffectRegistrationDataTests
                 </Inputs>
                 <Property name='ConstantBuffer' type='blob'>
                     <Property name='DisplayName' type='string' value='ConstantBuffer'/>
-                </Property>
-                <Property name='ResourceTextureManager0' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager0'/>
-                </Property>
-                <Property name='ResourceTextureManager1' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager1'/>
-                </Property>
-                <Property name='ResourceTextureManager2' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager2'/>
-                </Property>
-                <Property name='ResourceTextureManager3' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager3'/>
-                </Property>
-                <Property name='ResourceTextureManager4' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager4'/>
-                </Property>
-                <Property name='ResourceTextureManager5' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager5'/>
-                </Property>
-                <Property name='ResourceTextureManager6' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager6'/>
-                </Property>
-                <Property name='ResourceTextureManager7' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager7'/>
-                </Property>
-                <Property name='ResourceTextureManager8' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager8'/>
-                </Property>
-                <Property name='ResourceTextureManager9' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager9'/>
-                </Property>
-                <Property name='ResourceTextureManager10' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager10'/>
-                </Property>
-                <Property name='ResourceTextureManager11' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager11'/>
-                </Property>
-                <Property name='ResourceTextureManager12' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager12'/>
-                </Property>
-                <Property name='ResourceTextureManager13' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager13'/>
-                </Property>
-                <Property name='ResourceTextureManager14' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager14'/>
-                </Property>
-                <Property name='ResourceTextureManager15' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager15'/>
                 </Property>
                 <Property name='TransformMapper' type='iunknown'>
                     <Property name='DisplayName' type='string' value='TransformMapper'/>
@@ -147,6 +83,74 @@ public partial class D2D1EffectRegistrationDataTests
                 <Property name='ConstantBuffer' type='blob'>
                     <Property name='DisplayName' type='string' value='ConstantBuffer'/>
                 </Property>
+                <Property name='TransformMapper' type='iunknown'>
+                    <Property name='DisplayName' type='string' value='TransformMapper'/>
+                </Property>
+            </Effect>
+            """, data.PropertyXml);
+    }
+
+    [D2DInputCount(2)]
+    [D2DEffectId("ABF58390-91D2-4F58-AA2B-22D0F6AC069C")]
+    [D2DEffectDisplayName("EffectWithCustomMetadata")]
+    [D2DEffectDescription("A test effect with some custom metadata")]
+    [D2DEffectCategory("Test effects")]
+    [D2DEffectAuthor("Bob Ross")]
+    [AutoConstructor]
+    private readonly partial struct TestRegistrationBlobWithCustomMetadataShader : ID2D1PixelShader
+    {
+        private readonly float a;
+
+        public float4 Execute()
+        {
+            return this.a;
+        }
+    }
+
+    [TestMethod]
+    public unsafe void EffectRegistrationData_WithResourceTextures_Validate()
+    {
+        ReadOnlyMemory<byte> blob = D2D1PixelShaderEffect.GetRegistrationBlob<TestRegistrationBlobWithResourceTextures>(out _);
+        D2D1EffectRegistrationData.V1 data = D2D1EffectRegistrationData.V1.Load(blob);
+
+        Assert.IsTrue(data.EffectFactory is not null);
+        Assert.AreEqual(14, data.PropertyBindings.Length);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ConstantBuffer), data.PropertyBindings.Span[0].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.TransformMapper), data.PropertyBindings.Span[1].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager0), data.PropertyBindings.Span[2].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager1), data.PropertyBindings.Span[3].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager2), data.PropertyBindings.Span[4].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager3), data.PropertyBindings.Span[5].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager4), data.PropertyBindings.Span[6].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager5), data.PropertyBindings.Span[7].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager6), data.PropertyBindings.Span[8].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager7), data.PropertyBindings.Span[9].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager8), data.PropertyBindings.Span[10].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager9), data.PropertyBindings.Span[11].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager10), data.PropertyBindings.Span[12].PropertyName);
+        Assert.AreEqual(nameof(D2D1PixelShaderEffectProperty.ResourceTextureManager11), data.PropertyBindings.Span[13].PropertyName);
+
+        foreach (ref readonly D2D1PropertyBinding propertyBinding in data.PropertyBindings.Span)
+        {
+            Assert.IsTrue(propertyBinding.SetFunction is not null);
+            Assert.IsTrue(propertyBinding.GetFunction is not null);
+        }
+
+        Assert.AreEqual("""
+            <?xml version='1.0'?>
+            <Effect>
+                <Property name='DisplayName' type='string' value=''/>
+                <Property name='Description' type='string' value=''/>
+                <Property name='Category' type='string' value=''/>
+                <Property name='Author' type='string' value=''/>
+                <Inputs>
+                </Inputs>
+                <Property name='ConstantBuffer' type='blob'>
+                    <Property name='DisplayName' type='string' value='ConstantBuffer'/>
+                </Property>
+                <Property name='TransformMapper' type='iunknown'>
+                    <Property name='DisplayName' type='string' value='TransformMapper'/>
+                </Property>
                 <Property name='ResourceTextureManager0' type='iunknown'>
                     <Property name='DisplayName' type='string' value='ResourceTextureManager0'/>
                 </Property>
@@ -183,39 +187,53 @@ public partial class D2D1EffectRegistrationDataTests
                 <Property name='ResourceTextureManager11' type='iunknown'>
                     <Property name='DisplayName' type='string' value='ResourceTextureManager11'/>
                 </Property>
-                <Property name='ResourceTextureManager12' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager12'/>
-                </Property>
-                <Property name='ResourceTextureManager13' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager13'/>
-                </Property>
-                <Property name='ResourceTextureManager14' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager14'/>
-                </Property>
-                <Property name='ResourceTextureManager15' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='ResourceTextureManager15'/>
-                </Property>
-                <Property name='TransformMapper' type='iunknown'>
-                    <Property name='DisplayName' type='string' value='TransformMapper'/>
-                </Property>
             </Effect>
             """, data.PropertyXml);
     }
 
-    [D2DInputCount(2)]
-    [D2DEffectId("ABF58390-91D2-4F58-AA2B-22D0F6AC069C")]
-    [D2DEffectDisplayName("EffectWithCustomMetadata")]
-    [D2DEffectDescription("A test effect with some custom metadata")]
-    [D2DEffectCategory("Test effects")]
-    [D2DEffectAuthor("Bob Ross")]
+    [D2DInputCount(0)]
     [AutoConstructor]
-    private readonly partial struct TestRegistrationBlobWithCustomMetadataShader : ID2D1PixelShader
+    private readonly partial struct TestRegistrationBlobWithResourceTextures : ID2D1PixelShader
     {
-        private readonly float a;
+        [D2DResourceTextureIndex(0)]
+        public readonly D2D1ResourceTexture1D<float> t0;
+
+        [D2DResourceTextureIndex(1)]
+        public readonly D2D1ResourceTexture1D<float> t1;
+
+        [D2DResourceTextureIndex(2)]
+        public readonly D2D1ResourceTexture1D<float> t2;
+
+        [D2DResourceTextureIndex(3)]
+        public readonly D2D1ResourceTexture1D<float> t3;
+
+        [D2DResourceTextureIndex(4)]
+        public readonly D2D1ResourceTexture1D<float> t4;
+
+        [D2DResourceTextureIndex(5)]
+        public readonly D2D1ResourceTexture1D<float> t5;
+
+        [D2DResourceTextureIndex(6)]
+        public readonly D2D1ResourceTexture1D<float> t6;
+
+        [D2DResourceTextureIndex(7)]
+        public readonly D2D1ResourceTexture1D<float> t7;
+
+        [D2DResourceTextureIndex(8)]
+        public readonly D2D1ResourceTexture1D<float> t8;
+
+        [D2DResourceTextureIndex(9)]
+        public readonly D2D1ResourceTexture1D<float> t9;
+
+        [D2DResourceTextureIndex(10)]
+        public readonly D2D1ResourceTexture1D<float> t10;
+
+        [D2DResourceTextureIndex(11)]
+        public readonly D2D1ResourceTexture1D<float> t11;
 
         public float4 Execute()
         {
-            return this.a;
+            return 0;
         }
     }
 }

--- a/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
@@ -414,10 +414,10 @@ public sealed partial class BokehBlurEffect
             // Assign the resource textures
             for (int i = 0; i < numberOfComponents; i++)
             {
-                D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(verticalConvolutionEffectsForReals[i].Get(), kernels[i].Reals, 1);
-                D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(verticalConvolutionEffectsForImaginaries[i].Get(), kernels[i].Imaginaries, 1);
-                D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(horizontalConvolutionEffects[i].Get(), kernels[i].Reals, 2);
-                D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(horizontalConvolutionEffects[i].Get(), kernels[i].Imaginaries, 3);
+                D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(verticalConvolutionEffectsForReals[i].Get(), kernels[i].Reals, 0);
+                D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(verticalConvolutionEffectsForImaginaries[i].Get(), kernels[i].Imaginaries, 0);
+                D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(horizontalConvolutionEffects[i].Get(), kernels[i].Reals, 0);
+                D2D1PixelShaderEffect.SetResourceTextureManagerForD2D1Effect(horizontalConvolutionEffects[i].Get(), kernels[i].Imaginaries, 1);
             }
 
             // Set the constant buffers


### PR DESCRIPTION
### Closes #562

### Description

This PR updates the effect XML to only show the resource texture managers that are actually valid. It also introduces the explicit difference between the index of the resource texture _manager_, and the actual resource texture index, which may differ.