### PR TITLE
Optimize InputTypes memory manager for downlevel TFMs

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.Syntax.cs
@@ -76,8 +76,8 @@ partial class D2DPixelShaderDescriptorGenerator
 
                     // RVA field
                     writer.WriteLine();
-                    writer.WriteLine("/// <summary>The RVA data with the input type info.</summary>");
-                    writer.WriteLine("private static global::System.ReadOnlySpan<D2D1PixelShaderInputType> Data => new[]");
+                    writer.WriteLine("/// <summary>The data with the input type info.</summary>");
+                    writer.WriteLine("private static D2D1PixelShaderInputType[] Data = new[]");
                     writer.WriteLine("{");
                     writer.IncreaseIndent();
 
@@ -98,7 +98,7 @@ partial class D2DPixelShaderDescriptorGenerator
                         /// <inheritdoc/>
                         public override unsafe Span<D2D1PixelShaderInputType> GetSpan()
                         {
-                            return new(Unsafe.AsPointer(ref MemoryMarshal.GetReference(Data)), Data.Length);
+                            return Data;
                         }
 
                         /// <inheritdoc/>
@@ -111,7 +111,9 @@ partial class D2DPixelShaderDescriptorGenerator
                         /// <inheritdoc/>
                         public override unsafe MemoryHandle Pin(int elementIndex)
                         {
-                            return new(Unsafe.AsPointer(ref Unsafe.AsRef(in Data[elementIndex])), pinnable: this);
+                            GCHandle handle = GCHandle.Alloc(Data, GCHandleType.Pinned);
+
+                            return new(Unsafe.AsPointer(ref Data[elementIndex]), handle);
                         }
 
                         /// <inheritdoc/>


### PR DESCRIPTION
### Description

This PR temporarily replaces RVA spans with static arrays for the generated `InputTypes` properties, as it allows skipping array allocations every time on downlevel targets. It's a very small per regression on .NET 6+ targets. Once downlevel support is dropped, this will just be reverted to using an RVA span (which uses the new `CreateSpan` intrinsic).