### PR TITLE
Obsolete APIs to remove, bump package version

### DIFF
--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -60,7 +60,7 @@
     As such, this needs to be changed before a new release as well.
   -->
   <PropertyGroup>
-    <ComputeSharpPackageVersion>2.1.0</ComputeSharpPackageVersion>
+    <ComputeSharpPackageVersion>2.2.0</ComputeSharpPackageVersion>
     <IsCommitOnReleaseBranch>false</IsCommitOnReleaseBranch>
   </PropertyGroup>
 

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -5,6 +5,9 @@
 
     <!-- Samples don't need public XML docs for all APIs -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <!-- Ignore obsolete warnings (due to APIs pending removal for 3.0) -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
   <!-- Reference PolySharp for all .NET Standard 2.0 sample projects -->

--- a/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
+++ b/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
@@ -9,6 +9,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
+#pragma warning disable CS0618
+
 namespace ComputeSharp.Core.SourceGenerators;
 
 /// <summary>

--- a/src/ComputeSharp.Core/Attributes/AutoConstructorAttribute.cs
+++ b/src/ComputeSharp.Core/Attributes/AutoConstructorAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace ComputeSharp;
 
@@ -6,6 +7,11 @@ namespace ComputeSharp;
 /// An attribute that indicates that a target shader type should get an automatic constructor for all fields.
 /// </summary>
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Obsolete(
+    "This API (and its accompanying source generator) is being removed in a future version of ComputeSharp. " +
+    "If you're relying on this functionality, consider switching to primary constructors, once they are supported. " +
+    "Otherwise, consider using alternative source generators providing similar functionality available on NuGet.")]
 public sealed class AutoConstructorAttribute : Attribute
 {
 }

--- a/src/ComputeSharp.Dynamic/Attributes/ShaderMethodAttribute.cs
+++ b/src/ComputeSharp.Dynamic/Attributes/ShaderMethodAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace ComputeSharp;
 
@@ -10,6 +11,11 @@ namespace ComputeSharp;
 /// Methods also need to be static, though this can only be tested at runtime.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+[Obsolete(
+    "This API (and shader metaprogramming in general) is being removed in a future version of ComputeSharp. " +
+    "If you're relying on this functionality, consider manually implementing different shader variants. " +
+    "It is possible to still reuse code by moving it to helper methods that are used by multiple shaders.")]
 public sealed class ShaderMethodAttribute : Attribute
 {
 }

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -23,6 +23,9 @@
 
     <!-- Missing readonly modifier for readonly struct members (not needed in tests) -->
     <NoWarn>$(NoWarn);IDE0251</NoWarn>
+
+    <!-- Ignore obsolete warnings (due to APIs pending removal for 3.0) -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
   <!-- Reference PolySharp for all .NET Standard 2.0 test projects -->


### PR DESCRIPTION
### Description

This PR marks `[AutoConstructor]` and `[ShaderMethod]` as obsolete, and hides them.
Additionally, it bumps the package version to 2.2.