### PR TITLE
Reduce rooted metadata due to reflection

### DIFF
--- a/src/ComputeSharp.Core.SourceGenerators/ComputeSharp.Core.SourceGenerators.csproj
+++ b/src/ComputeSharp.Core.SourceGenerators/ComputeSharp.Core.SourceGenerators.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\Int3.g.cs" Link="ComputeSharp.Core\Primitives\Int\Int3.g.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\Int4.g.cs" Link="ComputeSharp.Core\Primitives\Int\Int4.g.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\IntMxN.g.cs" Link="ComputeSharp.Core\Primitives\Int\IntMxN.g.cs" />
+    <Compile Include="..\ComputeSharp.Core\Primitives\Internals\UndefinedData.cs" Link="ComputeSharp.Core\Primitives\Internals\UndefinedData.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt2.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt2.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt3.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt3.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt4.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt4.cs" />

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool2.g.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -14,11 +11,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Bool2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int x;
 
@@ -31,7 +23,7 @@ public unsafe partial struct Bool2
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref bool this[int i] => ref *(bool*)UndefinedData;
+    public ref bool this[int i] => ref *(bool*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Bool2"/> value with all components set to <see langword="false"/>.
@@ -70,196 +62,196 @@ public unsafe partial struct Bool2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 XX => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 XX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 XY => ref *(Bool2*)UndefinedData;
+    public ref Bool2 XY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 YX => ref *(Bool2*)UndefinedData;
+    public ref Bool2 YX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 YY => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 YY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XYX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YXY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>R</c> component.
@@ -278,196 +270,196 @@ public unsafe partial struct Bool2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 RR => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 RR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 RG => ref *(Bool2*)UndefinedData;
+    public ref Bool2 RG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 GR => ref *(Bool2*)UndefinedData;
+    public ref Bool2 GR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 GG => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 GG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RGR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GRR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GRR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GRG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GRG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGG => ref *(Bool4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool3.g.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -14,11 +11,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Bool3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int x;
 
@@ -34,7 +26,7 @@ public unsafe partial struct Bool3
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref bool this[int i] => ref *(bool*)UndefinedData;
+    public ref bool this[int i] => ref *(bool*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Bool3"/> value with all components set to <see langword="false"/>.
@@ -84,819 +76,819 @@ public unsafe partial struct Bool3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 XX => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 XX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 XY => ref *(Bool2*)UndefinedData;
+    public ref Bool2 XY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 XZ => ref *(Bool2*)UndefinedData;
+    public ref Bool2 XZ => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 YX => ref *(Bool2*)UndefinedData;
+    public ref Bool2 YX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 YY => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 YY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 YZ => ref *(Bool2*)UndefinedData;
+    public ref Bool2 YZ => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 ZX => ref *(Bool2*)UndefinedData;
+    public ref Bool2 ZX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 ZY => ref *(Bool2*)UndefinedData;
+    public ref Bool2 ZY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 ZZ => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 ZZ => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XYX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 XYZ => ref *(Bool3*)UndefinedData;
+    public ref Bool3 XYZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XZX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XZX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 XZY => ref *(Bool3*)UndefinedData;
+    public ref Bool3 XZY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XZZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XZZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YXY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 YXZ => ref *(Bool3*)UndefinedData;
+    public ref Bool3 YXZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 YZX => ref *(Bool3*)UndefinedData;
+    public ref Bool3 YZX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YZY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YZY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YZZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YZZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ZXY => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ZXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZXZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZXZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ZYX => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ZYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZYZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZYZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZZX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZZX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZZY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZZY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZZZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZZZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>R</c> component.
@@ -921,819 +913,819 @@ public unsafe partial struct Bool3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 RR => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 RR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 RG => ref *(Bool2*)UndefinedData;
+    public ref Bool2 RG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 RB => ref *(Bool2*)UndefinedData;
+    public ref Bool2 RB => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 GR => ref *(Bool2*)UndefinedData;
+    public ref Bool2 GR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 GG => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 GG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 GB => ref *(Bool2*)UndefinedData;
+    public ref Bool2 GB => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 BR => ref *(Bool2*)UndefinedData;
+    public ref Bool2 BR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 BG => ref *(Bool2*)UndefinedData;
+    public ref Bool2 BG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 BB => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 BB => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RGR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 RGB => ref *(Bool3*)UndefinedData;
+    public ref Bool3 RGB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RBR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RBR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 RBG => ref *(Bool3*)UndefinedData;
+    public ref Bool3 RBG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RBB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RBB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GRR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GRR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GRG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GRG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 GRB => ref *(Bool3*)UndefinedData;
+    public ref Bool3 GRB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 GBR => ref *(Bool3*)UndefinedData;
+    public ref Bool3 GBR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GBG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GBG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GBB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GBB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BRR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BRR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 BRG => ref *(Bool3*)UndefinedData;
+    public ref Bool3 BRG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BRB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BRB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 BGR => ref *(Bool3*)UndefinedData;
+    public ref Bool3 BGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BGB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BGB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BBR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BBR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BBG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BBG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BBB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BBB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBBB => ref *(Bool4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool4.g.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -14,11 +11,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Bool4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int x;
 
@@ -37,7 +29,7 @@ public unsafe partial struct Bool4
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref bool this[int i] => ref *(bool*)UndefinedData;
+    public ref bool this[int i] => ref *(bool*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Bool4"/> value with all components set to <see langword="false"/>.
@@ -98,2352 +90,2352 @@ public unsafe partial struct Bool4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 XX => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 XX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 XY => ref *(Bool2*)UndefinedData;
+    public ref Bool2 XY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 XZ => ref *(Bool2*)UndefinedData;
+    public ref Bool2 XZ => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 XW => ref *(Bool2*)UndefinedData;
+    public ref Bool2 XW => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 YX => ref *(Bool2*)UndefinedData;
+    public ref Bool2 YX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 YY => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 YY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 YZ => ref *(Bool2*)UndefinedData;
+    public ref Bool2 YZ => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 YW => ref *(Bool2*)UndefinedData;
+    public ref Bool2 YW => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 ZX => ref *(Bool2*)UndefinedData;
+    public ref Bool2 ZX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 ZY => ref *(Bool2*)UndefinedData;
+    public ref Bool2 ZY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 ZZ => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 ZZ => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 ZW => ref *(Bool2*)UndefinedData;
+    public ref Bool2 ZW => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 WX => ref *(Bool2*)UndefinedData;
+    public ref Bool2 WX => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 WY => ref *(Bool2*)UndefinedData;
+    public ref Bool2 WY => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 WZ => ref *(Bool2*)UndefinedData;
+    public ref Bool2 WZ => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 WW => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 WW => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XXW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XXW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XYX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 XYZ => ref *(Bool3*)UndefinedData;
+    public ref Bool3 XYZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 XYW => ref *(Bool3*)UndefinedData;
+    public ref Bool3 XYW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XZX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XZX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 XZY => ref *(Bool3*)UndefinedData;
+    public ref Bool3 XZY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XZZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XZZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 XZW => ref *(Bool3*)UndefinedData;
+    public ref Bool3 XZW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XWX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XWX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 XWY => ref *(Bool3*)UndefinedData;
+    public ref Bool3 XWY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 XWZ => ref *(Bool3*)UndefinedData;
+    public ref Bool3 XWZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 XWW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 XWW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YXY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 YXZ => ref *(Bool3*)UndefinedData;
+    public ref Bool3 YXZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 YXW => ref *(Bool3*)UndefinedData;
+    public ref Bool3 YXW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YYW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YYW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 YZX => ref *(Bool3*)UndefinedData;
+    public ref Bool3 YZX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YZY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YZY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YZZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YZZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 YZW => ref *(Bool3*)UndefinedData;
+    public ref Bool3 YZW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 YWX => ref *(Bool3*)UndefinedData;
+    public ref Bool3 YWX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YWY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YWY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 YWZ => ref *(Bool3*)UndefinedData;
+    public ref Bool3 YWZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 YWW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 YWW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ZXY => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ZXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZXZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZXZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ZXW => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ZXW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ZYX => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ZYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZYZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZYZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ZYW => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ZYW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZZX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZZX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZZY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZZY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZZZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZZZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZZW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZZW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ZWX => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ZWX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ZWY => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ZWY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZWZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZWZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ZWW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ZWW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WXX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WXX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 WXY => ref *(Bool3*)UndefinedData;
+    public ref Bool3 WXY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 WXZ => ref *(Bool3*)UndefinedData;
+    public ref Bool3 WXZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WXW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WXW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 WYX => ref *(Bool3*)UndefinedData;
+    public ref Bool3 WYX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WYY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WYY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 WYZ => ref *(Bool3*)UndefinedData;
+    public ref Bool3 WYZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WYW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WYW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 WZX => ref *(Bool3*)UndefinedData;
+    public ref Bool3 WZX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 WZY => ref *(Bool3*)UndefinedData;
+    public ref Bool3 WZY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WZZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WZZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WZW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WZW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WWX => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WWX => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WWY => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WWY => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WWZ => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WWZ => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 WWW => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 WWW => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XXWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XXWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 XYZW => ref *(Bool4*)UndefinedData;
+    public ref Bool4 XYZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 XYWZ => ref *(Bool4*)UndefinedData;
+    public ref Bool4 XYWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XYWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XYWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 XZYW => ref *(Bool4*)UndefinedData;
+    public ref Bool4 XZYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 XZWY => ref *(Bool4*)UndefinedData;
+    public ref Bool4 XZWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XZWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XZWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 XWYZ => ref *(Bool4*)UndefinedData;
+    public ref Bool4 XWYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 XWZY => ref *(Bool4*)UndefinedData;
+    public ref Bool4 XWZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 XWWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 XWWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 YXZW => ref *(Bool4*)UndefinedData;
+    public ref Bool4 YXZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 YXWZ => ref *(Bool4*)UndefinedData;
+    public ref Bool4 YXWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YXWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YXWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YYWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YYWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 YZXW => ref *(Bool4*)UndefinedData;
+    public ref Bool4 YZXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 YZWX => ref *(Bool4*)UndefinedData;
+    public ref Bool4 YZWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YZWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YZWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 YWXZ => ref *(Bool4*)UndefinedData;
+    public ref Bool4 YWXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 YWZX => ref *(Bool4*)UndefinedData;
+    public ref Bool4 YWZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 YWWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 YWWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ZXYW => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ZXYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ZXWY => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ZXWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZXWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZXWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ZYXW => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ZYXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ZYWX => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ZYWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZYWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZYWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZZWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZZWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ZWXY => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ZWXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ZWYX => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ZWYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ZWWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ZWWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 WXYZ => ref *(Bool4*)UndefinedData;
+    public ref Bool4 WXYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 WXZY => ref *(Bool4*)UndefinedData;
+    public ref Bool4 WXZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WXWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WXWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 WYXZ => ref *(Bool4*)UndefinedData;
+    public ref Bool4 WYXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 WYZX => ref *(Bool4*)UndefinedData;
+    public ref Bool4 WYZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WYWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WYWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 WZXY => ref *(Bool4*)UndefinedData;
+    public ref Bool4 WZXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 WZYX => ref *(Bool4*)UndefinedData;
+    public ref Bool4 WZYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WZWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WZWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWXX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWXX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWXY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWXY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWXZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWXZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWXW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWXW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWYX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWYX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWYY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWYY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWYZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWYZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWYW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWYW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWZX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWZX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWZY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWZY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWZZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWZZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWZW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWZW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWWX => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWWX => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWWY => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWWY => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWWZ => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWWZ => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 WWWW => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 WWWW => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the <c>R</c> component.
@@ -2474,2352 +2466,2352 @@ public unsafe partial struct Bool4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 RR => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 RR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 RG => ref *(Bool2*)UndefinedData;
+    public ref Bool2 RG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 RB => ref *(Bool2*)UndefinedData;
+    public ref Bool2 RB => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 RA => ref *(Bool2*)UndefinedData;
+    public ref Bool2 RA => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 GR => ref *(Bool2*)UndefinedData;
+    public ref Bool2 GR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 GG => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 GG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 GB => ref *(Bool2*)UndefinedData;
+    public ref Bool2 GB => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 GA => ref *(Bool2*)UndefinedData;
+    public ref Bool2 GA => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 BR => ref *(Bool2*)UndefinedData;
+    public ref Bool2 BR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 BG => ref *(Bool2*)UndefinedData;
+    public ref Bool2 BG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 BB => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 BB => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 BA => ref *(Bool2*)UndefinedData;
+    public ref Bool2 BA => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 AR => ref *(Bool2*)UndefinedData;
+    public ref Bool2 AR => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 AG => ref *(Bool2*)UndefinedData;
+    public ref Bool2 AG => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool2"/> value with the components <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool2 AB => ref *(Bool2*)UndefinedData;
+    public ref Bool2 AB => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool2"/> value with the components <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool2 AA => ref *(Bool2*)UndefinedData;
+    public readonly ref readonly Bool2 AA => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RRA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RRA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RGR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 RGB => ref *(Bool3*)UndefinedData;
+    public ref Bool3 RGB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 RGA => ref *(Bool3*)UndefinedData;
+    public ref Bool3 RGA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RBR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RBR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 RBG => ref *(Bool3*)UndefinedData;
+    public ref Bool3 RBG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RBB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RBB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 RBA => ref *(Bool3*)UndefinedData;
+    public ref Bool3 RBA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RAR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RAR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 RAG => ref *(Bool3*)UndefinedData;
+    public ref Bool3 RAG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 RAB => ref *(Bool3*)UndefinedData;
+    public ref Bool3 RAB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 RAA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 RAA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GRR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GRR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GRG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GRG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 GRB => ref *(Bool3*)UndefinedData;
+    public ref Bool3 GRB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 GRA => ref *(Bool3*)UndefinedData;
+    public ref Bool3 GRA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GGA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GGA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 GBR => ref *(Bool3*)UndefinedData;
+    public ref Bool3 GBR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GBG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GBG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GBB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GBB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 GBA => ref *(Bool3*)UndefinedData;
+    public ref Bool3 GBA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 GAR => ref *(Bool3*)UndefinedData;
+    public ref Bool3 GAR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GAG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GAG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 GAB => ref *(Bool3*)UndefinedData;
+    public ref Bool3 GAB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 GAA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 GAA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BRR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BRR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 BRG => ref *(Bool3*)UndefinedData;
+    public ref Bool3 BRG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BRB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BRB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 BRA => ref *(Bool3*)UndefinedData;
+    public ref Bool3 BRA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 BGR => ref *(Bool3*)UndefinedData;
+    public ref Bool3 BGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BGB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BGB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 BGA => ref *(Bool3*)UndefinedData;
+    public ref Bool3 BGA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BBR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BBR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BBG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BBG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BBB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BBB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BBA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BBA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 BAR => ref *(Bool3*)UndefinedData;
+    public ref Bool3 BAR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 BAG => ref *(Bool3*)UndefinedData;
+    public ref Bool3 BAG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BAB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BAB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 BAA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 BAA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ARR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ARR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ARG => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ARG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ARB => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ARB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ARA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ARA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 AGR => ref *(Bool3*)UndefinedData;
+    public ref Bool3 AGR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 AGG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 AGG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 AGB => ref *(Bool3*)UndefinedData;
+    public ref Bool3 AGB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 AGA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 AGA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ABR => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ABR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool3 ABG => ref *(Bool3*)UndefinedData;
+    public ref Bool3 ABG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ABB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ABB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 ABA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 ABA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 AAR => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 AAR => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 AAG => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 AAG => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 AAB => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 AAB => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool3 AAA => ref *(Bool3*)UndefinedData;
+    public readonly ref readonly Bool3 AAA => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RRAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RRAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 RGBA => ref *(Bool4*)UndefinedData;
+    public ref Bool4 RGBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 RGAB => ref *(Bool4*)UndefinedData;
+    public ref Bool4 RGAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RGAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RGAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 RBGA => ref *(Bool4*)UndefinedData;
+    public ref Bool4 RBGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 RBAG => ref *(Bool4*)UndefinedData;
+    public ref Bool4 RBAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RBAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RBAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RARR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RARR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RARG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RARG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RARB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RARB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RARA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RARA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RAGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RAGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RAGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RAGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 RAGB => ref *(Bool4*)UndefinedData;
+    public ref Bool4 RAGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RAGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RAGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RABR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RABR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 RABG => ref *(Bool4*)UndefinedData;
+    public ref Bool4 RABG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RABB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RABB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RABA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RABA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RAAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RAAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RAAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RAAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RAAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RAAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 RAAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 RAAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 GRBA => ref *(Bool4*)UndefinedData;
+    public ref Bool4 GRBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 GRAB => ref *(Bool4*)UndefinedData;
+    public ref Bool4 GRAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GRAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GRAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GGAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GGAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 GBRA => ref *(Bool4*)UndefinedData;
+    public ref Bool4 GBRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 GBAR => ref *(Bool4*)UndefinedData;
+    public ref Bool4 GBAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GBAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GBAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GARR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GARR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GARG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GARG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 GARB => ref *(Bool4*)UndefinedData;
+    public ref Bool4 GARB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GARA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GARA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GAGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GAGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GAGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GAGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GAGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GAGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GAGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GAGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 GABR => ref *(Bool4*)UndefinedData;
+    public ref Bool4 GABR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GABG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GABG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GABB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GABB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GABA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GABA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GAAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GAAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GAAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GAAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GAAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GAAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 GAAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 GAAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 BRGA => ref *(Bool4*)UndefinedData;
+    public ref Bool4 BRGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 BRAG => ref *(Bool4*)UndefinedData;
+    public ref Bool4 BRAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BRAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BRAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 BGRA => ref *(Bool4*)UndefinedData;
+    public ref Bool4 BGRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 BGAR => ref *(Bool4*)UndefinedData;
+    public ref Bool4 BGAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BGAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BGAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BBAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BBAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BARR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BARR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 BARG => ref *(Bool4*)UndefinedData;
+    public ref Bool4 BARG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BARB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BARB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BARA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BARA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 BAGR => ref *(Bool4*)UndefinedData;
+    public ref Bool4 BAGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BAGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BAGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BAGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BAGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BAGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BAGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BABR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BABR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BABG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BABG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BABB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BABB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BABA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BABA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BAAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BAAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BAAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BAAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BAAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BAAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 BAAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 BAAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ARGB => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ARGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ARBG => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ARBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ARAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ARAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGRG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 AGRB => ref *(Bool4*)UndefinedData;
+    public ref Bool4 AGRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 AGBR => ref *(Bool4*)UndefinedData;
+    public ref Bool4 AGBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AGAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AGAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABRR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABRR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ABRG => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ABRG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABRB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABRB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABRA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABRA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Bool4 ABGR => ref *(Bool4*)UndefinedData;
+    public ref Bool4 ABGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABBR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABBR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABBG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABBG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABBB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABBB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABBA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABBA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 ABAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 ABAA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AARR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AARR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AARG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AARG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AARB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AARB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AARA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AARA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AAGR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AAGR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AAGG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AAGG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AAGB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AAGB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AAGA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AAGA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AABR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AABR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AABG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AABG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AABB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AABB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AABA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AABA => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AAAR => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AAAR => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AAAG => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AAAG => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AAAB => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AAAB => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Bool4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Bool4 AAAA => ref *(Bool4*)UndefinedData;
+    public readonly ref readonly Bool4 AAAA => ref *(Bool4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/BoolMxN.g.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #pragma warning disable CS0660, CS0661
 
@@ -13,11 +10,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
 public unsafe partial struct Bool1x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool1x1), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -39,7 +31,7 @@ public unsafe partial struct Bool1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref *(bool*)UndefinedData;
+    public ref bool this[int row] => ref *(bool*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x1"/> instance.
@@ -51,7 +43,7 @@ public unsafe partial struct Bool1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x1"/> instance.
@@ -64,7 +56,7 @@ public unsafe partial struct Bool1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x1"/> instance.
@@ -78,7 +70,7 @@ public unsafe partial struct Bool1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -156,11 +148,6 @@ public unsafe partial struct Bool1x1
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Bool1x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool1x2), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -187,7 +174,7 @@ public unsafe partial struct Bool1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x2"/> instance.
@@ -199,7 +186,7 @@ public unsafe partial struct Bool1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x2"/> instance.
@@ -212,7 +199,7 @@ public unsafe partial struct Bool1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x2"/> instance.
@@ -226,7 +213,7 @@ public unsafe partial struct Bool1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -317,11 +304,6 @@ public unsafe partial struct Bool1x2
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Bool1x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool1x3), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -353,7 +335,7 @@ public unsafe partial struct Bool1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x3"/> instance.
@@ -365,7 +347,7 @@ public unsafe partial struct Bool1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x3"/> instance.
@@ -378,7 +360,7 @@ public unsafe partial struct Bool1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x3"/> instance.
@@ -392,7 +374,7 @@ public unsafe partial struct Bool1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -490,11 +472,6 @@ public unsafe partial struct Bool1x3
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Bool1x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool1x4), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -531,7 +508,7 @@ public unsafe partial struct Bool1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x4"/> instance.
@@ -543,7 +520,7 @@ public unsafe partial struct Bool1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x4"/> instance.
@@ -556,7 +533,7 @@ public unsafe partial struct Bool1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool1x4"/> instance.
@@ -570,7 +547,7 @@ public unsafe partial struct Bool1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -675,11 +652,6 @@ public unsafe partial struct Bool1x4
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Bool2x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2x1), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -706,7 +678,7 @@ public unsafe partial struct Bool2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref *(bool*)UndefinedData;
+    public ref bool this[int row] => ref *(bool*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x1"/> instance.
@@ -718,7 +690,7 @@ public unsafe partial struct Bool2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x1"/> instance.
@@ -731,7 +703,7 @@ public unsafe partial struct Bool2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x1"/> instance.
@@ -745,7 +717,7 @@ public unsafe partial struct Bool2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -836,11 +808,6 @@ public unsafe partial struct Bool2x1
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Bool2x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2x2), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -890,7 +857,7 @@ public unsafe partial struct Bool2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x2"/> instance.
@@ -902,7 +869,7 @@ public unsafe partial struct Bool2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x2"/> instance.
@@ -915,7 +882,7 @@ public unsafe partial struct Bool2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x2"/> instance.
@@ -929,7 +896,7 @@ public unsafe partial struct Bool2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -1028,11 +995,6 @@ public unsafe partial struct Bool2x2
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 4)]
 public unsafe partial struct Bool2x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2x3), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -1094,7 +1056,7 @@ public unsafe partial struct Bool2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x3"/> instance.
@@ -1106,7 +1068,7 @@ public unsafe partial struct Bool2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x3"/> instance.
@@ -1119,7 +1081,7 @@ public unsafe partial struct Bool2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x3"/> instance.
@@ -1133,7 +1095,7 @@ public unsafe partial struct Bool2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -1246,11 +1208,6 @@ public unsafe partial struct Bool2x3
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 4)]
 public unsafe partial struct Bool2x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool2x4), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -1324,7 +1281,7 @@ public unsafe partial struct Bool2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x4"/> instance.
@@ -1336,7 +1293,7 @@ public unsafe partial struct Bool2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x4"/> instance.
@@ -1349,7 +1306,7 @@ public unsafe partial struct Bool2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool2x4"/> instance.
@@ -1363,7 +1320,7 @@ public unsafe partial struct Bool2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -1490,11 +1447,6 @@ public unsafe partial struct Bool2x4
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Bool3x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3x1), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -1526,7 +1478,7 @@ public unsafe partial struct Bool3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref *(bool*)UndefinedData;
+    public ref bool this[int row] => ref *(bool*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x1"/> instance.
@@ -1538,7 +1490,7 @@ public unsafe partial struct Bool3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x1"/> instance.
@@ -1551,7 +1503,7 @@ public unsafe partial struct Bool3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x1"/> instance.
@@ -1565,7 +1517,7 @@ public unsafe partial struct Bool3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -1663,11 +1615,6 @@ public unsafe partial struct Bool3x1
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 4)]
 public unsafe partial struct Bool3x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3x2), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -1730,7 +1677,7 @@ public unsafe partial struct Bool3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x2"/> instance.
@@ -1742,7 +1689,7 @@ public unsafe partial struct Bool3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x2"/> instance.
@@ -1755,7 +1702,7 @@ public unsafe partial struct Bool3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x2"/> instance.
@@ -1769,7 +1716,7 @@ public unsafe partial struct Bool3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -1882,11 +1829,6 @@ public unsafe partial struct Bool3x2
 [StructLayout(LayoutKind.Explicit, Size = 36, Pack = 4)]
 public unsafe partial struct Bool3x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3x3), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -1967,7 +1909,7 @@ public unsafe partial struct Bool3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x3"/> instance.
@@ -1979,7 +1921,7 @@ public unsafe partial struct Bool3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x3"/> instance.
@@ -1992,7 +1934,7 @@ public unsafe partial struct Bool3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x3"/> instance.
@@ -2006,7 +1948,7 @@ public unsafe partial struct Bool3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -2140,11 +2082,6 @@ public unsafe partial struct Bool3x3
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 4)]
 public unsafe partial struct Bool3x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool3x4), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -2243,7 +2180,7 @@ public unsafe partial struct Bool3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x4"/> instance.
@@ -2255,7 +2192,7 @@ public unsafe partial struct Bool3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x4"/> instance.
@@ -2268,7 +2205,7 @@ public unsafe partial struct Bool3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool3x4"/> instance.
@@ -2282,7 +2219,7 @@ public unsafe partial struct Bool3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -2437,11 +2374,6 @@ public unsafe partial struct Bool3x4
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Bool4x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4x1), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -2478,7 +2410,7 @@ public unsafe partial struct Bool4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref bool this[int row] => ref *(bool*)UndefinedData;
+    public ref bool this[int row] => ref *(bool*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x1"/> instance.
@@ -2490,7 +2422,7 @@ public unsafe partial struct Bool4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x1"/> instance.
@@ -2503,7 +2435,7 @@ public unsafe partial struct Bool4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x1"/> instance.
@@ -2517,7 +2449,7 @@ public unsafe partial struct Bool4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -2622,11 +2554,6 @@ public unsafe partial struct Bool4x1
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 4)]
 public unsafe partial struct Bool4x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4x2), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -2702,7 +2629,7 @@ public unsafe partial struct Bool4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[int row] => ref *(Bool2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x2"/> instance.
@@ -2714,7 +2641,7 @@ public unsafe partial struct Bool4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x2"/> instance.
@@ -2727,7 +2654,7 @@ public unsafe partial struct Bool4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x2"/> instance.
@@ -2741,7 +2668,7 @@ public unsafe partial struct Bool4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -2868,11 +2795,6 @@ public unsafe partial struct Bool4x2
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 4)]
 public unsafe partial struct Bool4x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4x3), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -2972,7 +2894,7 @@ public unsafe partial struct Bool4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[int row] => ref *(Bool3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x3"/> instance.
@@ -2984,7 +2906,7 @@ public unsafe partial struct Bool4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x3"/> instance.
@@ -2997,7 +2919,7 @@ public unsafe partial struct Bool4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x3"/> instance.
@@ -3011,7 +2933,7 @@ public unsafe partial struct Bool4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].
@@ -3166,11 +3088,6 @@ public unsafe partial struct Bool4x3
 [StructLayout(LayoutKind.Explicit, Size = 64, Pack = 4)]
 public unsafe partial struct Bool4x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Bool4x4), sizeof(Bool4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -3294,7 +3211,7 @@ public unsafe partial struct Bool4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[int row] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x4"/> instance.
@@ -3306,7 +3223,7 @@ public unsafe partial struct Bool4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData;
+    public ref Bool2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Bool2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x4"/> instance.
@@ -3319,7 +3236,7 @@ public unsafe partial struct Bool4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData;
+    public ref Bool3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Bool3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Bool4x4"/> instance.
@@ -3333,7 +3250,7 @@ public unsafe partial struct Bool4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData;
+    public ref Bool4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Bool4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="bool"/> value representing the component at position [1, 1].

--- a/src/ComputeSharp.Core/Primitives/Double/Double2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double2.g.cs
@@ -3,9 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -16,11 +13,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 8)]
 public unsafe partial struct Double2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double2), sizeof(Double4));
-
     [FieldOffset(0)]
     private double x;
 
@@ -33,7 +25,7 @@ public unsafe partial struct Double2
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref double this[int i] => ref *(double*)UndefinedData;
+    public ref double this[int i] => ref *(double*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Double2"/> value with all components set to 0.
@@ -72,196 +64,196 @@ public unsafe partial struct Double2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 XX => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 XX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 XY => ref *(Double2*)UndefinedData;
+    public ref Double2 XY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 YX => ref *(Double2*)UndefinedData;
+    public ref Double2 YX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 YY => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 YY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XYX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YXY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>R</c> component.
@@ -280,196 +272,196 @@ public unsafe partial struct Double2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 RR => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 RR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 RG => ref *(Double2*)UndefinedData;
+    public ref Double2 RG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 GR => ref *(Double2*)UndefinedData;
+    public ref Double2 GR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 GG => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 GG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RGR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GRR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GRR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GRG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GRG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGG => ref *(Double4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Double/Double3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double3.g.cs
@@ -3,9 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -16,11 +13,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 8)]
 public unsafe partial struct Double3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double3), sizeof(Double4));
-
     [FieldOffset(0)]
     private double x;
 
@@ -36,7 +28,7 @@ public unsafe partial struct Double3
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref double this[int i] => ref *(double*)UndefinedData;
+    public ref double this[int i] => ref *(double*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Double3"/> value with all components set to 0.
@@ -86,819 +78,819 @@ public unsafe partial struct Double3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 XX => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 XX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 XY => ref *(Double2*)UndefinedData;
+    public ref Double2 XY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 XZ => ref *(Double2*)UndefinedData;
+    public ref Double2 XZ => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 YX => ref *(Double2*)UndefinedData;
+    public ref Double2 YX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 YY => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 YY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 YZ => ref *(Double2*)UndefinedData;
+    public ref Double2 YZ => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 ZX => ref *(Double2*)UndefinedData;
+    public ref Double2 ZX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 ZY => ref *(Double2*)UndefinedData;
+    public ref Double2 ZY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 ZZ => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 ZZ => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XYX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 XYZ => ref *(Double3*)UndefinedData;
+    public ref Double3 XYZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XZX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XZX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 XZY => ref *(Double3*)UndefinedData;
+    public ref Double3 XZY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XZZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XZZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YXY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 YXZ => ref *(Double3*)UndefinedData;
+    public ref Double3 YXZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 YZX => ref *(Double3*)UndefinedData;
+    public ref Double3 YZX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YZY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YZY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YZZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YZZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ZXY => ref *(Double3*)UndefinedData;
+    public ref Double3 ZXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZXZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZXZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ZYX => ref *(Double3*)UndefinedData;
+    public ref Double3 ZYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZYZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZYZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZZX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZZX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZZY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZZY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZZZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZZZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>R</c> component.
@@ -923,819 +915,819 @@ public unsafe partial struct Double3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 RR => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 RR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 RG => ref *(Double2*)UndefinedData;
+    public ref Double2 RG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 RB => ref *(Double2*)UndefinedData;
+    public ref Double2 RB => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 GR => ref *(Double2*)UndefinedData;
+    public ref Double2 GR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 GG => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 GG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 GB => ref *(Double2*)UndefinedData;
+    public ref Double2 GB => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 BR => ref *(Double2*)UndefinedData;
+    public ref Double2 BR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 BG => ref *(Double2*)UndefinedData;
+    public ref Double2 BG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 BB => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 BB => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RGR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 RGB => ref *(Double3*)UndefinedData;
+    public ref Double3 RGB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RBR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RBR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 RBG => ref *(Double3*)UndefinedData;
+    public ref Double3 RBG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RBB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RBB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GRR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GRR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GRG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GRG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 GRB => ref *(Double3*)UndefinedData;
+    public ref Double3 GRB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 GBR => ref *(Double3*)UndefinedData;
+    public ref Double3 GBR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GBG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GBG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GBB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GBB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BRR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BRR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 BRG => ref *(Double3*)UndefinedData;
+    public ref Double3 BRG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BRB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BRB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 BGR => ref *(Double3*)UndefinedData;
+    public ref Double3 BGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BGB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BGB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BBR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BBR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BBG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BBG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BBB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BBB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBBB => ref *(Double4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Double/Double4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/Double4.g.cs
@@ -3,9 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -16,11 +13,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 8)]
 public unsafe partial struct Double4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double4), sizeof(Double4));
-
     [FieldOffset(0)]
     private double x;
 
@@ -39,7 +31,7 @@ public unsafe partial struct Double4
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref double this[int i] => ref *(double*)UndefinedData;
+    public ref double this[int i] => ref *(double*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Double4"/> value with all components set to 0.
@@ -100,2352 +92,2352 @@ public unsafe partial struct Double4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 XX => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 XX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 XY => ref *(Double2*)UndefinedData;
+    public ref Double2 XY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 XZ => ref *(Double2*)UndefinedData;
+    public ref Double2 XZ => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 XW => ref *(Double2*)UndefinedData;
+    public ref Double2 XW => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 YX => ref *(Double2*)UndefinedData;
+    public ref Double2 YX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 YY => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 YY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 YZ => ref *(Double2*)UndefinedData;
+    public ref Double2 YZ => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 YW => ref *(Double2*)UndefinedData;
+    public ref Double2 YW => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 ZX => ref *(Double2*)UndefinedData;
+    public ref Double2 ZX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 ZY => ref *(Double2*)UndefinedData;
+    public ref Double2 ZY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 ZZ => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 ZZ => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 ZW => ref *(Double2*)UndefinedData;
+    public ref Double2 ZW => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 WX => ref *(Double2*)UndefinedData;
+    public ref Double2 WX => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 WY => ref *(Double2*)UndefinedData;
+    public ref Double2 WY => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 WZ => ref *(Double2*)UndefinedData;
+    public ref Double2 WZ => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 WW => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 WW => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XXW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XXW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XYX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 XYZ => ref *(Double3*)UndefinedData;
+    public ref Double3 XYZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 XYW => ref *(Double3*)UndefinedData;
+    public ref Double3 XYW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XZX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XZX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 XZY => ref *(Double3*)UndefinedData;
+    public ref Double3 XZY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XZZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XZZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 XZW => ref *(Double3*)UndefinedData;
+    public ref Double3 XZW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XWX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XWX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 XWY => ref *(Double3*)UndefinedData;
+    public ref Double3 XWY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 XWZ => ref *(Double3*)UndefinedData;
+    public ref Double3 XWZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 XWW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 XWW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YXY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 YXZ => ref *(Double3*)UndefinedData;
+    public ref Double3 YXZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 YXW => ref *(Double3*)UndefinedData;
+    public ref Double3 YXW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YYW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YYW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 YZX => ref *(Double3*)UndefinedData;
+    public ref Double3 YZX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YZY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YZY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YZZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YZZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 YZW => ref *(Double3*)UndefinedData;
+    public ref Double3 YZW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 YWX => ref *(Double3*)UndefinedData;
+    public ref Double3 YWX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YWY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YWY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 YWZ => ref *(Double3*)UndefinedData;
+    public ref Double3 YWZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 YWW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 YWW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ZXY => ref *(Double3*)UndefinedData;
+    public ref Double3 ZXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZXZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZXZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ZXW => ref *(Double3*)UndefinedData;
+    public ref Double3 ZXW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ZYX => ref *(Double3*)UndefinedData;
+    public ref Double3 ZYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZYZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZYZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ZYW => ref *(Double3*)UndefinedData;
+    public ref Double3 ZYW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZZX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZZX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZZY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZZY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZZZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZZZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZZW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZZW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ZWX => ref *(Double3*)UndefinedData;
+    public ref Double3 ZWX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ZWY => ref *(Double3*)UndefinedData;
+    public ref Double3 ZWY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZWZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZWZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ZWW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ZWW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WXX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WXX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 WXY => ref *(Double3*)UndefinedData;
+    public ref Double3 WXY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 WXZ => ref *(Double3*)UndefinedData;
+    public ref Double3 WXZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WXW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WXW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 WYX => ref *(Double3*)UndefinedData;
+    public ref Double3 WYX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WYY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WYY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 WYZ => ref *(Double3*)UndefinedData;
+    public ref Double3 WYZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WYW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WYW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 WZX => ref *(Double3*)UndefinedData;
+    public ref Double3 WZX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 WZY => ref *(Double3*)UndefinedData;
+    public ref Double3 WZY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WZZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WZZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WZW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WZW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WWX => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WWX => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WWY => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WWY => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WWZ => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WWZ => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 WWW => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 WWW => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XXWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XXWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 XYZW => ref *(Double4*)UndefinedData;
+    public ref Double4 XYZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 XYWZ => ref *(Double4*)UndefinedData;
+    public ref Double4 XYWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XYWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XYWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 XZYW => ref *(Double4*)UndefinedData;
+    public ref Double4 XZYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 XZWY => ref *(Double4*)UndefinedData;
+    public ref Double4 XZWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XZWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XZWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 XWYZ => ref *(Double4*)UndefinedData;
+    public ref Double4 XWYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 XWZY => ref *(Double4*)UndefinedData;
+    public ref Double4 XWZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 XWWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 XWWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 YXZW => ref *(Double4*)UndefinedData;
+    public ref Double4 YXZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 YXWZ => ref *(Double4*)UndefinedData;
+    public ref Double4 YXWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YXWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YXWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YYWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YYWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 YZXW => ref *(Double4*)UndefinedData;
+    public ref Double4 YZXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 YZWX => ref *(Double4*)UndefinedData;
+    public ref Double4 YZWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YZWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YZWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 YWXZ => ref *(Double4*)UndefinedData;
+    public ref Double4 YWXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 YWZX => ref *(Double4*)UndefinedData;
+    public ref Double4 YWZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 YWWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 YWWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ZXYW => ref *(Double4*)UndefinedData;
+    public ref Double4 ZXYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ZXWY => ref *(Double4*)UndefinedData;
+    public ref Double4 ZXWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZXWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZXWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ZYXW => ref *(Double4*)UndefinedData;
+    public ref Double4 ZYXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ZYWX => ref *(Double4*)UndefinedData;
+    public ref Double4 ZYWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZYWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZYWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZZWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZZWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ZWXY => ref *(Double4*)UndefinedData;
+    public ref Double4 ZWXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ZWYX => ref *(Double4*)UndefinedData;
+    public ref Double4 ZWYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ZWWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ZWWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 WXYZ => ref *(Double4*)UndefinedData;
+    public ref Double4 WXYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 WXZY => ref *(Double4*)UndefinedData;
+    public ref Double4 WXZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WXWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WXWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 WYXZ => ref *(Double4*)UndefinedData;
+    public ref Double4 WYXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 WYZX => ref *(Double4*)UndefinedData;
+    public ref Double4 WYZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WYWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WYWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 WZXY => ref *(Double4*)UndefinedData;
+    public ref Double4 WZXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 WZYX => ref *(Double4*)UndefinedData;
+    public ref Double4 WZYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WZWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WZWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWXX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWXX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWXY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWXY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWXZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWXZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWXW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWXW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWYX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWYX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWYY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWYY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWYZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWYZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWYW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWYW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWZX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWZX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWZY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWZY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWZZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWZZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWZW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWZW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWWX => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWWX => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWWY => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWWY => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWWZ => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWWZ => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 WWWW => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 WWWW => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the <c>R</c> component.
@@ -2476,2352 +2468,2352 @@ public unsafe partial struct Double4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 RR => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 RR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 RG => ref *(Double2*)UndefinedData;
+    public ref Double2 RG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 RB => ref *(Double2*)UndefinedData;
+    public ref Double2 RB => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 RA => ref *(Double2*)UndefinedData;
+    public ref Double2 RA => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 GR => ref *(Double2*)UndefinedData;
+    public ref Double2 GR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 GG => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 GG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 GB => ref *(Double2*)UndefinedData;
+    public ref Double2 GB => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 GA => ref *(Double2*)UndefinedData;
+    public ref Double2 GA => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 BR => ref *(Double2*)UndefinedData;
+    public ref Double2 BR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 BG => ref *(Double2*)UndefinedData;
+    public ref Double2 BG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 BB => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 BB => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 BA => ref *(Double2*)UndefinedData;
+    public ref Double2 BA => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 AR => ref *(Double2*)UndefinedData;
+    public ref Double2 AR => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 AG => ref *(Double2*)UndefinedData;
+    public ref Double2 AG => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double2"/> value with the components <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double2 AB => ref *(Double2*)UndefinedData;
+    public ref Double2 AB => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double2"/> value with the components <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double2 AA => ref *(Double2*)UndefinedData;
+    public readonly ref readonly Double2 AA => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RRA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RRA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RGR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 RGB => ref *(Double3*)UndefinedData;
+    public ref Double3 RGB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 RGA => ref *(Double3*)UndefinedData;
+    public ref Double3 RGA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RBR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RBR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 RBG => ref *(Double3*)UndefinedData;
+    public ref Double3 RBG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RBB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RBB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 RBA => ref *(Double3*)UndefinedData;
+    public ref Double3 RBA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RAR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RAR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 RAG => ref *(Double3*)UndefinedData;
+    public ref Double3 RAG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 RAB => ref *(Double3*)UndefinedData;
+    public ref Double3 RAB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 RAA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 RAA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GRR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GRR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GRG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GRG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 GRB => ref *(Double3*)UndefinedData;
+    public ref Double3 GRB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 GRA => ref *(Double3*)UndefinedData;
+    public ref Double3 GRA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GGA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GGA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 GBR => ref *(Double3*)UndefinedData;
+    public ref Double3 GBR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GBG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GBG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GBB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GBB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 GBA => ref *(Double3*)UndefinedData;
+    public ref Double3 GBA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 GAR => ref *(Double3*)UndefinedData;
+    public ref Double3 GAR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GAG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GAG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 GAB => ref *(Double3*)UndefinedData;
+    public ref Double3 GAB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 GAA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 GAA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BRR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BRR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 BRG => ref *(Double3*)UndefinedData;
+    public ref Double3 BRG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BRB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BRB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 BRA => ref *(Double3*)UndefinedData;
+    public ref Double3 BRA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 BGR => ref *(Double3*)UndefinedData;
+    public ref Double3 BGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BGB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BGB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 BGA => ref *(Double3*)UndefinedData;
+    public ref Double3 BGA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BBR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BBR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BBG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BBG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BBB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BBB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BBA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BBA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 BAR => ref *(Double3*)UndefinedData;
+    public ref Double3 BAR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 BAG => ref *(Double3*)UndefinedData;
+    public ref Double3 BAG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BAB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BAB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 BAA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 BAA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ARR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ARR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ARG => ref *(Double3*)UndefinedData;
+    public ref Double3 ARG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ARB => ref *(Double3*)UndefinedData;
+    public ref Double3 ARB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ARA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ARA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 AGR => ref *(Double3*)UndefinedData;
+    public ref Double3 AGR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 AGG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 AGG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 AGB => ref *(Double3*)UndefinedData;
+    public ref Double3 AGB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 AGA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 AGA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ABR => ref *(Double3*)UndefinedData;
+    public ref Double3 ABR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double3 ABG => ref *(Double3*)UndefinedData;
+    public ref Double3 ABG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ABB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ABB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 ABA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 ABA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 AAR => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 AAR => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 AAG => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 AAG => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 AAB => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 AAB => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double3 AAA => ref *(Double3*)UndefinedData;
+    public readonly ref readonly Double3 AAA => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RRAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RRAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 RGBA => ref *(Double4*)UndefinedData;
+    public ref Double4 RGBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 RGAB => ref *(Double4*)UndefinedData;
+    public ref Double4 RGAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RGAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RGAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 RBGA => ref *(Double4*)UndefinedData;
+    public ref Double4 RBGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 RBAG => ref *(Double4*)UndefinedData;
+    public ref Double4 RBAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RBAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RBAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RARR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RARR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RARG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RARG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RARB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RARB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RARA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RARA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RAGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RAGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RAGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RAGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 RAGB => ref *(Double4*)UndefinedData;
+    public ref Double4 RAGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RAGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RAGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RABR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RABR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 RABG => ref *(Double4*)UndefinedData;
+    public ref Double4 RABG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RABB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RABB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RABA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RABA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RAAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RAAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RAAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RAAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RAAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RAAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 RAAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 RAAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 GRBA => ref *(Double4*)UndefinedData;
+    public ref Double4 GRBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 GRAB => ref *(Double4*)UndefinedData;
+    public ref Double4 GRAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GRAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GRAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GGAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GGAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 GBRA => ref *(Double4*)UndefinedData;
+    public ref Double4 GBRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 GBAR => ref *(Double4*)UndefinedData;
+    public ref Double4 GBAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GBAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GBAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GARR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GARR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GARG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GARG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 GARB => ref *(Double4*)UndefinedData;
+    public ref Double4 GARB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GARA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GARA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GAGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GAGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GAGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GAGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GAGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GAGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GAGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GAGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 GABR => ref *(Double4*)UndefinedData;
+    public ref Double4 GABR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GABG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GABG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GABB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GABB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GABA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GABA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GAAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GAAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GAAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GAAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GAAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GAAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 GAAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 GAAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 BRGA => ref *(Double4*)UndefinedData;
+    public ref Double4 BRGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 BRAG => ref *(Double4*)UndefinedData;
+    public ref Double4 BRAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BRAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BRAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 BGRA => ref *(Double4*)UndefinedData;
+    public ref Double4 BGRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 BGAR => ref *(Double4*)UndefinedData;
+    public ref Double4 BGAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BGAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BGAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BBAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BBAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BARR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BARR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 BARG => ref *(Double4*)UndefinedData;
+    public ref Double4 BARG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BARB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BARB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BARA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BARA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 BAGR => ref *(Double4*)UndefinedData;
+    public ref Double4 BAGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BAGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BAGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BAGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BAGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BAGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BAGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BABR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BABR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BABG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BABG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BABB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BABB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BABA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BABA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BAAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BAAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BAAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BAAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BAAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BAAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 BAAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 BAAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ARGB => ref *(Double4*)UndefinedData;
+    public ref Double4 ARGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ARBG => ref *(Double4*)UndefinedData;
+    public ref Double4 ARBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ARAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ARAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGRG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 AGRB => ref *(Double4*)UndefinedData;
+    public ref Double4 AGRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 AGBR => ref *(Double4*)UndefinedData;
+    public ref Double4 AGBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AGAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AGAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABRR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABRR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ABRG => ref *(Double4*)UndefinedData;
+    public ref Double4 ABRG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABRB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABRB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABRA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABRA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Double4 ABGR => ref *(Double4*)UndefinedData;
+    public ref Double4 ABGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABBR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABBR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABBG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABBG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABBB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABBB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABBA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABBA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 ABAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 ABAA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AARR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AARR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AARG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AARG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AARB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AARB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AARA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AARA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AAGR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AAGR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AAGG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AAGG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AAGB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AAGB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AAGA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AAGA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AABR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AABR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AABG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AABG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AABB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AABB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AABA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AABA => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AAAR => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AAAR => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AAAG => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AAAG => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AAAB => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AAAB => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Double4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Double4 AAAA => ref *(Double4*)UndefinedData;
+    public readonly ref readonly Double4 AAAA => ref *(Double4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #pragma warning disable CS0660, CS0661
 
@@ -13,11 +10,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
 public unsafe partial struct Double1x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double1x1), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -39,7 +31,7 @@ public unsafe partial struct Double1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref *(double*)UndefinedData;
+    public ref double this[int row] => ref *(double*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x1"/> instance.
@@ -51,7 +43,7 @@ public unsafe partial struct Double1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x1"/> instance.
@@ -64,7 +56,7 @@ public unsafe partial struct Double1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x1"/> instance.
@@ -78,7 +70,7 @@ public unsafe partial struct Double1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -210,11 +202,6 @@ public unsafe partial struct Double1x1
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 8)]
 public unsafe partial struct Double1x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double1x2), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -241,7 +228,7 @@ public unsafe partial struct Double1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[int row] => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x2"/> instance.
@@ -253,7 +240,7 @@ public unsafe partial struct Double1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x2"/> instance.
@@ -266,7 +253,7 @@ public unsafe partial struct Double1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x2"/> instance.
@@ -280,7 +267,7 @@ public unsafe partial struct Double1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -425,11 +412,6 @@ public unsafe partial struct Double1x2
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 8)]
 public unsafe partial struct Double1x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double1x3), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -461,7 +443,7 @@ public unsafe partial struct Double1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[int row] => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x3"/> instance.
@@ -473,7 +455,7 @@ public unsafe partial struct Double1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x3"/> instance.
@@ -486,7 +468,7 @@ public unsafe partial struct Double1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x3"/> instance.
@@ -500,7 +482,7 @@ public unsafe partial struct Double1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -652,11 +634,6 @@ public unsafe partial struct Double1x3
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 8)]
 public unsafe partial struct Double1x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double1x4), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -693,7 +670,7 @@ public unsafe partial struct Double1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[int row] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x4"/> instance.
@@ -705,7 +682,7 @@ public unsafe partial struct Double1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x4"/> instance.
@@ -718,7 +695,7 @@ public unsafe partial struct Double1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double1x4"/> instance.
@@ -732,7 +709,7 @@ public unsafe partial struct Double1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -891,11 +868,6 @@ public unsafe partial struct Double1x4
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 8)]
 public unsafe partial struct Double2x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double2x1), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -922,7 +894,7 @@ public unsafe partial struct Double2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref *(double*)UndefinedData;
+    public ref double this[int row] => ref *(double*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x1"/> instance.
@@ -934,7 +906,7 @@ public unsafe partial struct Double2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x1"/> instance.
@@ -947,7 +919,7 @@ public unsafe partial struct Double2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x1"/> instance.
@@ -961,7 +933,7 @@ public unsafe partial struct Double2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -1106,11 +1078,6 @@ public unsafe partial struct Double2x1
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 8)]
 public unsafe partial struct Double2x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double2x2), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -1160,7 +1127,7 @@ public unsafe partial struct Double2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[int row] => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x2"/> instance.
@@ -1172,7 +1139,7 @@ public unsafe partial struct Double2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x2"/> instance.
@@ -1185,7 +1152,7 @@ public unsafe partial struct Double2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x2"/> instance.
@@ -1199,7 +1166,7 @@ public unsafe partial struct Double2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -1352,11 +1319,6 @@ public unsafe partial struct Double2x2
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 8)]
 public unsafe partial struct Double2x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double2x3), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -1418,7 +1380,7 @@ public unsafe partial struct Double2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[int row] => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x3"/> instance.
@@ -1430,7 +1392,7 @@ public unsafe partial struct Double2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x3"/> instance.
@@ -1443,7 +1405,7 @@ public unsafe partial struct Double2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x3"/> instance.
@@ -1457,7 +1419,7 @@ public unsafe partial struct Double2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -1624,11 +1586,6 @@ public unsafe partial struct Double2x3
 [StructLayout(LayoutKind.Explicit, Size = 64, Pack = 8)]
 public unsafe partial struct Double2x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double2x4), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -1702,7 +1659,7 @@ public unsafe partial struct Double2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[int row] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x4"/> instance.
@@ -1714,7 +1671,7 @@ public unsafe partial struct Double2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x4"/> instance.
@@ -1727,7 +1684,7 @@ public unsafe partial struct Double2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double2x4"/> instance.
@@ -1741,7 +1698,7 @@ public unsafe partial struct Double2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -1922,11 +1879,6 @@ public unsafe partial struct Double2x4
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 8)]
 public unsafe partial struct Double3x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double3x1), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -1958,7 +1910,7 @@ public unsafe partial struct Double3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref *(double*)UndefinedData;
+    public ref double this[int row] => ref *(double*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x1"/> instance.
@@ -1970,7 +1922,7 @@ public unsafe partial struct Double3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x1"/> instance.
@@ -1983,7 +1935,7 @@ public unsafe partial struct Double3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x1"/> instance.
@@ -1997,7 +1949,7 @@ public unsafe partial struct Double3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -2149,11 +2101,6 @@ public unsafe partial struct Double3x1
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 8)]
 public unsafe partial struct Double3x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double3x2), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -2216,7 +2163,7 @@ public unsafe partial struct Double3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[int row] => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x2"/> instance.
@@ -2228,7 +2175,7 @@ public unsafe partial struct Double3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x2"/> instance.
@@ -2241,7 +2188,7 @@ public unsafe partial struct Double3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x2"/> instance.
@@ -2255,7 +2202,7 @@ public unsafe partial struct Double3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -2422,11 +2369,6 @@ public unsafe partial struct Double3x2
 [StructLayout(LayoutKind.Explicit, Size = 72, Pack = 8)]
 public unsafe partial struct Double3x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double3x3), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -2507,7 +2449,7 @@ public unsafe partial struct Double3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[int row] => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x3"/> instance.
@@ -2519,7 +2461,7 @@ public unsafe partial struct Double3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x3"/> instance.
@@ -2532,7 +2474,7 @@ public unsafe partial struct Double3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x3"/> instance.
@@ -2546,7 +2488,7 @@ public unsafe partial struct Double3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -2734,11 +2676,6 @@ public unsafe partial struct Double3x3
 [StructLayout(LayoutKind.Explicit, Size = 96, Pack = 8)]
 public unsafe partial struct Double3x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double3x4), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -2837,7 +2774,7 @@ public unsafe partial struct Double3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[int row] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x4"/> instance.
@@ -2849,7 +2786,7 @@ public unsafe partial struct Double3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x4"/> instance.
@@ -2862,7 +2799,7 @@ public unsafe partial struct Double3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double3x4"/> instance.
@@ -2876,7 +2813,7 @@ public unsafe partial struct Double3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -3085,11 +3022,6 @@ public unsafe partial struct Double3x4
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 8)]
 public unsafe partial struct Double4x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double4x1), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -3126,7 +3058,7 @@ public unsafe partial struct Double4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref double this[int row] => ref *(double*)UndefinedData;
+    public ref double this[int row] => ref *(double*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x1"/> instance.
@@ -3138,7 +3070,7 @@ public unsafe partial struct Double4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x1"/> instance.
@@ -3151,7 +3083,7 @@ public unsafe partial struct Double4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x1"/> instance.
@@ -3165,7 +3097,7 @@ public unsafe partial struct Double4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -3324,11 +3256,6 @@ public unsafe partial struct Double4x1
 [StructLayout(LayoutKind.Explicit, Size = 64, Pack = 8)]
 public unsafe partial struct Double4x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double4x2), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -3404,7 +3331,7 @@ public unsafe partial struct Double4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[int row] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[int row] => ref *(Double2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x2"/> instance.
@@ -3416,7 +3343,7 @@ public unsafe partial struct Double4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x2"/> instance.
@@ -3429,7 +3356,7 @@ public unsafe partial struct Double4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x2"/> instance.
@@ -3443,7 +3370,7 @@ public unsafe partial struct Double4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -3624,11 +3551,6 @@ public unsafe partial struct Double4x2
 [StructLayout(LayoutKind.Explicit, Size = 96, Pack = 8)]
 public unsafe partial struct Double4x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double4x3), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -3728,7 +3650,7 @@ public unsafe partial struct Double4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[int row] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[int row] => ref *(Double3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x3"/> instance.
@@ -3740,7 +3662,7 @@ public unsafe partial struct Double4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x3"/> instance.
@@ -3753,7 +3675,7 @@ public unsafe partial struct Double4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x3"/> instance.
@@ -3767,7 +3689,7 @@ public unsafe partial struct Double4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].
@@ -3976,11 +3898,6 @@ public unsafe partial struct Double4x3
 [StructLayout(LayoutKind.Explicit, Size = 128, Pack = 8)]
 public unsafe partial struct Double4x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Double4x4), sizeof(Double4));
-
     [FieldOffset(0)]
     private double m11;
 
@@ -4104,7 +4021,7 @@ public unsafe partial struct Double4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double4 this[int row] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[int row] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x4"/> instance.
@@ -4116,7 +4033,7 @@ public unsafe partial struct Double4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData;
+    public ref Double2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Double2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x4"/> instance.
@@ -4129,7 +4046,7 @@ public unsafe partial struct Double4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData;
+    public ref Double3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Double3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Double4x4"/> instance.
@@ -4143,7 +4060,7 @@ public unsafe partial struct Double4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData;
+    public ref Double4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Double4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="double"/> value representing the component at position [1, 1].

--- a/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
@@ -4,9 +4,6 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -17,11 +14,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Float2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float2), sizeof(Float4));
-
     [FieldOffset(0)]
     private float x;
 
@@ -34,7 +26,7 @@ public unsafe partial struct Float2
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref float this[int i] => ref *(float*)UndefinedData;
+    public ref float this[int i] => ref *(float*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Float2"/> value with all components set to 0.
@@ -73,196 +65,196 @@ public unsafe partial struct Float2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 XX => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 XX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 XY => ref *(Float2*)UndefinedData;
+    public ref Float2 XY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 YX => ref *(Float2*)UndefinedData;
+    public ref Float2 YX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 YY => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 YY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XYX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YXY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>R</c> component.
@@ -281,196 +273,196 @@ public unsafe partial struct Float2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 RR => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 RR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 RG => ref *(Float2*)UndefinedData;
+    public ref Float2 RG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 GR => ref *(Float2*)UndefinedData;
+    public ref Float2 GR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 GG => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 GG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RGR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GRR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GRR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GRG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GRG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGG => ref *(Float4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
@@ -4,9 +4,6 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -17,11 +14,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Float3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float3), sizeof(Float4));
-
     [FieldOffset(0)]
     private float x;
 
@@ -37,7 +29,7 @@ public unsafe partial struct Float3
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref float this[int i] => ref *(float*)UndefinedData;
+    public ref float this[int i] => ref *(float*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Float3"/> value with all components set to 0.
@@ -87,819 +79,819 @@ public unsafe partial struct Float3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 XX => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 XX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 XY => ref *(Float2*)UndefinedData;
+    public ref Float2 XY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 XZ => ref *(Float2*)UndefinedData;
+    public ref Float2 XZ => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 YX => ref *(Float2*)UndefinedData;
+    public ref Float2 YX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 YY => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 YY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 YZ => ref *(Float2*)UndefinedData;
+    public ref Float2 YZ => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 ZX => ref *(Float2*)UndefinedData;
+    public ref Float2 ZX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 ZY => ref *(Float2*)UndefinedData;
+    public ref Float2 ZY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 ZZ => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 ZZ => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XYX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 XYZ => ref *(Float3*)UndefinedData;
+    public ref Float3 XYZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XZX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XZX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 XZY => ref *(Float3*)UndefinedData;
+    public ref Float3 XZY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XZZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XZZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YXY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 YXZ => ref *(Float3*)UndefinedData;
+    public ref Float3 YXZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 YZX => ref *(Float3*)UndefinedData;
+    public ref Float3 YZX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YZY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YZY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YZZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YZZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ZXY => ref *(Float3*)UndefinedData;
+    public ref Float3 ZXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZXZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZXZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ZYX => ref *(Float3*)UndefinedData;
+    public ref Float3 ZYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZYZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZYZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZZX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZZX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZZY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZZY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZZZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZZZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>R</c> component.
@@ -924,819 +916,819 @@ public unsafe partial struct Float3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 RR => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 RR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 RG => ref *(Float2*)UndefinedData;
+    public ref Float2 RG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 RB => ref *(Float2*)UndefinedData;
+    public ref Float2 RB => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 GR => ref *(Float2*)UndefinedData;
+    public ref Float2 GR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 GG => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 GG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 GB => ref *(Float2*)UndefinedData;
+    public ref Float2 GB => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 BR => ref *(Float2*)UndefinedData;
+    public ref Float2 BR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 BG => ref *(Float2*)UndefinedData;
+    public ref Float2 BG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 BB => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 BB => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RGR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 RGB => ref *(Float3*)UndefinedData;
+    public ref Float3 RGB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RBR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RBR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 RBG => ref *(Float3*)UndefinedData;
+    public ref Float3 RBG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RBB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RBB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GRR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GRR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GRG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GRG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 GRB => ref *(Float3*)UndefinedData;
+    public ref Float3 GRB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 GBR => ref *(Float3*)UndefinedData;
+    public ref Float3 GBR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GBG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GBG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GBB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GBB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BRR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BRR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 BRG => ref *(Float3*)UndefinedData;
+    public ref Float3 BRG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BRB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BRB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 BGR => ref *(Float3*)UndefinedData;
+    public ref Float3 BGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BGB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BGB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BBR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BBR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BBG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BBG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BBB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BBB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBBB => ref *(Float4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
@@ -4,9 +4,6 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -17,11 +14,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Float4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float4), sizeof(Float4));
-
     [FieldOffset(0)]
     private float x;
 
@@ -40,7 +32,7 @@ public unsafe partial struct Float4
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref float this[int i] => ref *(float*)UndefinedData;
+    public ref float this[int i] => ref *(float*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Float4"/> value with all components set to 0.
@@ -101,2352 +93,2352 @@ public unsafe partial struct Float4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 XX => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 XX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 XY => ref *(Float2*)UndefinedData;
+    public ref Float2 XY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 XZ => ref *(Float2*)UndefinedData;
+    public ref Float2 XZ => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 XW => ref *(Float2*)UndefinedData;
+    public ref Float2 XW => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 YX => ref *(Float2*)UndefinedData;
+    public ref Float2 YX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 YY => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 YY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 YZ => ref *(Float2*)UndefinedData;
+    public ref Float2 YZ => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 YW => ref *(Float2*)UndefinedData;
+    public ref Float2 YW => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 ZX => ref *(Float2*)UndefinedData;
+    public ref Float2 ZX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 ZY => ref *(Float2*)UndefinedData;
+    public ref Float2 ZY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 ZZ => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 ZZ => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 ZW => ref *(Float2*)UndefinedData;
+    public ref Float2 ZW => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 WX => ref *(Float2*)UndefinedData;
+    public ref Float2 WX => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 WY => ref *(Float2*)UndefinedData;
+    public ref Float2 WY => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 WZ => ref *(Float2*)UndefinedData;
+    public ref Float2 WZ => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 WW => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 WW => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XXW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XXW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XYX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 XYZ => ref *(Float3*)UndefinedData;
+    public ref Float3 XYZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 XYW => ref *(Float3*)UndefinedData;
+    public ref Float3 XYW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XZX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XZX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 XZY => ref *(Float3*)UndefinedData;
+    public ref Float3 XZY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XZZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XZZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 XZW => ref *(Float3*)UndefinedData;
+    public ref Float3 XZW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XWX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XWX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 XWY => ref *(Float3*)UndefinedData;
+    public ref Float3 XWY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 XWZ => ref *(Float3*)UndefinedData;
+    public ref Float3 XWZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 XWW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 XWW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YXY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 YXZ => ref *(Float3*)UndefinedData;
+    public ref Float3 YXZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 YXW => ref *(Float3*)UndefinedData;
+    public ref Float3 YXW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YYW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YYW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 YZX => ref *(Float3*)UndefinedData;
+    public ref Float3 YZX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YZY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YZY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YZZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YZZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 YZW => ref *(Float3*)UndefinedData;
+    public ref Float3 YZW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 YWX => ref *(Float3*)UndefinedData;
+    public ref Float3 YWX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YWY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YWY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 YWZ => ref *(Float3*)UndefinedData;
+    public ref Float3 YWZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 YWW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 YWW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ZXY => ref *(Float3*)UndefinedData;
+    public ref Float3 ZXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZXZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZXZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ZXW => ref *(Float3*)UndefinedData;
+    public ref Float3 ZXW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ZYX => ref *(Float3*)UndefinedData;
+    public ref Float3 ZYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZYZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZYZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ZYW => ref *(Float3*)UndefinedData;
+    public ref Float3 ZYW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZZX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZZX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZZY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZZY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZZZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZZZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZZW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZZW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ZWX => ref *(Float3*)UndefinedData;
+    public ref Float3 ZWX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ZWY => ref *(Float3*)UndefinedData;
+    public ref Float3 ZWY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZWZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZWZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ZWW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ZWW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WXX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WXX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 WXY => ref *(Float3*)UndefinedData;
+    public ref Float3 WXY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 WXZ => ref *(Float3*)UndefinedData;
+    public ref Float3 WXZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WXW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WXW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 WYX => ref *(Float3*)UndefinedData;
+    public ref Float3 WYX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WYY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WYY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 WYZ => ref *(Float3*)UndefinedData;
+    public ref Float3 WYZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WYW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WYW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 WZX => ref *(Float3*)UndefinedData;
+    public ref Float3 WZX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 WZY => ref *(Float3*)UndefinedData;
+    public ref Float3 WZY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WZZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WZZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WZW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WZW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WWX => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WWX => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WWY => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WWY => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WWZ => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WWZ => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 WWW => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 WWW => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XXWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XXWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 XYZW => ref *(Float4*)UndefinedData;
+    public ref Float4 XYZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 XYWZ => ref *(Float4*)UndefinedData;
+    public ref Float4 XYWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XYWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XYWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 XZYW => ref *(Float4*)UndefinedData;
+    public ref Float4 XZYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 XZWY => ref *(Float4*)UndefinedData;
+    public ref Float4 XZWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XZWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XZWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 XWYZ => ref *(Float4*)UndefinedData;
+    public ref Float4 XWYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 XWZY => ref *(Float4*)UndefinedData;
+    public ref Float4 XWZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 XWWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 XWWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 YXZW => ref *(Float4*)UndefinedData;
+    public ref Float4 YXZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 YXWZ => ref *(Float4*)UndefinedData;
+    public ref Float4 YXWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YXWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YXWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YYWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YYWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 YZXW => ref *(Float4*)UndefinedData;
+    public ref Float4 YZXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 YZWX => ref *(Float4*)UndefinedData;
+    public ref Float4 YZWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YZWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YZWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 YWXZ => ref *(Float4*)UndefinedData;
+    public ref Float4 YWXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 YWZX => ref *(Float4*)UndefinedData;
+    public ref Float4 YWZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 YWWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 YWWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ZXYW => ref *(Float4*)UndefinedData;
+    public ref Float4 ZXYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ZXWY => ref *(Float4*)UndefinedData;
+    public ref Float4 ZXWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZXWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZXWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ZYXW => ref *(Float4*)UndefinedData;
+    public ref Float4 ZYXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ZYWX => ref *(Float4*)UndefinedData;
+    public ref Float4 ZYWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZYWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZYWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZZWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZZWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ZWXY => ref *(Float4*)UndefinedData;
+    public ref Float4 ZWXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ZWYX => ref *(Float4*)UndefinedData;
+    public ref Float4 ZWYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ZWWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ZWWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 WXYZ => ref *(Float4*)UndefinedData;
+    public ref Float4 WXYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 WXZY => ref *(Float4*)UndefinedData;
+    public ref Float4 WXZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WXWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WXWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 WYXZ => ref *(Float4*)UndefinedData;
+    public ref Float4 WYXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 WYZX => ref *(Float4*)UndefinedData;
+    public ref Float4 WYZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WYWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WYWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 WZXY => ref *(Float4*)UndefinedData;
+    public ref Float4 WZXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 WZYX => ref *(Float4*)UndefinedData;
+    public ref Float4 WZYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WZWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WZWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWXX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWXX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWXY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWXY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWXZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWXZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWXW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWXW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWYX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWYX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWYY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWYY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWYZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWYZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWYW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWYW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWZX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWZX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWZY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWZY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWZZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWZZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWZW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWZW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWWX => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWWX => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWWY => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWWY => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWWZ => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWWZ => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 WWWW => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 WWWW => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the <c>R</c> component.
@@ -2477,2352 +2469,2352 @@ public unsafe partial struct Float4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 RR => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 RR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 RG => ref *(Float2*)UndefinedData;
+    public ref Float2 RG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 RB => ref *(Float2*)UndefinedData;
+    public ref Float2 RB => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 RA => ref *(Float2*)UndefinedData;
+    public ref Float2 RA => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 GR => ref *(Float2*)UndefinedData;
+    public ref Float2 GR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 GG => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 GG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 GB => ref *(Float2*)UndefinedData;
+    public ref Float2 GB => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 GA => ref *(Float2*)UndefinedData;
+    public ref Float2 GA => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 BR => ref *(Float2*)UndefinedData;
+    public ref Float2 BR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 BG => ref *(Float2*)UndefinedData;
+    public ref Float2 BG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 BB => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 BB => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 BA => ref *(Float2*)UndefinedData;
+    public ref Float2 BA => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 AR => ref *(Float2*)UndefinedData;
+    public ref Float2 AR => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 AG => ref *(Float2*)UndefinedData;
+    public ref Float2 AG => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float2"/> value with the components <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float2 AB => ref *(Float2*)UndefinedData;
+    public ref Float2 AB => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float2"/> value with the components <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float2 AA => ref *(Float2*)UndefinedData;
+    public readonly ref readonly Float2 AA => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RRA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RRA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RGR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 RGB => ref *(Float3*)UndefinedData;
+    public ref Float3 RGB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 RGA => ref *(Float3*)UndefinedData;
+    public ref Float3 RGA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RBR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RBR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 RBG => ref *(Float3*)UndefinedData;
+    public ref Float3 RBG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RBB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RBB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 RBA => ref *(Float3*)UndefinedData;
+    public ref Float3 RBA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RAR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RAR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 RAG => ref *(Float3*)UndefinedData;
+    public ref Float3 RAG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 RAB => ref *(Float3*)UndefinedData;
+    public ref Float3 RAB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 RAA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 RAA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GRR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GRR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GRG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GRG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 GRB => ref *(Float3*)UndefinedData;
+    public ref Float3 GRB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 GRA => ref *(Float3*)UndefinedData;
+    public ref Float3 GRA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GGA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GGA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 GBR => ref *(Float3*)UndefinedData;
+    public ref Float3 GBR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GBG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GBG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GBB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GBB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 GBA => ref *(Float3*)UndefinedData;
+    public ref Float3 GBA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 GAR => ref *(Float3*)UndefinedData;
+    public ref Float3 GAR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GAG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GAG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 GAB => ref *(Float3*)UndefinedData;
+    public ref Float3 GAB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 GAA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 GAA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BRR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BRR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 BRG => ref *(Float3*)UndefinedData;
+    public ref Float3 BRG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BRB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BRB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 BRA => ref *(Float3*)UndefinedData;
+    public ref Float3 BRA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 BGR => ref *(Float3*)UndefinedData;
+    public ref Float3 BGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BGB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BGB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 BGA => ref *(Float3*)UndefinedData;
+    public ref Float3 BGA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BBR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BBR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BBG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BBG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BBB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BBB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BBA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BBA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 BAR => ref *(Float3*)UndefinedData;
+    public ref Float3 BAR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 BAG => ref *(Float3*)UndefinedData;
+    public ref Float3 BAG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BAB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BAB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 BAA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 BAA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ARR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ARR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ARG => ref *(Float3*)UndefinedData;
+    public ref Float3 ARG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ARB => ref *(Float3*)UndefinedData;
+    public ref Float3 ARB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ARA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ARA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 AGR => ref *(Float3*)UndefinedData;
+    public ref Float3 AGR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 AGG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 AGG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 AGB => ref *(Float3*)UndefinedData;
+    public ref Float3 AGB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 AGA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 AGA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ABR => ref *(Float3*)UndefinedData;
+    public ref Float3 ABR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float3 ABG => ref *(Float3*)UndefinedData;
+    public ref Float3 ABG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ABB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ABB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 ABA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 ABA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 AAR => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 AAR => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 AAG => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 AAG => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 AAB => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 AAB => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float3 AAA => ref *(Float3*)UndefinedData;
+    public readonly ref readonly Float3 AAA => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RRAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RRAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 RGBA => ref *(Float4*)UndefinedData;
+    public ref Float4 RGBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 RGAB => ref *(Float4*)UndefinedData;
+    public ref Float4 RGAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RGAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RGAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 RBGA => ref *(Float4*)UndefinedData;
+    public ref Float4 RBGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 RBAG => ref *(Float4*)UndefinedData;
+    public ref Float4 RBAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RBAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RBAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RARR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RARR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RARG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RARG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RARB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RARB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RARA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RARA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RAGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RAGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RAGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RAGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 RAGB => ref *(Float4*)UndefinedData;
+    public ref Float4 RAGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RAGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RAGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RABR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RABR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 RABG => ref *(Float4*)UndefinedData;
+    public ref Float4 RABG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RABB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RABB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RABA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RABA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RAAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RAAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RAAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RAAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RAAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RAAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 RAAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 RAAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 GRBA => ref *(Float4*)UndefinedData;
+    public ref Float4 GRBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 GRAB => ref *(Float4*)UndefinedData;
+    public ref Float4 GRAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GRAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GRAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GGAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GGAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 GBRA => ref *(Float4*)UndefinedData;
+    public ref Float4 GBRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 GBAR => ref *(Float4*)UndefinedData;
+    public ref Float4 GBAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GBAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GBAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GARR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GARR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GARG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GARG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 GARB => ref *(Float4*)UndefinedData;
+    public ref Float4 GARB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GARA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GARA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GAGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GAGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GAGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GAGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GAGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GAGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GAGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GAGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 GABR => ref *(Float4*)UndefinedData;
+    public ref Float4 GABR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GABG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GABG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GABB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GABB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GABA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GABA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GAAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GAAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GAAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GAAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GAAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GAAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 GAAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 GAAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 BRGA => ref *(Float4*)UndefinedData;
+    public ref Float4 BRGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 BRAG => ref *(Float4*)UndefinedData;
+    public ref Float4 BRAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BRAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BRAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 BGRA => ref *(Float4*)UndefinedData;
+    public ref Float4 BGRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 BGAR => ref *(Float4*)UndefinedData;
+    public ref Float4 BGAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BGAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BGAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BBAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BBAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BARR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BARR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 BARG => ref *(Float4*)UndefinedData;
+    public ref Float4 BARG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BARB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BARB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BARA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BARA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 BAGR => ref *(Float4*)UndefinedData;
+    public ref Float4 BAGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BAGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BAGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BAGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BAGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BAGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BAGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BABR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BABR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BABG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BABG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BABB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BABB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BABA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BABA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BAAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BAAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BAAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BAAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BAAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BAAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 BAAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 BAAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ARGB => ref *(Float4*)UndefinedData;
+    public ref Float4 ARGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ARBG => ref *(Float4*)UndefinedData;
+    public ref Float4 ARBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ARAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ARAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGRG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 AGRB => ref *(Float4*)UndefinedData;
+    public ref Float4 AGRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 AGBR => ref *(Float4*)UndefinedData;
+    public ref Float4 AGBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AGAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AGAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABRR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABRR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ABRG => ref *(Float4*)UndefinedData;
+    public ref Float4 ABRG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABRB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABRB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABRA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABRA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Float4 ABGR => ref *(Float4*)UndefinedData;
+    public ref Float4 ABGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABBR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABBR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABBG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABBG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABBB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABBB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABBA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABBA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 ABAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 ABAA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AARR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AARR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AARG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AARG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AARB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AARB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AARA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AARA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AAGR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AAGR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AAGG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AAGG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AAGB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AAGB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AAGA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AAGA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AABR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AABR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AABG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AABG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AABB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AABB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AABA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AABA => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AAAR => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AAAR => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AAAG => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AAAG => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AAAB => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AAAB => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Float4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Float4 AAAA => ref *(Float4*)UndefinedData;
+    public readonly ref readonly Float4 AAAA => ref *(Float4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
@@ -2,9 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #pragma warning disable CS0660, CS0661
 
@@ -14,11 +11,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
 public unsafe partial struct Float1x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float1x1), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -40,7 +32,7 @@ public unsafe partial struct Float1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref *(float*)UndefinedData;
+    public ref float this[int row] => ref *(float*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x1"/> instance.
@@ -52,7 +44,7 @@ public unsafe partial struct Float1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x1"/> instance.
@@ -65,7 +57,7 @@ public unsafe partial struct Float1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x1"/> instance.
@@ -79,7 +71,7 @@ public unsafe partial struct Float1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -229,11 +221,6 @@ public unsafe partial struct Float1x1
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Float1x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float1x2), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -260,7 +247,7 @@ public unsafe partial struct Float1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[int row] => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x2"/> instance.
@@ -272,7 +259,7 @@ public unsafe partial struct Float1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x2"/> instance.
@@ -285,7 +272,7 @@ public unsafe partial struct Float1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x2"/> instance.
@@ -299,7 +286,7 @@ public unsafe partial struct Float1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -546,11 +533,6 @@ public unsafe partial struct Float1x2
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Float1x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float1x3), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -582,7 +564,7 @@ public unsafe partial struct Float1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[int row] => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x3"/> instance.
@@ -594,7 +576,7 @@ public unsafe partial struct Float1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x3"/> instance.
@@ -607,7 +589,7 @@ public unsafe partial struct Float1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x3"/> instance.
@@ -621,7 +603,7 @@ public unsafe partial struct Float1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -875,11 +857,6 @@ public unsafe partial struct Float1x3
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Float1x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float1x4), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -916,7 +893,7 @@ public unsafe partial struct Float1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[int row] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x4"/> instance.
@@ -928,7 +905,7 @@ public unsafe partial struct Float1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x4"/> instance.
@@ -941,7 +918,7 @@ public unsafe partial struct Float1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float1x4"/> instance.
@@ -955,7 +932,7 @@ public unsafe partial struct Float1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -1216,11 +1193,6 @@ public unsafe partial struct Float1x4
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Float2x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float2x1), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -1247,7 +1219,7 @@ public unsafe partial struct Float2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref *(float*)UndefinedData;
+    public ref float this[int row] => ref *(float*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x1"/> instance.
@@ -1259,7 +1231,7 @@ public unsafe partial struct Float2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x1"/> instance.
@@ -1272,7 +1244,7 @@ public unsafe partial struct Float2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x1"/> instance.
@@ -1286,7 +1258,7 @@ public unsafe partial struct Float2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -1519,11 +1491,6 @@ public unsafe partial struct Float2x1
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Float2x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float2x2), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -1573,7 +1540,7 @@ public unsafe partial struct Float2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[int row] => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x2"/> instance.
@@ -1585,7 +1552,7 @@ public unsafe partial struct Float2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x2"/> instance.
@@ -1598,7 +1565,7 @@ public unsafe partial struct Float2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x2"/> instance.
@@ -1612,7 +1579,7 @@ public unsafe partial struct Float2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -1783,11 +1750,6 @@ public unsafe partial struct Float2x2
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 4)]
 public unsafe partial struct Float2x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float2x3), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -1849,7 +1811,7 @@ public unsafe partial struct Float2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[int row] => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x3"/> instance.
@@ -1861,7 +1823,7 @@ public unsafe partial struct Float2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x3"/> instance.
@@ -1874,7 +1836,7 @@ public unsafe partial struct Float2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x3"/> instance.
@@ -1888,7 +1850,7 @@ public unsafe partial struct Float2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -2157,11 +2119,6 @@ public unsafe partial struct Float2x3
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 4)]
 public unsafe partial struct Float2x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float2x4), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -2235,7 +2192,7 @@ public unsafe partial struct Float2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[int row] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x4"/> instance.
@@ -2247,7 +2204,7 @@ public unsafe partial struct Float2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x4"/> instance.
@@ -2260,7 +2217,7 @@ public unsafe partial struct Float2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float2x4"/> instance.
@@ -2274,7 +2231,7 @@ public unsafe partial struct Float2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -2557,11 +2514,6 @@ public unsafe partial struct Float2x4
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Float3x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float3x1), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -2593,7 +2545,7 @@ public unsafe partial struct Float3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref *(float*)UndefinedData;
+    public ref float this[int row] => ref *(float*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x1"/> instance.
@@ -2605,7 +2557,7 @@ public unsafe partial struct Float3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x1"/> instance.
@@ -2618,7 +2570,7 @@ public unsafe partial struct Float3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x1"/> instance.
@@ -2632,7 +2584,7 @@ public unsafe partial struct Float3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -2872,11 +2824,6 @@ public unsafe partial struct Float3x1
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 4)]
 public unsafe partial struct Float3x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float3x2), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -2939,7 +2886,7 @@ public unsafe partial struct Float3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[int row] => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x2"/> instance.
@@ -2951,7 +2898,7 @@ public unsafe partial struct Float3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x2"/> instance.
@@ -2964,7 +2911,7 @@ public unsafe partial struct Float3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x2"/> instance.
@@ -2978,7 +2925,7 @@ public unsafe partial struct Float3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -3247,11 +3194,6 @@ public unsafe partial struct Float3x2
 [StructLayout(LayoutKind.Explicit, Size = 36, Pack = 4)]
 public unsafe partial struct Float3x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float3x3), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -3332,7 +3274,7 @@ public unsafe partial struct Float3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[int row] => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x3"/> instance.
@@ -3344,7 +3286,7 @@ public unsafe partial struct Float3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x3"/> instance.
@@ -3357,7 +3299,7 @@ public unsafe partial struct Float3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x3"/> instance.
@@ -3371,7 +3313,7 @@ public unsafe partial struct Float3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -3577,11 +3519,6 @@ public unsafe partial struct Float3x3
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 4)]
 public unsafe partial struct Float3x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float3x4), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -3680,7 +3617,7 @@ public unsafe partial struct Float3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[int row] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x4"/> instance.
@@ -3692,7 +3629,7 @@ public unsafe partial struct Float3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x4"/> instance.
@@ -3705,7 +3642,7 @@ public unsafe partial struct Float3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float3x4"/> instance.
@@ -3719,7 +3656,7 @@ public unsafe partial struct Float3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -4030,11 +3967,6 @@ public unsafe partial struct Float3x4
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Float4x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float4x1), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -4071,7 +4003,7 @@ public unsafe partial struct Float4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref float this[int row] => ref *(float*)UndefinedData;
+    public ref float this[int row] => ref *(float*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x1"/> instance.
@@ -4083,7 +4015,7 @@ public unsafe partial struct Float4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x1"/> instance.
@@ -4096,7 +4028,7 @@ public unsafe partial struct Float4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x1"/> instance.
@@ -4110,7 +4042,7 @@ public unsafe partial struct Float4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -4357,11 +4289,6 @@ public unsafe partial struct Float4x1
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 4)]
 public unsafe partial struct Float4x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float4x2), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -4437,7 +4364,7 @@ public unsafe partial struct Float4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[int row] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[int row] => ref *(Float2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x2"/> instance.
@@ -4449,7 +4376,7 @@ public unsafe partial struct Float4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x2"/> instance.
@@ -4462,7 +4389,7 @@ public unsafe partial struct Float4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x2"/> instance.
@@ -4476,7 +4403,7 @@ public unsafe partial struct Float4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -4759,11 +4686,6 @@ public unsafe partial struct Float4x2
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 4)]
 public unsafe partial struct Float4x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float4x3), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -4863,7 +4785,7 @@ public unsafe partial struct Float4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[int row] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[int row] => ref *(Float3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x3"/> instance.
@@ -4875,7 +4797,7 @@ public unsafe partial struct Float4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x3"/> instance.
@@ -4888,7 +4810,7 @@ public unsafe partial struct Float4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x3"/> instance.
@@ -4902,7 +4824,7 @@ public unsafe partial struct Float4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].
@@ -5213,11 +5135,6 @@ public unsafe partial struct Float4x3
 [StructLayout(LayoutKind.Explicit, Size = 64, Pack = 4)]
 public unsafe partial struct Float4x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Float4x4), sizeof(Float4));
-
     [FieldOffset(0)]
     private float m11;
 
@@ -5341,7 +5258,7 @@ public unsafe partial struct Float4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float4 this[int row] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[int row] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x4"/> instance.
@@ -5353,7 +5270,7 @@ public unsafe partial struct Float4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData;
+    public ref Float2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Float2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x4"/> instance.
@@ -5366,7 +5283,7 @@ public unsafe partial struct Float4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData;
+    public ref Float3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Float3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Float4x4"/> instance.
@@ -5380,7 +5297,7 @@ public unsafe partial struct Float4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData;
+    public ref Float4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Float4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="float"/> value representing the component at position [1, 1].

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
@@ -4,9 +4,6 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -17,11 +14,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Int2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int2), sizeof(Int4));
-
     [FieldOffset(0)]
     private int x;
 
@@ -34,7 +26,7 @@ public unsafe partial struct Int2
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref int this[int i] => ref *(int*)UndefinedData;
+    public ref int this[int i] => ref *(int*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Int2"/> value with all components set to 0.
@@ -73,196 +65,196 @@ public unsafe partial struct Int2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 XX => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 XX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 XY => ref *(Int2*)UndefinedData;
+    public ref Int2 XY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 YX => ref *(Int2*)UndefinedData;
+    public ref Int2 YX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 YY => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 YY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XYX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YXY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>R</c> component.
@@ -281,196 +273,196 @@ public unsafe partial struct Int2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 RR => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 RR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 RG => ref *(Int2*)UndefinedData;
+    public ref Int2 RG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 GR => ref *(Int2*)UndefinedData;
+    public ref Int2 GR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 GG => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 GG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RGR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GRR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GRR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GRG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GRG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGG => ref *(Int4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
@@ -4,9 +4,6 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -17,11 +14,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Int3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int3), sizeof(Int4));
-
     [FieldOffset(0)]
     private int x;
 
@@ -37,7 +29,7 @@ public unsafe partial struct Int3
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref int this[int i] => ref *(int*)UndefinedData;
+    public ref int this[int i] => ref *(int*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Int3"/> value with all components set to 0.
@@ -87,819 +79,819 @@ public unsafe partial struct Int3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 XX => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 XX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 XY => ref *(Int2*)UndefinedData;
+    public ref Int2 XY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 XZ => ref *(Int2*)UndefinedData;
+    public ref Int2 XZ => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 YX => ref *(Int2*)UndefinedData;
+    public ref Int2 YX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 YY => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 YY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 YZ => ref *(Int2*)UndefinedData;
+    public ref Int2 YZ => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 ZX => ref *(Int2*)UndefinedData;
+    public ref Int2 ZX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 ZY => ref *(Int2*)UndefinedData;
+    public ref Int2 ZY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 ZZ => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 ZZ => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XYX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 XYZ => ref *(Int3*)UndefinedData;
+    public ref Int3 XYZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XZX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XZX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 XZY => ref *(Int3*)UndefinedData;
+    public ref Int3 XZY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XZZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XZZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YXY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 YXZ => ref *(Int3*)UndefinedData;
+    public ref Int3 YXZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 YZX => ref *(Int3*)UndefinedData;
+    public ref Int3 YZX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YZY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YZY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YZZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YZZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ZXY => ref *(Int3*)UndefinedData;
+    public ref Int3 ZXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZXZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZXZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ZYX => ref *(Int3*)UndefinedData;
+    public ref Int3 ZYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZYZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZYZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZZX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZZX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZZY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZZY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZZZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZZZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>R</c> component.
@@ -924,819 +916,819 @@ public unsafe partial struct Int3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 RR => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 RR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 RG => ref *(Int2*)UndefinedData;
+    public ref Int2 RG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 RB => ref *(Int2*)UndefinedData;
+    public ref Int2 RB => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 GR => ref *(Int2*)UndefinedData;
+    public ref Int2 GR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 GG => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 GG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 GB => ref *(Int2*)UndefinedData;
+    public ref Int2 GB => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 BR => ref *(Int2*)UndefinedData;
+    public ref Int2 BR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 BG => ref *(Int2*)UndefinedData;
+    public ref Int2 BG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 BB => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 BB => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RGR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 RGB => ref *(Int3*)UndefinedData;
+    public ref Int3 RGB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RBR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RBR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 RBG => ref *(Int3*)UndefinedData;
+    public ref Int3 RBG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RBB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RBB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GRR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GRR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GRG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GRG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 GRB => ref *(Int3*)UndefinedData;
+    public ref Int3 GRB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 GBR => ref *(Int3*)UndefinedData;
+    public ref Int3 GBR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GBG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GBG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GBB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GBB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BRR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BRR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 BRG => ref *(Int3*)UndefinedData;
+    public ref Int3 BRG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BRB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BRB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 BGR => ref *(Int3*)UndefinedData;
+    public ref Int3 BGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BGB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BGB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BBR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BBR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BBG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BBG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BBB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BBB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBBB => ref *(Int4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
@@ -4,9 +4,6 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -17,11 +14,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Int4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int4), sizeof(Int4));
-
     [FieldOffset(0)]
     private int x;
 
@@ -40,7 +32,7 @@ public unsafe partial struct Int4
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref int this[int i] => ref *(int*)UndefinedData;
+    public ref int this[int i] => ref *(int*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="Int4"/> value with all components set to 0.
@@ -101,2352 +93,2352 @@ public unsafe partial struct Int4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 XX => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 XX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 XY => ref *(Int2*)UndefinedData;
+    public ref Int2 XY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 XZ => ref *(Int2*)UndefinedData;
+    public ref Int2 XZ => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 XW => ref *(Int2*)UndefinedData;
+    public ref Int2 XW => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 YX => ref *(Int2*)UndefinedData;
+    public ref Int2 YX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 YY => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 YY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 YZ => ref *(Int2*)UndefinedData;
+    public ref Int2 YZ => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 YW => ref *(Int2*)UndefinedData;
+    public ref Int2 YW => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 ZX => ref *(Int2*)UndefinedData;
+    public ref Int2 ZX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 ZY => ref *(Int2*)UndefinedData;
+    public ref Int2 ZY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 ZZ => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 ZZ => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 ZW => ref *(Int2*)UndefinedData;
+    public ref Int2 ZW => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 WX => ref *(Int2*)UndefinedData;
+    public ref Int2 WX => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 WY => ref *(Int2*)UndefinedData;
+    public ref Int2 WY => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 WZ => ref *(Int2*)UndefinedData;
+    public ref Int2 WZ => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 WW => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 WW => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XXW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XXW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XYX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 XYZ => ref *(Int3*)UndefinedData;
+    public ref Int3 XYZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 XYW => ref *(Int3*)UndefinedData;
+    public ref Int3 XYW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XZX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XZX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 XZY => ref *(Int3*)UndefinedData;
+    public ref Int3 XZY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XZZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XZZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 XZW => ref *(Int3*)UndefinedData;
+    public ref Int3 XZW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XWX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XWX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 XWY => ref *(Int3*)UndefinedData;
+    public ref Int3 XWY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 XWZ => ref *(Int3*)UndefinedData;
+    public ref Int3 XWZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 XWW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 XWW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YXY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 YXZ => ref *(Int3*)UndefinedData;
+    public ref Int3 YXZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 YXW => ref *(Int3*)UndefinedData;
+    public ref Int3 YXW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YYW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YYW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 YZX => ref *(Int3*)UndefinedData;
+    public ref Int3 YZX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YZY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YZY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YZZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YZZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 YZW => ref *(Int3*)UndefinedData;
+    public ref Int3 YZW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 YWX => ref *(Int3*)UndefinedData;
+    public ref Int3 YWX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YWY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YWY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 YWZ => ref *(Int3*)UndefinedData;
+    public ref Int3 YWZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 YWW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 YWW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ZXY => ref *(Int3*)UndefinedData;
+    public ref Int3 ZXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZXZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZXZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ZXW => ref *(Int3*)UndefinedData;
+    public ref Int3 ZXW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ZYX => ref *(Int3*)UndefinedData;
+    public ref Int3 ZYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZYZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZYZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ZYW => ref *(Int3*)UndefinedData;
+    public ref Int3 ZYW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZZX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZZX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZZY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZZY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZZZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZZZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZZW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZZW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ZWX => ref *(Int3*)UndefinedData;
+    public ref Int3 ZWX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ZWY => ref *(Int3*)UndefinedData;
+    public ref Int3 ZWY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZWZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZWZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ZWW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ZWW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WXX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WXX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 WXY => ref *(Int3*)UndefinedData;
+    public ref Int3 WXY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 WXZ => ref *(Int3*)UndefinedData;
+    public ref Int3 WXZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WXW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WXW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 WYX => ref *(Int3*)UndefinedData;
+    public ref Int3 WYX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WYY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WYY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 WYZ => ref *(Int3*)UndefinedData;
+    public ref Int3 WYZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WYW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WYW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 WZX => ref *(Int3*)UndefinedData;
+    public ref Int3 WZX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 WZY => ref *(Int3*)UndefinedData;
+    public ref Int3 WZY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WZZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WZZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WZW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WZW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WWX => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WWX => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WWY => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WWY => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WWZ => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WWZ => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 WWW => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 WWW => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XXWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XXWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 XYZW => ref *(Int4*)UndefinedData;
+    public ref Int4 XYZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 XYWZ => ref *(Int4*)UndefinedData;
+    public ref Int4 XYWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XYWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XYWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 XZYW => ref *(Int4*)UndefinedData;
+    public ref Int4 XZYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 XZWY => ref *(Int4*)UndefinedData;
+    public ref Int4 XZWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XZWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XZWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 XWYZ => ref *(Int4*)UndefinedData;
+    public ref Int4 XWYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 XWZY => ref *(Int4*)UndefinedData;
+    public ref Int4 XWZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 XWWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 XWWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 YXZW => ref *(Int4*)UndefinedData;
+    public ref Int4 YXZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 YXWZ => ref *(Int4*)UndefinedData;
+    public ref Int4 YXWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YXWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YXWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YYWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YYWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 YZXW => ref *(Int4*)UndefinedData;
+    public ref Int4 YZXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 YZWX => ref *(Int4*)UndefinedData;
+    public ref Int4 YZWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YZWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YZWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 YWXZ => ref *(Int4*)UndefinedData;
+    public ref Int4 YWXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 YWZX => ref *(Int4*)UndefinedData;
+    public ref Int4 YWZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 YWWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 YWWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ZXYW => ref *(Int4*)UndefinedData;
+    public ref Int4 ZXYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ZXWY => ref *(Int4*)UndefinedData;
+    public ref Int4 ZXWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZXWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZXWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ZYXW => ref *(Int4*)UndefinedData;
+    public ref Int4 ZYXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ZYWX => ref *(Int4*)UndefinedData;
+    public ref Int4 ZYWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZYWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZYWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZZWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZZWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ZWXY => ref *(Int4*)UndefinedData;
+    public ref Int4 ZWXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ZWYX => ref *(Int4*)UndefinedData;
+    public ref Int4 ZWYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ZWWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ZWWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 WXYZ => ref *(Int4*)UndefinedData;
+    public ref Int4 WXYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 WXZY => ref *(Int4*)UndefinedData;
+    public ref Int4 WXZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WXWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WXWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 WYXZ => ref *(Int4*)UndefinedData;
+    public ref Int4 WYXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 WYZX => ref *(Int4*)UndefinedData;
+    public ref Int4 WYZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WYWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WYWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 WZXY => ref *(Int4*)UndefinedData;
+    public ref Int4 WZXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 WZYX => ref *(Int4*)UndefinedData;
+    public ref Int4 WZYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WZWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WZWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWXX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWXX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWXY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWXY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWXZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWXZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWXW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWXW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWYX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWYX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWYY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWYY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWYZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWYZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWYW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWYW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWZX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWZX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWZY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWZY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWZZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWZZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWZW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWZW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWWX => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWWX => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWWY => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWWY => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWWZ => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWWZ => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 WWWW => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 WWWW => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the <c>R</c> component.
@@ -2477,2352 +2469,2352 @@ public unsafe partial struct Int4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 RR => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 RR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 RG => ref *(Int2*)UndefinedData;
+    public ref Int2 RG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 RB => ref *(Int2*)UndefinedData;
+    public ref Int2 RB => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 RA => ref *(Int2*)UndefinedData;
+    public ref Int2 RA => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 GR => ref *(Int2*)UndefinedData;
+    public ref Int2 GR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 GG => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 GG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 GB => ref *(Int2*)UndefinedData;
+    public ref Int2 GB => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 GA => ref *(Int2*)UndefinedData;
+    public ref Int2 GA => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 BR => ref *(Int2*)UndefinedData;
+    public ref Int2 BR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 BG => ref *(Int2*)UndefinedData;
+    public ref Int2 BG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 BB => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 BB => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 BA => ref *(Int2*)UndefinedData;
+    public ref Int2 BA => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 AR => ref *(Int2*)UndefinedData;
+    public ref Int2 AR => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 AG => ref *(Int2*)UndefinedData;
+    public ref Int2 AG => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int2"/> value with the components <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int2 AB => ref *(Int2*)UndefinedData;
+    public ref Int2 AB => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int2"/> value with the components <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int2 AA => ref *(Int2*)UndefinedData;
+    public readonly ref readonly Int2 AA => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RRA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RRA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RGR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 RGB => ref *(Int3*)UndefinedData;
+    public ref Int3 RGB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 RGA => ref *(Int3*)UndefinedData;
+    public ref Int3 RGA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RBR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RBR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 RBG => ref *(Int3*)UndefinedData;
+    public ref Int3 RBG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RBB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RBB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 RBA => ref *(Int3*)UndefinedData;
+    public ref Int3 RBA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RAR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RAR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 RAG => ref *(Int3*)UndefinedData;
+    public ref Int3 RAG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 RAB => ref *(Int3*)UndefinedData;
+    public ref Int3 RAB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 RAA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 RAA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GRR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GRR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GRG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GRG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 GRB => ref *(Int3*)UndefinedData;
+    public ref Int3 GRB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 GRA => ref *(Int3*)UndefinedData;
+    public ref Int3 GRA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GGA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GGA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 GBR => ref *(Int3*)UndefinedData;
+    public ref Int3 GBR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GBG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GBG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GBB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GBB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 GBA => ref *(Int3*)UndefinedData;
+    public ref Int3 GBA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 GAR => ref *(Int3*)UndefinedData;
+    public ref Int3 GAR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GAG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GAG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 GAB => ref *(Int3*)UndefinedData;
+    public ref Int3 GAB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 GAA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 GAA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BRR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BRR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 BRG => ref *(Int3*)UndefinedData;
+    public ref Int3 BRG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BRB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BRB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 BRA => ref *(Int3*)UndefinedData;
+    public ref Int3 BRA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 BGR => ref *(Int3*)UndefinedData;
+    public ref Int3 BGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BGB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BGB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 BGA => ref *(Int3*)UndefinedData;
+    public ref Int3 BGA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BBR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BBR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BBG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BBG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BBB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BBB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BBA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BBA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 BAR => ref *(Int3*)UndefinedData;
+    public ref Int3 BAR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 BAG => ref *(Int3*)UndefinedData;
+    public ref Int3 BAG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BAB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BAB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 BAA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 BAA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ARR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ARR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ARG => ref *(Int3*)UndefinedData;
+    public ref Int3 ARG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ARB => ref *(Int3*)UndefinedData;
+    public ref Int3 ARB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ARA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ARA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 AGR => ref *(Int3*)UndefinedData;
+    public ref Int3 AGR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 AGG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 AGG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 AGB => ref *(Int3*)UndefinedData;
+    public ref Int3 AGB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 AGA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 AGA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ABR => ref *(Int3*)UndefinedData;
+    public ref Int3 ABR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int3 ABG => ref *(Int3*)UndefinedData;
+    public ref Int3 ABG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ABB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ABB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 ABA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 ABA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 AAR => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 AAR => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 AAG => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 AAG => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 AAB => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 AAB => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int3 AAA => ref *(Int3*)UndefinedData;
+    public readonly ref readonly Int3 AAA => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RRAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RRAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 RGBA => ref *(Int4*)UndefinedData;
+    public ref Int4 RGBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 RGAB => ref *(Int4*)UndefinedData;
+    public ref Int4 RGAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RGAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RGAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 RBGA => ref *(Int4*)UndefinedData;
+    public ref Int4 RBGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 RBAG => ref *(Int4*)UndefinedData;
+    public ref Int4 RBAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RBAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RBAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RARR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RARR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RARG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RARG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RARB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RARB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RARA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RARA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RAGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RAGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RAGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RAGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 RAGB => ref *(Int4*)UndefinedData;
+    public ref Int4 RAGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RAGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RAGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RABR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RABR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 RABG => ref *(Int4*)UndefinedData;
+    public ref Int4 RABG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RABB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RABB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RABA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RABA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RAAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RAAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RAAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RAAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RAAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RAAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 RAAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 RAAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 GRBA => ref *(Int4*)UndefinedData;
+    public ref Int4 GRBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 GRAB => ref *(Int4*)UndefinedData;
+    public ref Int4 GRAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GRAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GRAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GGAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GGAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 GBRA => ref *(Int4*)UndefinedData;
+    public ref Int4 GBRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 GBAR => ref *(Int4*)UndefinedData;
+    public ref Int4 GBAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GBAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GBAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GARR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GARR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GARG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GARG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 GARB => ref *(Int4*)UndefinedData;
+    public ref Int4 GARB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GARA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GARA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GAGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GAGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GAGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GAGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GAGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GAGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GAGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GAGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 GABR => ref *(Int4*)UndefinedData;
+    public ref Int4 GABR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GABG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GABG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GABB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GABB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GABA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GABA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GAAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GAAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GAAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GAAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GAAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GAAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 GAAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 GAAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 BRGA => ref *(Int4*)UndefinedData;
+    public ref Int4 BRGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 BRAG => ref *(Int4*)UndefinedData;
+    public ref Int4 BRAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BRAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BRAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 BGRA => ref *(Int4*)UndefinedData;
+    public ref Int4 BGRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 BGAR => ref *(Int4*)UndefinedData;
+    public ref Int4 BGAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BGAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BGAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BBAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BBAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BARR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BARR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 BARG => ref *(Int4*)UndefinedData;
+    public ref Int4 BARG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BARB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BARB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BARA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BARA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 BAGR => ref *(Int4*)UndefinedData;
+    public ref Int4 BAGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BAGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BAGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BAGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BAGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BAGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BAGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BABR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BABR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BABG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BABG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BABB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BABB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BABA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BABA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BAAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BAAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BAAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BAAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BAAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BAAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 BAAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 BAAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ARGB => ref *(Int4*)UndefinedData;
+    public ref Int4 ARGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ARBG => ref *(Int4*)UndefinedData;
+    public ref Int4 ARBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ARAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ARAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGRG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 AGRB => ref *(Int4*)UndefinedData;
+    public ref Int4 AGRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 AGBR => ref *(Int4*)UndefinedData;
+    public ref Int4 AGBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AGAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AGAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABRR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABRR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ABRG => ref *(Int4*)UndefinedData;
+    public ref Int4 ABRG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABRB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABRB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABRA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABRA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref Int4 ABGR => ref *(Int4*)UndefinedData;
+    public ref Int4 ABGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABBR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABBR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABBG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABBG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABBB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABBB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABBA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABBA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 ABAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 ABAA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AARR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AARR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AARG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AARG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AARB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AARB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AARA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AARA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AAGR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AAGR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AAGG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AAGG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AAGB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AAGB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AAGA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AAGA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AABR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AABR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AABG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AABG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AABB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AABB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AABA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AABA => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AAAR => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AAAR => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AAAG => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AAAG => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AAAB => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AAAB => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="Int4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly Int4 AAAA => ref *(Int4*)UndefinedData;
+    public readonly ref readonly Int4 AAAA => ref *(Int4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -2,9 +2,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #pragma warning disable CS0660, CS0661
 
@@ -14,11 +11,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
 public unsafe partial struct Int1x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int1x1), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -40,7 +32,7 @@ public unsafe partial struct Int1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref *(int*)UndefinedData;
+    public ref int this[int row] => ref *(int*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x1"/> instance.
@@ -52,7 +44,7 @@ public unsafe partial struct Int1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x1"/> instance.
@@ -65,7 +57,7 @@ public unsafe partial struct Int1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x1"/> instance.
@@ -79,7 +71,7 @@ public unsafe partial struct Int1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -327,11 +319,6 @@ public unsafe partial struct Int1x1
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Int1x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int1x2), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -358,7 +345,7 @@ public unsafe partial struct Int1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[int row] => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x2"/> instance.
@@ -370,7 +357,7 @@ public unsafe partial struct Int1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x2"/> instance.
@@ -383,7 +370,7 @@ public unsafe partial struct Int1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x2"/> instance.
@@ -397,7 +384,7 @@ public unsafe partial struct Int1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -742,11 +729,6 @@ public unsafe partial struct Int1x2
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Int1x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int1x3), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -778,7 +760,7 @@ public unsafe partial struct Int1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[int row] => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x3"/> instance.
@@ -790,7 +772,7 @@ public unsafe partial struct Int1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x3"/> instance.
@@ -803,7 +785,7 @@ public unsafe partial struct Int1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x3"/> instance.
@@ -817,7 +799,7 @@ public unsafe partial struct Int1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -1169,11 +1151,6 @@ public unsafe partial struct Int1x3
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Int1x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int1x4), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -1210,7 +1187,7 @@ public unsafe partial struct Int1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[int row] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x4"/> instance.
@@ -1222,7 +1199,7 @@ public unsafe partial struct Int1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x4"/> instance.
@@ -1235,7 +1212,7 @@ public unsafe partial struct Int1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int1x4"/> instance.
@@ -1249,7 +1226,7 @@ public unsafe partial struct Int1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -1608,11 +1585,6 @@ public unsafe partial struct Int1x4
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct Int2x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int2x1), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -1639,7 +1611,7 @@ public unsafe partial struct Int2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref *(int*)UndefinedData;
+    public ref int this[int row] => ref *(int*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x1"/> instance.
@@ -1651,7 +1623,7 @@ public unsafe partial struct Int2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x1"/> instance.
@@ -1664,7 +1636,7 @@ public unsafe partial struct Int2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x1"/> instance.
@@ -1678,7 +1650,7 @@ public unsafe partial struct Int2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -2009,11 +1981,6 @@ public unsafe partial struct Int2x1
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Int2x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int2x2), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -2063,7 +2030,7 @@ public unsafe partial struct Int2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[int row] => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x2"/> instance.
@@ -2075,7 +2042,7 @@ public unsafe partial struct Int2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x2"/> instance.
@@ -2088,7 +2055,7 @@ public unsafe partial struct Int2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x2"/> instance.
@@ -2102,7 +2069,7 @@ public unsafe partial struct Int2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -2371,11 +2338,6 @@ public unsafe partial struct Int2x2
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 4)]
 public unsafe partial struct Int2x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int2x3), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -2437,7 +2399,7 @@ public unsafe partial struct Int2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[int row] => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x3"/> instance.
@@ -2449,7 +2411,7 @@ public unsafe partial struct Int2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x3"/> instance.
@@ -2462,7 +2424,7 @@ public unsafe partial struct Int2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x3"/> instance.
@@ -2476,7 +2438,7 @@ public unsafe partial struct Int2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -2843,11 +2805,6 @@ public unsafe partial struct Int2x3
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 4)]
 public unsafe partial struct Int2x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int2x4), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -2921,7 +2878,7 @@ public unsafe partial struct Int2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[int row] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x4"/> instance.
@@ -2933,7 +2890,7 @@ public unsafe partial struct Int2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x4"/> instance.
@@ -2946,7 +2903,7 @@ public unsafe partial struct Int2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int2x4"/> instance.
@@ -2960,7 +2917,7 @@ public unsafe partial struct Int2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -3341,11 +3298,6 @@ public unsafe partial struct Int2x4
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct Int3x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int3x1), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -3377,7 +3329,7 @@ public unsafe partial struct Int3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref *(int*)UndefinedData;
+    public ref int this[int row] => ref *(int*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x1"/> instance.
@@ -3389,7 +3341,7 @@ public unsafe partial struct Int3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x1"/> instance.
@@ -3402,7 +3354,7 @@ public unsafe partial struct Int3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x1"/> instance.
@@ -3416,7 +3368,7 @@ public unsafe partial struct Int3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -3754,11 +3706,6 @@ public unsafe partial struct Int3x1
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 4)]
 public unsafe partial struct Int3x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int3x2), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -3821,7 +3768,7 @@ public unsafe partial struct Int3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[int row] => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x2"/> instance.
@@ -3833,7 +3780,7 @@ public unsafe partial struct Int3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x2"/> instance.
@@ -3846,7 +3793,7 @@ public unsafe partial struct Int3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x2"/> instance.
@@ -3860,7 +3807,7 @@ public unsafe partial struct Int3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -4227,11 +4174,6 @@ public unsafe partial struct Int3x2
 [StructLayout(LayoutKind.Explicit, Size = 36, Pack = 4)]
 public unsafe partial struct Int3x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int3x3), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -4312,7 +4254,7 @@ public unsafe partial struct Int3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[int row] => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x3"/> instance.
@@ -4324,7 +4266,7 @@ public unsafe partial struct Int3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x3"/> instance.
@@ -4337,7 +4279,7 @@ public unsafe partial struct Int3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x3"/> instance.
@@ -4351,7 +4293,7 @@ public unsafe partial struct Int3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -4655,11 +4597,6 @@ public unsafe partial struct Int3x3
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 4)]
 public unsafe partial struct Int3x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int3x4), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -4758,7 +4695,7 @@ public unsafe partial struct Int3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[int row] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x4"/> instance.
@@ -4770,7 +4707,7 @@ public unsafe partial struct Int3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x4"/> instance.
@@ -4783,7 +4720,7 @@ public unsafe partial struct Int3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int3x4"/> instance.
@@ -4797,7 +4734,7 @@ public unsafe partial struct Int3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -5206,11 +5143,6 @@ public unsafe partial struct Int3x4
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct Int4x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int4x1), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -5247,7 +5179,7 @@ public unsafe partial struct Int4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref int this[int row] => ref *(int*)UndefinedData;
+    public ref int this[int row] => ref *(int*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x1"/> instance.
@@ -5259,7 +5191,7 @@ public unsafe partial struct Int4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x1"/> instance.
@@ -5272,7 +5204,7 @@ public unsafe partial struct Int4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x1"/> instance.
@@ -5286,7 +5218,7 @@ public unsafe partial struct Int4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -5631,11 +5563,6 @@ public unsafe partial struct Int4x1
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 4)]
 public unsafe partial struct Int4x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int4x2), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -5711,7 +5638,7 @@ public unsafe partial struct Int4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[int row] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[int row] => ref *(Int2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x2"/> instance.
@@ -5723,7 +5650,7 @@ public unsafe partial struct Int4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x2"/> instance.
@@ -5736,7 +5663,7 @@ public unsafe partial struct Int4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x2"/> instance.
@@ -5750,7 +5677,7 @@ public unsafe partial struct Int4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -6131,11 +6058,6 @@ public unsafe partial struct Int4x2
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 4)]
 public unsafe partial struct Int4x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int4x3), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -6235,7 +6157,7 @@ public unsafe partial struct Int4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[int row] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[int row] => ref *(Int3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x3"/> instance.
@@ -6247,7 +6169,7 @@ public unsafe partial struct Int4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x3"/> instance.
@@ -6260,7 +6182,7 @@ public unsafe partial struct Int4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x3"/> instance.
@@ -6274,7 +6196,7 @@ public unsafe partial struct Int4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].
@@ -6683,11 +6605,6 @@ public unsafe partial struct Int4x3
 [StructLayout(LayoutKind.Explicit, Size = 64, Pack = 4)]
 public unsafe partial struct Int4x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(Int4x4), sizeof(Int4));
-
     [FieldOffset(0)]
     private int m11;
 
@@ -6811,7 +6728,7 @@ public unsafe partial struct Int4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int4 this[int row] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[int row] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x4"/> instance.
@@ -6823,7 +6740,7 @@ public unsafe partial struct Int4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData;
+    public ref Int2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(Int2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x4"/> instance.
@@ -6836,7 +6753,7 @@ public unsafe partial struct Int4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData;
+    public ref Int3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(Int3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="Int4x4"/> instance.
@@ -6850,7 +6767,7 @@ public unsafe partial struct Int4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData;
+    public ref Int4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(Int4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="int"/> value representing the component at position [1, 1].

--- a/src/ComputeSharp.Core/Primitives/Internals/UndefinedData.cs
+++ b/src/ComputeSharp.Core/Primitives/Internals/UndefinedData.cs
@@ -1,0 +1,19 @@
+#if NET6_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#else
+using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
+#endif
+
+namespace ComputeSharp;
+
+/// <summary>
+/// A helper class with shared undefined data for all HLSL primitive types.
+/// This reduces allocations and minimizes reflection metadata kept per type.
+/// </summary>
+internal static class UndefinedData
+{
+    /// <summary>
+    /// The shared memory with undefined data (has size of <see cref="Double4"/>, as it's the maximum needed at once).
+    /// </summary>
+    public static readonly unsafe void* Memory = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UndefinedData), sizeof(Double4));
+}

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -18,9 +18,6 @@ using System.Runtime.InteropServices;
         WriteLine("using ComputeSharp.Core.Intrinsics.Attributes;");
     }
 #>
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #pragma warning disable CS0660, CS0661
 
@@ -50,12 +47,7 @@ void GenerateMatrixProperties(string typeName, int rows, int columns, int elemen
 [StructLayout(LayoutKind.Explicit, Size = <#=(elementSize * rows * columns)#>, Pack = <#=elementSize#>)]
 public unsafe partial struct <#=fullTypeName#>
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(<#=fullTypeName#>), sizeof(<#=typeName#>4));
 <#
-    WriteLine("");
     PushIndent("    ");
 
     // Generate the private fields
@@ -155,7 +147,7 @@ public unsafe partial struct <#=fullTypeName#>
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref <#=rowTypeName#> this[int row] => ref *(<#=rowTypeName#>*)UndefinedData;
+    public ref <#=rowTypeName#> this[int row] => ref *(<#=rowTypeName#>*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="<#=fullTypeName#>"/> instance.
@@ -167,7 +159,7 @@ public unsafe partial struct <#=fullTypeName#>
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref <#=typeName#>2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(<#=typeName#>2*)UndefinedData;
+    public ref <#=typeName#>2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(<#=typeName#>2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="<#=fullTypeName#>"/> instance.
@@ -180,7 +172,7 @@ public unsafe partial struct <#=fullTypeName#>
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref <#=typeName#>3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(<#=typeName#>3*)UndefinedData;
+    public ref <#=typeName#>3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(<#=typeName#>3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="<#=fullTypeName#>"/> instance.
@@ -194,7 +186,7 @@ public unsafe partial struct <#=fullTypeName#>
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref <#=typeName#>4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(<#=typeName#>4*)UndefinedData;
+    public ref <#=typeName#>4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(<#=typeName#>4*)UndefinedData.Memory;
 <#
     for (int i = 1; i <= rows; i++)
     for (int j = 1; j <= columns; j++)

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
@@ -3,9 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -16,11 +13,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct UInt2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt2), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint x;
 
@@ -33,7 +25,7 @@ public unsafe partial struct UInt2
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref uint this[int i] => ref *(uint*)UndefinedData;
+    public ref uint this[int i] => ref *(uint*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="UInt2"/> value with all components set to 0.
@@ -72,196 +64,196 @@ public unsafe partial struct UInt2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 XX => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 XX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 XY => ref *(UInt2*)UndefinedData;
+    public ref UInt2 XY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 YX => ref *(UInt2*)UndefinedData;
+    public ref UInt2 YX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 YY => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 YY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XYX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YXY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>R</c> component.
@@ -280,196 +272,196 @@ public unsafe partial struct UInt2
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 RR => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 RR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 RG => ref *(UInt2*)UndefinedData;
+    public ref UInt2 RG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 GR => ref *(UInt2*)UndefinedData;
+    public ref UInt2 GR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 GG => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 GG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RGR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GRR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GRR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GRG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GRG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGG => ref *(UInt4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
@@ -3,9 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -16,11 +13,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct UInt3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt3), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint x;
 
@@ -36,7 +28,7 @@ public unsafe partial struct UInt3
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref uint this[int i] => ref *(uint*)UndefinedData;
+    public ref uint this[int i] => ref *(uint*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="UInt3"/> value with all components set to 0.
@@ -86,819 +78,819 @@ public unsafe partial struct UInt3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 XX => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 XX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 XY => ref *(UInt2*)UndefinedData;
+    public ref UInt2 XY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 XZ => ref *(UInt2*)UndefinedData;
+    public ref UInt2 XZ => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 YX => ref *(UInt2*)UndefinedData;
+    public ref UInt2 YX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 YY => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 YY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 YZ => ref *(UInt2*)UndefinedData;
+    public ref UInt2 YZ => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 ZX => ref *(UInt2*)UndefinedData;
+    public ref UInt2 ZX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 ZY => ref *(UInt2*)UndefinedData;
+    public ref UInt2 ZY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 ZZ => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 ZZ => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XYX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 XYZ => ref *(UInt3*)UndefinedData;
+    public ref UInt3 XYZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XZX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XZX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 XZY => ref *(UInt3*)UndefinedData;
+    public ref UInt3 XZY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XZZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XZZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YXY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 YXZ => ref *(UInt3*)UndefinedData;
+    public ref UInt3 YXZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 YZX => ref *(UInt3*)UndefinedData;
+    public ref UInt3 YZX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YZY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YZY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YZZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YZZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ZXY => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ZXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZXZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZXZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ZYX => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ZYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZYZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZYZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZZX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZZX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZZY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZZY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZZZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZZZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>R</c> component.
@@ -923,819 +915,819 @@ public unsafe partial struct UInt3
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 RR => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 RR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 RG => ref *(UInt2*)UndefinedData;
+    public ref UInt2 RG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 RB => ref *(UInt2*)UndefinedData;
+    public ref UInt2 RB => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 GR => ref *(UInt2*)UndefinedData;
+    public ref UInt2 GR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 GG => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 GG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 GB => ref *(UInt2*)UndefinedData;
+    public ref UInt2 GB => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 BR => ref *(UInt2*)UndefinedData;
+    public ref UInt2 BR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 BG => ref *(UInt2*)UndefinedData;
+    public ref UInt2 BG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 BB => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 BB => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RGR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 RGB => ref *(UInt3*)UndefinedData;
+    public ref UInt3 RGB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RBR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RBR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 RBG => ref *(UInt3*)UndefinedData;
+    public ref UInt3 RBG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RBB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RBB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GRR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GRR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GRG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GRG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 GRB => ref *(UInt3*)UndefinedData;
+    public ref UInt3 GRB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 GBR => ref *(UInt3*)UndefinedData;
+    public ref UInt3 GBR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GBG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GBG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GBB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GBB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BRR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BRR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 BRG => ref *(UInt3*)UndefinedData;
+    public ref UInt3 BRG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BRB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BRB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 BGR => ref *(UInt3*)UndefinedData;
+    public ref UInt3 BGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BGB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BGB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BBR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BBR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BBG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BBG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BBB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BBB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBBB => ref *(UInt4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
@@ -3,9 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -16,11 +13,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct UInt4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt4), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint x;
 
@@ -39,7 +31,7 @@ public unsafe partial struct UInt4
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref uint this[int i] => ref *(uint*)UndefinedData;
+    public ref uint this[int i] => ref *(uint*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a <see cref="UInt4"/> value with all components set to 0.
@@ -100,2352 +92,2352 @@ public unsafe partial struct UInt4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 XX => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 XX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 XY => ref *(UInt2*)UndefinedData;
+    public ref UInt2 XY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 XZ => ref *(UInt2*)UndefinedData;
+    public ref UInt2 XZ => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 XW => ref *(UInt2*)UndefinedData;
+    public ref UInt2 XW => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 YX => ref *(UInt2*)UndefinedData;
+    public ref UInt2 YX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 YY => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 YY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 YZ => ref *(UInt2*)UndefinedData;
+    public ref UInt2 YZ => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 YW => ref *(UInt2*)UndefinedData;
+    public ref UInt2 YW => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 ZX => ref *(UInt2*)UndefinedData;
+    public ref UInt2 ZX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 ZY => ref *(UInt2*)UndefinedData;
+    public ref UInt2 ZY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 ZZ => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 ZZ => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 ZW => ref *(UInt2*)UndefinedData;
+    public ref UInt2 ZW => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 WX => ref *(UInt2*)UndefinedData;
+    public ref UInt2 WX => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 WY => ref *(UInt2*)UndefinedData;
+    public ref UInt2 WY => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 WZ => ref *(UInt2*)UndefinedData;
+    public ref UInt2 WZ => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 WW => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 WW => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XXW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XXW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XYX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 XYZ => ref *(UInt3*)UndefinedData;
+    public ref UInt3 XYZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 XYW => ref *(UInt3*)UndefinedData;
+    public ref UInt3 XYW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XZX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XZX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 XZY => ref *(UInt3*)UndefinedData;
+    public ref UInt3 XZY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XZZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XZZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 XZW => ref *(UInt3*)UndefinedData;
+    public ref UInt3 XZW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XWX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XWX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 XWY => ref *(UInt3*)UndefinedData;
+    public ref UInt3 XWY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 XWZ => ref *(UInt3*)UndefinedData;
+    public ref UInt3 XWZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 XWW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 XWW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YXY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 YXZ => ref *(UInt3*)UndefinedData;
+    public ref UInt3 YXZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 YXW => ref *(UInt3*)UndefinedData;
+    public ref UInt3 YXW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YYW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YYW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 YZX => ref *(UInt3*)UndefinedData;
+    public ref UInt3 YZX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YZY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YZY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YZZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YZZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 YZW => ref *(UInt3*)UndefinedData;
+    public ref UInt3 YZW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 YWX => ref *(UInt3*)UndefinedData;
+    public ref UInt3 YWX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YWY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YWY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 YWZ => ref *(UInt3*)UndefinedData;
+    public ref UInt3 YWZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 YWW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 YWW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ZXY => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ZXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZXZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZXZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ZXW => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ZXW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ZYX => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ZYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZYZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZYZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ZYW => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ZYW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZZX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZZX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZZY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZZY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZZZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZZZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZZW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZZW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ZWX => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ZWX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ZWY => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ZWY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZWZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZWZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ZWW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ZWW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WXX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WXX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 WXY => ref *(UInt3*)UndefinedData;
+    public ref UInt3 WXY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 WXZ => ref *(UInt3*)UndefinedData;
+    public ref UInt3 WXZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WXW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WXW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 WYX => ref *(UInt3*)UndefinedData;
+    public ref UInt3 WYX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WYY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WYY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 WYZ => ref *(UInt3*)UndefinedData;
+    public ref UInt3 WYZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WYW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WYW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 WZX => ref *(UInt3*)UndefinedData;
+    public ref UInt3 WZX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 WZY => ref *(UInt3*)UndefinedData;
+    public ref UInt3 WZY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WZZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WZZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WZW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WZW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WWX => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WWX => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WWY => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WWY => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WWZ => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WWZ => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 WWW => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 WWW => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XXWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XXWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 XYZW => ref *(UInt4*)UndefinedData;
+    public ref UInt4 XYZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 XYWZ => ref *(UInt4*)UndefinedData;
+    public ref UInt4 XYWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XYWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XYWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 XZYW => ref *(UInt4*)UndefinedData;
+    public ref UInt4 XZYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 XZWY => ref *(UInt4*)UndefinedData;
+    public ref UInt4 XZWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XZWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XZWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 XWYZ => ref *(UInt4*)UndefinedData;
+    public ref UInt4 XWYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 XWZY => ref *(UInt4*)UndefinedData;
+    public ref UInt4 XWZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="X"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 XWWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 XWWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 YXZW => ref *(UInt4*)UndefinedData;
+    public ref UInt4 YXZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 YXWZ => ref *(UInt4*)UndefinedData;
+    public ref UInt4 YXWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YXWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YXWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YYWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YYWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 YZXW => ref *(UInt4*)UndefinedData;
+    public ref UInt4 YZXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 YZWX => ref *(UInt4*)UndefinedData;
+    public ref UInt4 YZWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YZWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YZWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 YWXZ => ref *(UInt4*)UndefinedData;
+    public ref UInt4 YWXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 YWZX => ref *(UInt4*)UndefinedData;
+    public ref UInt4 YWZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 YWWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 YWWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ZXYW => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ZXYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ZXWY => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ZXWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZXWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZXWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ZYXW => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ZYXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ZYWX => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ZYWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZYWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZYWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZZWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZZWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ZWXY => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ZWXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ZWYX => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ZWYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ZWWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ZWWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 WXYZ => ref *(UInt4*)UndefinedData;
+    public ref UInt4 WXYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 WXZY => ref *(UInt4*)UndefinedData;
+    public ref UInt4 WXZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="X"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WXWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WXWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 WYXZ => ref *(UInt4*)UndefinedData;
+    public ref UInt4 WYXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 WYZX => ref *(UInt4*)UndefinedData;
+    public ref UInt4 WYZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WYWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WYWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 WZXY => ref *(UInt4*)UndefinedData;
+    public ref UInt4 WZXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 WZYX => ref *(UInt4*)UndefinedData;
+    public ref UInt4 WZYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WZWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WZWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWXX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWXX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWXY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWXY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWXZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWXZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="X"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWXW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWXW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWYX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWYX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWYY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWYY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWYZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWYZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWYW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWYW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWZX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWZX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWZY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWZY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWZZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWZZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWZW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWZW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="X"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWWX => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWWX => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Y"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWWY => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWWY => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="Z"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWWZ => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWWZ => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="W"/>, <see cref="W"/>, <see cref="W"/>, <see cref="W"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 WWWW => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 WWWW => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the <c>R</c> component.
@@ -2476,2352 +2468,2352 @@ public unsafe partial struct UInt4
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 RR => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 RR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 RG => ref *(UInt2*)UndefinedData;
+    public ref UInt2 RG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 RB => ref *(UInt2*)UndefinedData;
+    public ref UInt2 RB => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 RA => ref *(UInt2*)UndefinedData;
+    public ref UInt2 RA => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 GR => ref *(UInt2*)UndefinedData;
+    public ref UInt2 GR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 GG => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 GG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 GB => ref *(UInt2*)UndefinedData;
+    public ref UInt2 GB => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 GA => ref *(UInt2*)UndefinedData;
+    public ref UInt2 GA => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 BR => ref *(UInt2*)UndefinedData;
+    public ref UInt2 BR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 BG => ref *(UInt2*)UndefinedData;
+    public ref UInt2 BG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 BB => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 BB => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 BA => ref *(UInt2*)UndefinedData;
+    public ref UInt2 BA => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 AR => ref *(UInt2*)UndefinedData;
+    public ref UInt2 AR => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 AG => ref *(UInt2*)UndefinedData;
+    public ref UInt2 AG => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt2"/> value with the components <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt2 AB => ref *(UInt2*)UndefinedData;
+    public ref UInt2 AB => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt2"/> value with the components <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt2 AA => ref *(UInt2*)UndefinedData;
+    public readonly ref readonly UInt2 AA => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RRA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RRA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RGR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 RGB => ref *(UInt3*)UndefinedData;
+    public ref UInt3 RGB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 RGA => ref *(UInt3*)UndefinedData;
+    public ref UInt3 RGA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RBR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RBR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 RBG => ref *(UInt3*)UndefinedData;
+    public ref UInt3 RBG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RBB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RBB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 RBA => ref *(UInt3*)UndefinedData;
+    public ref UInt3 RBA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RAR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RAR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 RAG => ref *(UInt3*)UndefinedData;
+    public ref UInt3 RAG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 RAB => ref *(UInt3*)UndefinedData;
+    public ref UInt3 RAB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 RAA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 RAA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GRR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GRR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GRG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GRG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 GRB => ref *(UInt3*)UndefinedData;
+    public ref UInt3 GRB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 GRA => ref *(UInt3*)UndefinedData;
+    public ref UInt3 GRA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GGA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GGA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 GBR => ref *(UInt3*)UndefinedData;
+    public ref UInt3 GBR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GBG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GBG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GBB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GBB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 GBA => ref *(UInt3*)UndefinedData;
+    public ref UInt3 GBA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 GAR => ref *(UInt3*)UndefinedData;
+    public ref UInt3 GAR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GAG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GAG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 GAB => ref *(UInt3*)UndefinedData;
+    public ref UInt3 GAB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 GAA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 GAA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BRR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BRR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 BRG => ref *(UInt3*)UndefinedData;
+    public ref UInt3 BRG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BRB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BRB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 BRA => ref *(UInt3*)UndefinedData;
+    public ref UInt3 BRA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 BGR => ref *(UInt3*)UndefinedData;
+    public ref UInt3 BGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BGB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BGB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 BGA => ref *(UInt3*)UndefinedData;
+    public ref UInt3 BGA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BBR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BBR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BBG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BBG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BBB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BBB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BBA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BBA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 BAR => ref *(UInt3*)UndefinedData;
+    public ref UInt3 BAR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 BAG => ref *(UInt3*)UndefinedData;
+    public ref UInt3 BAG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BAB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BAB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 BAA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 BAA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ARR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ARR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ARG => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ARG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ARB => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ARB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ARA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ARA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 AGR => ref *(UInt3*)UndefinedData;
+    public ref UInt3 AGR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 AGG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 AGG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 AGB => ref *(UInt3*)UndefinedData;
+    public ref UInt3 AGB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 AGA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 AGA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ABR => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ABR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt3 ABG => ref *(UInt3*)UndefinedData;
+    public ref UInt3 ABG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ABB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ABB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 ABA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 ABA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 AAR => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 AAR => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 AAG => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 AAG => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 AAB => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 AAB => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt3"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt3 AAA => ref *(UInt3*)UndefinedData;
+    public readonly ref readonly UInt3 AAA => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RRAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RRAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 RGBA => ref *(UInt4*)UndefinedData;
+    public ref UInt4 RGBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 RGAB => ref *(UInt4*)UndefinedData;
+    public ref UInt4 RGAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RGAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RGAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 RBGA => ref *(UInt4*)UndefinedData;
+    public ref UInt4 RBGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 RBAG => ref *(UInt4*)UndefinedData;
+    public ref UInt4 RBAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RBAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RBAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RARR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RARR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RARG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RARG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RARB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RARB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RARA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RARA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RAGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RAGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RAGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RAGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 RAGB => ref *(UInt4*)UndefinedData;
+    public ref UInt4 RAGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RAGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RAGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RABR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RABR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 RABG => ref *(UInt4*)UndefinedData;
+    public ref UInt4 RABG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RABB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RABB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RABA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RABA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RAAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RAAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RAAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RAAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RAAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RAAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="R"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 RAAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 RAAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 GRBA => ref *(UInt4*)UndefinedData;
+    public ref UInt4 GRBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 GRAB => ref *(UInt4*)UndefinedData;
+    public ref UInt4 GRAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GRAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GRAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GGAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GGAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 GBRA => ref *(UInt4*)UndefinedData;
+    public ref UInt4 GBRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 GBAR => ref *(UInt4*)UndefinedData;
+    public ref UInt4 GBAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GBAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GBAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GARR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GARR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GARG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GARG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 GARB => ref *(UInt4*)UndefinedData;
+    public ref UInt4 GARB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GARA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GARA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GAGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GAGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GAGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GAGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GAGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GAGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GAGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GAGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 GABR => ref *(UInt4*)UndefinedData;
+    public ref UInt4 GABR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GABG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GABG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GABB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GABB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GABA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GABA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GAAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GAAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GAAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GAAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GAAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GAAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="G"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 GAAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 GAAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 BRGA => ref *(UInt4*)UndefinedData;
+    public ref UInt4 BRGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 BRAG => ref *(UInt4*)UndefinedData;
+    public ref UInt4 BRAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BRAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BRAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 BGRA => ref *(UInt4*)UndefinedData;
+    public ref UInt4 BGRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 BGAR => ref *(UInt4*)UndefinedData;
+    public ref UInt4 BGAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BGAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BGAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BBAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BBAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BARR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BARR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 BARG => ref *(UInt4*)UndefinedData;
+    public ref UInt4 BARG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BARB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BARB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BARA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BARA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 BAGR => ref *(UInt4*)UndefinedData;
+    public ref UInt4 BAGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BAGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BAGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BAGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BAGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BAGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BAGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BABR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BABR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BABG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BABG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BABB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BABB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BABA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BABA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BAAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BAAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BAAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BAAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BAAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BAAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="B"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 BAAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 BAAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ARGB => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ARGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ARBG => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ARBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="R"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ARAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ARAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGRG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 AGRB => ref *(UInt4*)UndefinedData;
+    public ref UInt4 AGRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 AGBR => ref *(UInt4*)UndefinedData;
+    public ref UInt4 AGBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="G"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AGAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AGAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABRR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABRR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ABRG => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ABRG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABRB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABRB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABRA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABRA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref UInt4 ABGR => ref *(UInt4*)UndefinedData;
+    public ref UInt4 ABGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABBR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABBR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABBG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABBG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABBB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABBB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABBA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABBA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="B"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 ABAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 ABAA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AARR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AARR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AARG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AARG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AARB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AARB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="R"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AARA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AARA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AAGR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AAGR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AAGG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AAGG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AAGB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AAGB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="G"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AAGA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AAGA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AABR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AABR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AABG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AABG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AABB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AABB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="B"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AABA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AABA => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="R"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AAAR => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AAAR => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="G"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AAAG => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AAAG => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="B"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AAAB => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AAAB => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a readonly reference to the <see cref="UInt4"/> value with the components <see cref="A"/>, <see cref="A"/>, <see cref="A"/>, <see cref="A"/>.
     /// </summary>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public readonly ref readonly UInt4 AAAA => ref *(UInt4*)UndefinedData;
+    public readonly ref readonly UInt4 AAAA => ref *(UInt4*)UndefinedData.Memory;
 
 #if !SOURCE_GENERATOR
 

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -1,9 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #pragma warning disable CS0660, CS0661
 
@@ -13,11 +10,6 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
 public unsafe partial struct UInt1x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt1x1), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -39,7 +31,7 @@ public unsafe partial struct UInt1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref *(uint*)UndefinedData;
+    public ref uint this[int row] => ref *(uint*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x1"/> instance.
@@ -51,7 +43,7 @@ public unsafe partial struct UInt1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x1"/> instance.
@@ -64,7 +56,7 @@ public unsafe partial struct UInt1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x1"/> instance.
@@ -78,7 +70,7 @@ public unsafe partial struct UInt1x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -301,11 +293,6 @@ public unsafe partial struct UInt1x1
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct UInt1x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt1x2), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -332,7 +319,7 @@ public unsafe partial struct UInt1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x2"/> instance.
@@ -344,7 +331,7 @@ public unsafe partial struct UInt1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x2"/> instance.
@@ -357,7 +344,7 @@ public unsafe partial struct UInt1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x2"/> instance.
@@ -371,7 +358,7 @@ public unsafe partial struct UInt1x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -607,11 +594,6 @@ public unsafe partial struct UInt1x2
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct UInt1x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt1x3), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -643,7 +625,7 @@ public unsafe partial struct UInt1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x3"/> instance.
@@ -655,7 +637,7 @@ public unsafe partial struct UInt1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x3"/> instance.
@@ -668,7 +650,7 @@ public unsafe partial struct UInt1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x3"/> instance.
@@ -682,7 +664,7 @@ public unsafe partial struct UInt1x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -925,11 +907,6 @@ public unsafe partial struct UInt1x3
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct UInt1x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt1x4), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -966,7 +943,7 @@ public unsafe partial struct UInt1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x4"/> instance.
@@ -978,7 +955,7 @@ public unsafe partial struct UInt1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x4"/> instance.
@@ -991,7 +968,7 @@ public unsafe partial struct UInt1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt1x4"/> instance.
@@ -1005,7 +982,7 @@ public unsafe partial struct UInt1x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -1255,11 +1232,6 @@ public unsafe partial struct UInt1x4
 [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
 public unsafe partial struct UInt2x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt2x1), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -1286,7 +1258,7 @@ public unsafe partial struct UInt2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref *(uint*)UndefinedData;
+    public ref uint this[int row] => ref *(uint*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x1"/> instance.
@@ -1298,7 +1270,7 @@ public unsafe partial struct UInt2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x1"/> instance.
@@ -1311,7 +1283,7 @@ public unsafe partial struct UInt2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x1"/> instance.
@@ -1325,7 +1297,7 @@ public unsafe partial struct UInt2x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -1561,11 +1533,6 @@ public unsafe partial struct UInt2x1
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct UInt2x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt2x2), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -1615,7 +1582,7 @@ public unsafe partial struct UInt2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x2"/> instance.
@@ -1627,7 +1594,7 @@ public unsafe partial struct UInt2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x2"/> instance.
@@ -1640,7 +1607,7 @@ public unsafe partial struct UInt2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x2"/> instance.
@@ -1654,7 +1621,7 @@ public unsafe partial struct UInt2x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -1898,11 +1865,6 @@ public unsafe partial struct UInt2x2
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 4)]
 public unsafe partial struct UInt2x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt2x3), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -1964,7 +1926,7 @@ public unsafe partial struct UInt2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x3"/> instance.
@@ -1976,7 +1938,7 @@ public unsafe partial struct UInt2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x3"/> instance.
@@ -1989,7 +1951,7 @@ public unsafe partial struct UInt2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x3"/> instance.
@@ -2003,7 +1965,7 @@ public unsafe partial struct UInt2x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -2261,11 +2223,6 @@ public unsafe partial struct UInt2x3
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 4)]
 public unsafe partial struct UInt2x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt2x4), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -2339,7 +2296,7 @@ public unsafe partial struct UInt2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x4"/> instance.
@@ -2351,7 +2308,7 @@ public unsafe partial struct UInt2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x4"/> instance.
@@ -2364,7 +2321,7 @@ public unsafe partial struct UInt2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt2x4"/> instance.
@@ -2378,7 +2335,7 @@ public unsafe partial struct UInt2x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -2650,11 +2607,6 @@ public unsafe partial struct UInt2x4
 [StructLayout(LayoutKind.Explicit, Size = 12, Pack = 4)]
 public unsafe partial struct UInt3x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt3x1), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -2686,7 +2638,7 @@ public unsafe partial struct UInt3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref *(uint*)UndefinedData;
+    public ref uint this[int row] => ref *(uint*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x1"/> instance.
@@ -2698,7 +2650,7 @@ public unsafe partial struct UInt3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x1"/> instance.
@@ -2711,7 +2663,7 @@ public unsafe partial struct UInt3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x1"/> instance.
@@ -2725,7 +2677,7 @@ public unsafe partial struct UInt3x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -2968,11 +2920,6 @@ public unsafe partial struct UInt3x1
 [StructLayout(LayoutKind.Explicit, Size = 24, Pack = 4)]
 public unsafe partial struct UInt3x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt3x2), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -3035,7 +2982,7 @@ public unsafe partial struct UInt3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x2"/> instance.
@@ -3047,7 +2994,7 @@ public unsafe partial struct UInt3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x2"/> instance.
@@ -3060,7 +3007,7 @@ public unsafe partial struct UInt3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x2"/> instance.
@@ -3074,7 +3021,7 @@ public unsafe partial struct UInt3x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -3332,11 +3279,6 @@ public unsafe partial struct UInt3x2
 [StructLayout(LayoutKind.Explicit, Size = 36, Pack = 4)]
 public unsafe partial struct UInt3x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt3x3), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -3417,7 +3359,7 @@ public unsafe partial struct UInt3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x3"/> instance.
@@ -3429,7 +3371,7 @@ public unsafe partial struct UInt3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x3"/> instance.
@@ -3442,7 +3384,7 @@ public unsafe partial struct UInt3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x3"/> instance.
@@ -3456,7 +3398,7 @@ public unsafe partial struct UInt3x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -3735,11 +3677,6 @@ public unsafe partial struct UInt3x3
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 4)]
 public unsafe partial struct UInt3x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt3x4), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -3838,7 +3775,7 @@ public unsafe partial struct UInt3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x4"/> instance.
@@ -3850,7 +3787,7 @@ public unsafe partial struct UInt3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x4"/> instance.
@@ -3863,7 +3800,7 @@ public unsafe partial struct UInt3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt3x4"/> instance.
@@ -3877,7 +3814,7 @@ public unsafe partial struct UInt3x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -4177,11 +4114,6 @@ public unsafe partial struct UInt3x4
 [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 4)]
 public unsafe partial struct UInt4x1
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt4x1), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -4218,7 +4150,7 @@ public unsafe partial struct UInt4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref uint this[int row] => ref *(uint*)UndefinedData;
+    public ref uint this[int row] => ref *(uint*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x1"/> instance.
@@ -4230,7 +4162,7 @@ public unsafe partial struct UInt4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x1"/> instance.
@@ -4243,7 +4175,7 @@ public unsafe partial struct UInt4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x1"/> instance.
@@ -4257,7 +4189,7 @@ public unsafe partial struct UInt4x1
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -4507,11 +4439,6 @@ public unsafe partial struct UInt4x1
 [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 4)]
 public unsafe partial struct UInt4x2
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt4x2), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -4587,7 +4514,7 @@ public unsafe partial struct UInt4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[int row] => ref *(UInt2*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x2"/> instance.
@@ -4599,7 +4526,7 @@ public unsafe partial struct UInt4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x2"/> instance.
@@ -4612,7 +4539,7 @@ public unsafe partial struct UInt4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x2"/> instance.
@@ -4626,7 +4553,7 @@ public unsafe partial struct UInt4x2
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -4898,11 +4825,6 @@ public unsafe partial struct UInt4x2
 [StructLayout(LayoutKind.Explicit, Size = 48, Pack = 4)]
 public unsafe partial struct UInt4x3
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt4x3), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -5002,7 +4924,7 @@ public unsafe partial struct UInt4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[int row] => ref *(UInt3*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x3"/> instance.
@@ -5014,7 +4936,7 @@ public unsafe partial struct UInt4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x3"/> instance.
@@ -5027,7 +4949,7 @@ public unsafe partial struct UInt4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x3"/> instance.
@@ -5041,7 +4963,7 @@ public unsafe partial struct UInt4x3
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].
@@ -5341,11 +5263,6 @@ public unsafe partial struct UInt4x3
 [StructLayout(LayoutKind.Explicit, Size = 64, Pack = 4)]
 public unsafe partial struct UInt4x4
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(UInt4x4), sizeof(UInt4));
-
     [FieldOffset(0)]
     private uint m11;
 
@@ -5469,7 +5386,7 @@ public unsafe partial struct UInt4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[int row] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x4"/> instance.
@@ -5481,7 +5398,7 @@ public unsafe partial struct UInt4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData;
+    public ref UInt2 this[MatrixIndex xy0, MatrixIndex xy1] => ref *(UInt2*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x4"/> instance.
@@ -5494,7 +5411,7 @@ public unsafe partial struct UInt4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>
     [UnscopedRef]
-    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData;
+    public ref UInt3 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2] => ref *(UInt3*)UndefinedData.Memory;
         
     /// <summary>
     /// Gets a swizzled reference to a specific sequence of items in the current <see cref="UInt4x4"/> instance.
@@ -5508,7 +5425,7 @@ public unsafe partial struct UInt4x4
     /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
     /// </remarks>s
     [UnscopedRef]
-    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData;
+    public ref UInt4 this[MatrixIndex xy0, MatrixIndex xy1, MatrixIndex xy2, MatrixIndex xy3] => ref *(UInt4*)UndefinedData.Memory;
 
     /// <summary>
     /// Gets a reference to the <see cref="uint"/> value representing the component at position [1, 1].

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -75,9 +75,6 @@ void GenerateVectorProperties(string typeName, int elementSize)
         WriteLine("using ComputeSharp.Core.Intrinsics.Attributes;");
     }
 #>
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 #nullable enable
 #pragma warning disable CS0660, CS0661
@@ -88,12 +85,7 @@ namespace ComputeSharp;
 [StructLayout(LayoutKind.Explicit, Size = <#=(elementSize * i)#>, Pack = <#=elementSize#>)]
 public unsafe partial struct <#=typeName#>
 {
-    /// <summary>
-    /// A private buffer to which the undefined properties will point to.
-    /// </summary>
-    private static readonly void* UndefinedData = (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(<#=typeName#>), sizeof(<#=elementTypeName#>4));
 <#
-    WriteLine("");
     PushIndent("    ");
 
     // Generate the private fields
@@ -112,7 +104,7 @@ public unsafe partial struct <#=typeName#>
     /// <param name="i">The index of the component to access.</param>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     [UnscopedRef]
-    public ref <#=hlslElementTypeName#> this[int i] => ref *(<#=hlslElementTypeName#>*)UndefinedData;
+    public ref <#=hlslElementTypeName#> this[int i] => ref *(<#=hlslElementTypeName#>*)UndefinedData.Memory;
 
 <#
     // Generate the true/false and zero/one properties
@@ -230,7 +222,7 @@ public unsafe partial struct <#=typeName#>
             // Property
             WriteLine("[UnscopedRef]");
             Write($"public {refType} {propertyType} {propertyName} ");
-            WriteLine($"=> ref *({propertyType}*)UndefinedData;");
+            WriteLine($"=> ref *({propertyType}*)UndefinedData.Memory;");
         }
     }
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -49,6 +49,7 @@
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\Int3.g.cs" Link="ComputeSharp.Core\Primitives\Int\Int3.g.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\Int4.g.cs" Link="ComputeSharp.Core\Primitives\Int\Int4.g.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\IntMxN.g.cs" Link="ComputeSharp.Core\Primitives\Int\IntMxN.g.cs" />
+    <Compile Include="..\ComputeSharp.Core\Primitives\Internals\UndefinedData.cs" Link="ComputeSharp.Core\Primitives\Internals\UndefinedData.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt2.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt2.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt3.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt3.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt4.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt4.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -82,6 +82,7 @@
     <Compile Include="..\ComputeSharp.D2D1\Interfaces\Descriptors\ID2D1PixelShaderDescriptor{T}.cs" Link="ComputeSharp.D2D1\Interfaces\Descriptors\ID2D1PixelShaderDescriptor{T}.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Intrinsics\D2D.cs" Link="ComputeSharp.D2D1\Intrinsics\D2D.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" Link="ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Shaders\Interop\Helpers\D2D1AssemblyAssociatedMemory.cs" Link="ComputeSharp.D2D1\Shaders\Interop\Helpers\D2D1AssemblyAssociatedMemory.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Interop\D2D1InputDescription.cs" Link="ComputeSharp.D2D1\Shaders\Interop\D2D1InputDescription.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Interop\D2D1PixelShaderInputType.cs" Link="ComputeSharp.D2D1\Shaders\Interop\D2D1PixelShaderInputType.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Interop\D2D1ResourceTextureDescription.cs" Link="ComputeSharp.D2D1\Shaders\Interop\D2D1ResourceTextureDescription.cs" />

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -6,9 +6,6 @@ using ComputeSharp.D2D1.Shaders.Interop.Effects.ResourceManagers;
 using ComputeSharp.D2D1.Shaders.Interop.Effects.TransformMappers;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 namespace ComputeSharp.D2D1.Interop.Effects;
 
@@ -47,7 +44,7 @@ internal unsafe partial struct PixelShaderEffect
     /// <returns>The combined vtable for <see cref="ID2D1EffectImpl"/> and <see cref="ID2D1DrawTransform"/>.</returns>
     private static void** InitVtblForID2D1EffectImplAndID2D1DrawTransform()
     {
-        void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(PixelShaderEffect), sizeof(void*) * 14);
+        void** lpVtbl = (void**)D2D1AssemblyAssociatedMemory.Allocate(sizeof(void*) * 14);
 
         // ID2D1EffectImpl
 #if NET6_0_OR_GREATER

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.cs
@@ -2,11 +2,9 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using ComputeSharp.D2D1.Interop;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 namespace ComputeSharp.D2D1.Shaders.Interop.Effects.ResourceManagers;
 
@@ -45,7 +43,7 @@ internal unsafe partial struct D2D1ResourceTextureManagerImpl
     /// <returns>The combined vtable for <see cref="ID2D1ResourceTextureManager"/> and <see cref="ID2D1ResourceTextureManagerInternal"/>.</returns>
     private static void** InitVtblForID2D1ResourceTextureManagerAndID2D1ResourceTextureManagerInternal()
     {
-        void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(D2D1ResourceTextureManagerImpl), sizeof(void*) * 10);
+        void** lpVtbl = (void**)D2D1AssemblyAssociatedMemory.Allocate(sizeof(void*) * 10);
 
         // ID2D1ResourceTextureManager
 #if NET6_0_OR_GREATER

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/TransformMappers/D2D1DrawInfoUpdateContextImpl.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/TransformMappers/D2D1DrawInfoUpdateContextImpl.cs
@@ -2,11 +2,9 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using ComputeSharp.D2D1.Interop;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 namespace ComputeSharp.D2D1.Shaders.Interop.Effects.TransformMappers;
 
@@ -45,7 +43,7 @@ internal unsafe partial struct D2D1DrawInfoUpdateContextImpl
     /// <returns>The combined vtable for <see cref="ID2D1DrawInfoUpdateContext"/> and <see cref="ID2D1DrawInfoUpdateContextInternal"/>.</returns>
     private static void** InitVtblForID2D1DrawInfoUpdateContextAndID2D1DrawInfoUpdateContextInternal()
     {
-        void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(D2D1DrawInfoUpdateContextImpl), sizeof(void*) * 10);
+        void** lpVtbl = (void**)D2D1AssemblyAssociatedMemory.Allocate(sizeof(void*) * 10);
 
         // ID2D1ResourceTextureManager
 #if NET6_0_OR_GREATER

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/TransformMappers/D2D1TransformMapperImpl.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/TransformMappers/D2D1TransformMapperImpl.cs
@@ -3,11 +3,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Interop.Effects;
 using TerraFX.Interop.Windows;
-#if !NET6_0_OR_GREATER
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
-#endif
 
 namespace ComputeSharp.D2D1.Shaders.Interop.Effects.TransformMappers;
 
@@ -46,7 +44,7 @@ internal unsafe partial struct D2D1TransformMapperImpl
     /// <returns>The combined vtable for <see cref="ID2D1TransformMapper"/> and <see cref="ID2D1TransformMapperInternal"/>.</returns>
     private static void** InitVtblForID2D1TransformMapperAndID2D1TransformMapperInternal()
     {
-        void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(D2D1TransformMapperImpl), sizeof(void*) * 10);
+        void** lpVtbl = (void**)D2D1AssemblyAssociatedMemory.Allocate(sizeof(void*) * 10);
 
         // ID2D1ResourceTextureManager
 #if NET6_0_OR_GREATER

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Helpers/D2D1AssemblyAssociatedMemory.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Helpers/D2D1AssemblyAssociatedMemory.cs
@@ -1,0 +1,31 @@
+#if NET6_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#else
+using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
+#endif
+
+namespace ComputeSharp.D2D1.Interop;
+
+/// <summary>
+/// A helper type to allocate memory that's associated with the current assembly.
+/// </summary>
+internal static unsafe class D2D1AssemblyAssociatedMemory
+{
+    /// <summary>
+    /// Allocate memory that is associated with the current assembly, and it will be freed if and when it is unloaded.
+    /// </summary>
+    /// <param name="size">The amount of memory in bytes to allocate.</param>
+    /// <returns>The allocated memory.</returns>
+    public static unsafe void* Allocate(int size)
+    {
+        // This is a size optimization specifically for AOT scenarios. The RuntimeHelpers.AllocateTypeAssociatedMemory API
+        // requires a Type instance being passed to it, and doing typeof(T) ends up rooting a fair amount of extra metadata
+        // and code for those types. This is especially the case for value types, as the reflection stack assumea that the
+        // type T might be boxed, and therefore allocates code to handle equality on boxed instances, which also causes
+        // implemented interfaces (eg. IEquatable<T>) to be rooted, if present. This method works around this issue by
+        // only invoking this API on an empty type, which minimizes the codegen increase. This is still safe, as types are
+        // not unloaded one by one. Rather, the entire assembly they belong to is unloaded. So given all uses of this API
+        // are from within this same assembly, there is no functional difference than associating memory to the various types.
+        return (void*)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(D2D1AssemblyAssociatedMemory), size);
+    }
+}

--- a/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.ID3DInclude.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.ID3DInclude.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using ComputeSharp.D2D1.Interop;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 #if NET6_0_OR_GREATER
 using MemoryMarshal2 = System.Runtime.InteropServices.MemoryMarshal;
 #else
 using MemoryMarshal2 = ComputeSharp.NetStandard.MemoryMarshal;
-using RuntimeHelpers = ComputeSharp.NetStandard.RuntimeHelpers;
 #endif
 
 namespace ComputeSharp.D2D1.Shaders.Translation;
@@ -51,7 +51,7 @@ partial class D3DCompiler
         /// <returns>The method table pointer for <see cref="ID3DIncludeForD2DHelpers"/>.</returns>
         private static void** InitVtbl()
         {
-            void** lpVtbl = (void**)RuntimeHelpers.AllocateTypeAssociatedMemory(typeof(ID3DIncludeForD2DHelpers), sizeof(void*) * 2);
+            void** lpVtbl = (void**)D2D1AssemblyAssociatedMemory.Allocate(sizeof(void*) * 2);
 
 #if NET6_0_OR_GREATER
             lpVtbl[0] = (delegate* unmanaged<ID3DIncludeForD2DHelpers*, D3D_INCLUDE_TYPE, sbyte*, void*, void**, uint*, int>)&Open;

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -48,6 +48,7 @@
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\Int3.g.cs" Link="ComputeSharp.Core\Primitives\Int\Int3.g.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\Int4.g.cs" Link="ComputeSharp.Core\Primitives\Int\Int4.g.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\Int\IntMxN.g.cs" Link="ComputeSharp.Core\Primitives\Int\IntMxN.g.cs" />
+    <Compile Include="..\ComputeSharp.Core\Primitives\Internals\UndefinedData.cs" Link="ComputeSharp.Core\Primitives\Internals\UndefinedData.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt2.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt2.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt3.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt3.cs" />
     <Compile Include="..\ComputeSharp.Core\Primitives\UInt\UInt4.cs" Link="ComputeSharp.Core\Primitives\UInt\UInt4.cs" />


### PR DESCRIPTION
### Description

This PR includes some minor binary size improvements on NativeAOT with ComputeSharp.D2D1 especially.
Results in ~14 KB saves for a minimal self-contained native library exporting a D2D pixel shader.