### PR TITLE
Switch to TerraFX.Interop.Windows in unit tests

### DIFF
--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -12,8 +12,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
-    <PackageReference Include="Vortice.Win32.Graphics.Direct2D" Version="1.9.34" />
-    <PackageReference Include="Vortice.Win32.Graphics.Direct3D11" Version="1.9.34" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.22621.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -4,8 +4,8 @@ using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Tests.Effects;
 using ComputeSharp.D2D1.Tests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Win32;
-using Win32.Graphics.Direct2D;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 #pragma warning disable IDE0022, IDE0044
 

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
@@ -11,10 +11,8 @@ using ComputeSharp.Tests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using Win32;
-using Win32.Graphics.Direct2D;
-using HRESULT = Win32.HResult;
-using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 #pragma warning disable CS0649, IDE0044
 
@@ -59,7 +57,7 @@ public partial class D2D1ResourceTextureManagerTests
         Guid uuidOfGarbage = Guid.NewGuid();
 
         // Any other random QueryInterface should fail
-        Assert.AreEqual(HRESULT.NoInterface, resourceTextureManager.AsIID(&uuidOfGarbage, &garbage));
+        Assert.AreEqual(E.E_NOINTERFACE, (int)resourceTextureManager.AsIID(&uuidOfGarbage, &garbage));
 
         Assert.IsTrue(garbage.Get() is null);
     }

--- a/tests/ComputeSharp.D2D1.Tests/D2D1TransformMapperTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1TransformMapperTests.cs
@@ -8,13 +8,9 @@ using ComputeSharp.D2D1.Tests.Helpers;
 using ComputeSharp.SwapChain.Shaders.D2D1;
 using ComputeSharp.Tests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Win32;
-using Win32.Graphics.Direct2D;
-using HRESULT = Win32.HResult;
-using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 using Rectangle = System.Drawing.Rectangle;
-
-#pragma warning disable CS0649, IDE0044
 
 namespace ComputeSharp.D2D1.Tests;
 
@@ -118,7 +114,7 @@ public partial class D2D1TransformMapperTests
 
         HRESULT hresult = unknown.CopyTo(&uuidOfTransformMapperInternal, (void**)transformMapperInternal.GetAddressOf());
 
-        Assert.AreEqual(hresult, HRESULT.Ok);
+        Assert.AreEqual((int)hresult, S.S_OK);
         Assert.IsTrue(transformMapperInternal.Get() is not null);
 
         IntPtr handlePtr;
@@ -128,7 +124,7 @@ public partial class D2D1TransformMapperTests
             transformMapperInternal.Get(),
             (void**)&handlePtr);
 
-        Assert.AreEqual(hresult, HRESULT.Ok);
+        Assert.AreEqual((int)hresult, S.S_OK);
 
         GCHandle handle = GCHandle.FromIntPtr(handlePtr);
 

--- a/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
@@ -9,21 +9,10 @@ using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Tests.Extensions;
 using ComputeSharp.D2D1.Tests.Helpers;
 using SixLabors.ImageSharp;
-using Win32;
-using Win32.Graphics.Direct2D;
-using D2D1_BORDER_EDGE_MODE = Win32.Graphics.Direct2D.BorderEdgeMode;
-using D2D1_BORDER_PROP = Win32.Graphics.Direct2D.BorderProp;
-using D2D1_BUFFER_PRECISION = Win32.Graphics.Direct2D.BufferPrecision;
-using D2D1_COMPOSITE_MODE = Win32.Graphics.Direct2D.Common.CompositeMode;
-using D2D1_COMPOSITE_PROP = Win32.Graphics.Direct2D.CompositeProp;
-using D2D1_INTERPOLATION_MODE = Win32.Graphics.Direct2D.InterpolationMode;
-using D2D1_PROPERTY = Win32.Graphics.Direct2D.Property;
-using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
-using D2D1_RENDERING_CONTROLS = Win32.Graphics.Direct2D.RenderingControls;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.D2D1.Tests.Effects;
-
-using D2D1 = Win32.Graphics.Direct2D.Apis;
 
 /// <summary>
 /// A bokeh blur effect, using linearly separable convolutions in the complex space for better efficiency.
@@ -310,7 +299,7 @@ public sealed partial class BokehBlurEffect
 
         // Set the buffer precision for the whole context to 32 bits per channel. This avoids
         // color banding issues due to intermediate buffers clamping to just 8 bits per channel.
-        d2D1RenderingControls.bufferPrecision = D2D1_BUFFER_PRECISION.Precision32BitFloat;
+        d2D1RenderingControls.bufferPrecision = D2D1_BUFFER_PRECISION.D2D1_BUFFER_PRECISION_32BPC_FLOAT;
 
         d2D1DeviceContext.Get()->SetRenderingControls(&d2D1RenderingControls);
 
@@ -350,31 +339,31 @@ public sealed partial class BokehBlurEffect
 
             // Create the border effect to clamp the input image
             d2D1DeviceContext.Get()->CreateEffect(
-                effectId: (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in D2D1.CLSID_D2D1Border)),
+                effectId: (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in CLSID.CLSID_D2D1Border)),
                 effect: borderEffect.GetAddressOf()).Assert();
 
-            D2D1_BORDER_EDGE_MODE d2D1BorderEdgeMode = D2D1_BORDER_EDGE_MODE.Clamp;
+            D2D1_BORDER_EDGE_MODE d2D1BorderEdgeMode = D2D1_BORDER_EDGE_MODE.D2D1_BORDER_EDGE_MODE_CLAMP;
 
             // Set the border mode to clamp on both axes
-            borderEffect.Get()->SetValue((uint)D2D1_BORDER_PROP.EdgeModeX, (byte*)&d2D1BorderEdgeMode, sizeof(D2D1_BORDER_EDGE_MODE)).Assert();
-            borderEffect.Get()->SetValue((uint)D2D1_BORDER_PROP.EdgeModeY, (byte*)&d2D1BorderEdgeMode, sizeof(D2D1_BORDER_EDGE_MODE)).Assert();
+            borderEffect.Get()->SetValue((uint)D2D1_BORDER_PROP.D2D1_BORDER_PROP_EDGE_MODE_X, (byte*)&d2D1BorderEdgeMode, sizeof(D2D1_BORDER_EDGE_MODE)).Assert();
+            borderEffect.Get()->SetValue((uint)D2D1_BORDER_PROP.D2D1_BORDER_PROP_EDGE_MODE_Y, (byte*)&d2D1BorderEdgeMode, sizeof(D2D1_BORDER_EDGE_MODE)).Assert();
 
             // If partials need to be summed, also create the composite effect
             if (numberOfComponents > 1)
             {
                 d2D1DeviceContext.Get()->CreateEffect(
-                    effectId: (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in D2D1.CLSID_D2D1Composite)),
+                    effectId: (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in CLSID.CLSID_D2D1Composite)),
                     effect: compositeEffect.GetAddressOf()).Assert();
 
-                D2D1_BUFFER_PRECISION d2D1BufferPrecision = D2D1_BUFFER_PRECISION.Precision32BitFloat;
+                D2D1_BUFFER_PRECISION d2D1BufferPrecision = D2D1_BUFFER_PRECISION.D2D1_BUFFER_PRECISION_32BPC_FLOAT;
 
                 // Set the channel precision to 32 bits manually to avoid banding
-                compositeEffect.Get()->SetValue((uint)D2D1_PROPERTY.Precision, (byte*)&d2D1BufferPrecision, sizeof(D2D1_BUFFER_PRECISION)).Assert();
+                compositeEffect.Get()->SetValue(unchecked((uint)D2D1_PROPERTY.D2D1_PROPERTY_PRECISION), (byte*)&d2D1BufferPrecision, sizeof(D2D1_BUFFER_PRECISION)).Assert();
 
-                D2D1_COMPOSITE_MODE d2D1CompositeMode = D2D1_COMPOSITE_MODE.Plus;
+                D2D1_COMPOSITE_MODE d2D1CompositeMode = D2D1_COMPOSITE_MODE.D2D1_COMPOSITE_MODE_PLUS;
 
                 // Set the mode to plus
-                compositeEffect.Get()->SetValue((uint)D2D1_COMPOSITE_PROP.Mode, (byte*)&d2D1CompositeMode, sizeof(D2D1_COMPOSITE_MODE)).Assert();
+                compositeEffect.Get()->SetValue((uint)D2D1_COMPOSITE_PROP.D2D1_COMPOSITE_PROP_MODE, (byte*)&d2D1CompositeMode, sizeof(D2D1_COMPOSITE_MODE)).Assert();
             }
 
             ReadOnlyMemory<byte> pixels = ImageHelper.LoadBitmapFromFile(sourcePath, out uint width, out uint height);
@@ -468,8 +457,8 @@ public sealed partial class BokehBlurEffect
                 effect: inverseGammaExposureEffect.Get(),
                 targetOffset: null,
                 imageRectangle: null,
-                interpolationMode: D2D1_INTERPOLATION_MODE.NearestNeighbor,
-                compositeMode: D2D1_COMPOSITE_MODE.SourceCopy);
+                interpolationMode: D2D1_INTERPOLATION_MODE.D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
+                compositeMode: D2D1_COMPOSITE_MODE.D2D1_COMPOSITE_MODE_SOURCE_COPY);
 
             d2D1DeviceContext.Get()->EndDraw().Assert();
 

--- a/tests/ComputeSharp.D2D1.Tests/Extensions/ComPtrExtensions.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Extensions/ComPtrExtensions.cs
@@ -1,5 +1,5 @@
 using System.Runtime.CompilerServices;
-using Win32;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.D2D1.Tests.Extensions;
 
@@ -17,7 +17,7 @@ internal static class ComPtrExtensions
     /// <returns>The moved <see cref="ComPtr{T}"/> instance.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ComPtr<T> Move<T>(this in ComPtr<T> ptr)
-        where T : unmanaged
+        where T : unmanaged, IUnknown.Interface
     {
         ComPtr<T> copy = default;
 

--- a/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Extensions/HRESULTExtensions.cs
@@ -1,10 +1,8 @@
 using System.ComponentModel;
 using System.Diagnostics;
-#if NET6_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
-#endif
 using System.Runtime.CompilerServices;
-using HRESULT = Win32.HResult;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.D2D1.Tests.Extensions;
 
@@ -47,9 +45,7 @@ internal static class HRESULTExtensions
     /// Throws a <see cref="Win32Exception"/>.
     /// </summary>
     /// <param name="result">The input return code.</param>
-#if NET6_0_OR_GREATER
     [DoesNotReturn]
-#endif
     private static void ThrowWin32Exception(int result)
     {
         throw new Win32Exception(result);

--- a/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1Helper.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1Helper.cs
@@ -1,32 +1,9 @@
 using System;
-using System.Drawing;
 using ComputeSharp.D2D1.Tests.Extensions;
-using Win32;
-using Win32.Graphics.Direct2D;
-using Win32.Graphics.Direct3D11;
-using Win32.Graphics.Dxgi;
-using D2D1_ALPHA_MODE = Win32.Graphics.Direct2D.Common.AlphaMode;
-using D2D1_BITMAP_OPTIONS = Win32.Graphics.Direct2D.BitmapOptions;
-using D2D1_DEVICE_CONTEXT_OPTIONS = Win32.Graphics.Direct2D.DeviceContextOptions;
-using D2D1_FACTORY_OPTIONS = Win32.Graphics.Direct2D.FactoryOptions;
-using D2D1_FACTORY_TYPE = Win32.Graphics.Direct2D.FactoryType;
-using D2D1_INTERPOLATION_MODE = Win32.Graphics.Direct2D.InterpolationMode;
-using D2D1_COMPOSITE_MODE = Win32.Graphics.Direct2D.Common.CompositeMode;
-using D2D1_MAP_OPTIONS = Win32.Graphics.Direct2D.MapOptions;
-using D2D_RECT_U = Win32.Numerics.Rect;
-using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
-using D2D1_BITMAP_PROPERTIES = Win32.Graphics.Direct2D.BitmapProperties;
-using D2D1_BITMAP_PROPERTIES1 = Win32.Graphics.Direct2D.BitmapProperties1;
-using D3D_FEATURE_LEVEL = Win32.Graphics.Direct3D.FeatureLevel;
-using D3D_DRIVER_TYPE = Win32.Graphics.Direct3D.DriverType;
-using D3D11_CREATE_DEVICE_FLAG = Win32.Graphics.Direct3D11.CreateDeviceFlags;
-using DXGI_FORMAT = Win32.Graphics.Dxgi.Common.Format;
-using D3D11 = Win32.Graphics.Direct3D11.Apis;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.D2D1.Tests.Helpers;
-
-using D2D1 = Win32.Graphics.Direct2D.Apis;
-using Win32 = Win32.Apis;
 
 /// <summary>
 /// A <see langword="class"/> that uses the D2D1 APIs to configure and run effects.
@@ -45,9 +22,9 @@ internal static class D2D1Helper
         D2D1_FACTORY_OPTIONS d2D1FactoryOptions = default;
 
         // Create a Direct2D factory
-        D2D1.D2D1CreateFactory(
-            factoryType: singleThreaded ? D2D1_FACTORY_TYPE.SingleThreaded : D2D1_FACTORY_TYPE.MultiThreaded,
-            riid: Win32.__uuidof<ID2D1Factory2>(),
+        DirectX.D2D1CreateFactory(
+            factoryType: singleThreaded ? D2D1_FACTORY_TYPE.D2D1_FACTORY_TYPE_SINGLE_THREADED : D2D1_FACTORY_TYPE.D2D1_FACTORY_TYPE_MULTI_THREADED,
+            riid: Windows.__uuidof<ID2D1Factory2>(),
             pFactoryOptions: &d2D1FactoryOptions,
             ppIFactory: (void**)d2D1Factory2.GetAddressOf()).Assert();
 
@@ -65,22 +42,22 @@ internal static class D2D1Helper
 
         D3D_FEATURE_LEVEL* featureLevels = stackalloc[]
         {
-            D3D_FEATURE_LEVEL.Level_11_1,
-            D3D_FEATURE_LEVEL.Level_11_0,
-            D3D_FEATURE_LEVEL.Level_10_1,
-            D3D_FEATURE_LEVEL.Level_10_0,
-            D3D_FEATURE_LEVEL.Level_9_3,
-            D3D_FEATURE_LEVEL.Level_9_2,
-            D3D_FEATURE_LEVEL.Level_9_1
+            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_11_1,
+            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_11_0,
+            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_10_1,
+            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_10_0,
+            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_9_3,
+            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_9_2,
+            D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_9_1
         };
         D3D_FEATURE_LEVEL d3DFeatureLevel;
 
         // Create the Direct3D 11 API device and context
-        D3D11.D3D11CreateDevice(
+        DirectX.D3D11CreateDevice(
             pAdapter: null,
-            DriverType: D3D_DRIVER_TYPE.Hardware,
-            Software: IntPtr.Zero,
-            Flags: D3D11_CREATE_DEVICE_FLAG.BgraSupport,
+            DriverType: D3D_DRIVER_TYPE.D3D_DRIVER_TYPE_HARDWARE,
+            Software: HMODULE.NULL,
+            Flags: (uint)D3D11_CREATE_DEVICE_FLAG.D3D11_CREATE_DEVICE_BGRA_SUPPORT,
             pFeatureLevels: featureLevels,
             FeatureLevels: 7,
             SDKVersion: D3D11.D3D11_SDK_VERSION,
@@ -114,7 +91,7 @@ internal static class D2D1Helper
 
         // Create a D2D1 device context
         d2D1Device->CreateDeviceContext(
-            options: D2D1_DEVICE_CONTEXT_OPTIONS.None,
+            options: D2D1_DEVICE_CONTEXT_OPTIONS.D2D1_DEVICE_CONTEXT_OPTIONS_NONE,
             deviceContext: d2D1DeviceContext.GetAddressOf()).Assert();
 
         return d2D1DeviceContext.Move();
@@ -138,11 +115,11 @@ internal static class D2D1Helper
     {
         using ComPtr<ID2D1Bitmap> d2D1BitmapSource = default;
 
-        Size d2DSize = new((int)width, (int)height);
+        D2D_SIZE_U d2DSize = new(width, height);
 
         D2D1_BITMAP_PROPERTIES d2DBitmapProperties = default;
-        d2DBitmapProperties.pixelFormat.format = DXGI_FORMAT.B8G8R8A8Unorm;
-        d2DBitmapProperties.pixelFormat.alphaMode = D2D1_ALPHA_MODE.Premultiplied;
+        d2DBitmapProperties.pixelFormat.format = DXGI_FORMAT.DXGI_FORMAT_B8G8R8A8_UNORM;
+        d2DBitmapProperties.pixelFormat.alphaMode = D2D1_ALPHA_MODE.D2D1_ALPHA_MODE_PREMULTIPLIED;
         d2DBitmapProperties.dpiX = 96;
         d2DBitmapProperties.dpiY = 96;
 
@@ -171,12 +148,12 @@ internal static class D2D1Helper
     /// <returns>A new <see cref="ID2D1Bitmap"/> instance.</returns>
     public static unsafe ComPtr<ID2D1Bitmap> CreateD2D1BitmapAndSetAsTarget(ID2D1DeviceContext* d2D1DeviceContext, uint width, uint height)
     {
-        Size d2DSize = new((int)width, (int)height);
+        D2D_SIZE_U d2DSize = new(width, height);
 
         D2D1_BITMAP_PROPERTIES1 d2DBitmapProperties1Target = default;
-        d2DBitmapProperties1Target.pixelFormat.format = DXGI_FORMAT.B8G8R8A8Unorm;
-        d2DBitmapProperties1Target.pixelFormat.alphaMode = D2D1_ALPHA_MODE.Premultiplied;
-        d2DBitmapProperties1Target.bitmapOptions = D2D1_BITMAP_OPTIONS.Target | D2D1_BITMAP_OPTIONS.CannotDraw;
+        d2DBitmapProperties1Target.pixelFormat.format = DXGI_FORMAT.DXGI_FORMAT_B8G8R8A8_UNORM;
+        d2DBitmapProperties1Target.pixelFormat.alphaMode = D2D1_ALPHA_MODE.D2D1_ALPHA_MODE_PREMULTIPLIED;
+        d2DBitmapProperties1Target.bitmapOptions = D2D1_BITMAP_OPTIONS.D2D1_BITMAP_OPTIONS_TARGET | D2D1_BITMAP_OPTIONS.D2D1_BITMAP_OPTIONS_CANNOT_DRAW;
 
         using ComPtr<ID2D1Bitmap> d2D1Bitmap1Target = default;
 
@@ -202,12 +179,12 @@ internal static class D2D1Helper
     /// <returns>A new <see cref="ID2D1Bitmap1"/> instance.</returns>
     public static unsafe ComPtr<ID2D1Bitmap1> CreateD2D1Bitmap1Buffer(ID2D1DeviceContext* d2D1DeviceContext, ID2D1Bitmap* d2D1Bitmap, out D2D1_MAPPED_RECT d2D1MappedRect)
     {
-        Size d2DSize = d2D1Bitmap->GetPixelSize();
+        D2D_SIZE_U d2DSize = d2D1Bitmap->GetPixelSize();
 
         D2D1_BITMAP_PROPERTIES1 d2DBitmapProperties1Buffer = default;
-        d2DBitmapProperties1Buffer.pixelFormat.format = DXGI_FORMAT.B8G8R8A8Unorm;
-        d2DBitmapProperties1Buffer.pixelFormat.alphaMode = D2D1_ALPHA_MODE.Premultiplied;
-        d2DBitmapProperties1Buffer.bitmapOptions = D2D1_BITMAP_OPTIONS.CpuRead | D2D1_BITMAP_OPTIONS.CannotDraw;
+        d2DBitmapProperties1Buffer.pixelFormat.format = DXGI_FORMAT.DXGI_FORMAT_B8G8R8A8_UNORM;
+        d2DBitmapProperties1Buffer.pixelFormat.alphaMode = D2D1_ALPHA_MODE.D2D1_ALPHA_MODE_PREMULTIPLIED;
+        d2DBitmapProperties1Buffer.bitmapOptions = D2D1_BITMAP_OPTIONS.D2D1_BITMAP_OPTIONS_CPU_READ | D2D1_BITMAP_OPTIONS.D2D1_BITMAP_OPTIONS_CANNOT_DRAW;
 
         using ComPtr<ID2D1Bitmap1> d2D1Bitmap1Buffer = default;
 
@@ -219,12 +196,12 @@ internal static class D2D1Helper
             bitmapProperties: &d2DBitmapProperties1Buffer,
             bitmap: d2D1Bitmap1Buffer.GetAddressOf()).Assert();
 
-        Point d2DPointDestination = default;
+        D2D_POINT_2U d2DPointDestination = default;
         D2D_RECT_U d2DRectSource = default;
-        d2DRectSource.Top = 0;
-        d2DRectSource.Left = 0;
-        d2DRectSource.Right = d2DSize.Width;
-        d2DRectSource.Bottom = d2DSize.Height;
+        d2DRectSource.top = 0;
+        d2DRectSource.left = 0;
+        d2DRectSource.right = d2DSize.width;
+        d2DRectSource.bottom = d2DSize.height;
 
         // Copy the image from the target to the readback bitmap
         _ = d2D1Bitmap1Buffer.Get()->CopyFromBitmap(
@@ -236,7 +213,7 @@ internal static class D2D1Helper
         {
             // Map the buffer bitmap
             d2D1Bitmap1Buffer.Get()->Map(
-                options: D2D1_MAP_OPTIONS.Read,
+                options: D2D1_MAP_OPTIONS.D2D1_MAP_OPTIONS_READ,
                 mappedRect: d2D1MappedRectPtr).Assert();
         }
 
@@ -257,8 +234,8 @@ internal static class D2D1Helper
             effect: d2D1Effect,
             targetOffset: null,
             imageRectangle: null,
-            interpolationMode: D2D1_INTERPOLATION_MODE.NearestNeighbor,
-            compositeMode: D2D1_COMPOSITE_MODE.SourceCopy);
+            interpolationMode: D2D1_INTERPOLATION_MODE.D2D1_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
+            compositeMode: D2D1_COMPOSITE_MODE.D2D1_COMPOSITE_MODE_SOURCE_COPY);
 
         d2D1DeviceContext->EndDraw().Assert();
     }

--- a/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1TestRunner.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Helpers/D2D1TestRunner.cs
@@ -5,9 +5,8 @@ using System.Runtime.CompilerServices;
 using ComputeSharp.D2D1.Descriptors;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.Tests.Helpers;
-using Win32;
-using Win32.Graphics.Direct2D;
-using D2D1_MAPPED_RECT = Win32.Graphics.Direct2D.MappedRect;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.D2D1.Tests.Helpers;
 

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -14,8 +14,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="Vortice.Win32.Graphics.Direct3D12" Version="1.9.34" />
-    <PackageReference Include="Vortice.Win32.Graphics.Dxgi" Version="1.9.34" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
@@ -7,12 +7,10 @@ using ComputeSharp.Tests.Attributes;
 using ComputeSharp.Tests.DeviceLost.Helpers;
 using ComputeSharp.Tests.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Win32;
-using Win32.Graphics.Direct3D12;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.Tests.DeviceLost;
-
-using Win32 = Win32.Apis;
 
 [TestClass]
 [TestCategory("DeviceDisposal")]
@@ -65,7 +63,7 @@ public partial class DeviceDisposalTests
 
         graphicsDevice.Dispose();
 
-        InteropServices.GetID3D12Device(graphicsDevice, Win32.__uuidof<ID3D12Device>(), (void**)d3D12Device.GetAddressOf());
+        InteropServices.GetID3D12Device(graphicsDevice, Windows.__uuidof<ID3D12Device>(), (void**)d3D12Device.GetAddressOf());
     }
 
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests.DeviceLost/DeviceLostTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/DeviceLostTests.cs
@@ -5,8 +5,8 @@ using ComputeSharp.Tests.Attributes;
 using ComputeSharp.Tests.DeviceLost.Helpers;
 using ComputeSharp.Tests.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Win32;
-using Win32.Graphics.Direct3D12;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.Tests.DeviceLost;
 

--- a/tests/ComputeSharp.Tests.DeviceLost/GetDefaultDeviceTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/GetDefaultDeviceTests.cs
@@ -2,10 +2,8 @@ using System;
 using System.Threading.Tasks;
 using ComputeSharp.Tests.DeviceLost.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Win32;
-using Win32.Graphics.Direct3D12;
-using DXGI = Win32.Graphics.Dxgi.Apis;
-using HRESULT = Win32.HResult;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.Tests.DeviceLost;
 
@@ -77,7 +75,7 @@ public class GetDefaultDeviceTests
                 HRESULT removalReason = d3D12Device.Get()->GetDeviceRemovedReason();
 
                 // Sanity check that the device is in fact removed
-                Assert.AreEqual(DXGI.DXGI_ERROR_DEVICE_REMOVED, removalReason);
+                Assert.AreEqual(DXGI.DXGI_ERROR_DEVICE_REMOVED, (int)removalReason);
             }
 
             // Calling GraphicsDevice.GetDefault() will now throw, because the native device has not been disposed properly

--- a/tests/ComputeSharp.Tests.DeviceLost/Helpers/GraphicsDeviceHelper.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/Helpers/GraphicsDeviceHelper.cs
@@ -2,12 +2,10 @@ using System;
 using System.Threading.Tasks;
 using ComputeSharp.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Win32;
-using Win32.Graphics.Direct3D12;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.Tests.DeviceLost.Helpers;
-
-using Win32 = Win32.Apis;
 
 /// <summary>
 /// A helper to do common checks on native device objects.
@@ -23,7 +21,7 @@ internal static class GraphicsDeviceHelper
     {
         fixed (ID3D12Device** ppvObject = d3D12Device)
         {
-            InteropServices.GetID3D12Device(graphicsDevice, Win32.__uuidof<ID3D12Device>(), (void**)ppvObject);
+            InteropServices.GetID3D12Device(graphicsDevice, Windows.__uuidof<ID3D12Device>(), (void**)ppvObject);
         }
     }
 

--- a/tests/ComputeSharp.Tests/AllocationServicesTests.cs
+++ b/tests/ComputeSharp.Tests/AllocationServicesTests.cs
@@ -9,8 +9,7 @@ using ComputeSharp.Interop;
 using ComputeSharp.Tests.Attributes;
 using ComputeSharp.Tests.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Win32;
-using HRESULT = Win32.HResult;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.Tests;
 
@@ -155,14 +154,14 @@ public unsafe class AllocationServicesTests
             allocationPtr.Get(),
             wrappedD3D12ResourcePtr.GetAddressOf());
 
-        Assert.IsTrue(hresult.Success);
+        Assert.IsTrue(hresult.SUCCEEDED);
 
         using ComPtr<IUnknown> d3D12ResourceUnknown = default;
         using ComPtr<IUnknown> wrappedD3D12ResourceUnknown = default;
 
         // Compare the identity of the D3D12 resource from the managed resource, and the one from the allocation
-        Assert.IsTrue(d3D12ResourcePtr.CopyTo<IUnknown>(d3D12ResourceUnknown.GetAddressOf()).Success);
-        Assert.IsTrue(wrappedD3D12ResourcePtr.CopyTo<IUnknown>(wrappedD3D12ResourceUnknown.GetAddressOf()).Success);
+        Assert.IsTrue(d3D12ResourcePtr.CopyTo<IUnknown>(d3D12ResourceUnknown.GetAddressOf()).SUCCEEDED);
+        Assert.IsTrue(wrappedD3D12ResourcePtr.CopyTo<IUnknown>(wrappedD3D12ResourceUnknown.GetAddressOf()).SUCCEEDED);
         Assert.AreEqual((nint)d3D12ResourceUnknown.Get(), (nint)wrappedD3D12ResourceUnknown.Get());
 
         // The allocation is kept alive by the resource at this point

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
-    <PackageReference Include="Vortice.Win32.Graphics.Direct3D12" Version="1.9.34" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.22621.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests/Extensions/ComPtrExtensions.cs
+++ b/tests/ComputeSharp.Tests/Extensions/ComPtrExtensions.cs
@@ -1,6 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Win32;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.Tests.Extensions;
 
@@ -17,7 +17,7 @@ internal static class ComPtrExtensions
     /// <returns>The reference count value for <paramref name="ptr"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe uint GetReferenceCount<T>(this in ComPtr<T> ptr)
-        where T : unmanaged
+        where T : unmanaged, IUnknown.Interface
     {
         if (ptr.Get() is null)
         {

--- a/tests/ComputeSharp.Tests/InteropServicesTests.cs
+++ b/tests/ComputeSharp.Tests/InteropServicesTests.cs
@@ -4,15 +4,10 @@ using ComputeSharp.Resources;
 using ComputeSharp.Tests.Attributes;
 using ComputeSharp.Tests.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Win32;
-using Win32.Graphics.Direct3D12;
-using D3D12_RESOURCE_DIMENSION = Win32.Graphics.Direct3D12.ResourceDimension;
-using HRESULT = Win32.HResult;
-using LUID = Win32.Luid;
+using TerraFX.Interop.DirectX;
+using TerraFX.Interop.Windows;
 
 namespace ComputeSharp.Tests;
-
-using Win32 = Win32.Apis;
 
 [TestClass]
 [TestCategory("InteropServices")]
@@ -24,7 +19,7 @@ public unsafe partial class InteropServicesTests
     {
         using ComPtr<ID3D12Device> d3D12Device = default;
 
-        InteropServices.GetID3D12Device(device.Get(), Win32.__uuidof<ID3D12Device>(), (void**)d3D12Device.GetAddressOf());
+        InteropServices.GetID3D12Device(device.Get(), Windows.__uuidof<ID3D12Device>(), (void**)d3D12Device.GetAddressOf());
 
         Assert.IsTrue(d3D12Device.Get() != null);
 
@@ -34,9 +29,9 @@ public unsafe partial class InteropServicesTests
 
         d3D12Device.Dispose();
 
-        int hResult = InteropServices.TryGetID3D12Device(device.Get(), Win32.__uuidof<ID3D12Device>(), (void**)d3D12Device.GetAddressOf());
+        int hResult = InteropServices.TryGetID3D12Device(device.Get(), Windows.__uuidof<ID3D12Device>(), (void**)d3D12Device.GetAddressOf());
 
-        Assert.AreEqual(hResult, (int)HRESULT.Ok);
+        Assert.AreEqual(hResult, S.S_OK);
         Assert.IsTrue(d3D12Device.Get() != null);
 
         luid = d3D12Device.Get()->GetAdapterLuid();
@@ -55,19 +50,19 @@ public unsafe partial class InteropServicesTests
 
         using (Buffer<float> buffer = device.Get().AllocateBuffer<float>(bufferType, 128))
         {
-            InteropServices.GetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            InteropServices.GetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Buffer);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_BUFFER);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
 
             d3D12Resource.Dispose();
 
-            int hResult = InteropServices.TryGetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            int hResult = InteropServices.TryGetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
-            Assert.AreEqual(hResult, (int)HRESULT.Ok);
+            Assert.AreEqual(hResult, S.S_OK);
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Buffer);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_BUFFER);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
         }
 
@@ -86,19 +81,19 @@ public unsafe partial class InteropServicesTests
 
         using (Texture2D<float> buffer = device.Get().AllocateTexture2D<float>(bufferType, 16, 16))
         {
-            InteropServices.GetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            InteropServices.GetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Texture2D);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_TEXTURE2D);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
 
             d3D12Resource.Dispose();
 
-            int hResult = InteropServices.TryGetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            int hResult = InteropServices.TryGetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
-            Assert.AreEqual(hResult, (int)HRESULT.Ok);
+            Assert.AreEqual(hResult, S.S_OK);
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Texture2D);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_TEXTURE2D);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
         }
 
@@ -115,19 +110,19 @@ public unsafe partial class InteropServicesTests
 
         using (Texture3D<float> buffer = device.Get().AllocateTexture3D<float>(bufferType, 16, 16, 4))
         {
-            InteropServices.GetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            InteropServices.GetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Texture3D);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_TEXTURE3D);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
 
             d3D12Resource.Dispose();
 
-            int hResult = InteropServices.TryGetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            int hResult = InteropServices.TryGetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
-            Assert.AreEqual(hResult, (int)HRESULT.Ok);
+            Assert.AreEqual(hResult, S.S_OK);
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Texture3D);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_TEXTURE3D);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
         }
 
@@ -144,19 +139,19 @@ public unsafe partial class InteropServicesTests
 
         using (TransferBuffer<float> buffer = device.Get().AllocateTransferBuffer<float>(bufferType, 128))
         {
-            InteropServices.GetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            InteropServices.GetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Buffer);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_BUFFER);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
 
             d3D12Resource.Dispose();
 
-            int hResult = InteropServices.TryGetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            int hResult = InteropServices.TryGetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
-            Assert.AreEqual(hResult, (int)HRESULT.Ok);
+            Assert.AreEqual(hResult, S.S_OK);
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Buffer);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_BUFFER);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
         }
 
@@ -173,19 +168,19 @@ public unsafe partial class InteropServicesTests
 
         using (TransferTexture2D<float> buffer = device.Get().AllocateTransferTexture2D<float>(bufferType, 16, 16))
         {
-            InteropServices.GetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            InteropServices.GetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Buffer);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_BUFFER);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
 
             d3D12Resource.Dispose();
 
-            int hResult = InteropServices.TryGetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            int hResult = InteropServices.TryGetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
-            Assert.AreEqual(hResult, (int)HRESULT.Ok);
+            Assert.AreEqual(hResult, S.S_OK);
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Buffer);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_BUFFER);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
         }
 
@@ -202,19 +197,19 @@ public unsafe partial class InteropServicesTests
 
         using (TransferTexture3D<float> buffer = device.Get().AllocateTransferTexture3D<float>(bufferType, 16, 16, 4))
         {
-            InteropServices.GetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            InteropServices.GetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Buffer);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_BUFFER);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
 
             d3D12Resource.Dispose();
 
-            int hResult = InteropServices.TryGetID3D12Resource(buffer, Win32.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
+            int hResult = InteropServices.TryGetID3D12Resource(buffer, Windows.__uuidof<ID3D12Resource>(), (void**)d3D12Resource.GetAddressOf());
 
-            Assert.AreEqual(hResult, (int)HRESULT.Ok);
+            Assert.AreEqual(hResult, S.S_OK);
             Assert.IsTrue(d3D12Resource.Get() != null);
-            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.Buffer);
+            Assert.AreEqual(d3D12Resource.Get()->GetDesc().Dimension, D3D12_RESOURCE_DIMENSION.D3D12_RESOURCE_DIMENSION_BUFFER);
             Assert.IsTrue(d3D12Resource.GetReferenceCount() > 1);
         }
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,17 +6,14 @@
     <!-- Test projects never need to be packaged -->
     <IsPackable>false</IsPackable>
 
-    <!-- Ignore warnings for public fields (TerraFX polyfills) -->
-    <NoWarn>$(NoWarn);CS0649</NoWarn>
+    <!-- Ignore warnings for ambiguous XML docs (to remove after renaming ComputeSharp Win32 bindings) -->
+    <NoWarn>$(NoWarn);CS0419</NoWarn>
 
     <!-- Unit tests don't need public XML docs -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <!-- Ignore platform compatibility warnings -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-
-    <!-- Ignore warnings for usings outside of a namespace (needed for some Vortice.Win32 type aliases) -->
-    <NoWarn>$(NoWarn);IDE0065</NoWarn>
 
     <!-- Missing readonly modifier for readonly struct members (not needed in tests) -->
     <NoWarn>$(NoWarn);IDE0251</NoWarn>


### PR DESCRIPTION
### Description

This PR switches all unit tests to use TerraFX.Interop.Windows (instead of Vortice.Win32), since they're all .NET 6+ now.