### PR TITLE
Use ImmutableArrayBuilder<T> to create HLSL source

### DIFF
--- a/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
+++ b/src/ComputeSharp.Core.SourceGenerators/AutoConstructorGenerator.cs
@@ -68,8 +68,8 @@ public sealed class AutoConstructorGenerator : IIncrementalGenerator
         /// <returns>The <see cref="ConstructorInfo"/> instance for <paramref name="structDeclarationSymbol"/>.</returns>
         public static ConstructorInfo GetData(INamedTypeSymbol structDeclarationSymbol)
         {
-            using ImmutableArrayBuilder<ParameterInfo> parameters = ImmutableArrayBuilder<ParameterInfo>.Rent();
-            using ImmutableArrayBuilder<string> defaulted = ImmutableArrayBuilder<string>.Rent();
+            using ImmutableArrayBuilder<ParameterInfo> parameters = new();
+            using ImmutableArrayBuilder<string> defaulted = new();
 
             foreach (IFieldSymbol fieldSymbol in structDeclarationSymbol.GetMembers().OfType<IFieldSymbol>())
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectId.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectId.cs
@@ -87,7 +87,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
                 string assemblyName = typeSymbol.ContainingAssembly?.Name ?? string.Empty;
 
-                using ImmutableArrayBuilder<char> charBuffer = ImmutableArrayBuilder<char>.Rent();
+                using ImmutableArrayBuilder<char> charBuffer = new();
 
                 // Format the fully qualified name into a pooled builder to avoid the string allocation
                 typeSymbol.AppendFullyQualifiedMetadataName(in charBuffer);

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
 using ComputeSharp.SourceGeneration.Mappings;
@@ -527,17 +526,17 @@ partial class D2DPixelShaderDescriptorGenerator
             ImmutableArray<int> inputComplexIndices,
             bool requiresScenePosition)
         {
-            StringBuilder hlslBuilder = new();
+            using ImmutableArrayBuilder<char> hlslBuilder = ImmutableArrayBuilder<char>.Rent();
 
             void AppendLF()
             {
-                _ = hlslBuilder.Append('\n');
+                hlslBuilder.Add('\n');
             }
 
             void AppendLineAndLF(string text)
             {
-                _ = hlslBuilder.Append(text);
-                _ = hlslBuilder.Append('\n');
+                hlslBuilder.AddRange(text.AsSpan());
+                hlslBuilder.Add('\n');
             }
 
             // Header

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
@@ -105,8 +105,8 @@ partial class D2DPixelShaderDescriptorGenerator
             out ImmutableArray<(string Name, string HlslType)> valueFields,
             out ImmutableArray<(string Name, string HlslType, int Index)> resourceTextureFields)
         {
-            using ImmutableArrayBuilder<(string, string)> values = ImmutableArrayBuilder<(string, string)>.Rent();
-            using ImmutableArrayBuilder<(string, string, int)> resourceTextures = ImmutableArrayBuilder<(string, string, int)>.Rent();
+            using ImmutableArrayBuilder<(string, string)> values = new();
+            using ImmutableArrayBuilder<(string, string, int)> resourceTextures = new();
 
             foreach (IFieldSymbol fieldSymbol in structDeclarationSymbol.GetMembers().OfType<IFieldSymbol>())
             {
@@ -198,7 +198,7 @@ partial class D2DPixelShaderDescriptorGenerator
             IDictionary<IFieldSymbol, string> constantDefinitions,
             out bool needsD2D1RequiresScenePosition)
         {
-            using ImmutableArrayBuilder<(string, string, string?)> builder = ImmutableArrayBuilder<(string, string, string?)>.Rent();
+            using ImmutableArrayBuilder<(string, string, string?)> builder = new();
 
             needsD2D1RequiresScenePosition = false;
 
@@ -279,7 +279,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
             string? entryPoint = null;
 
-            using ImmutableArrayBuilder<(string, string)> methods = ImmutableArrayBuilder<(string, string)>.Rent();
+            using ImmutableArrayBuilder<(string, string)> methods = new();
 
             needsD2D1RequiresScenePosition = false;
 
@@ -357,7 +357,7 @@ partial class D2DPixelShaderDescriptorGenerator
         /// <returns>A sequence of discovered constants to declare in the shader.</returns>
         private static ImmutableArray<(string Name, string Value)> GetDefinedConstants(IReadOnlyDictionary<IFieldSymbol, string> constantDefinitions)
         {
-            using ImmutableArrayBuilder<(string, string)> builder = ImmutableArrayBuilder<(string, string)>.Rent();
+            using ImmutableArrayBuilder<(string, string)> builder = new();
 
             foreach (KeyValuePair<IFieldSymbol, string> constant in constantDefinitions)
             {
@@ -384,7 +384,7 @@ partial class D2DPixelShaderDescriptorGenerator
             IEnumerable<INamedTypeSymbol> types,
             IReadOnlyDictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods)
         {
-            using ImmutableArrayBuilder<(string, string)> builder = ImmutableArrayBuilder<(string, string)>.Rent();
+            using ImmutableArrayBuilder<(string, string)> builder = new();
 
             IReadOnlyCollection<INamedTypeSymbol> invalidTypes;
 
@@ -526,7 +526,7 @@ partial class D2DPixelShaderDescriptorGenerator
             ImmutableArray<int> inputComplexIndices,
             bool requiresScenePosition)
         {
-            using ImmutableArrayBuilder<char> hlslBuilder = ImmutableArrayBuilder<char>.Rent();
+            using ImmutableArrayBuilder<char> hlslBuilder = new();
 
             void AppendLF()
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.Syntax.cs
@@ -71,7 +71,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
                 using (writer.WriteBlock())
                 {
-                    using ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>> dataMembers = ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>>.Rent();
+                    using ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>> dataMembers = new();
 
                     RegisterAdditionalDataMemberSyntax(info, dataMembers);
                     ResourceTextureDescriptions.RegisterAdditionalDataMemberSyntax(info, dataMembers);

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.cs
@@ -30,7 +30,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             int inputCount = 0;
 
-            using ImmutableArrayBuilder<InputDescription> inputDescriptionsBuilder = ImmutableArrayBuilder<InputDescription>.Rent();
+            using ImmutableArrayBuilder<InputDescription> inputDescriptionsBuilder = new();
 
             foreach (AttributeData attributeData in structDeclarationSymbol.GetAttributes())
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.cs
@@ -41,8 +41,8 @@ partial class D2DPixelShaderDescriptorGenerator
 
             inputCount = 0;
 
-            using ImmutableArrayBuilder<int> inputSimpleIndicesBuilder = ImmutableArrayBuilder<int>.Rent();
-            using ImmutableArrayBuilder<int> inputComplexIndicesBuilder = ImmutableArrayBuilder<int>.Rent();
+            using ImmutableArrayBuilder<int> inputSimpleIndicesBuilder = new();
+            using ImmutableArrayBuilder<int> inputComplexIndicesBuilder = new();
 
             foreach (AttributeData attributeData in structDeclarationSymbol.GetAttributes())
             {
@@ -154,7 +154,7 @@ partial class D2DPixelShaderDescriptorGenerator
             }
 
             // Build the combined input types list now that inputs have been validated
-            using ImmutableArrayBuilder<uint> combinedBuilder = ImmutableArrayBuilder<uint>.Rent();
+            using ImmutableArrayBuilder<uint> combinedBuilder = new();
 
             for (int i = 0; i < inputCount; i++)
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.LoadConstantBuffer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.LoadConstantBuffer.cs
@@ -124,7 +124,7 @@ partial class D2DPixelShaderDescriptorGenerator
             // each row needs to be at a multiple of 16 bytes (a float4 register).
             if (HlslKnownTypes.IsNonLinearMatrixType(typeName, out string? elementName, out int rows, out int columns))
             {
-                using ImmutableArrayBuilder<int> builder = ImmutableArrayBuilder<int>.Rent();
+                using ImmutableArrayBuilder<int> builder = new();
 
                 for (int j = 0; j < rows; j++)
                 {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ResourceTextureDescriptions.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ResourceTextureDescriptions.cs
@@ -31,7 +31,7 @@ partial class D2DPixelShaderDescriptorGenerator
             int inputCount,
             out ImmutableArray<ResourceTextureDescription> resourceTextureDescriptions)
         {
-            using ImmutableArrayBuilder<(int? Index, int Rank)> resourceTextureInfos = ImmutableArrayBuilder<(int? Index, int Rank)>.Rent();
+            using ImmutableArrayBuilder<(int? Index, int Rank)> resourceTextureInfos = new();
 
             foreach (IFieldSymbol fieldSymbol in structDeclarationSymbol.GetMembers().OfType<IFieldSymbol>())
             {
@@ -72,7 +72,7 @@ partial class D2DPixelShaderDescriptorGenerator
             }
 
             // Extract the resource texture descriptions for the rest of the pipeline
-            using (ImmutableArrayBuilder<ResourceTextureDescription> resourceTextureDescriptionsBuilder = ImmutableArrayBuilder<ResourceTextureDescription>.Rent())
+            using (ImmutableArrayBuilder<ResourceTextureDescription> resourceTextureDescriptionsBuilder = new())
             {
                 foreach ((int? index, int rank) in resourceTextureInfos.WrittenSpan)
                 {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -76,7 +76,7 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
 
                     token.ThrowIfCancellationRequested();
 
-                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = ImmutableArrayBuilder<DiagnosticInfo>.Rent();
+                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = new();
 
                     // LoadDispatchData() info
                     ImmutableArray<FieldInfo> fieldInfos = LoadConstantBuffer.GetInfo(
@@ -201,7 +201,7 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
         // Generate the source files, if any
         context.RegisterSourceOutput(outputInfo, static (context, item) =>
         {
-            using ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>> declaredMembers = ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>>.Rent();
+            using ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>> declaredMembers = new();
 
             declaredMembers.Add(EffectId.WriteSyntax);
             declaredMembers.Add(EffectMetadata.WriteEffectDisplayNameSyntax);
@@ -224,15 +224,15 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
             declaredMembers.Add(CreateFromConstantBuffer.WriteSyntax);
             declaredMembers.Add(LoadConstantBuffer.WriteSyntax);
 
-            using ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>> additionalTypes = ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>>.Rent();
-            using ImmutableHashSetBuilder<string> usingDirectives = ImmutableHashSetBuilder<string>.Rent();
+            using ImmutableArrayBuilder<IndentedTextWriter.Callback<D2D1ShaderInfo>> additionalTypes = new();
+            using ImmutableHashSetBuilder<string> usingDirectives = new();
 
             LoadConstantBuffer.RegisterAdditionalTypeSyntax(item, additionalTypes, usingDirectives);
             InputDescriptions.RegisterAdditionalTypeSyntax(item, additionalTypes, usingDirectives);
             InputTypes.RegisterAdditionalTypeSyntax(item, additionalTypes, usingDirectives);
             HlslBytecode.RegisterAdditionalTypeSyntax(item, additionalTypes, usingDirectives);
 
-            using IndentedTextWriter writer = IndentedTextWriter.Rent();
+            using IndentedTextWriter writer = new();
 
             item.Hierarchy.WriteSyntax(
                 state: item,

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -35,7 +35,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                     MethodDeclarationSyntax methodDeclaration = (MethodDeclarationSyntax)context.TargetNode;
                     IMethodSymbol methodSymbol = (IMethodSymbol)context.TargetSymbol;
 
-                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = ImmutableArrayBuilder<DiagnosticInfo>.Rent();
+                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = new();
 
                     // Get the remaining info for the current shader
                     ImmutableArray<ushort> modifiers = methodDeclaration.Modifiers.Select(token => (ushort)token.Kind()).ToImmutableArray();
@@ -89,7 +89,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
         // Generate the shader bytecode methods
         context.RegisterSourceOutput(outputInfo, static (context, item) =>
         {
-            using IndentedTextWriter writer = IndentedTextWriter.Rent();
+            using IndentedTextWriter writer = new();
 
             item.Hierarchy.WriteSyntax(
                 state: item,

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Helpers/SyntaxFormattingHelper.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Helpers/SyntaxFormattingHelper.cs
@@ -103,7 +103,7 @@ internal static class SyntaxFormattingHelper
     /// </remarks>
     public static string BuildByteArrayInitializationExpressionString(ReadOnlySpan<byte> bytecode)
     {
-        using ImmutableArrayBuilder<char> builder = ImmutableArrayBuilder<char>.Rent();
+        using ImmutableArrayBuilder<char> builder = new();
 
         builder.AddRange(FormattedBytes[bytecode[0]].AsSpan());
 

--- a/src/ComputeSharp.SourceGeneration/Extensions/IFieldSymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/IFieldSymbolExtensions.cs
@@ -16,7 +16,7 @@ internal static class IFieldSymbolExtensions
     /// <returns>The fully qualified metadata name for <paramref name="symbol"/>.</returns>
     public static string GetFullyQualifiedMetadataName(this IFieldSymbol symbol)
     {
-        using ImmutableArrayBuilder<char> builder = ImmutableArrayBuilder<char>.Rent();
+        using ImmutableArrayBuilder<char> builder = new();
 
         symbol.ContainingType!.AppendFullyQualifiedMetadataName(in builder);
 

--- a/src/ComputeSharp.SourceGeneration/Extensions/IMethodSymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/IMethodSymbolExtensions.cs
@@ -17,7 +17,7 @@ internal static class IMethodSymbolExtensions
     /// <returns>The fully qualified metadata name for <paramref name="symbol"/>.</returns>
     public static string GetFullyQualifiedMetadataName(this IMethodSymbol symbol, bool includeParameters = false)
     {
-        using ImmutableArrayBuilder<char> builder = ImmutableArrayBuilder<char>.Rent();
+        using ImmutableArrayBuilder<char> builder = new();
 
         symbol.ContainingType!.AppendFullyQualifiedMetadataName(in builder);
 

--- a/src/ComputeSharp.SourceGeneration/Extensions/IPropertySymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/IPropertySymbolExtensions.cs
@@ -16,7 +16,7 @@ internal static class IPropertySymbolExtensions
     /// <returns>The fully qualified metadata name for <paramref name="symbol"/>.</returns>
     public static string GetFullyQualifiedMetadataName(this IPropertySymbol symbol)
     {
-        using ImmutableArrayBuilder<char> builder = ImmutableArrayBuilder<char>.Rent();
+        using ImmutableArrayBuilder<char> builder = new();
 
         symbol.ContainingType!.AppendFullyQualifiedMetadataName(in builder);
 

--- a/src/ComputeSharp.SourceGeneration/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/ITypeSymbolExtensions.cs
@@ -17,7 +17,7 @@ internal static class ITypeSymbolExtensions
     /// <returns>Whether <paramref name="symbol"/> has a full name equals to <paramref name="name"/>.</returns>
     public static bool HasFullyQualifiedMetadataName(this ITypeSymbol symbol, string name)
     {
-        using ImmutableArrayBuilder<char> builder = ImmutableArrayBuilder<char>.Rent();
+        using ImmutableArrayBuilder<char> builder = new();
 
         symbol.AppendFullyQualifiedMetadataName(in builder);
 
@@ -50,7 +50,7 @@ internal static class ITypeSymbolExtensions
     /// <returns>The fully qualified metadata name for <paramref name="symbol"/>.</returns>
     public static string GetFullyQualifiedMetadataName(this ITypeSymbol symbol)
     {
-        using ImmutableArrayBuilder<char> builder = ImmutableArrayBuilder<char>.Rent();
+        using ImmutableArrayBuilder<char> builder = new();
 
         symbol.AppendFullyQualifiedMetadataName(in builder);
 

--- a/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
@@ -25,21 +25,11 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
     private Writer? writer;
 
     /// <summary>
-    /// Creates a <see cref="ImmutableArrayBuilder{T}"/> value with a pooled underlying data writer.
+    /// Creates a new <see cref="ImmutableArrayBuilder{T}"/> object.
     /// </summary>
-    /// <returns>A <see cref="ImmutableArrayBuilder{T}"/> instance to write data to.</returns>
-    public static ImmutableArrayBuilder<T> Rent()
+    public ImmutableArrayBuilder()
     {
-        return new(SharedObjectPool.Allocate());
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="ImmutableArrayBuilder{T}"/> object with the specified parameters.
-    /// </summary>
-    /// <param name="writer">The target data writer to use.</param>
-    private ImmutableArrayBuilder(Writer writer)
-    {
-        this.writer = writer;
+        this.writer = SharedObjectPool.Allocate();
     }
 
     /// <summary>

--- a/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
@@ -89,6 +89,12 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
         this.writer!.AddRange(items);
     }
 
+    /// <inheritdoc cref="ImmutableArray{T}.Builder.Clear"/>
+    public readonly void Clear()
+    {
+        this.writer!.Clear();
+    }
+
     /// <summary>
     /// Inserts an item to the builder at the specified index.
     /// </summary>
@@ -203,6 +209,12 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index += items.Length;
         }
 
+        /// <inheritdoc cref="ImmutableArrayBuilder{T}.Clear"/>
+        public void Clear(ReadOnlySpan<T> items)
+        {
+            this.index = 0;
+        }
+
         /// <inheritdoc cref="ImmutableArrayBuilder{T}.Insert"/>
         public void Insert(int index, T item)
         {
@@ -227,7 +239,9 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
         /// </summary>
         public void Clear()
         {
-            if (typeof(T) != typeof(char))
+            if (typeof(T) != typeof(byte) &&
+                typeof(T) != typeof(char) &&
+                typeof(T) != typeof(int))
             {
                 this.array.AsSpan(0, this.index).Clear();
             }

--- a/src/ComputeSharp.SourceGeneration/Helpers/ImmutableHashSetBuilder{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/ImmutableHashSetBuilder{T}.cs
@@ -27,21 +27,11 @@ internal struct ImmutableHashSetBuilder<T> : IDisposable
     private HashSet<T>? set;
 
     /// <summary>
-    /// Creates a <see cref="ImmutableHashSetBuilder{T}"/> value with a pooled underlying data writer.
+    /// Creates a new <see cref="ImmutableHashSetBuilder{T}"/> object.
     /// </summary>
-    /// <returns>A <see cref="ImmutableHashSetBuilder{T}"/> instance to write data to.</returns>
-    public static ImmutableHashSetBuilder<T> Rent()
+    public ImmutableHashSetBuilder()
     {
-        return new(SharedObjectPool.Allocate());
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="ImmutableHashSetBuilder{T}"/> object with the specified parameters.
-    /// </summary>
-    /// <param name="set">The target <see cref="HashSet{T}"/> instance to use.</param>
-    private ImmutableHashSetBuilder(HashSet<T> set)
-    {
-        this.set = set;
+        this.set = SharedObjectPool.Allocate();
     }
 
     /// <summary>

--- a/src/ComputeSharp.SourceGeneration/Helpers/IndentedTextWriter.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/IndentedTextWriter.cs
@@ -45,21 +45,11 @@ internal sealed class IndentedTextWriter : IDisposable
     private string[] availableIndentations;
 
     /// <summary>
-    /// Creates an <see cref="IndentedTextWriter"/> instance with a pooled underlying data writer.
+    /// Creates a new <see cref="IndentedTextWriter"/> object.
     /// </summary>
-    /// <returns>An <see cref="IndentedTextWriter"/> instance to write data to.</returns>
-    public static IndentedTextWriter Rent()
+    public IndentedTextWriter()
     {
-        return new(ImmutableArrayBuilder<char>.Rent());
-    }
-
-    /// <summary>
-    /// Creates a new <see cref="IndentedTextWriter"/> object with the specified parameters.
-    /// </summary>
-    /// <param name="builder">The target <see cref="ImmutableArrayBuilder{T}"/> instance to use.</param>
-    private IndentedTextWriter(ImmutableArrayBuilder<char> builder)
-    {
-        this.builder = builder;
+        this.builder = new ImmutableArrayBuilder<char>();
         this.currentIndentationLevel = 0;
         this.currentIndentation = "";
         this.availableIndentations = new string[4];

--- a/src/ComputeSharp.SourceGeneration/Models/HierarchyInfo.cs
+++ b/src/ComputeSharp.SourceGeneration/Models/HierarchyInfo.cs
@@ -24,7 +24,7 @@ internal sealed partial record HierarchyInfo(string FullyQualifiedMetadataName, 
     /// <returns>A <see cref="HierarchyInfo"/> instance describing <paramref name="typeSymbol"/>.</returns>
     public static HierarchyInfo From(INamedTypeSymbol typeSymbol)
     {
-        using ImmutableArrayBuilder<TypeInfo> hierarchy = ImmutableArrayBuilder<TypeInfo>.Rent();
+        using ImmutableArrayBuilder<TypeInfo> hierarchy = new();
 
         for (INamedTypeSymbol? parent = typeSymbol;
              parent is not null;
@@ -115,7 +115,7 @@ internal sealed partial record HierarchyInfo(string FullyQualifiedMetadataName, 
     /// <returns>The fully qualified type name for the current instance.</returns>
     public string GetFullyQualifiedTypeName()
     {
-        using ImmutableArrayBuilder<char> fullyQualifiedTypeName = ImmutableArrayBuilder<char>.Rent();
+        using ImmutableArrayBuilder<char> fullyQualifiedTypeName = new();
 
         fullyQualifiedTypeName.AddRange("global::".AsSpan());
         fullyQualifiedTypeName.AddRange(Namespace.AsSpan());

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.Syntax.cs
@@ -85,7 +85,7 @@ partial class IShaderGenerator
         /// <returns>The series of statements to build the HLSL source to compile to execute the current shader.</returns>
         private static ImmutableArray<StatementSyntax> GenerateRenderMethodBody(HlslShaderSourceInfo hlslSourceInfo, int hierarchyDepth)
         {
-            using ImmutableArrayBuilder<StatementSyntax> statements = ImmutableArrayBuilder<StatementSyntax>.Rent();
+            using ImmutableArrayBuilder<StatementSyntax> statements = new();
 
             StringBuilder textBuilder = new();
             int capturedDelegates = 0;

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -105,8 +105,8 @@ partial class IShaderGenerator
                 ICollection<INamedTypeSymbol> types,
                 bool isComputeShader)
         {
-            using ImmutableArrayBuilder<(string, string, string)> resources = ImmutableArrayBuilder<(string, string, string)>.Rent();
-            using ImmutableArrayBuilder<(string, string)> values = ImmutableArrayBuilder<(string, string)>.Rent();
+            using ImmutableArrayBuilder<(string, string, string)> resources = new();
+            using ImmutableArrayBuilder<(string, string)> values = new();
 
             bool hlslResourceFound = false;
 
@@ -199,7 +199,7 @@ partial class IShaderGenerator
             ICollection<INamedTypeSymbol> discoveredTypes,
             IDictionary<IFieldSymbol, string> constantDefinitions)
         {
-            using ImmutableArrayBuilder<(string, string, string?)> builder = ImmutableArrayBuilder<(string, string, string?)>.Rent();
+            using ImmutableArrayBuilder<(string, string, string?)> builder = new();
 
             foreach (FieldDeclarationSyntax fieldDeclaration in structDeclaration.Members.OfType<FieldDeclarationSyntax>())
             {
@@ -263,7 +263,7 @@ partial class IShaderGenerator
             INamedTypeSymbol structDeclarationSymbol,
             ICollection<INamedTypeSymbol> types)
         {
-            using ImmutableArrayBuilder<(string, string, int?)> builder = ImmutableArrayBuilder<(string, string, int?)>.Rent();
+            using ImmutableArrayBuilder<(string, string, int?)> builder = new();
 
             foreach (IFieldSymbol fieldSymbol in structDeclarationSymbol.GetMembers().OfType<IFieldSymbol>())
             {
@@ -337,7 +337,7 @@ partial class IShaderGenerator
                 where syntaxNode.IsKind(SyntaxKind.MethodDeclaration)
                 select (MethodDeclarationSyntax)syntaxNode).ToImmutableArray();
 
-            using ImmutableArrayBuilder<(string, string)> methods = ImmutableArrayBuilder<(string, string)>.Rent();
+            using ImmutableArrayBuilder<(string, string)> methods = new();
 
             string? entryPoint = null;
             bool isSamplerUsed = false;
@@ -425,7 +425,7 @@ partial class IShaderGenerator
         /// <returns>A sequence of discovered constants to declare in the shader.</returns>
         internal static ImmutableArray<(string Name, string Value)> GetDefinedConstants(IReadOnlyDictionary<IFieldSymbol, string> constantDefinitions)
         {
-            using ImmutableArrayBuilder<(string, string)> builder = ImmutableArrayBuilder<(string, string)>.Rent();
+            using ImmutableArrayBuilder<(string, string)> builder = new();
 
             foreach (KeyValuePair<IFieldSymbol, string> constant in constantDefinitions)
             {
@@ -452,7 +452,7 @@ partial class IShaderGenerator
             IEnumerable<INamedTypeSymbol> types,
             IReadOnlyDictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods)
         {
-            using ImmutableArrayBuilder<(string, string)> builder = ImmutableArrayBuilder<(string, string)>.Rent();
+            using ImmutableArrayBuilder<(string, string)> builder = new();
 
             IReadOnlyCollection<INamedTypeSymbol> invalidTypes;
 
@@ -567,7 +567,7 @@ partial class IShaderGenerator
             bool isSamplerUsed,
             string executeMethod)
         {
-            using ImmutableArrayBuilder<char> hlslBuilder = ImmutableArrayBuilder<char>.Rent();
+            using ImmutableArrayBuilder<char> hlslBuilder = new();
 
             void AppendLF()
             {

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateBuildHlslSourceMethod.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
 using ComputeSharp.SourceGeneration.Mappings;
@@ -566,38 +565,37 @@ partial class IShaderGenerator
             bool isComputeShader,
             string? implicitTextureType,
             bool isSamplerUsed,
-
             string executeMethod)
         {
-            StringBuilder hlslBuilder = new();
+            using ImmutableArrayBuilder<char> hlslBuilder = ImmutableArrayBuilder<char>.Rent();
 
             void AppendLF()
             {
-                _ = hlslBuilder.Append('\n');
+                hlslBuilder.Add('\n');
             }
 
             void AppendLine(string text)
             {
-                _ = hlslBuilder.Append(text);
+                hlslBuilder.AddRange(text.AsSpan());
             }
 
             void AppendLineAndLF(string text)
             {
-                _ = hlslBuilder.Append(text);
-                _ = hlslBuilder.Append('\n');
+                hlslBuilder.AddRange(text.AsSpan());
+                hlslBuilder.Add('\n');
             }
 
             void AppendCharacterAndLF(char c)
             {
-                _ = hlslBuilder.Append(c);
-                _ = hlslBuilder.Append('\n');
+                hlslBuilder.Add(c);
+                hlslBuilder.Add('\n');
             }
 
             string FlushText()
             {
                 string text = hlslBuilder.ToString();
 
-                _ = hlslBuilder.Clear();
+                hlslBuilder.Clear();
 
                 return text;
             }

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.Syntax.cs
@@ -68,7 +68,7 @@ partial class IShaderGenerator
             int resourceCount,
             int root32BitConstantsCount)
         {
-            using ImmutableArrayBuilder<StatementSyntax> statements = ImmutableArrayBuilder<StatementSyntax>.Rent();
+            using ImmutableArrayBuilder<StatementSyntax> statements = new();
 
             // global::System.Span<uint> span0 = stackalloc uint[<VARIABLES>];
             statements.Add(

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchDataMethod.cs
@@ -149,7 +149,7 @@ partial class IShaderGenerator
             // each row needs to be at a multiple of 16 bytes (a float4 register).
             if (HlslKnownTypes.IsNonLinearMatrixType(typeName, out string? elementName, out int rows, out int columns))
             {
-                using ImmutableArrayBuilder<int> builder = ImmutableArrayBuilder<int>.Rent();
+                using ImmutableArrayBuilder<int> builder = new();
 
                 for (int j = 0; j < rows; j++)
                 {

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchMetadataMethod.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchMetadataMethod.Syntax.cs
@@ -55,7 +55,7 @@ partial class IShaderGenerator
         /// <returns>The sequence of <see cref="StatementSyntax"/> instances to load shader dispatch data.</returns>
         private static ImmutableArray<StatementSyntax> GetDispatchMetadataLoadingStatements(DispatchMetadataInfo metadataInfo)
         {
-            using ImmutableArrayBuilder<StatementSyntax> statements = ImmutableArrayBuilder<StatementSyntax>.Rent();
+            using ImmutableArrayBuilder<StatementSyntax> statements = new();
 
             // global::System.Span<byte> span0 = stackalloc byte[5];
             statements.Add(

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchMetadataMethod.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.CreateLoadDispatchMetadataMethod.cs
@@ -27,7 +27,7 @@ partial class IShaderGenerator
             bool isSamplerUsed,
             ImmutableArray<FieldInfo> capturedFields)
         {
-            using ImmutableArrayBuilder<ResourceDescriptor> descriptors = ImmutableArrayBuilder<ResourceDescriptor>.Rent();
+            using ImmutableArrayBuilder<ResourceDescriptor> descriptors = new();
 
             int constantBufferOffset = 1;
             int readOnlyResourceOffset = 0;

--- a/src/ComputeSharp.SourceGenerators/IShaderGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/IShaderGenerator.cs
@@ -55,7 +55,7 @@ public sealed partial class IShaderGenerator : IIncrementalGenerator
                         return default;
                     }
 
-                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = ImmutableArrayBuilder<DiagnosticInfo>.Rent();
+                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = new();
 
                     // GetDispatchId() info
                     ImmutableArray<string> dispatchIdInfo = GetDispatchId.GetInfo(typeSymbol);

--- a/src/ComputeSharp.SourceGenerators/ShaderMethodSourceGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ShaderMethodSourceGenerator.cs
@@ -78,7 +78,7 @@ public sealed partial class ShaderMethodSourceGenerator : IIncrementalGenerator
             IMethodSymbol methodSymbol,
             out ImmutableArray<DiagnosticInfo> diagnostics)
         {
-            using ImmutableArrayBuilder<DiagnosticInfo> builder = ImmutableArrayBuilder<DiagnosticInfo>.Rent();
+            using ImmutableArrayBuilder<DiagnosticInfo> builder = new();
 
             // We need to sets to track all discovered custom types and static methods
             HashSet<INamedTypeSymbol> discoveredTypes = new(SymbolEqualityComparer.Default);
@@ -136,7 +136,7 @@ public sealed partial class ShaderMethodSourceGenerator : IIncrementalGenerator
                 .NormalizeWhitespace(eol: "\n")
                 .ToFullString();
 
-            using ImmutableArrayBuilder<(string, string)> methods = ImmutableArrayBuilder<(string, string)>.Rent();
+            using ImmutableArrayBuilder<(string, string)> methods = new();
 
             // Emit the extracted local functions
             foreach (KeyValuePair<string, LocalFunctionStatementSyntax> localFunction in shaderSourceRewriter.LocalFunctions)


### PR DESCRIPTION
### Description

This PR uses `ImmutableArrayBuilder<T>` to build HLSL source, which effectively adds pooling to that logic.
It also refactors the construction of all source generator builder types to make them simpler.