### PR TITLE
Remove multi-targeting, only use one .NET TFM per project

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -66,9 +66,6 @@ jobs:
   # Run all unit tests referencing the ComputeSharp projects directly
   run-tests:
     needs: [build-solution]
-    strategy:
-      matrix:
-        framework: [net7.0, net6.0]
     runs-on: windows-2022
 
     # Set the environment variable which is then looked up in ComputeSharp.Dynamic.
@@ -81,46 +78,41 @@ jobs:
 
       # DirectX 12 unit tests
     - name: Run ComputeSharp.Tests
-      run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release /p:Platform=x64 -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.DisableDynamicCompilation
-      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests.DisableDynamicCompilation\ComputeSharp.Tests.DisableDynamicCompilation.csproj -c Release /p:Platform=x64 -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.GlobalStatements
-      run: dotnet run --project tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      run: dotnet run --project tests\ComputeSharp.Tests.GlobalStatements\ComputeSharp.Tests.GlobalStatements.csproj -c Release /p:Platform=x64 -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.Internals
-      run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests.Internals\ComputeSharp.Tests.Internals.csproj -c Release /p:Platform=x64 -v n -l "console;verbosity=detailed"
 
-      # Only run the source generators tests once, as they're not runtime specific
-    - if: matrix.framework == 'net6.0'
-      name: Run ComputeSharp.Tests.SourceGenerators
+      # Run the source generator tests as well (even though they're not really runtime specific)
+    - name: Run ComputeSharp.Tests.SourceGenerators
       run: dotnet test tests\ComputeSharp.Tests.SourceGenerators\ComputeSharp.Tests.SourceGenerators.csproj -v n -l "console;verbosity=detailed"
     
       # DirectX 12 device lost unit tests.
       # These tests are run one class at a time to ensure there's no accidental conflicts between any of them. This is because
       # the code paths being tested in this project are heavily dependent on process-wide mutable state (ie. DirectX 12 devices).
     - name: Run ComputeSharp.Tests.DeviceLost "DeviceDisposal"
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.DeviceLost "DeviceLost"
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceLost" -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceLost" -c Release -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.DeviceLost "GetDefaultDevice"
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=GetDefaultDevice" -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=GetDefaultDevice" -c Release -v n -l "console;verbosity=detailed"
 
       # D2D1 unit tests
     - name: Run ComputeSharp.D2D1.Tests
-      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.D2D1.Tests\ComputeSharp.D2D1.Tests.csproj -c Release -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes
-      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -f ${{matrix.framework}} -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -v n -l "console;verbosity=detailed"
 
       # Run the D2D1 source generators tests as well (only on .NET 6, like for the DX12 ones)
-    - if: matrix.framework == 'net6.0'
-      name: Run ComputeSharp.D2D1.Tests.SourceGenerators
+    - name: Run ComputeSharp.D2D1.Tests.SourceGenerators
       run: dotnet test tests\ComputeSharp.D2D1.Tests.SourceGenerators\ComputeSharp.D2D1.Tests.SourceGenerators.csproj -v n -l "console;verbosity=detailed"
 
   # Run all unit tests using D3D12MA
   run-tests-d3d12ma:
     needs: [build-solution]
-    strategy:
-      matrix:
-        framework: [net7.0, net6.0]
     runs-on: windows-2022
     env:
       CI_RUNNER_DOTNET_TEST_PLATFORM: x64
@@ -130,20 +122,17 @@ jobs:
 
       # D3D12MA tests (main ComputeSharp tests, as well as the device lost ones)
     - name: Run ComputeSharp.Tests
-      run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release -f ${{matrix.framework}} /p:Platform=x64 /p:UseD3D12MemoryAllocator=true -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests\ComputeSharp.Tests.csproj -c Release /p:Platform=x64 /p:UseD3D12MemoryAllocator=true -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.DeviceLost "DeviceDisposal"
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release -f ${{matrix.framework}} /p:UseD3D12MemoryAllocator=true -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceDisposal" -c Release /p:UseD3D12MemoryAllocator=true -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.DeviceLost "DeviceLost"
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceLost" -c Release -f ${{matrix.framework}} /p:UseD3D12MemoryAllocator=true -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=DeviceLost" -c Release /p:UseD3D12MemoryAllocator=true -v n -l "console;verbosity=detailed"
     - name: Run ComputeSharp.Tests.DeviceLost "GetDefaultDevice"
-      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=GetDefaultDevice" -c Release -f ${{matrix.framework}} /p:UseD3D12MemoryAllocator=true -v n -l "console;verbosity=detailed"
+      run: dotnet test tests\ComputeSharp.Tests.DeviceLost\ComputeSharp.Tests.DeviceLost.csproj --filter "TestCategory=GetDefaultDevice" -c Release /p:UseD3D12MemoryAllocator=true -v n -l "console;verbosity=detailed"
 
   # Run all Win2D tests (separately, as they need VS Test)
   run-tests-win2d:
     needs: [build-solution]
-    strategy:
-      matrix:
-        configuration: [Debug, Release]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -153,36 +142,33 @@ jobs:
     
       # Build the D2D1 WinAppSDK unit tests
     - name: Build ComputeSharp.D2D1.WinUI.Tests
-      run: msbuild tests\ComputeSharp.D2D1.WinUI.Tests\ComputeSharp.D2D1.WinUI.Tests.csproj /restore -t:build /p:Configuration=${{matrix.configuration}} /p:Platform=x64
+      run: msbuild tests\ComputeSharp.D2D1.WinUI.Tests\ComputeSharp.D2D1.WinUI.Tests.csproj /restore -t:build /p:Configuration=Release /p:Platform=x64
 
       # Run the D2D1 WinAppSDK unit tests with VS Test again
     - name: Run ComputeSharp.D2D1.WinUI.Tests
       run: >
         $vs_path = vswhere -latest -products * -requires Microsoft.VisualStudio.Workload.ManagedDesktop -requiresAny -property installationPath;
         $vstest_path = join-path $vs_path 'Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe';
-        & $vstest_path /Platform:x64 tests\ComputeSharp.D2D1.WinUI.Tests\bin\x64\${{matrix.configuration}}\net6.0-windows10.0.22621.0\win10-x64\ComputeSharp.D2D1.WinUI.Tests.build.appxrecipe
+        & $vstest_path /Platform:x64 tests\ComputeSharp.D2D1.WinUI.Tests\bin\x64\Release\net6.0-windows10.0.22621.0\win10-x64\ComputeSharp.D2D1.WinUI.Tests.build.appxrecipe
 
   # Run all the local samples to ensure they build and run with no errors
   run-samples:
     needs: [build-solution]
-    strategy:
-      matrix:
-        framework: [net7.0, net6.0]
     runs-on: windows-2022
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
     - name: Build and run ComputeSharp.Sample
       run: >
-        dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -p:Platform=x64 -v n;
+        dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
         samples\ComputeSharp.Sample\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.Sample.exe
     - name: Build and run ComputeSharp.Sample.FSharp
       run: >
-        dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -p:Platform=x64 -v n;
+        dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
         samples\ComputeSharp.Sample.FSharp\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.Sample.FSharp.exe
     - name: Build and run ComputeSharp.ImageProcessing.csproj
       run: >
-        dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -p:Platform=x64 -v n;
+        dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
         samples\ComputeSharp.ImageProcessing\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.ImageProcessing.exe
 
   # Run the NativeAOT samples as well
@@ -204,7 +190,7 @@ jobs:
     - name: Publish ComputeSharp.SwapChain.Cli with NativeAOT (speed)
       run: >
         $env:COMPUTESHARP_SWAPCHAIN_CLI_PUBLISH_AOT='true';
-        dotnet publish samples\ComputeSharp.SwapChain.Cli\ComputeSharp.SwapChain.Cli.csproj -c Release -f net7.0 -r win-${{matrix.platform}} -v n
+        dotnet publish samples\ComputeSharp.SwapChain.Cli\ComputeSharp.SwapChain.Cli.csproj -c Release -r win-${{matrix.platform}} -v n
       
       # If on x64, also run it (this script will launch it and let it run for 2 seconds, before closing it).
       # Note: for this and all other equivalent tests below, we're only throwing on failures that are not
@@ -236,7 +222,7 @@ jobs:
         $env:COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED='true';
         $env:COMPUTESHARP_SWAPCHAIN_CLI_DISABLE_REFLECTION='true';
         git clean -fdx;
-        dotnet publish samples\ComputeSharp.SwapChain.Cli\ComputeSharp.SwapChain.Cli.csproj -c Release -f net7.0 -r win-${{matrix.platform}} -v n
+        dotnet publish samples\ComputeSharp.SwapChain.Cli\ComputeSharp.SwapChain.Cli.csproj -c Release -r win-${{matrix.platform}} -v n
       
       # Again only on x64, also run the sample and validate it works correctly
     - if: matrix.platform == 'x64'
@@ -290,9 +276,6 @@ jobs:
   # a test to ensure the NuGet packages work in a consuming project.
   verify-packages:
     needs: [build-packages]
-    strategy:
-      matrix:
-        framework: [net7.0, net6.0]
     runs-on: windows-2022
     steps:
     - name: Git checkout
@@ -305,35 +288,33 @@ jobs:
         name: nuget_packages
         path: artifacts
     - name: Build and run ComputeSharp.NuGet
-      run: dotnet run --project tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -v n
+      run: dotnet run --project tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -r win-x64 --no-self-contained -v n
     - name: Build and run ComputeSharp.Dynamic.NuGet
-      run: dotnet run --project tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -v n
+      run: dotnet run --project tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -r win-x64 --no-self-contained -v n
     - name: Build and run ComputeSharp.Pix.NuGet
-      run: dotnet run --project tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f ${{matrix.framework}} -r win-x64 --no-self-contained -v n
+      run: dotnet run --project tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -r win-x64 --no-self-contained -v n
     
       # Run the extra tests to validate a number of build and publishing configurations.
       # This is used to ensure the native dependencies can always be loaded correctly
       # regardless of whether the app is shipping with R2R, self-contained, etc.
-      # Like with the source generator tests, only run these once on the .NET 6 target.
-    - if: matrix.framework == 'net6.0'
-      name: Run ComputeSharp.Tests.NativeLibrariesResolver
+    - name: Run ComputeSharp.Tests.NativeLibrariesResolver
       run: dotnet test tests\ComputeSharp.Tests.NativeLibrariesResolver\ComputeSharp.Tests.NativeLibrariesResolver.csproj -v n -l "console;verbosity=detailed"
     
-      # If on .NET 7, also run the NativeAOT publishing tests
-    - if: matrix.framework == 'net7.0'
-      name: Publish and run ComputeSharp.NuGet with NativeAOT
+      # Also run the NativeAOT publishing tests
+    - name: Publish and run ComputeSharp.NuGet with NativeAOT
       run: >
-        dotnet publish tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -f net7.0 -r win-x64 -v n;
+        $env:COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT='true';
+        dotnet publish tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -r win-x64 -v n;
         tests\ComputeSharp.NuGet\bin\Release\net7.0\win-x64\publish\ComputeSharp.NuGet.exe
-    - if: matrix.framework == 'net7.0'
-      name: Publish and run ComputeSharp.Dynamic.NuGet with NativeAOT
+    - name: Publish and run ComputeSharp.Dynamic.NuGet with NativeAOT
       run: >
-        dotnet publish tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -f net7.0 -r win-x64 -v n;
+        $env:COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT='true';
+        dotnet publish tests\ComputeSharp.Dynamic.NuGet\ComputeSharp.Dynamic.NuGet.csproj -c Release -r win-x64 -v n;
         tests\ComputeSharp.Dynamic.NuGet\bin\Release\net7.0\win-x64\publish\ComputeSharp.Dynamic.NuGet.exe
-    - if: matrix.framework == 'net7.0'
-      name: Publish and run ComputeSharp.Pix.NuGet with NativeAOT
+    - name: Publish and run ComputeSharp.Pix.NuGet with NativeAOT
       run: >
-        dotnet publish tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -f net7.0 -r win-x64 -v n;
+        $env:COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT='true';
+        dotnet publish tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -r win-x64 -v n;
         tests\ComputeSharp.Pix.NuGet\bin\Release\net7.0\win-x64\publish\ComputeSharp.Pix.NuGet.exe
 
   # Publish the packages to GitHub packages

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -161,15 +161,15 @@ jobs:
     - name: Build and run ComputeSharp.Sample
       run: >
         dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
-        samples\ComputeSharp.Sample\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.Sample.exe
+        samples\ComputeSharp.Sample\bin\x64\Release\net6.0\win-x64\ComputeSharp.Sample.exe
     - name: Build and run ComputeSharp.Sample.FSharp
       run: >
         dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
-        samples\ComputeSharp.Sample.FSharp\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.Sample.FSharp.exe
+        samples\ComputeSharp.Sample.FSharp\bin\x64\Release\net6.0\win-x64\ComputeSharp.Sample.FSharp.exe
     - name: Build and run ComputeSharp.ImageProcessing.csproj
       run: >
         dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
-        samples\ComputeSharp.ImageProcessing\bin\x64\Release\${{matrix.framework}}\win-x64\ComputeSharp.ImageProcessing.exe
+        samples\ComputeSharp.ImageProcessing\bin\x64\Release\net6.0\win-x64\ComputeSharp.ImageProcessing.exe
 
   # Run the NativeAOT samples as well
   run-samples-aot:

--- a/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
+++ b/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <LangVersion>5.0</LangVersion>
   </PropertyGroup>

--- a/samples/ComputeSharp.Sample/ComputeSharp.Sample.csproj
+++ b/samples/ComputeSharp.Sample/ComputeSharp.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Dynamic.NuGet/ComputeSharp.Dynamic.NuGet.csproj
+++ b/tests/ComputeSharp.Dynamic.NuGet/ComputeSharp.Dynamic.NuGet.csproj
@@ -1,18 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <NoWarn>$(NoWarn);IL2026</NoWarn>
+    <PublishAot Condition="'$(COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT)' == 'true'">true</PublishAot>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       ..\..\artifacts;
     </RestoreSources>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PublishAot>true</PublishAot>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <NoWarn>$(NoWarn);IL2026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.NuGet/ComputeSharp.NuGet.csproj
+++ b/tests/ComputeSharp.NuGet/ComputeSharp.NuGet.csproj
@@ -1,18 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <NoWarn>$(NoWarn);IL2026</NoWarn>
+    <PublishAot Condition="'$(COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT)' == 'true'">true</PublishAot>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       ..\..\artifacts;
     </RestoreSources>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PublishAot>true</PublishAot>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <NoWarn>$(NoWarn);IL2026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Pix.NuGet/ComputeSharp.Pix.NuGet.csproj
+++ b/tests/ComputeSharp.Pix.NuGet/ComputeSharp.Pix.NuGet.csproj
@@ -1,18 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <NoWarn>$(NoWarn);IL2026</NoWarn>
+    <PublishAot Condition="'$(COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT)' == 'true'">true</PublishAot>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       ..\..\artifacts;
     </RestoreSources>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <PublishAot>true</PublishAot>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <NoWarn>$(NoWarn);IL2026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
+++ b/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/DynamicNativeLibrariesResolverTests.cs
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/DynamicNativeLibrariesResolverTests.cs
@@ -25,13 +25,12 @@ public class DynamicNativeLibrariesResolverTests : NativeLibrariesResolverTestsB
             path = Path.GetDirectoryName(path)!;
         }
 
-        string corePackagingProjectPath = Path.Combine(path, "src", "ComputeSharp.Core", "ComputeSharp.Core.msbuildproj");
-        string packagingProjectPath = Path.Combine(path, "src", "ComputeSharp.Package", "ComputeSharp.Package.msbuildproj");
-        string dynamicPackagingProjectPath = Path.Combine(path, "src", "ComputeSharp.Dynamic.Package", "ComputeSharp.Dynamic.Package.msbuildproj");
+        string coreProjectPath = Path.Combine(path, "src", "ComputeSharp.Core", "ComputeSharp.Core.csproj");
+        string projectPath = Path.Combine(path, "src", "ComputeSharp.Package", "ComputeSharp.Package.csproj");
+        string dynamicProjectPath = Path.Combine(path, "src", "ComputeSharp.Dynamic", "ComputeSharp.Dynamic.csproj");
 
-        // Run dotnet pack and on the packaging projects, to ensure the local NuGet packages are available
-        Process.Start("dotnet", $"pack {corePackagingProjectPath} -c Release").WaitForExit();
-        Process.Start("dotnet", $"pack {packagingProjectPath} -c Release").WaitForExit();
-        Process.Start("dotnet", $"pack {dynamicPackagingProjectPath} -c Release").WaitForExit();
+        Process.Start("dotnet", $"pack {coreProjectPath} -c Release").WaitForExit();
+        Process.Start("dotnet", $"pack {projectPath} -c Release").WaitForExit();
+        Process.Start("dotnet", $"pack {dynamicProjectPath} -c Release").WaitForExit();
     }
 }

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/Helpers/NativeLibrariesResolverTestsBase.cs
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/Helpers/NativeLibrariesResolverTestsBase.cs
@@ -42,7 +42,7 @@ public abstract class NativeLibrariesResolverTestsBase
     {
         CleanSampleProject(configuration, rid);
 
-        Assert.AreEqual(0, Exec(SampleProjectDirectory, "dotnet", $"run -c {configuration} -f net6.0 {ToOption(rid)}"));
+        Assert.AreEqual(0, Exec(SampleProjectDirectory, "dotnet", $"run -c {configuration} {ToOption(rid)}"));
     }
 
     [TestMethod]
@@ -55,7 +55,7 @@ public abstract class NativeLibrariesResolverTestsBase
         CleanSampleProject(configuration, rid);
         BuildSampleProject(configuration, rid);
 
-        string realtivePathToDll = Path.Combine("bin", $"{configuration}", "net6.0", $"{ToDirectory(rid)}", $"{SampleProjectName}.dll");
+        string realtivePathToDll = Path.Combine("bin", $"{configuration}", "net7.0", $"{ToDirectory(rid)}", $"{SampleProjectName}.dll");
 
         Assert.AreEqual(0, Exec(SampleProjectDirectory, "dotnet", realtivePathToDll));
     }
@@ -70,7 +70,7 @@ public abstract class NativeLibrariesResolverTestsBase
         CleanSampleProject(configuration, rid);
         BuildSampleProject(configuration, rid);
 
-        string pathToDllDirectory = Path.Combine(SampleProjectDirectory, "bin", $"{configuration}", "net6.0", $"{ToDirectory(rid)}");
+        string pathToDllDirectory = Path.Combine(SampleProjectDirectory, "bin", $"{configuration}", "net7.0", $"{ToDirectory(rid)}");
 
         Assert.AreEqual(0, Exec(pathToDllDirectory, "dotnet", $"{SampleProjectName}.dll"));
     }
@@ -85,7 +85,7 @@ public abstract class NativeLibrariesResolverTestsBase
         CleanSampleProject(configuration, rid);
         BuildSampleProject(configuration, rid);
 
-        string relativePathToAppHost = Path.Combine("bin", $"{configuration}", "net6.0", $"{ToDirectory(rid)}", $"{SampleProjectName}.exe");
+        string relativePathToAppHost = Path.Combine("bin", $"{configuration}", "net7.0", $"{ToDirectory(rid)}", $"{SampleProjectName}.exe");
 
         Assert.AreEqual(0, Exec(SampleProjectDirectory, relativePathToAppHost, ""));
     }
@@ -100,7 +100,7 @@ public abstract class NativeLibrariesResolverTestsBase
         CleanSampleProject(configuration, rid);
         BuildSampleProject(configuration, rid);
 
-        string pathToAppHostDirectory = Path.Combine(SampleProjectDirectory, "bin", $"{configuration}", "net6.0", $"{ToDirectory(rid)}");
+        string pathToAppHostDirectory = Path.Combine(SampleProjectDirectory, "bin", $"{configuration}", "net7.0", $"{ToDirectory(rid)}");
 
         Assert.AreEqual(0, Exec(pathToAppHostDirectory, $"{SampleProjectName}.exe", ""));
     }
@@ -118,9 +118,9 @@ public abstract class NativeLibrariesResolverTestsBase
         // Furthermore, only publishing in Release mode is tested.
         CleanSampleProject(Configuration.Release, RID.Win_x64);
 
-        _ = Exec(SampleProjectDirectory, "dotnet", $"publish -c Release -f net6.0 -r win-x64 {ToOption(publishMode)} {ToOption(deploymentMode)} {ToOption(nativeLibsDeploymentMode)} /bl");
+        _ = Exec(SampleProjectDirectory, "dotnet", $"publish -c Release -r win-x64 {ToOption(publishMode)} {ToOption(deploymentMode)} {ToOption(nativeLibsDeploymentMode)} /bl");
 
-        string pathToAppHost = Path.Combine("bin", $"Release", "net6.0", "win-x64", "publish", $"{SampleProjectName}.exe");
+        string pathToAppHost = Path.Combine("bin", $"Release", "net7.0", "win-x64", "publish", $"{SampleProjectName}.exe");
 
         Assert.AreEqual(0, Exec(SampleProjectDirectory, pathToAppHost, ""));
     }

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/NativeLibrariesResolverTests.cs
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/NativeLibrariesResolverTests.cs
@@ -25,11 +25,10 @@ public class NativeLibrariesResolverTests : NativeLibrariesResolverTestsBase
             path = Path.GetDirectoryName(path)!;
         }
 
-        string corePackagingProjectPath = Path.Combine(path, "src", "ComputeSharp.Core", "ComputeSharp.Core.msbuildproj");
-        string packagingProjectPath = Path.Combine(path, "src", "ComputeSharp.Package", "ComputeSharp.Package.msbuildproj");
+        string coreProjectPath = Path.Combine(path, "src", "ComputeSharp.Core", "ComputeSharp.Core.csproj");
+        string projectPath = Path.Combine(path, "src", "ComputeSharp", "ComputeSharp.csproj");
 
-        // Run dotnet pack and on the packaging projects, to ensure the local NuGet packages are available
-        Process.Start("dotnet", $"pack {corePackagingProjectPath} -c Release").WaitForExit();
-        Process.Start("dotnet", $"pack {packagingProjectPath} -c Release").WaitForExit();
+        Process.Start("dotnet", $"pack {coreProjectPath} -c Release").WaitForExit();
+        Process.Start("dotnet", $"pack {projectPath} -c Release").WaitForExit();
     }
 }

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/PixNativeLibrariesResolverTests.cs
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/PixNativeLibrariesResolverTests.cs
@@ -25,13 +25,13 @@ public class PixNativeLibrariesResolverTests : NativeLibrariesResolverTestsBase
             path = Path.GetDirectoryName(path)!;
         }
 
-        string corePackagingProjectPath = Path.Combine(path, "src", "ComputeSharp.Core", "ComputeSharp.Core.msbuildproj");
-        string packagingProjectPath = Path.Combine(path, "src", "ComputeSharp.Package", "ComputeSharp.Package.msbuildproj");
-        string pixPackagingProjectPath = Path.Combine(path, "src", "ComputeSharp.Pix.Package", "ComputeSharp.Pix.Package.msbuildproj");
+        string coreProjectPath = Path.Combine(path, "src", "ComputeSharp.Core", "ComputeSharp.Core.csproj");
+        string projectPath = Path.Combine(path, "src", "ComputeSharp.Package", "ComputeSharp.Package.csproj");
+        string pixProjectPath = Path.Combine(path, "src", "ComputeSharp.Pix", "ComputeSharp.Pix.csproj");
 
         // Run dotnet pack and on the packaging projects, to ensure the local NuGet packages are available
-        Process.Start("dotnet", $"pack {corePackagingProjectPath} -c Release").WaitForExit();
-        Process.Start("dotnet", $"pack {packagingProjectPath} -c Release").WaitForExit();
-        Process.Start("dotnet", $"pack {pixPackagingProjectPath} -c Release").WaitForExit();
+        Process.Start("dotnet", $"pack {coreProjectPath} -c Release").WaitForExit();
+        Process.Start("dotnet", $"pack {projectPath} -c Release").WaitForExit();
+        Process.Start("dotnet", $"pack {pixProjectPath} -c Release").WaitForExit();
     }
 }

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 


### PR DESCRIPTION
### Contributes to #598

### Description

This PR removes all multi-targeting, and makes each project only target one .NET TFM. This is an incremental step towards migrating all projects to only target .NET 8, and drop all previous TFMs in the process (ie. both .NET 6 and .NET 7).