### PR TITLE
Tweak ComPtr extensions, fix IsSameInstance bug

### DIFF
--- a/src/ComputeSharp.D2D1.UI/Extensions/ICanvasDeviceExtensions.cs
+++ b/src/ComputeSharp.D2D1.UI/Extensions/ICanvasDeviceExtensions.cs
@@ -77,7 +77,7 @@ internal static unsafe class ICanvasDeviceExtensions
         else
         {
             // Otherwise, just use the input device context
-            *d2D1DeviceContextEffective = new ComPtr<ID2D1DeviceContext>(d2D1DeviceContext);
+            ComPtr.WriteTo(d2D1DeviceContext, out *d2D1DeviceContextEffective);
         }
     }
 }

--- a/src/ComputeSharp.D2D1.UI/Extensions/IUnknownExtensions.cs
+++ b/src/ComputeSharp.D2D1.UI/Extensions/IUnknownExtensions.cs
@@ -39,8 +39,8 @@ internal static unsafe class IUnknownExtensions
         using ComPtr<IUnknown> leftUnknown = default;
         using ComPtr<IUnknown> rightUnknown = default;
 
-        ((IUnknown*)Unsafe.AsPointer(ref left))->QueryInterface(Win32.__uuidof<T>(), leftUnknown.GetVoidAddressOf()).Assert();
-        ((IUnknown*)right)->QueryInterface(Win32.__uuidof<T>(), rightUnknown.GetVoidAddressOf()).Assert();
+        ((IUnknown*)Unsafe.AsPointer(ref left))->QueryInterface(Win32.__uuidof<IUnknown>(), leftUnknown.GetVoidAddressOf()).Assert();
+        ((IUnknown*)right)->QueryInterface(Win32.__uuidof<IUnknown>(), rightUnknown.GetVoidAddressOf()).Assert();
 
         return leftUnknown.Get() == rightUnknown.Get();
     }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1DrawTransformMethods.cs
@@ -311,7 +311,7 @@ partial struct PixelShaderEffect
             try
             {
                 // Store the new ID2D1DrawInfo object
-                ComPtr<ID2D1DrawInfo>.CopyTo(drawInfo, ref @this->d2D1DrawInfo);
+                ComPtr.CopyTo(drawInfo, ref @this->d2D1DrawInfo);
 
                 Guid shaderId = @this->GetGlobals().EffectId;
                 D2D1PixelOptions pixelOptions = @this->GetGlobals().PixelOptions;

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
@@ -153,7 +153,7 @@ internal unsafe partial struct PixelShaderEffect
 
                 for (int i = 0; i < resourceTextureDescriptions.Length; i++)
                 {
-                    using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = @this->resourceTextureManagerBuffer[i];
+                    using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = new(@this->resourceTextureManagerBuffer[i]);
 
                     // If the current resource texture manager is not set, we cannot render, as there's an unbound resource texture
                     if (resourceTextureManager.Get() is null)

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
@@ -115,7 +115,7 @@ internal unsafe partial struct PixelShaderEffect
                 transformGraph->SetSingleTransformNode((ID2D1TransformNode*)&@this->lpVtblForID2D1DrawTransform).Assert();
 
                 // Store the new ID2D1EffectContext object
-                ComPtr<ID2D1EffectContext>.CopyTo(effectContext, ref @this->d2D1EffectContext);
+                ComPtr.CopyTo(effectContext, ref @this->d2D1EffectContext);
 
                 return S.S_OK;
             }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
@@ -244,7 +244,7 @@ unsafe partial struct PixelShaderEffect
 
             default(ArgumentNullException).ThrowIfNull(value);
 
-            using ComPtr<IUnknown> unknown = (IUnknown*)value;
+            using ComPtr<IUnknown> unknown = new((IUnknown*)value);
             using ComPtr<ID2D1TransformMapper> transformMapper = default;
 
             // Check that the input object implements ID2D1TransformMapper
@@ -280,7 +280,7 @@ unsafe partial struct PixelShaderEffect
             default(ArgumentOutOfRangeException).ThrowIfLessThan((int)dataSize, sizeof(void*), nameof(dataSize));
             default(ArgumentOutOfRangeException).ThrowIfGreaterThanOrEqual(index, GetGlobals().ResourceTextureCount);
 
-            using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = this.resourceTextureManagerBuffer[index];
+            using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = new(this.resourceTextureManagerBuffer[index]);
 
             resourceTextureManager.CopyTo((ID2D1ResourceTextureManager**)data).Assert();
 
@@ -316,7 +316,7 @@ unsafe partial struct PixelShaderEffect
 
             default(ArgumentNullException).ThrowIfNull(value);
 
-            using ComPtr<IUnknown> unknown = (IUnknown*)value;
+            using ComPtr<IUnknown> unknown = new((IUnknown*)value);
             using ComPtr<ID2D1ResourceTextureManager> resourceTextureManager = default;
 
             // Check that the input object implements ID2D1ResourceTextureManager

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
@@ -251,7 +251,7 @@ unsafe partial struct PixelShaderEffect
             unknown.CopyTo(transformMapper.GetAddressOf()).Assert();
 
             // If there's already an existing manager, release it
-            ComPtr.Release(@this->d2D1TransformMapper);
+            ComPtr.Dispose(@this->d2D1TransformMapper);
 
             // Store the transform mapper manager into the effect
             @this->d2D1TransformMapper = transformMapper.Detach();
@@ -343,7 +343,7 @@ unsafe partial struct PixelShaderEffect
             ref ID2D1ResourceTextureManager* currentResourceTextureManager = ref this.resourceTextureManagerBuffer[index];
 
             // If there's already an existing manager at this index, release it
-            ComPtr.Release(currentResourceTextureManager);
+            ComPtr.Dispose(currentResourceTextureManager);
 
             // Store the resource texture manager into the buffer
             currentResourceTextureManager = resourceTextureManager.Detach();

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Properties.cs
@@ -251,7 +251,7 @@ unsafe partial struct PixelShaderEffect
             unknown.CopyTo(transformMapper.GetAddressOf()).Assert();
 
             // If there's already an existing manager, release it
-            ComPtr<ID2D1TransformMapper>.Release(@this->d2D1TransformMapper);
+            ComPtr.Release(@this->d2D1TransformMapper);
 
             // Store the transform mapper manager into the effect
             @this->d2D1TransformMapper = transformMapper.Detach();
@@ -343,7 +343,7 @@ unsafe partial struct PixelShaderEffect
             ref ID2D1ResourceTextureManager* currentResourceTextureManager = ref this.resourceTextureManagerBuffer[index];
 
             // If there's already an existing manager at this index, release it
-            ComPtr<ID2D1ResourceTextureManager>.Release(currentResourceTextureManager);
+            ComPtr.Release(currentResourceTextureManager);
 
             // Store the resource texture manager into the buffer
             currentResourceTextureManager = resourceTextureManager.Detach();

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using ComputeSharp.D2D1.Shaders.Interop.Effects.ResourceManagers;
 using ComputeSharp.D2D1.Shaders.Interop.Effects.TransformMappers;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
@@ -232,16 +231,16 @@ internal unsafe partial struct PixelShaderEffect
 
             NativeMemory.Free(this.constantBuffer);
 
-            ComPtr<ID2D1TransformMapper>.Release(this.d2D1TransformMapper);
-            ComPtr<ID2D1DrawInfo>.Release(this.d2D1DrawInfo);
-            ComPtr<ID2D1EffectContext>.Release(this.d2D1EffectContext);
+            ComPtr.Release(this.d2D1TransformMapper);
+            ComPtr.Release(this.d2D1DrawInfo);
+            ComPtr.Release(this.d2D1EffectContext);
 
             // Retrieve all possible resource texture managers in use and release the ones that had been
             // assigned (from one of the property bindings). We just hardcode 16 here and dont access
             // the globals, as technically invoking APIs on it might throw an exception.
             for (int i = 0; i < 16; i++)
             {
-                ComPtr<ID2D1ResourceTextureManager>.Release(this.resourceTextureManagerBuffer[i]);
+                ComPtr.Release(this.resourceTextureManagerBuffer[i]);
             }
 
             NativeMemory.Free(Unsafe.AsPointer(ref this));

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -231,16 +231,16 @@ internal unsafe partial struct PixelShaderEffect
 
             NativeMemory.Free(this.constantBuffer);
 
-            ComPtr.Release(this.d2D1TransformMapper);
-            ComPtr.Release(this.d2D1DrawInfo);
-            ComPtr.Release(this.d2D1EffectContext);
+            ComPtr.Dispose(this.d2D1TransformMapper);
+            ComPtr.Dispose(this.d2D1DrawInfo);
+            ComPtr.Dispose(this.d2D1EffectContext);
 
             // Retrieve all possible resource texture managers in use and release the ones that had been
             // assigned (from one of the property bindings). We just hardcode 16 here and dont access
             // the globals, as technically invoking APIs on it might throw an exception.
             for (int i = 0; i < 16; i++)
             {
-                ComPtr.Release(this.resourceTextureManagerBuffer[i]);
+                ComPtr.Dispose(this.resourceTextureManagerBuffer[i]);
             }
 
             NativeMemory.Free(Unsafe.AsPointer(ref this));

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.ID2D1ResourceTextureManagerInternal.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.ID2D1ResourceTextureManagerInternal.cs
@@ -124,7 +124,7 @@ partial struct D2D1ResourceTextureManagerImpl
                         // Now, the effect context can actually be stored safely while holding the lock.
                         // This is guaranteed to be the case here, as this method is only called (as per
                         // contact of the COM interface) from ID2D1EffectImpl, which holds the D2D lock.
-                        ComPtr<ID2D1EffectContext>.WriteTo(effectContext, out @this->d2D1EffectContext);
+                        ComPtr.WriteTo(effectContext, out @this->d2D1EffectContext);
 
                         @this->d2D1Multithread = d2D1Multithread.Detach();
                     }
@@ -161,7 +161,7 @@ partial struct D2D1ResourceTextureManagerImpl
                 // If the texture has already been created, just return it
                 if (@this->d2D1ResourceTexture is not null)
                 {
-                    ComPtr<ID2D1ResourceTexture>.WriteTo(@this->d2D1ResourceTexture, out *resourceTexture);
+                    ComPtr.WriteTo(@this->d2D1ResourceTexture, out *resourceTexture);
 
                     return S.S_OK;
                 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.cs
@@ -249,7 +249,7 @@ internal unsafe partial struct D2D1ResourceTextureManagerImpl
                 this.d2D1Multithread->Enter();
 
                 // Release the resource too if it has been created
-                ComPtr<ID2D1ResourceTexture>.Release(this.d2D1ResourceTexture);
+                ComPtr.Release(this.d2D1ResourceTexture);
 
                 // Now that the resource, if any, has been released, the effect context can also
                 // be released. This must be done only after any associated resource textures have

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/ResourceManagers/D2D1ResourceTextureManagerImpl.cs
@@ -249,7 +249,7 @@ internal unsafe partial struct D2D1ResourceTextureManagerImpl
                 this.d2D1Multithread->Enter();
 
                 // Release the resource too if it has been created
-                ComPtr.Release(this.d2D1ResourceTexture);
+                ComPtr.Dispose(this.d2D1ResourceTexture);
 
                 // Now that the resource, if any, has been released, the effect context can also
                 // be released. This must be done only after any associated resource textures have

--- a/src/ComputeSharp.Dynamic/Shaders/Translation/ShaderCompiler.cs
+++ b/src/ComputeSharp.Dynamic/Shaders/Translation/ShaderCompiler.cs
@@ -134,7 +134,7 @@ internal sealed unsafe partial class ShaderCompiler
             return dxcBlobBytecode.Move();
         }
 
-        return ThrowHslsCompilationException(dxcOperationResult);
+        return ThrowHslsCompilationException(dxcOperationResult.Get());
     }
 
     /// <summary>

--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
@@ -348,7 +348,7 @@ internal sealed unsafe partial class SwapChainManager<TOwner> : ReferenceTracked
 
         using (ComPtr<IDXGISwapChain> idxgiSwapChain = default)
         {
-            this.dxgiSwapChain3.CopyTo(&idxgiSwapChain).Assert();
+            this.dxgiSwapChain3.CopyTo(idxgiSwapChain.GetAddressOf()).Assert();
 
             this.swapChainPanelNative.Get()->SetSwapChain(idxgiSwapChain.Get()).Assert();
         }

--- a/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
+++ b/src/ComputeSharp.UI/Helpers/SwapChainManager.cs
@@ -337,7 +337,7 @@ internal sealed unsafe partial class SwapChainManager<TOwner> : ReferenceTracked
             this.d3D12Device.Get()->CreateCommandList(
                 0,
                 D3D12_COMMAND_LIST_TYPE.D3D12_COMMAND_LIST_TYPE_DIRECT,
-                this.d3D12CommandAllocator,
+                this.d3D12CommandAllocator.Get(),
                 null,
                 Win32.__uuidof<ID3D12GraphicsCommandList>(),
                 (void**)d3D12GraphicsCommandList).Assert();

--- a/src/ComputeSharp/Graphics/Commands/CommandList.cs
+++ b/src/ComputeSharp/Graphics/Commands/CommandList.cs
@@ -55,7 +55,7 @@ internal unsafe struct CommandList : IDisposable
         // Set the heap descriptor if the command list is not for copy operations
         if (d3D12CommandListType is not D3D12_COMMAND_LIST_TYPE_COPY)
         {
-            device.SetDescriptorHeapForCommandList(this.d3D12GraphicsCommandList);
+            device.SetDescriptorHeapForCommandList(this.d3D12GraphicsCommandList.Get());
         }
     }
 
@@ -78,7 +78,7 @@ internal unsafe struct CommandList : IDisposable
             out this.d3D12CommandAllocator.GetPinnableReference());
 
         // Set the heap descriptor for the command list
-        device.SetDescriptorHeapForCommandList(this.d3D12GraphicsCommandList);
+        device.SetDescriptorHeapForCommandList(this.d3D12GraphicsCommandList.Get());
     }
 
     /// <summary>

--- a/src/ComputeSharp/Graphics/Commands/Interop/ID3D12DescriptorHandleAllocator.cs
+++ b/src/ComputeSharp/Graphics/Commands/Interop/ID3D12DescriptorHandleAllocator.cs
@@ -83,7 +83,7 @@ internal unsafe struct ID3D12DescriptorHandleAllocator : IDisposable
     /// <summary>
     /// Gets the <see cref="ID3D12DescriptorHeap"/> in use for the current <see cref="ID3D12DescriptorHandleAllocator"/> instance.
     /// </summary>
-    public readonly ID3D12DescriptorHeap* D3D12DescriptorHeap => this.d3D12DescriptorHeap;
+    public readonly ID3D12DescriptorHeap* D3D12DescriptorHeap => this.d3D12DescriptorHeap.Get();
 
     /// <summary>
     /// Rents a new bundle of CPU and GPU handles to use in a resource.

--- a/src/ComputeSharp/Graphics/GraphicsDevice.Execute.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.Execute.cs
@@ -49,14 +49,14 @@ unsafe partial class GraphicsDevice
         {
             case D3D12_COMMAND_LIST_TYPE_COMPUTE:
                 commandListPool = ref this.computeCommandListPool;
-                d3D12CommandQueue = this.d3D12ComputeCommandQueue;
-                d3D12Fence = this.d3D12ComputeFence;
+                d3D12CommandQueue = this.d3D12ComputeCommandQueue.Get();
+                d3D12Fence = this.d3D12ComputeFence.Get();
                 d3D12FenceValue = ref this.nextD3D12ComputeFenceValue;
                 break;
             case D3D12_COMMAND_LIST_TYPE_COPY:
                 commandListPool = ref this.copyCommandListPool;
-                d3D12CommandQueue = this.d3D12CopyCommandQueue;
-                d3D12Fence = this.d3D12CopyFence;
+                d3D12CommandQueue = this.d3D12CopyCommandQueue.Get();
+                d3D12Fence = this.d3D12CopyFence.Get();
                 d3D12FenceValue = ref this.nextD3D12CopyFenceValue;
                 break;
             default: default(ArgumentException).Throw(nameof(commandList)); return;

--- a/src/ComputeSharp/Graphics/GraphicsDevice.Resources.cs
+++ b/src/ComputeSharp/Graphics/GraphicsDevice.Resources.cs
@@ -31,7 +31,7 @@ unsafe partial class GraphicsDevice
         }
         else
         {
-            allocation = null;
+            allocation = default;
             d3D12Resource = this.d3D12Device.Get()->CreateCommittedResource(resourceType, sizeInBytes, IsCacheCoherentUMA);
         }
     }
@@ -68,7 +68,7 @@ unsafe partial class GraphicsDevice
         }
         else
         {
-            allocation = null;
+            allocation = default;
 
             d3D12Resource = this.d3D12Device.Get()->CreateCommittedResource(
                 resourceType,
@@ -114,7 +114,7 @@ unsafe partial class GraphicsDevice
         }
         else
         {
-            allocation = null;
+            allocation = default;
 
             d3D12Resource = this.d3D12Device.Get()->CreateCommittedResource(
                 resourceType,
@@ -164,7 +164,7 @@ unsafe partial class GraphicsDevice
         }
         else
         {
-            allocation = null;
+            allocation = default;
 
             d3D12Resource = this.d3D12Device.Get()->CreateCommittedResource(
                 resourceType,

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Buffer{T}.cs
@@ -150,7 +150,7 @@ public abstract unsafe partial class Buffer<T> : IReferenceTrackedObject, IGraph
     /// <summary>
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
-    internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+    internal ID3D12Resource* D3D12Resource => this.d3D12Resource.Get();
 
     /// <summary>
     /// Gets the <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture1D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture1D{T}.cs
@@ -135,7 +135,7 @@ public abstract unsafe partial class Texture1D<T> : IReferenceTrackedObject, IGr
     /// <summary>
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
-    internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+    internal ID3D12Resource* D3D12Resource => this.d3D12Resource.Get();
 
     /// <summary>
     /// Gets the <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture2D{T}.cs
@@ -144,7 +144,7 @@ public abstract unsafe partial class Texture2D<T> : IReferenceTrackedObject, IGr
     /// <summary>
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
-    internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+    internal ID3D12Resource* D3D12Resource => this.d3D12Resource.Get();
 
     /// <summary>
     /// Gets the <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/Texture3D{T}.cs
@@ -153,7 +153,7 @@ public abstract unsafe partial class Texture3D<T> : IReferenceTrackedObject, IGr
     /// <summary>
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
-    internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+    internal ID3D12Resource* D3D12Resource => this.d3D12Resource.Get();
 
     /// <summary>
     /// Gets the <see cref="D3D12_GPU_DESCRIPTOR_HANDLE"/> instance for the current resource.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferBuffer{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferBuffer{T}.cs
@@ -95,7 +95,7 @@ public abstract unsafe partial class TransferBuffer<T> : IReferenceTrackedObject
     /// <summary>
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
-    internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+    internal ID3D12Resource* D3D12Resource => this.d3D12Resource.Get();
 
     /// <summary>
     /// Gets the pointer to the start of the mapped buffer data.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture1D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture1D{T}.cs
@@ -100,7 +100,7 @@ public abstract unsafe partial class TransferTexture1D<T> : IReferenceTrackedObj
     /// <summary>
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
-    internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+    internal ID3D12Resource* D3D12Resource => this.d3D12Resource.Get();
 
     /// <summary>
     /// Gets the <see cref="D3D12_PLACED_SUBRESOURCE_FOOTPRINT"/> value for the current resource.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture2D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture2D{T}.cs
@@ -107,7 +107,7 @@ public abstract unsafe partial class TransferTexture2D<T> : IReferenceTrackedObj
     /// <summary>
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
-    internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+    internal ID3D12Resource* D3D12Resource => this.d3D12Resource.Get();
 
     /// <summary>
     /// Gets the <see cref="D3D12_PLACED_SUBRESOURCE_FOOTPRINT"/> value for the current resource.

--- a/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture3D{T}.cs
+++ b/src/ComputeSharp/Graphics/Resources/Abstract/TransferTexture3D{T}.cs
@@ -115,7 +115,7 @@ public abstract unsafe partial class TransferTexture3D<T> : IReferenceTrackedObj
     /// <summary>
     /// Gets the <see cref="ID3D12Resource"/> instance currently mapped.
     /// </summary>
-    internal ID3D12Resource* D3D12Resource => this.d3D12Resource;
+    internal ID3D12Resource* D3D12Resource => this.d3D12Resource.Get();
 
     /// <summary>
     /// Gets the <see cref="D3D12_PLACED_SUBRESOURCE_FOOTPRINT"/> value for the current resource.

--- a/src/ComputeSharp/Shaders/Models/PipelineData.cs
+++ b/src/ComputeSharp/Shaders/Models/PipelineData.cs
@@ -35,12 +35,12 @@ internal sealed unsafe class PipelineData : ReferenceTrackedObject
     /// <summary>
     /// Gets the <see cref="ID3D12RootSignature"/> instance for the current <see cref="PipelineData"/> object.
     /// </summary>
-    public ID3D12RootSignature* D3D12RootSignature => this.d3D12RootSignature;
+    public ID3D12RootSignature* D3D12RootSignature => this.d3D12RootSignature.Get();
 
     /// <summary>
     /// Gets the <see cref="ID3D12PipelineState"/> instance for the current <see cref="PipelineData"/> object.
     /// </summary>
-    public ID3D12PipelineState* D3D12PipelineState => this.d3D12PipelineState;
+    public ID3D12PipelineState* D3D12PipelineState => this.d3D12PipelineState.Get();
 
     /// <inheritdoc/>
     protected override void DangerousOnDispose()

--- a/src/TerraFX.Interop.Windows/ComPtr`1.cs
+++ b/src/TerraFX.Interop.Windows/ComPtr`1.cs
@@ -6,10 +6,10 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using static TerraFX.Interop.Windows.Windows;
 using static TerraFX.Interop.Windows.S;
-using System.Diagnostics.CodeAnalysis;
 
 namespace TerraFX.Interop.Windows;
 
@@ -19,12 +19,12 @@ namespace TerraFX.Interop.Windows;
 internal static unsafe class ComPtr
 {
     /// <summary>
-    /// Releases a target COM object, if it's not <see langword="null"/>.
+    /// Disposes a target COM object, if it's not <see langword="null"/>.
     /// </summary>
     /// <typeparam name="T">The type of COM objects to work with.</typeparam>
     /// <param name="other">The COM object to potentially release.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Release<T>(T* other)
+    public static void Dispose<T>(T* other)
         where T : unmanaged
     {
         if (other is not null)

--- a/src/TerraFX.Interop.Windows/ComPtr`1.cs
+++ b/src/TerraFX.Interop.Windows/ComPtr`1.cs
@@ -98,56 +98,6 @@ internal unsafe struct ComPtr<T> : IDisposable
         InternalAddRef();
     }
 
-    /// <summary>Converts the current object reference to type <typeparamref name="U"/> and assigns that to a target <see cref="ComPtr{T}"/> value.</summary>
-    /// <typeparam name="U">The interface type to use to try casting the current COM object.</typeparam>
-    /// <param name="p">A raw pointer to the target <see cref="ComPtr{T}"/> value to write to.</param>
-    /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target type <typeparamref name="U"/>.</returns>
-    /// <remarks>This method will automatically release the target COM object pointed to by <paramref name="p"/>, if any.</remarks>
-    public readonly HRESULT As<U>(ComPtr<U>* p)
-        where U : unmanaged
-    {
-        return ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)p->ReleaseAndGetAddressOf());
-    }
-
-    /// <summary>Converts the current object reference to type <typeparamref name="U"/> and assigns that to a target <see cref="ComPtr{T}"/> value.</summary>
-    /// <typeparam name="U">The interface type to use to try casting the current COM object.</typeparam>
-    /// <param name="other">A reference to the target <see cref="ComPtr{T}"/> value to write to.</param>
-    /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target type <typeparamref name="U"/>.</returns>
-    /// <remarks>This method will automatically release the target COM object pointed to by <paramref name="other"/>, if any.</remarks>
-    public readonly HRESULT As<U>(ref ComPtr<U> other)
-        where U : unmanaged
-    {
-        U* ptr;
-        HRESULT result = ((IUnknown*)ptr_)->QueryInterface(__uuidof<U>(), (void**)&ptr);
-
-        other.Attach(ptr);
-        return result;
-    }
-
-    /// <summary>Converts the current object reference to a type indicated by the given IID and assigns that to a target <see cref="ComPtr{T}"/> value.</summary>
-    /// <param name="riid">The IID indicating the interface type to convert the COM object reference to.</param>
-    /// <param name="other">A raw pointer to the target <see cref="ComPtr{T}"/> value to write to.</param>
-    /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target IID.</returns>
-    /// <remarks>This method will automatically release the target COM object pointed to by <paramref name="other"/>, if any.</remarks>
-    public readonly HRESULT AsIID(Guid* riid, ComPtr<IUnknown>* other)
-    {
-        return ((IUnknown*)ptr_)->QueryInterface(riid, (void**)other->ReleaseAndGetAddressOf());
-    }
-
-    /// <summary>Converts the current object reference to a type indicated by the given IID and assigns that to a target <see cref="ComPtr{T}"/> value.</summary>
-    /// <param name="riid">The IID indicating the interface type to convert the COM object reference to.</param>
-    /// <param name="other">A reference to the target <see cref="ComPtr{T}"/> value to write to.</param>
-    /// <returns>The result of <see cref="IUnknown.QueryInterface"/> for the target IID.</returns>
-    /// <remarks>This method will automatically release the target COM object pointed to by <paramref name="other"/>, if any.</remarks>
-    public readonly HRESULT AsIID(Guid* riid, ref ComPtr<IUnknown> other)
-    {
-        IUnknown* ptr;
-        HRESULT result = ((IUnknown*)ptr_)->QueryInterface(riid, (void**)&ptr);
-
-        other.Attach(ptr);
-        return result;
-    }
-
     /// <summary>Releases the current COM object, if any, and replaces the internal pointer with an input raw pointer.</summary>
     /// <param name="other">The input raw pointer to wrap.</param>
     /// <remarks>This method will release the current raw pointer, if any, but it will not increment the references for <paramref name="other"/>.</remarks>
@@ -308,16 +258,9 @@ internal unsafe struct ComPtr<T> : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public T** ReleaseAndGetAddressOf()
     {
-        _ = InternalRelease();
-        return GetAddressOf();
-    }
+        Dispose();
 
-    /// <summary>Resets the current instance by decrementing the reference count for the target COM object and setting the internal raw pointer to <see langword="null"/>.</summary>
-    /// <returns>The updated reference count for the COM object that was in use, if any.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public uint Reset()
-    {
-        return InternalRelease();
+        return GetAddressOf();
     }
 
     /// <summary>Swaps the current COM object reference with that of a given <see cref="ComPtr{T}"/> instance.</summary>
@@ -349,20 +292,5 @@ internal unsafe struct ComPtr<T> : IDisposable
         {
             _ = ((IUnknown*)temp)->AddRef();
         }
-    }
-
-    // Decrements the reference count for the current COM object, if any
-    private uint InternalRelease()
-    {
-        uint @ref = 0;
-        T* temp = ptr_;
-
-        if (temp != null)
-        {
-            ptr_ = null;
-            @ref = ((IUnknown*)temp)->Release();
-        }
-
-        return @ref;
     }
 }

--- a/src/TerraFX.Interop.Windows/ComPtr`1.cs
+++ b/src/TerraFX.Interop.Windows/ComPtr`1.cs
@@ -98,26 +98,6 @@ internal unsafe struct ComPtr<T> : IDisposable
         InternalAddRef();
     }
 
-    /// <summary>Creates a new <see cref="ComPtr{T}"/> instance from a second one and increments the ref count.</summary>
-    /// <param name="other">The other <see cref="ComPtr{T}"/> instance to copy.</param>
-    public ComPtr(ComPtr<T> other)
-    {
-        ptr_ = other.ptr_;
-        InternalAddRef();
-    }
-
-    /// <summary>Converts a raw pointer to a new <see cref="ComPtr{T}"/> instance and increments the ref count.</summary>
-    /// <param name="other">The raw pointer to wrap.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator ComPtr<T>(T* other)
-        => new ComPtr<T>(other);
-
-    /// <summary>Unwraps a <see cref="ComPtr{T}"/> instance and returns the internal raw pointer.</summary>
-    /// <param name="other">The <see cref="ComPtr{T}"/> instance to unwrap.</param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator T*(ComPtr<T> other)
-        => other.Get();
-
     /// <summary>Converts the current object reference to type <typeparamref name="U"/> and assigns that to a target <see cref="ComPtr{T}"/> value.</summary>
     /// <typeparam name="U">The interface type to use to try casting the current COM object.</typeparam>
     /// <param name="p">A raw pointer to the target <see cref="ComPtr{T}"/> value to write to.</param>


### PR DESCRIPTION
### Description

This PR includes two changes:
- Refactors some `ComPtr` extensions
- Fixes the wrong IID in the `IsSameInstance` extension

All `ComPtr` APIs will eventually be unified for 3.0, once all code can be updated together more simply (no NS2.0).