### PR TITLE
Remove redundant ComPtr<T> extensions

### DIFF
--- a/src/ComputeSharp.D2D1.WinUI/Extensions/ICanvasDeviceExtensions.cs
+++ b/src/ComputeSharp.D2D1.WinUI/Extensions/ICanvasDeviceExtensions.cs
@@ -24,7 +24,7 @@ internal static unsafe class ICanvasDeviceExtensions
         // Get the ICanvasResourceWrapperNative wrapper around the input device
         canvasDevice.QueryInterface(
             riid: Win32.__uuidof<ICanvasResourceWrapperNative>(),
-            ppvObject: canvasDeviceResourceWrapperNative.GetVoidAddressOf()).Assert();
+            ppvObject: (void**)canvasDeviceResourceWrapperNative.GetAddressOf()).Assert();
 
         // Get the underlying ID2D1Device1 instance in use
         HRESULT hresult = canvasDeviceResourceWrapperNative.Get()->GetNativeResource(
@@ -61,7 +61,7 @@ internal static unsafe class ICanvasDeviceExtensions
                 // Get the ID2D1DeviceContextPool interface reference
                 canvasDevice.QueryInterface(
                     riid: Win32.__uuidof<ID2D1DeviceContextPool>(),
-                    ppvObject: d2D1DeviceContextPool.GetVoidAddressOf()).Assert();
+                    ppvObject: (void**)d2D1DeviceContextPool.GetAddressOf()).Assert();
 
                 // Get a new ID2D1DeviceContextLease object from the retrieved pool
                 d2D1DeviceContextPool.Get()->GetDeviceContextLease(d2D1DeviceContextLease).Assert();

--- a/src/ComputeSharp.D2D1.WinUI/Extensions/IUnknownExtensions.cs
+++ b/src/ComputeSharp.D2D1.WinUI/Extensions/IUnknownExtensions.cs
@@ -35,8 +35,8 @@ internal static unsafe class IUnknownExtensions
         using ComPtr<IUnknown> leftUnknown = default;
         using ComPtr<IUnknown> rightUnknown = default;
 
-        ((IUnknown*)Unsafe.AsPointer(ref left))->QueryInterface(Win32.__uuidof<IUnknown>(), leftUnknown.GetVoidAddressOf()).Assert();
-        ((IUnknown*)right)->QueryInterface(Win32.__uuidof<IUnknown>(), rightUnknown.GetVoidAddressOf()).Assert();
+        ((IUnknown*)Unsafe.AsPointer(ref left))->QueryInterface(Win32.__uuidof<IUnknown>(), (void**)leftUnknown.GetAddressOf()).Assert();
+        ((IUnknown*)right)->QueryInterface(Win32.__uuidof<IUnknown>(), (void**)rightUnknown.GetAddressOf()).Assert();
 
         return leftUnknown.Get() == rightUnknown.Get();
     }

--- a/src/ComputeSharp.D2D1/Extensions/ComPtrExtensions.cs
+++ b/src/ComputeSharp.D2D1/Extensions/ComPtrExtensions.cs
@@ -10,20 +10,6 @@ namespace ComputeSharp.D2D1.Extensions;
 internal static class ComPtrExtensions
 {
     /// <summary>
-    /// Gets the address of the current <see cref="ComPtr{T}"/> instance as a raw <see langword="void"/> double pointer.
-    /// </summary>
-    /// <typeparam name="T">The type to wrap in the current <see cref="ComPtr{T}"/> instance.</typeparam>
-    /// <param name="ptr">The input <see cref="ComPtr{T}"/> instance to get the address for.</param>
-    /// <returns>The raw pointer to the input <see cref="ComPtr{T}"/> instance.</returns>
-    /// <remarks>This method is only valid when the current <see cref="ComPtr{T}"/> instance is on the stack or pinned.</remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe void** GetVoidAddressOf<T>(this in ComPtr<T> ptr)
-        where T : unmanaged
-    {
-        return (void**)Unsafe.AsPointer(ref Unsafe.AsRef(in ptr));
-    }
-
-    /// <summary>
     /// Moves the current <see cref="ComPtr{T}"/> instance and resets it without releasing the reference.
     /// </summary>
     /// <typeparam name="T">The type to wrap in the current <see cref="ComPtr{T}"/> instance.</typeparam>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -44,7 +44,7 @@ public static class D2D1ReflectionServices
                     pSrcData: hlslBytecodePtr,
                     SrcDataSize: (nuint)hlslBytecode.Length,
                     pInterface: Windows.__uuidof<ID3D11ShaderReflection>(),
-                    ppReflector: d3D11ShaderReflection.GetVoidAddressOf()).Assert();
+                    ppReflector: (void**)d3D11ShaderReflection.GetAddressOf()).Assert();
             }
         }
         else
@@ -59,7 +59,7 @@ public static class D2D1ReflectionServices
                 pSrcData: (byte*)dynamicBytecode.Get()->GetBufferPointer(),
                 SrcDataSize: dynamicBytecode.Get()->GetBufferSize(),
                 pInterface: Windows.__uuidof<ID3D11ShaderReflection>(),
-                ppReflector: d3D11ShaderReflection.GetVoidAddressOf()).Assert();
+                ppReflector: (void**)d3D11ShaderReflection.GetAddressOf()).Assert();
         }
 
         D3D11_SHADER_DESC d3D11ShaderDescription;

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Extensions/ID2D1EffectContextExtensions.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Extensions/ID2D1EffectContextExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.CompilerServices;
-using ComputeSharp.D2D1.Extensions;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 
@@ -89,7 +88,7 @@ internal static unsafe class ID2D1EffectContextExtensions
             pSrcData: bytecode,
             SrcDataSize: (uint)bytecodeSize,
             pInterface: Windows.__uuidof<ID3D11ShaderReflection>(),
-            ppReflector: d3D11ShaderReflection.GetVoidAddressOf());
+            ppReflector: (void**)d3D11ShaderReflection.GetAddressOf());
 
         if (!Windows.SUCCEEDED(hresult))
         {

--- a/src/ComputeSharp.D3D12MemoryAllocator/Interop/ID3D12MemoryAllocatorImpl.cs
+++ b/src/ComputeSharp.D3D12MemoryAllocator/Interop/ID3D12MemoryAllocatorImpl.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using ComputeSharp.Core.Extensions;
 using ComputeSharp.Interop.Allocation;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
@@ -199,7 +198,7 @@ internal unsafe struct ID3D12MemoryAllocatorImpl
             pOptimizedClearValue: null,
             ppAllocation: d3D12MA_allocation.GetAddressOf(),
             riidResource: Windows.__uuidof<ID3D12Resource>(),
-            ppvResource: d3D12Resource.GetVoidAddressOf());
+            ppvResource: (void**)d3D12Resource.GetAddressOf());
 
         if (!Windows.SUCCEEDED(hresult))
         {

--- a/src/ComputeSharp.Dynamic/Shaders/Interop/ReflectionServices.cs
+++ b/src/ComputeSharp.Dynamic/Shaders/Interop/ReflectionServices.cs
@@ -115,7 +115,7 @@ public static class ReflectionServices
         DirectX.DxcCreateInstance(
             (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in CLSID.CLSID_DxcLibrary)),
             Windows.__uuidof<IDxcUtils>(),
-            dxcUtils.GetVoidAddressOf()).Assert();
+            (void**)dxcUtils.GetAddressOf()).Assert();
 
         using ComPtr<ID3D12ShaderReflection> d3D12ShaderReflection = default;
 
@@ -126,7 +126,7 @@ public static class ReflectionServices
         dxcUtils.Get()->CreateReflection(
             &dxcBuffer,
             Windows.__uuidof<ID3D12ShaderReflection>(),
-            d3D12ShaderReflection.GetVoidAddressOf()).Assert();
+            (void**)d3D12ShaderReflection.GetAddressOf()).Assert();
 
         D3D12_SHADER_DESC d3D12ShaderDescription;
 

--- a/src/ComputeSharp.Dynamic/Shaders/Translation/ShaderCompiler.cs
+++ b/src/ComputeSharp.Dynamic/Shaders/Translation/ShaderCompiler.cs
@@ -46,12 +46,12 @@ internal sealed unsafe partial class ShaderCompiler
         DirectX.DxcCreateInstance(
             (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in CLSID.CLSID_DxcCompiler)),
             Windows.__uuidof<IDxcCompiler>(),
-            dxcCompiler.GetVoidAddressOf()).Assert();
+            (void**)dxcCompiler.GetAddressOf()).Assert();
 
         DirectX.DxcCreateInstance(
             (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(in CLSID.CLSID_DxcLibrary)),
             Windows.__uuidof<IDxcLibrary>(),
-            dxcLibrary.GetVoidAddressOf()).Assert();
+            (void**)dxcLibrary.GetAddressOf()).Assert();
 
         dxcLibrary.Get()->CreateIncludeHandler(dxcIncludeHandler.GetAddressOf()).Assert();
 

--- a/src/ComputeSharp.WinUI/Extensions/IDXGIAdapterExtensions.cs
+++ b/src/ComputeSharp.WinUI/Extensions/IDXGIAdapterExtensions.cs
@@ -22,7 +22,7 @@ internal static unsafe class IDXGIAdapterExtensions
     {
         using ComPtr<IDXGIAdapter1> dxgiAdapter1 = default;
 
-        dxgiAdapter.QueryInterface(Win32.__uuidof<IDXGIAdapter1>(), dxgiAdapter1.GetVoidAddressOf()).Assert();
+        dxgiAdapter.QueryInterface(Win32.__uuidof<IDXGIAdapter1>(), (void**)dxgiAdapter1.GetAddressOf()).Assert();
 
         using ComPtr<IDXGIOutput> dxgiOutput = default;
 

--- a/src/ComputeSharp/Graphics/Extensions/Interop/ComPtrExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ComPtrExtensions.cs
@@ -9,27 +9,6 @@ namespace ComputeSharp.Core.Extensions;
 internal static class ComPtrExtensions
 {
     /// <summary>
-    /// Reinterprets the current <see cref="ComPtr{T}"/> instance as one of type <see cref="IUnknown"/>.
-    /// </summary>
-    /// <typeparam name="T">The type of the current <see cref="ComPtr{T}"/> instance.</typeparam>
-    /// <param name="ptr">The input <see cref="ComPtr{T}"/> instance to upcast.</param>
-    /// <returns>A <see cref="ComPtr{T}"/> instance of type <see cref="IUnknown"/>.</returns>
-    /// <remarks>
-    /// This method is meant to be used in a chained expression and it does not increment the reference
-    /// count for the input pointer. Do not expose the return value of this extension to consumers.
-    /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe ref readonly ComPtr<IUnknown> AsIUnknown<T>(this in ComPtr<T> ptr)
-#if NET6_0_OR_GREATER
-        where T : unmanaged, IUnknown.Interface
-#else
-        where T : unmanaged
-#endif
-    {
-        return ref Unsafe.As<ComPtr<T>, ComPtr<IUnknown>>(ref Unsafe.AsRef(in ptr));
-    }
-
-    /// <summary>
     /// Moves the current <see cref="ComPtr{T}"/> instance and resets it without releasing the reference.
     /// </summary>
     /// <typeparam name="T">The type to wrap in the current <see cref="ComPtr{T}"/> instance.</typeparam>

--- a/src/ComputeSharp/Graphics/Extensions/Interop/ComPtrExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ComPtrExtensions.cs
@@ -30,24 +30,6 @@ internal static class ComPtrExtensions
     }
 
     /// <summary>
-    /// Gets the address of the current <see cref="ComPtr{T}"/> instance as a raw <see langword="void"/> double pointer.
-    /// </summary>
-    /// <typeparam name="T">The type to wrap in the current <see cref="ComPtr{T}"/> instance.</typeparam>
-    /// <param name="ptr">The input <see cref="ComPtr{T}"/> instance to get the address for.</param>
-    /// <returns>The raw pointer to the input <see cref="ComPtr{T}"/> instance.</returns>
-    /// <remarks>This method is only valid when the current <see cref="ComPtr{T}"/> instance is on the stack or pinned.</remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static unsafe void** GetVoidAddressOf<T>(this in ComPtr<T> ptr)
-#if NET6_0_OR_GREATER
-        where T : unmanaged, IUnknown.Interface
-#else
-        where T : unmanaged
-#endif
-    {
-        return (void**)Unsafe.AsPointer(ref Unsafe.AsRef(in ptr));
-    }
-
-    /// <summary>
     /// Moves the current <see cref="ComPtr{T}"/> instance and resets it without releasing the reference.
     /// </summary>
     /// <typeparam name="T">The type to wrap in the current <see cref="ComPtr{T}"/> instance.</typeparam>

--- a/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/Interop/ID3D12DeviceExtensions.cs
@@ -80,7 +80,7 @@ internal static unsafe class ID3D12DeviceExtensions
             d3D12ResourceStates,
             null,
             Windows.__uuidof<ID3D12Resource>(),
-            d3D12Resource.GetVoidAddressOf()).Assert();
+            (void**)d3D12Resource.GetAddressOf()).Assert();
 
         return d3D12Resource.Move();
     }
@@ -140,7 +140,7 @@ internal static unsafe class ID3D12DeviceExtensions
             d3D12ResourceStates,
             null,
             Windows.__uuidof<ID3D12Resource>(),
-            d3D12Resource.GetVoidAddressOf()).Assert();
+            (void**)d3D12Resource.GetAddressOf()).Assert();
 
         return d3D12Resource.Move();
     }
@@ -202,7 +202,7 @@ internal static unsafe class ID3D12DeviceExtensions
             d3D12ResourceStates,
             null,
             Windows.__uuidof<ID3D12Resource>(),
-            d3D12Resource.GetVoidAddressOf()).Assert();
+            (void**)d3D12Resource.GetAddressOf()).Assert();
 
         return d3D12Resource.Move();
     }
@@ -266,7 +266,7 @@ internal static unsafe class ID3D12DeviceExtensions
             d3D12ResourceStates,
             null,
             Windows.__uuidof<ID3D12Resource>(),
-            d3D12Resource.GetVoidAddressOf()).Assert();
+            (void**)d3D12Resource.GetAddressOf()).Assert();
 
         return d3D12Resource.Move();
     }
@@ -281,7 +281,7 @@ internal static unsafe class ID3D12DeviceExtensions
     {
         ComPtr<ID3D12InfoQueue> d3D12InfoQueue = default;
 
-        d3D12Device.QueryInterface(Windows.__uuidof<ID3D12InfoQueue>(), d3D12InfoQueue.GetVoidAddressOf()).Assert();
+        d3D12Device.QueryInterface(Windows.__uuidof<ID3D12InfoQueue>(), (void**)d3D12InfoQueue.GetAddressOf()).Assert();
 
         D3D12_MESSAGE_ID* d3D12MessageIds = stackalloc D3D12_MESSAGE_ID[3]
         {
@@ -332,7 +332,7 @@ internal static unsafe class ID3D12DeviceExtensions
         d3D12Device.CreateCommandQueue(
             &d3D12CommandQueueDesc,
             Windows.__uuidof<ID3D12CommandQueue>(),
-            d3D12CommandQueue.GetVoidAddressOf()).Assert();
+            (void**)d3D12CommandQueue.GetAddressOf()).Assert();
 
         return d3D12CommandQueue.Move();
     }
@@ -351,7 +351,7 @@ internal static unsafe class ID3D12DeviceExtensions
             0,
             D3D12_FENCE_FLAG_NONE,
             Windows.__uuidof<ID3D12Fence>(),
-            d3D12Fence.GetVoidAddressOf()).Assert();
+            (void**)d3D12Fence.GetAddressOf()).Assert();
 
         return d3D12Fence.Move();
     }
@@ -377,7 +377,7 @@ internal static unsafe class ID3D12DeviceExtensions
         d3D12Device.CreateDescriptorHeap(
             &d3D12DescriptorHeapDesc,
             Windows.__uuidof<ID3D12DescriptorHeap>(),
-            d3D12DescriptorHeap.GetVoidAddressOf()).Assert();
+            (void**)d3D12DescriptorHeap.GetAddressOf()).Assert();
 
         return d3D12DescriptorHeap.Move();
     }
@@ -545,7 +545,7 @@ internal static unsafe class ID3D12DeviceExtensions
         d3D12Device.CreateCommandAllocator(
             d3D12CommandListType,
             Windows.__uuidof<ID3D12CommandAllocator>(),
-            d3D12CommandAllocator.GetVoidAddressOf()).Assert();
+            (void**)d3D12CommandAllocator.GetAddressOf()).Assert();
 
         return d3D12CommandAllocator.Move();
     }
@@ -573,7 +573,7 @@ internal static unsafe class ID3D12DeviceExtensions
             d3D12CommandAllocator,
             d3D12PipelineState,
             Windows.__uuidof<ID3D12GraphicsCommandList>(),
-            d3D12GraphicsCommandList.GetVoidAddressOf()).Assert();
+            (void**)d3D12GraphicsCommandList.GetAddressOf()).Assert();
 
         return d3D12GraphicsCommandList.Move();
     }

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
@@ -137,7 +137,7 @@ partial class DeviceHelper
                         dxgiAdapter1.Get()->GetDesc1(&dxgiDescription1).Assert();
 
                         HRESULT createDeviceResult = DirectX.D3D12CreateDevice(
-                            dxgiAdapter1.AsIUnknown().Get(),
+                            (IUnknown*)dxgiAdapter1.Get(),
                             D3D_FEATURE_LEVEL_11_0,
                             Windows.__uuidof<ID3D12Device>(),
                             null);
@@ -148,7 +148,7 @@ partial class DeviceHelper
                             using ComPtr<ID3D12Device> d3D12Device = default;
 
                             DirectX.D3D12CreateDevice(
-                                dxgiAdapter1.AsIUnknown().Get(),
+                                (IUnknown*)dxgiAdapter1.Get(),
                                 D3D_FEATURE_LEVEL_11_0,
                                 Windows.__uuidof<ID3D12Device>(),
                                 (void**)d3D12Device.GetAddressOf()).Assert();
@@ -178,7 +178,7 @@ partial class DeviceHelper
                         }
 
                         HRESULT createDeviceResult = DirectX.D3D12CreateDevice(
-                            dxgiAdapter1.AsIUnknown().Get(),
+                            (IUnknown*)dxgiAdapter1.Get(),
                             D3D_FEATURE_LEVEL_11_0,
                             Windows.__uuidof<ID3D12Device>(),
                             null);
@@ -189,7 +189,7 @@ partial class DeviceHelper
                             using ComPtr<ID3D12Device> d3D12Device = default;
 
                             DirectX.D3D12CreateDevice(
-                                dxgiAdapter1.AsIUnknown().Get(),
+                                (IUnknown*)dxgiAdapter1.Get(),
                                 D3D_FEATURE_LEVEL_11_0,
                                 Windows.__uuidof<ID3D12Device>(),
                                 (void**)d3D12Device.GetAddressOf()).Assert();

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.Enumerator.cs
@@ -126,11 +126,11 @@ partial class DeviceHelper
                         this.index,
                         DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
                         Windows.__uuidof<IDXGIAdapter1>(),
-                        dxgiAdapter1.GetVoidAddressOf());
+                        (void**)dxgiAdapter1.GetAddressOf());
 
                     if (enumAdapters1Result == DXGI.DXGI_ERROR_NOT_FOUND)
                     {
-                        this.dxgiFactory6.Get()->EnumWarpAdapter(Windows.__uuidof<IDXGIAdapter1>(), dxgiAdapter1.GetVoidAddressOf()).Assert();
+                        this.dxgiFactory6.Get()->EnumWarpAdapter(Windows.__uuidof<IDXGIAdapter1>(), (void**)dxgiAdapter1.GetAddressOf()).Assert();
 
                         DXGI_ADAPTER_DESC1 dxgiDescription1;
 
@@ -151,7 +151,7 @@ partial class DeviceHelper
                                 dxgiAdapter1.AsIUnknown().Get(),
                                 D3D_FEATURE_LEVEL_11_0,
                                 Windows.__uuidof<ID3D12Device>(),
-                                d3D12Device.GetVoidAddressOf()).Assert();
+                                (void**)d3D12Device.GetAddressOf()).Assert();
 
                             this.graphicsDevice = GetOrCreateDevice(d3D12Device.Get(), (IDXGIAdapter*)dxgiAdapter1.Get(), &dxgiDescription1);
                             this.isCompleted = true;
@@ -192,7 +192,7 @@ partial class DeviceHelper
                                 dxgiAdapter1.AsIUnknown().Get(),
                                 D3D_FEATURE_LEVEL_11_0,
                                 Windows.__uuidof<ID3D12Device>(),
-                                d3D12Device.GetVoidAddressOf()).Assert();
+                                (void**)d3D12Device.GetAddressOf()).Assert();
 
                             if (d3D12Device.Get()->IsShaderModelSupported(D3D_SHADER_MODEL_6_0))
                             {

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.ID3D12InfoQueue.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.ID3D12InfoQueue.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
-using ComputeSharp.Core.Extensions;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
 using static TerraFX.Interop.DirectX.D3D12_MESSAGE_ID;
@@ -105,7 +104,7 @@ partial class DeviceHelper
                             // Get the DRED data
                             int hresult = device.D3D12Device->QueryInterface(
                                 riid: Windows.__uuidof<ID3D12DeviceRemovedExtendedData1>(),
-                                ppvObject: d3D12DeviceRemovedExtendedData.GetVoidAddressOf());
+                                ppvObject: (void**)d3D12DeviceRemovedExtendedData.GetAddressOf());
 
                             default(Win32Exception).ThrowIfFailed(hresult);
 

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.IDXGIFactory6.cs
@@ -44,7 +44,7 @@ partial class DeviceHelper
 
         using ComPtr<IDXGIFactory4> dxgiFactory4 = default;
 
-        DirectX.CreateDXGIFactory2(IDXGIFactoryCreationFlags, Windows.__uuidof<IDXGIFactory4>(), dxgiFactory4.GetVoidAddressOf()).Assert();
+        DirectX.CreateDXGIFactory2(IDXGIFactoryCreationFlags, Windows.__uuidof<IDXGIFactory4>(), (void**)dxgiFactory4.GetAddressOf()).Assert();
 
         HRESULT result = dxgiFactory4.CopyTo(dxgiFactory6);
 
@@ -73,7 +73,7 @@ partial class DeviceHelper
         using ComPtr<ID3D12Debug> d3D12Debug = default;
         using ComPtr<ID3D12Debug1> d3D12Debug1 = default;
 
-        DirectX.D3D12GetDebugInterface(Windows.__uuidof<ID3D12Debug>(), d3D12Debug.GetVoidAddressOf()).Assert();
+        DirectX.D3D12GetDebugInterface(Windows.__uuidof<ID3D12Debug>(), (void**)d3D12Debug.GetAddressOf()).Assert();
 
         d3D12Debug.Get()->EnableDebugLayer();
 
@@ -93,7 +93,7 @@ partial class DeviceHelper
 
         DirectX.D3D12GetDebugInterface(
             riid: Windows.__uuidof<ID3D12DeviceRemovedExtendedDataSettings1>(),
-            ppvDebug: d3D12DeviceRemovedExtendedDataSettings.GetVoidAddressOf()).Assert();
+            ppvDebug: (void**)d3D12DeviceRemovedExtendedDataSettings.GetAddressOf()).Assert();
 
         // Enable the auto-breadcrumbs and page faults reporting
         d3D12DeviceRemovedExtendedDataSettings.Get()->SetAutoBreadcrumbsEnablement(D3D12_DRED_ENABLEMENT.D3D12_DRED_ENABLEMENT_FORCED_ON);

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
@@ -98,7 +98,7 @@ internal static partial class DeviceHelper
             //   3) The call fails for other reasons. In this case the adapter is simply skipped.
             //      This might be the case if an adapter doesn't support the requested feature level.
             HRESULT createDeviceResult = DirectX.D3D12CreateDevice(
-                dxgiAdapter1.AsIUnknown().Get(),
+                (IUnknown*)dxgiAdapter1.Get(),
                 D3D_FEATURE_LEVEL_11_0,
                 Windows.__uuidof<ID3D12Device>(),
                 (void**)d3D12DeviceCandidate.GetAddressOf());
@@ -142,7 +142,7 @@ internal static partial class DeviceHelper
         using ComPtr<ID3D12Device> d3D12DeviceCandidate = default;
 
         HRESULT createDeviceResult = DirectX.D3D12CreateDevice(
-            dxgiAdapter1.AsIUnknown().Get(),
+            (IUnknown*)dxgiAdapter1.Get(),
             D3D_FEATURE_LEVEL_11_0,
             Windows.__uuidof<ID3D12Device>(),
             (void**)d3D12DeviceCandidate.GetAddressOf());

--- a/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/DeviceHelper.cs
@@ -71,7 +71,7 @@ internal static partial class DeviceHelper
                 i++,
                 DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE,
                 Windows.__uuidof<IDXGIAdapter1>(),
-                dxgiAdapter1.GetVoidAddressOf());
+                (void**)dxgiAdapter1.GetAddressOf());
 
             if (enumAdapters1Result == DXGI.DXGI_ERROR_NOT_FOUND)
             {
@@ -101,7 +101,7 @@ internal static partial class DeviceHelper
                 dxgiAdapter1.AsIUnknown().Get(),
                 D3D_FEATURE_LEVEL_11_0,
                 Windows.__uuidof<ID3D12Device>(),
-                d3D12DeviceCandidate.GetVoidAddressOf());
+                (void**)d3D12DeviceCandidate.GetAddressOf());
 
             // Check and throw if the device is a device lost state and not disposed properly
             default(InvalidOperationException).ThrowIf(createDeviceResult.IsDeviceLostReason());
@@ -135,7 +135,7 @@ internal static partial class DeviceHelper
 
         using ComPtr<IDXGIAdapter1> dxgiAdapter1 = default;
 
-        dxgiFactory6.Get()->EnumWarpAdapter(Windows.__uuidof<IDXGIAdapter1>(), dxgiAdapter1.GetVoidAddressOf()).Assert();
+        dxgiFactory6.Get()->EnumWarpAdapter(Windows.__uuidof<IDXGIAdapter1>(), (void**)dxgiAdapter1.GetAddressOf()).Assert();
 
         dxgiAdapter1.Get()->GetDesc1(dxgiDescription1).Assert();
 
@@ -145,7 +145,7 @@ internal static partial class DeviceHelper
             dxgiAdapter1.AsIUnknown().Get(),
             D3D_FEATURE_LEVEL_11_0,
             Windows.__uuidof<ID3D12Device>(),
-            d3D12DeviceCandidate.GetVoidAddressOf());
+            (void**)d3D12DeviceCandidate.GetAddressOf());
 
         default(InvalidOperationException).ThrowIf(createDeviceResult.IsDeviceLostReason());
 

--- a/src/ComputeSharp/Graphics/Helpers/WICHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/WICHelper.cs
@@ -30,7 +30,7 @@ internal sealed unsafe class WICHelper
             null,
             (uint)CLSCTX.CLSCTX_INPROC_SERVER,
             Windows.__uuidof<IWICImagingFactory2>(),
-            wicImagingFactory2.GetVoidAddressOf()).Assert();
+            (void**)wicImagingFactory2.GetAddressOf()).Assert();
 
         this.wicImagingFactory2 = wicImagingFactory2.Move();
     }

--- a/src/ComputeSharp/Shaders/Extensions/Interop/ID3D12DeviceExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/Interop/ID3D12DeviceExtensions.cs
@@ -83,7 +83,7 @@ internal static unsafe class ID3D12DeviceExtensions
             d3D3Blob.Get()->GetBufferPointer(),
             d3D3Blob.Get()->GetBufferSize(),
             Windows.__uuidof<ID3D12RootSignature>(),
-            d3D12RootSignature.GetVoidAddressOf()).Assert();
+            (void**)d3D12RootSignature.GetAddressOf()).Assert();
 
         return d3D12RootSignature.Move();
     }
@@ -113,7 +113,7 @@ internal static unsafe class ID3D12DeviceExtensions
         d3D12Device.CreateComputePipelineState(
             &d3D12ComputePipelineStateDescription,
             Windows.__uuidof<ID3D12PipelineState>(),
-            d3D12PipelineState.GetVoidAddressOf()).Assert();
+            (void**)d3D12PipelineState.GetAddressOf()).Assert();
 
         return d3D12PipelineState.Move();
     }


### PR DESCRIPTION
### Description

This PR removes two `ComPtr<T>` extensions that weren't actually needed, really.