### PR TITLE
Fix handling partial record struct types, add test

### DIFF
--- a/src/ComputeSharp.SourceGeneration/Models/TypeInfo.cs
+++ b/src/ComputeSharp.SourceGeneration/Models/TypeInfo.cs
@@ -21,6 +21,7 @@ internal sealed record TypeInfo(string QualifiedName, TypeKind Kind, bool IsReco
     {
         return Kind switch
         {
+            TypeKind.Struct when IsRecord => "record struct",
             TypeKind.Struct => "struct",
             TypeKind.Interface => "interface",
             TypeKind.Class when IsRecord => "record",

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -975,4 +975,37 @@ public partial class D2D1PixelShaderTests
         Assert.AreEqual(left.container1.i2x2.M22, right.container1.i2x2.M22);
         Assert.AreEqual(left.container1.d, right.container1.d);
     }
+
+    public partial class ContainingClass
+    {
+        public partial record ContainingRecord
+        {
+            public partial struct ContainingStruct
+            {
+                public partial record struct ContainingRecordStruct
+                {
+                    public partial interface IContainingInterface
+                    {
+                        [D2DInputCount(0)]
+                        [D2DGeneratedPixelShaderDescriptor]
+                        [AutoConstructor]
+                        public readonly partial struct DeeplyNestedShader : ID2D1PixelShader
+                        {
+                            public float4 Execute()
+                            {
+                                return 0;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    [TestMethod]
+    public void DeeplyNestedShaderType_VerifyGenerator()
+    {
+        // Just a sanity check that the generated code is present
+        Assert.AreEqual(0, D2D1PixelShader.GetInputCount<ContainingClass.ContainingRecord.ContainingStruct.ContainingRecordStruct.IContainingInterface.DeeplyNestedShader>());
+    }
 }


### PR DESCRIPTION
### Description

This PR fixes the hierarchy model to correctly handle record struct types as well.