### PR TITLE
Leverage static abstracts in interfaces in all descriptor interfaces

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.CreateFromConstantBuffer.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.CreateFromConstantBuffer.Syntax.cs
@@ -24,7 +24,7 @@ partial class D2DPixelShaderDescriptorGenerator
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
             writer.WriteLine("[global::System.Runtime.CompilerServices.SkipLocalsInit]");
-            writer.WriteLine($"readonly unsafe {typeName} global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{typeName}>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)");
+            writer.WriteLine($"static unsafe {typeName} global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{typeName}>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)");
 
             using (writer.WriteBlock())
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectId.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectId.Syntax.cs
@@ -19,7 +19,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly ref readonly global::System.Guid global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.EffectId");
+            writer.WriteLine($"static ref readonly global::System.Guid global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.EffectId");
 
             using (writer.WriteBlock())
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectMetadata.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectMetadata.Syntax.cs
@@ -61,7 +61,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.Write($"readonly string? global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{qualifiedName}>.{propertyName} => ");
+            writer.Write($"static string? global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{qualifiedName}>.{propertyName} => ");
 
             // Append null or the metadata value as a string literal
             if (metadataValue is null)

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.Syntax.cs
@@ -22,7 +22,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly ComputeSharp.D2D1.D2D1ShaderProfile global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ShaderProfile => global::ComputeSharp.D2D1.D2D1ShaderProfile.{info.HlslInfoKey.ShaderProfile};");
+            writer.WriteLine($"static ComputeSharp.D2D1.D2D1ShaderProfile global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ShaderProfile => global::ComputeSharp.D2D1.D2D1ShaderProfile.{info.HlslInfoKey.ShaderProfile};");
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly ComputeSharp.D2D1.D2D1CompileOptions global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.CompileOptions => {compileOptionsExpression};");
+            writer.WriteLine($"static ComputeSharp.D2D1.D2D1CompileOptions global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.CompileOptions => {compileOptionsExpression};");
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.Write($"readonly global::System.ReadOnlyMemory<byte> global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.HlslBytecode => ");
+            writer.Write($"static global::System.ReadOnlyMemory<byte> global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.HlslBytecode => ");
 
             // If there is no bytecode, just return a default expression.
             // Otherwise, return the memory manager backed memory instance.

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.Syntax.cs
@@ -19,7 +19,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly string global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.HlslSource =>");
+            writer.WriteLine($"static string global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.HlslSource =>");
             writer.IncreaseIndent();
             writer.WriteLine("\"\"\"");
             writer.Write(info.HlslInfoKey.HlslSource, isMultiline: true);

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.Syntax.cs
@@ -21,7 +21,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.Write($"readonly global::System.ReadOnlyMemory<global::ComputeSharp.D2D1.Interop.D2D1InputDescription> global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.InputDescriptions => ");
+            writer.Write($"static global::System.ReadOnlyMemory<global::ComputeSharp.D2D1.Interop.D2D1InputDescription> global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.InputDescriptions => ");
 
             // If there are no input descriptions, just return a default expression.
             // Otherwise, return the shared array with cached input descriptions.

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.Syntax.cs
@@ -19,7 +19,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.Write($"readonly global::System.ReadOnlyMemory<global::ComputeSharp.D2D1.Interop.D2D1PixelShaderInputType> global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.InputTypes => ");
+            writer.Write($"static global::System.ReadOnlyMemory<global::ComputeSharp.D2D1.Interop.D2D1PixelShaderInputType> global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.InputTypes => ");
 
             // If there are no inputs, simply return a default expression. Otherwise, create
             // a ReadOnlyMemory<D2D1PixelShaderInputType> instance from the memory manager.

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.LoadConstantBuffer.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.LoadConstantBuffer.Syntax.cs
@@ -24,7 +24,7 @@ partial class D2DPixelShaderDescriptorGenerator
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
             writer.WriteLine("[global::System.Runtime.CompilerServices.SkipLocalsInit]");
-            writer.WriteLine($"readonly unsafe void global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{typeName}>.LoadConstantBuffer<TLoader>(in {typeName} shader, ref TLoader loader)");
+            writer.WriteLine($"static unsafe void global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{typeName}>.LoadConstantBuffer<TLoader>(in {typeName} shader, ref TLoader loader)");
 
             using (writer.WriteBlock())
             {

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.NumericProperties.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.NumericProperties.Syntax.cs
@@ -21,7 +21,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ConstantBufferSize => {info.ConstantBufferSizeInBytes};");
+            writer.WriteLine($"static int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ConstantBufferSize => {info.ConstantBufferSizeInBytes};");
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.InputCount => {info.InputTypes.Length};");
+            writer.WriteLine($"static int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.InputCount => {info.InputTypes.Length};");
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ResourceTextureCount => {info.ResourceTextureDescriptions.Length};");
+            writer.WriteLine($"static int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ResourceTextureCount => {info.ResourceTextureDescriptions.Length};");
         }
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.OutputBuffer.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.OutputBuffer.Syntax.cs
@@ -28,7 +28,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly ComputeSharp.D2D1.D2D1BufferPrecision global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.BufferPrecision => {bufferPrecisionExpression};");
+            writer.WriteLine($"static ComputeSharp.D2D1.D2D1BufferPrecision global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.BufferPrecision => {bufferPrecisionExpression};");
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly ComputeSharp.D2D1.D2D1ChannelDepth global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ChannelDepth => {channelDepthExpression};");
+            writer.WriteLine($"static ComputeSharp.D2D1.D2D1ChannelDepth global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ChannelDepth => {channelDepthExpression};");
         }
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.PixelOptions.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.PixelOptions.Syntax.cs
@@ -26,7 +26,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly ComputeSharp.D2D1.D2D1PixelOptions global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.PixelOptions => {pixelOptionsExpression};");
+            writer.WriteLine($"static ComputeSharp.D2D1.D2D1PixelOptions global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.PixelOptions => {pixelOptionsExpression};");
         }
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ResourceTextureDescriptions.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ResourceTextureDescriptions.Syntax.cs
@@ -21,7 +21,7 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.Write($"readonly global::System.ReadOnlyMemory<global::ComputeSharp.D2D1.Interop.D2D1ResourceTextureDescription> global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ResourceTextureDescriptions => ");
+            writer.Write($"static global::System.ReadOnlyMemory<global::ComputeSharp.D2D1.Interop.D2D1ResourceTextureDescription> global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ResourceTextureDescriptions => ");
 
             // If there are no resource texture descriptions, just return a default expression.
             // Otherwise, return a memory instance from the generated static readonly array.

--- a/src/ComputeSharp.D2D1.WinUI/Extensions/ID2D1EffectExtensions.cs
+++ b/src/ComputeSharp.D2D1.WinUI/Extensions/ID2D1EffectExtensions.cs
@@ -25,7 +25,7 @@ internal static unsafe class ID2D1EffectExtensions
     public static T GetConstantBuffer<T>(this ref ID2D1Effect d2D1Effect)
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        int constantBufferSize = D2D1PixelShader.GetConstantBufferSize<T>();
+        int constantBufferSize = T.ConstantBufferSize;
 
         // Special cases the constant buffer type being empty. If that's the case, there is no
         // need to try to retrieve the constant buffer from the underlying effect anyway, and
@@ -67,7 +67,7 @@ internal static unsafe class ID2D1EffectExtensions
         // avoid crashing when someone's just setting an empty constant buffer, which is
         // unnecessary but still valid (eg. a stateless shader). This could be the case if
         // someone was eg. binding or using some other automated system to set constant buffer.
-        if (D2D1PixelShader.GetConstantBufferSize<T>() == 0)
+        if (T.ConstantBufferSize == 0)
         {
             return;
         }

--- a/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.ICanvasEffectFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.ICanvasEffectFactoryNative.cs
@@ -2,7 +2,6 @@ using System;
 using System.Runtime.CompilerServices;
 using ABI.Microsoft.Graphics.Canvas;
 using ComputeSharp.D2D1.Extensions;
-using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.WinUI.Extensions;
 using ComputeSharp.D2D1.WinUI.Helpers;
 using ComputeSharp.Win32;
@@ -63,7 +62,7 @@ unsafe partial class PixelShaderEffect<T>
                 if (!this.isEffectFactoryRegistered)
                 {
                     ResourceManager.RegisterEffectFactory(
-                        effectId: D2D1PixelShaderEffect.GetEffectId<T>(),
+                        effectId: T.EffectId,
                         factory: new EffectFactory());
 
                     this.isEffectFactoryRegistered = true;

--- a/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.ICanvasImageInterop.cs
+++ b/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.ICanvasImageInterop.cs
@@ -250,7 +250,7 @@ unsafe partial class PixelShaderEffect<T>
     {
         fixed (ID2D1Effect** d2D1Effect = this.d2D1Effect)
         {
-            Guid effectId = D2D1PixelShaderEffect.GetEffectId<T>();
+            Guid effectId = T.EffectId;
 
             using ComPtr<ID2D1DeviceContext> d2D1DeviceContextEffective = default;
             using ComPtr<ID2D1DeviceContextLease> d2D1DeviceContextLease = default;

--- a/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.Properties.ResourceTextureManagerCollection.cs
+++ b/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.Properties.ResourceTextureManagerCollection.cs
@@ -223,11 +223,9 @@ partial class PixelShaderEffect<T>
         /// <returns>The bitmask of indices for resource textures in the target shader.</returns>
         private static int GetIndexBitmask()
         {
-            Unsafe.SkipInit(out T shader);
-
             int indexBitmask = 0;
 
-            foreach (ref readonly D2D1ResourceTextureDescription description in shader.ResourceTextureDescriptions.Span)
+            foreach (ref readonly D2D1ResourceTextureDescription description in T.ResourceTextureDescriptions.Span)
             {
                 indexBitmask |= 1 << description.Index;
             }
@@ -241,9 +239,7 @@ partial class PixelShaderEffect<T>
         /// <returns>The collection of valid indices for the current effect.</returns>
         private static ImmutableArray<int> GetIndices()
         {
-            Unsafe.SkipInit(out T shader);
-
-            ReadOnlySpan<D2D1ResourceTextureDescription> descriptions = shader.ResourceTextureDescriptions.Span;
+            ReadOnlySpan<D2D1ResourceTextureDescription> descriptions = T.ResourceTextureDescriptions.Span;
 
             // Skip the array allocation if there are no resource texture descriptions
             if (descriptions.IsEmpty)

--- a/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.Properties.SourceCollection.cs
+++ b/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.Properties.SourceCollection.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
-using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.WinUI.Buffers;
 using ComputeSharp.D2D1.WinUI.Collections;
 using Windows.Graphics.Effects;
@@ -41,7 +40,7 @@ partial class PixelShaderEffect<T>
         public int Count
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => D2D1PixelShader.GetInputCount<T>();
+            get => T.InputCount;
         }
 
         /// <inheritdoc/>
@@ -49,13 +48,13 @@ partial class PixelShaderEffect<T>
         {
             get
             {
-                default(ArgumentOutOfRangeException).ThrowIfNotInRange(index, 0, D2D1PixelShader.GetInputCount<T>(), nameof(index));
+                default(ArgumentOutOfRangeException).ThrowIfNotInRange(index, 0, T.InputCount, nameof(index));
 
                 return Owner.GetSource(index);
             }
             set
             {
-                default(ArgumentOutOfRangeException).ThrowIfNotInRange(index, 0, D2D1PixelShader.GetInputCount<T>(), nameof(index));
+                default(ArgumentOutOfRangeException).ThrowIfNotInRange(index, 0, T.InputCount, nameof(index));
 
                 Owner.SetSource(value, index);
             }
@@ -210,7 +209,7 @@ partial class PixelShaderEffect<T>
         /// <returns>The collection of valid indices for the current effect.</returns>
         private static ImmutableArray<int> GetIndices()
         {
-            int inputCount = D2D1PixelShader.GetInputCount<T>();
+            int inputCount = T.InputCount;
 
             if (inputCount == 0)
             {

--- a/src/ComputeSharp.D2D1/Interfaces/Descriptors/ID2D1PixelShaderDescriptor{T}.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/Descriptors/ID2D1PixelShaderDescriptor{T}.cs
@@ -18,7 +18,7 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <remarks>
     /// This only applies to effects created from <see cref="D2D1PixelShaderEffect"/>.
     /// </remarks>
-    ref readonly Guid EffectId { get; }
+    static abstract ref readonly Guid EffectId { get; }
 
     /// <summary>
     /// Gets the display name of the D2D effect using this shader, if specified.
@@ -26,7 +26,7 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <remarks>
     /// This only applies to effects created from <see cref="D2D1PixelShaderEffect"/>.
     /// </remarks>
-    string? EffectDisplayName { get; }
+    static abstract string? EffectDisplayName { get; }
 
     /// <summary>
     /// Gets the description of the D2D effect using this shader, if specified.
@@ -34,7 +34,7 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <remarks>
     /// This only applies to effects created from <see cref="D2D1PixelShaderEffect"/>.
     /// </remarks>
-    string? EffectDescription { get; }
+    static abstract string? EffectDescription { get; }
 
     /// <summary>
     /// Gets the category of the D2D effect using this shader, if specified.
@@ -42,7 +42,7 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <remarks>
     /// This only applies to effects created from <see cref="D2D1PixelShaderEffect"/>.
     /// </remarks>
-    string? EffectCategory { get; }
+    static abstract string? EffectCategory { get; }
 
     /// <summary>
     /// Gets the author of the D2D effect using this shader, if specified.
@@ -50,52 +50,52 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <remarks>
     /// This only applies to effects created from <see cref="D2D1PixelShaderEffect"/>.
     /// </remarks>
-    string? EffectAuthor { get; }
+    static abstract string? EffectAuthor { get; }
 
     /// <summary>
     /// Gets the size in bytes of the constant buffer for the current shader.
     /// </summary>
-    int ConstantBufferSize { get; }
+    static abstract int ConstantBufferSize { get; }
 
     /// <summary>
     /// Gets the number of inputs for the current shader.
     /// </summary>
-    int InputCount { get; }
+    static abstract int InputCount { get; }
 
     /// <summary>
     /// Gets the number of resource textures for the current shader.
     /// </summary>
-    int ResourceTextureCount { get; }
+    static abstract int ResourceTextureCount { get; }
 
     /// <summary>
     /// Gets the input types for the current shader.
     /// </summary>
-    ReadOnlyMemory<D2D1PixelShaderInputType> InputTypes { get; }
+    static abstract ReadOnlyMemory<D2D1PixelShaderInputType> InputTypes { get; }
 
     /// <summary>
     /// Gets the input descriptions for the current shader.
     /// </summary>
-    ReadOnlyMemory<D2D1InputDescription> InputDescriptions { get; }
+    static abstract ReadOnlyMemory<D2D1InputDescription> InputDescriptions { get; }
 
     /// <summary>
     /// Gets the resource texture descriptions for the shader.
     /// </summary>
-    ReadOnlyMemory<D2D1ResourceTextureDescription> ResourceTextureDescriptions { get; }
+    static abstract ReadOnlyMemory<D2D1ResourceTextureDescription> ResourceTextureDescriptions { get; }
 
     /// <summary>
     /// Gets the pixel options for the current shader.
     /// </summary>
-    D2D1PixelOptions PixelOptions { get; }
+    static abstract D2D1PixelOptions PixelOptions { get; }
 
     /// <summary>
     /// Gets the buffer precision for the shader.
     /// </summary>
-    D2D1BufferPrecision BufferPrecision { get; }
+    static abstract D2D1BufferPrecision BufferPrecision { get; }
 
     /// <summary>
     /// Gets the channel depth for the shader.
     /// </summary>
-    D2D1ChannelDepth ChannelDepth { get; }
+    static abstract D2D1ChannelDepth ChannelDepth { get; }
 
     /// <summary>
     /// Gets the shader profile for the current shader.
@@ -103,7 +103,7 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <remarks>
     /// This shader profile is either explicitly set by users, or the default one for D2D1 shaders.
     /// </remarks>
-    D2D1ShaderProfile ShaderProfile { get; }
+    static abstract D2D1ShaderProfile ShaderProfile { get; }
 
     /// <summary>
     /// Gets the compile options for the current shader.
@@ -111,12 +111,12 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <remarks>
     /// This compile options are either explicitly set by users, or the default one for D2D1 shaders.
     /// </remarks>
-    D2D1CompileOptions CompileOptions { get; }
+    static abstract D2D1CompileOptions CompileOptions { get; }
 
     /// <summary>
     /// Gets the HLSL source code for the current shader instance.
     /// </summary>
-    string HlslSource { get; }
+    static abstract string HlslSource { get; }
 
     /// <summary>
     /// Gets the HLSL bytecode for the current shader, if available.
@@ -124,14 +124,14 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <remarks>
     /// If no precompiled HLSL bytecode is available, the returned <see cref="ReadOnlyMemory{T}"/> instance will be empty.
     /// </remarks>
-    ReadOnlyMemory<byte> HlslBytecode { get; }
+    static abstract ReadOnlyMemory<byte> HlslBytecode { get; }
 
     /// <summary>
     /// Creates a new <typeparamref name="T"/> shader instance from a constant buffer.
     /// </summary>
     /// <param name="buffer">The input constant buffer to read.</param>
     /// <remarks>The input buffer must be retrieved from <see cref="LoadConstantBuffer"/>.</remarks>
-    T CreateFromConstantBuffer(ReadOnlySpan<byte> buffer);
+    static abstract T CreateFromConstantBuffer(ReadOnlySpan<byte> buffer);
 
     /// <summary>
     /// Loads the constant buffer of a given input shader.
@@ -139,6 +139,6 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// <typeparam name="TLoader">The type of data loader being used.</typeparam>
     /// <param name="shader">The input shader to load the constant buffer for.</param>
     /// <param name="loader">The <typeparamref name="TLoader"/> instance to use to load the constant buffer.</param>
-    void LoadConstantBuffer<TLoader>(in T shader, ref TLoader loader)
+    static abstract void LoadConstantBuffer<TLoader>(in T shader, ref TLoader loader)
         where TLoader : struct, ID2D1ConstantBufferLoader;
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1DrawInfoUpdateContext{T}.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1DrawInfoUpdateContext{T}.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Runtime.CompilerServices;
 using ComputeSharp.D2D1.Descriptors;
 using ComputeSharp.D2D1.Extensions;
 using ComputeSharp.D2D1.Shaders.Interop.Effects.TransformMappers;
@@ -45,9 +44,7 @@ public readonly unsafe ref struct D2D1DrawInfoUpdateContext<T>
             this.d2D1DrawInfoUpdateContext->GetConstantBuffer(pBuffer, constantBufferSize).Assert();
         }
 
-        Unsafe.SkipInit(out T shader);
-
-        shader = shader.CreateFromConstantBuffer(buffer);
+        T shader = T.CreateFromConstantBuffer(buffer);
 
         ArrayPool<byte>.Shared.Return(buffer);
 
@@ -62,6 +59,6 @@ public readonly unsafe ref struct D2D1DrawInfoUpdateContext<T>
     {
         D2D1DrawInfoUpdateContextConstantBufferLoader dataLoader = new(this.d2D1DrawInfoUpdateContext);
 
-        Unsafe.AsRef(in shader).LoadConstantBuffer(in shader, ref dataLoader);
+        T.LoadConstantBuffer(in shader, ref dataLoader);
     }
 }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
@@ -20,9 +20,7 @@ public static class D2D1PixelShader
     public static int GetConstantBufferSize<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.ConstantBufferSize;
+        return T.ConstantBufferSize;
     }
 
     /// <summary>
@@ -33,9 +31,7 @@ public static class D2D1PixelShader
     public static int GetInputCount<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.InputCount;
+        return T.InputCount;
     }
 
     /// <summary>
@@ -46,9 +42,7 @@ public static class D2D1PixelShader
     public static int GetResourceTextureCount<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.ResourceTextureCount;
+        return T.ResourceTextureCount;
     }
 
     /// <summary>
@@ -59,9 +53,7 @@ public static class D2D1PixelShader
     public static ReadOnlyMemory<D2D1PixelShaderInputType> GetInputTypes<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.InputTypes;
+        return T.InputTypes;
     }
 
     /// <summary>
@@ -72,9 +64,7 @@ public static class D2D1PixelShader
     public static ReadOnlyMemory<D2D1InputDescription> GetInputDescriptions<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.InputDescriptions;
+        return T.InputDescriptions;
     }
 
     /// <summary>
@@ -85,9 +75,7 @@ public static class D2D1PixelShader
     public static ReadOnlyMemory<D2D1ResourceTextureDescription> GetResourceTextureDescriptions<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.ResourceTextureDescriptions;
+        return T.ResourceTextureDescriptions;
     }
 
     /// <summary>
@@ -98,9 +86,7 @@ public static class D2D1PixelShader
     public static D2D1PixelOptions GetPixelOptions<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.PixelOptions;
+        return T.PixelOptions;
     }
 
     /// <summary>
@@ -111,9 +97,7 @@ public static class D2D1PixelShader
     public static D2D1BufferPrecision GetOutputBufferPrecision<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.BufferPrecision;
+        return T.BufferPrecision;
     }
 
     /// <summary>
@@ -124,9 +108,7 @@ public static class D2D1PixelShader
     public static D2D1ChannelDepth GetOutputBufferChannelDepth<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.ChannelDepth;
+        return T.ChannelDepth;
     }
 
     /// <summary>
@@ -144,13 +126,11 @@ public static class D2D1PixelShader
     public static ReadOnlyMemory<byte> LoadBytecode<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
         // This method is the one used by the built-in ID2D1Effect, so it has special optimization
         // to help both performance and especially trimming. That is, we first check whether the
         // HLSL code is already available, which should get completely inlined when using the
         // generated code. This allows the entire fallback path below to be trimmed out.
-        if (shader.HlslBytecode is ReadOnlyMemory<byte> { Length: > 0 } hlslBytecode)
+        if (T.HlslBytecode is ReadOnlyMemory<byte> { Length: > 0 } hlslBytecode)
         {
             return hlslBytecode;
         }
@@ -334,16 +314,12 @@ public static class D2D1PixelShader
         out D2D1CompileOptions effectiveCompileOptions)
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        string hlslSource = shader.HlslSource;
-
         // Set the effective profile and option to the requested ones or the default values
-        effectiveShaderProfile = requestedShaderProfile ?? shader.ShaderProfile;
-        effectiveCompileOptions = requestedCompileOptions ?? shader.CompileOptions;
+        effectiveShaderProfile = requestedShaderProfile ?? T.ShaderProfile;
+        effectiveCompileOptions = requestedCompileOptions ?? T.CompileOptions;
 
         // Compile the shader with the current settings
-        using ComPtr<ID3DBlob> dynamicBytecode = D3DCompiler.Compile(hlslSource.AsSpan(), effectiveShaderProfile, effectiveCompileOptions);
+        using ComPtr<ID3DBlob> dynamicBytecode = D3DCompiler.Compile(T.HlslSource, effectiveShaderProfile, effectiveCompileOptions);
 
         byte* bytecodePtr = (byte*)dynamicBytecode.Get()->GetBufferPointer();
         int bytecodeSize = (int)dynamicBytecode.Get()->GetBufferSize();
@@ -367,15 +343,13 @@ public static class D2D1PixelShader
         out D2D1CompileOptions effectiveCompileOptions)
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
         // Check whether there is precompiled bytecode we can use
-        if (shader.HlslBytecode is ReadOnlyMemory<byte> { Length: > 0 } hlslBytecode &&
-            (requestedShaderProfile is null || shader.ShaderProfile == requestedShaderProfile.GetValueOrDefault()) &&
-            (requestedCompileOptions is null || shader.CompileOptions == requestedCompileOptions.GetValueOrDefault()))
+        if (T.HlslBytecode is ReadOnlyMemory<byte> { Length: > 0 } hlslBytecode &&
+            (requestedShaderProfile is null || T.ShaderProfile == requestedShaderProfile.GetValueOrDefault()) &&
+            (requestedCompileOptions is null || T.CompileOptions == requestedCompileOptions.GetValueOrDefault()))
         {
-            effectiveShaderProfile = shader.ShaderProfile;
-            effectiveCompileOptions = shader.CompileOptions;
+            effectiveShaderProfile = T.ShaderProfile;
+            effectiveCompileOptions = T.CompileOptions;
 
             return hlslBytecode;
         }
@@ -398,7 +372,7 @@ public static class D2D1PixelShader
     {
         D2D1ByteArrayConstantBufferLoader dataLoader = default;
 
-        Unsafe.AsRef(in shader).LoadConstantBuffer(in shader, ref dataLoader);
+        T.LoadConstantBuffer(in shader, ref dataLoader);
 
         return dataLoader.GetResultingDispatchData();
     }
@@ -437,7 +411,7 @@ public static class D2D1PixelShader
         {
             D2D1ByteBufferConstantBufferLoader dataLoader = new(buffer, span.Length);
 
-            Unsafe.AsRef(in shader).LoadConstantBuffer(in shader, ref dataLoader);
+            T.LoadConstantBuffer(in shader, ref dataLoader);
 
             return dataLoader.TryGetWrittenBytes(out bytesWritten);
         }
@@ -458,7 +432,7 @@ public static class D2D1PixelShader
 
         D2D1DrawInfoConstantBufferLoader dataLoader = new((ID2D1DrawInfo*)d2D1DrawInfo);
 
-        Unsafe.AsRef(in shader).LoadConstantBuffer(in shader, ref dataLoader);
+        T.LoadConstantBuffer(in shader, ref dataLoader);
     }
 
     /// <summary>
@@ -490,11 +464,9 @@ public static class D2D1PixelShader
     public static bool TryCreateFromConstantBuffer<T>(ReadOnlySpan<byte> span, out T shader)
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out shader);
-
-        if (span.Length >= shader.ConstantBufferSize)
+        if (span.Length >= T.ConstantBufferSize)
         {
-            shader = shader.CreateFromConstantBuffer(span);
+            shader = T.CreateFromConstantBuffer(span);
 
             return true;
         }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Buffers;
-using System.Runtime.CompilerServices;
 using System.Text;
 using ComputeSharp.D2D1.Descriptors;
 using ComputeSharp.D2D1.Extensions;
@@ -26,9 +25,7 @@ public static unsafe class D2D1PixelShaderEffect
     public static ref readonly Guid GetEffectId<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return ref shader.EffectId;
+        return ref T.EffectId;
     }
 
     /// <summary>
@@ -39,9 +36,7 @@ public static unsafe class D2D1PixelShaderEffect
     public static string? GetEffectDisplayName<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.EffectDisplayName;
+        return T.EffectDisplayName;
     }
 
     /// <summary>
@@ -52,9 +47,7 @@ public static unsafe class D2D1PixelShaderEffect
     public static string? GetEffectDescription<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.EffectDescription;
+        return T.EffectDescription;
     }
 
     /// <summary>
@@ -65,9 +58,7 @@ public static unsafe class D2D1PixelShaderEffect
     public static string? GetEffectCategory<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.EffectCategory;
+        return T.EffectCategory;
     }
 
     /// <summary>
@@ -78,9 +69,7 @@ public static unsafe class D2D1PixelShaderEffect
     public static string? GetEffectAuthor<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        return shader.EffectAuthor;
+        return T.EffectAuthor;
     }
 
     /// <summary>
@@ -194,7 +183,7 @@ public static unsafe class D2D1PixelShaderEffect
                     classId: pGuid,
                     propertyXml: (ushort*)pXml,
                     bindings: d2D1PropertyBinding,
-                    bindingsCount: (uint)(D2D1PixelShaderEffectProperty.NumberOfAlwaysAvailableProperties + D2D1PixelShader.GetResourceTextureCount<T>()),
+                    bindingsCount: (uint)(D2D1PixelShaderEffectProperty.NumberOfAlwaysAvailableProperties + T.ResourceTextureCount),
                     effectFactory: PixelShaderEffect.Globals<T>.Instance.Factory).Assert();
             }
 
@@ -249,8 +238,8 @@ public static unsafe class D2D1PixelShaderEffect
         writer.Write(D2D1EffectRegistrationData.V1.BlobId);
 
         // Effect id and number of inputs
-        writer.Write(GetEffectId<T>());
-        writer.Write(D2D1PixelShader.GetInputCount<T>());
+        writer.Write(T.EffectId);
+        writer.Write(T.InputCount);
 
         // Retrieve the effect XML and include it into the registration blob
         using (D2D1EffectXmlFactory.EffectXml effectXml = D2D1EffectXmlFactory.GetXmlBuffer<T>())
@@ -272,7 +261,7 @@ public static unsafe class D2D1PixelShaderEffect
         }
 
         // Bindings
-        writer.Write(D2D1PixelShaderEffectProperty.NumberOfAlwaysAvailableProperties + D2D1PixelShader.GetResourceTextureCount<T>());
+        writer.Write(D2D1PixelShaderEffectProperty.NumberOfAlwaysAvailableProperties + T.ResourceTextureCount);
         writer.Write("ConstantBuffer"u8);
         writer.Write((byte)'\0');
         writer.Write((nint)(delegate* unmanaged<IUnknown*, byte*, uint, uint*, HRESULT>)&PixelShaderEffect.GetConstantBufferImpl);
@@ -283,7 +272,7 @@ public static unsafe class D2D1PixelShaderEffect
         writer.Write((nint)(delegate* unmanaged<IUnknown*, byte*, uint, HRESULT>)&PixelShaderEffect.SetTransformMapperImpl);
 
         // Add all resource texture manager property bindings
-        for (int i = 0; i < D2D1PixelShader.GetResourceTextureCount<T>(); i++)
+        for (int i = 0; i < T.ResourceTextureCount; i++)
         {
             switch (i)
             {
@@ -441,7 +430,7 @@ public static unsafe class D2D1PixelShaderEffect
 
         D2D1EffectConstantBufferLoader dataLoader = new((ID2D1Effect*)d2D1Effect);
 
-        Unsafe.AsRef(in shader).LoadConstantBuffer(in shader, ref dataLoader);
+        T.LoadConstantBuffer(in shader, ref dataLoader);
     }
 
     /// <summary>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1ReflectionServices.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.CompilerServices;
 using ComputeSharp.D2D1.Descriptors;
 using ComputeSharp.D2D1.Extensions;
 using ComputeSharp.Win32;
@@ -27,8 +26,6 @@ public static class D2D1ReflectionServices
     public static unsafe D2D1ShaderInfo GetShaderInfo<T>()
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
         ReadOnlyMemory<byte> hlslBytecode = D2D1PixelShader.LoadBytecode<T>();
 
         using ComPtr<ID3D11ShaderReflection> d3D11ShaderReflection = default;
@@ -52,7 +49,7 @@ public static class D2D1ReflectionServices
 
         return new(
             CompilerVersion: new string(d3D11ShaderDescription.Creator),
-            HlslSource: shader.HlslSource,
+            HlslSource: T.HlslSource,
             HlslBytecode: hlslBytecode,
             ConstantBufferCount: d3D11ShaderDescription.ConstantBuffers,
             BoundResourceCount: d3D11ShaderDescription.BoundResources,

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Globals{T}.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.Globals{T}.cs
@@ -107,34 +107,34 @@ internal unsafe partial struct PixelShaderEffect
         public static Globals<T> Instance { get; } = new();
 
         /// <inheritdoc/>
-        public override ref readonly Guid EffectId => ref D2D1PixelShaderEffect.GetEffectId<T>();
+        public override ref readonly Guid EffectId => ref T.EffectId;
 
         /// <inheritdoc/>
-        public override int ConstantBufferSize => D2D1PixelShader.GetConstantBufferSize<T>();
+        public override int ConstantBufferSize => T.ConstantBufferSize;
 
         /// <inheritdoc/>
-        public override int InputCount => D2D1PixelShader.GetInputCount<T>();
+        public override int InputCount => T.InputCount;
 
         /// <inheritdoc/>
-        public override int ResourceTextureCount => D2D1PixelShader.GetResourceTextureCount<T>();
+        public override int ResourceTextureCount => T.ResourceTextureCount;
 
         /// <inheritdoc/>
-        public override ReadOnlyMemory<D2D1PixelShaderInputType> InputTypes => D2D1PixelShader.GetInputTypes<T>();
+        public override ReadOnlyMemory<D2D1PixelShaderInputType> InputTypes => T.InputTypes;
 
         /// <inheritdoc/>
-        public override ReadOnlyMemory<D2D1InputDescription> InputDescriptions => D2D1PixelShader.GetInputDescriptions<T>();
+        public override ReadOnlyMemory<D2D1InputDescription> InputDescriptions => T.InputDescriptions;
 
         /// <inheritdoc/>
-        public override ReadOnlyMemory<D2D1ResourceTextureDescription> ResourceTextureDescriptions => D2D1PixelShader.GetResourceTextureDescriptions<T>();
+        public override ReadOnlyMemory<D2D1ResourceTextureDescription> ResourceTextureDescriptions => T.ResourceTextureDescriptions;
 
         /// <inheritdoc/>
-        public override D2D1PixelOptions PixelOptions => D2D1PixelShader.GetPixelOptions<T>();
+        public override D2D1PixelOptions PixelOptions => T.PixelOptions;
 
         /// <inheritdoc/>
-        public override D2D1BufferPrecision BufferPrecision => D2D1PixelShader.GetOutputBufferPrecision<T>();
+        public override D2D1BufferPrecision BufferPrecision => T.BufferPrecision;
 
         /// <inheritdoc/>
-        public override D2D1ChannelDepth ChannelDepth => D2D1PixelShader.GetOutputBufferChannelDepth<T>();
+        public override D2D1ChannelDepth ChannelDepth => T.ChannelDepth;
 
         /// <inheritdoc/>
         public override ReadOnlyMemory<byte> HlslBytecode

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Helpers/D2D1EffectXmlFactory.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Helpers/D2D1EffectXmlFactory.cs
@@ -26,12 +26,12 @@ internal static unsafe class D2D1EffectXmlFactory
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
         // Compute all necessary values first, outside of the lock
-        string? displayName = D2D1PixelShaderEffect.GetEffectDisplayName<T>();
-        string? description = D2D1PixelShaderEffect.GetEffectDescription<T>();
-        string? category = D2D1PixelShaderEffect.GetEffectCategory<T>();
-        string? author = D2D1PixelShaderEffect.GetEffectAuthor<T>();
-        int inputCount = D2D1PixelShader.GetInputCount<T>();
-        int resourceTextureCount = D2D1PixelShader.GetResourceTextureCount<T>();
+        string? displayName = T.EffectDisplayName;
+        string? description = T.EffectDescription;
+        string? category = T.EffectCategory;
+        string? author = T.EffectAuthor;
+        int inputCount = T.InputCount;
+        int resourceTextureCount = T.ResourceTextureCount;
 
         StringBuilder builder = XmlBuilder;
 

--- a/src/ComputeSharp.Dxc/Interop/ReflectionServices.cs
+++ b/src/ComputeSharp.Dxc/Interop/ReflectionServices.cs
@@ -43,9 +43,7 @@ public static partial class ReflectionServices
     private static unsafe ShaderInfo GetNonGenericShaderInfo<T>()
         where T : struct, IComputeShaderDescriptor<T>
     {
-        Unsafe.SkipInit(out T shader);
-
-        ReadOnlyMemory<byte> hlslBytecode = shader.HlslBytecode;
+        ReadOnlyMemory<byte> hlslBytecode = T.HlslBytecode;
 
         using ComPtr<IDxcUtils> dxcUtils = default;
 
@@ -77,7 +75,7 @@ public static partial class ReflectionServices
 
         return new(
             CompilerVersion: new string(d3D12ShaderDescription.Creator),
-            HlslSource: shader.HlslSource,
+            HlslSource: T.HlslSource,
             HlslBytecode: hlslBytecode,
             ConstantBufferCount: d3D12ShaderDescription.ConstantBuffers,
             BoundResourceCount: d3D12ShaderDescription.BoundResources,

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.DispatchDataLoading.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.DispatchDataLoading.Syntax.cs
@@ -23,7 +23,7 @@ partial class ComputeShaderDescriptorGenerator
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
             writer.WriteLine("[global::System.Runtime.CompilerServices.SkipLocalsInit]");
-            writer.WriteLine($"readonly void global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{typeName}>.LoadConstantBuffer<TLoader>(in {typeName} shader, ref TLoader loader, int x, int y, int z)");
+            writer.WriteLine($"static void global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{typeName}>.LoadConstantBuffer<TLoader>(in {typeName} shader, ref TLoader loader, int x, int y, int z)");
 
             using (writer.WriteBlock())
             {
@@ -99,7 +99,7 @@ partial class ComputeShaderDescriptorGenerator
 
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly void global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{typeName}>.LoadGraphicsResources<TLoader>(in {typeName} shader, ref TLoader loader)");
+            writer.WriteLine($"static void global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{typeName}>.LoadGraphicsResources<TLoader>(in {typeName} shader, ref TLoader loader)");
 
             using (writer.WriteBlock())
             {

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.Syntax.cs
@@ -20,7 +20,7 @@ partial class ComputeShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.Write($"readonly global::System.ReadOnlyMemory<byte> global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.HlslBytecode => ");
+            writer.Write($"static global::System.ReadOnlyMemory<byte> global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.HlslBytecode => ");
 
             // Just like with the D2D1 generator, only return the MemoryManager<T> if we do have HLSL bytecode
             if (info.HlslInfo is not HlslBytecodeInfo.Success)
@@ -118,42 +118,6 @@ partial class ComputeShaderDescriptorGenerator
             }
 
             callbacks.Add(Callback);
-        }
-
-        /// <summary>
-        /// Writes the <c>ThreadsX</c> property.
-        /// </summary>
-        /// <param name="info">The input <see cref="ShaderInfo"/> instance with gathered shader info.</param>
-        /// <param name="writer">The <see cref="IndentedTextWriter"/> instance to write into.</param>
-        public static void WriteThreadsXSyntax(ShaderInfo info, IndentedTextWriter writer)
-        {
-            writer.WriteLine("/// <inheritdoc/>");
-            writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsX => {info.ThreadsX};");
-        }
-
-        /// <summary>
-        /// Writes the <c>ThreadsY</c> property.
-        /// </summary>
-        /// <param name="info">The input <see cref="ShaderInfo"/> instance with gathered shader info.</param>
-        /// <param name="writer">The <see cref="IndentedTextWriter"/> instance to write into.</param>
-        public static void WriteThreadsYSyntax(ShaderInfo info, IndentedTextWriter writer)
-        {
-            writer.WriteLine("/// <inheritdoc/>");
-            writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsY => {info.ThreadsY};");
-        }
-
-        /// <summary>
-        /// Writes the <c>ThreadsZ</c> property.
-        /// </summary>
-        /// <param name="info">The input <see cref="ShaderInfo"/> instance with gathered shader info.</param>
-        /// <param name="writer">The <see cref="IndentedTextWriter"/> instance to write into.</param>
-        public static void WriteThreadsZSyntax(ShaderInfo info, IndentedTextWriter writer)
-        {
-            writer.WriteLine("/// <inheritdoc/>");
-            writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsZ => {info.ThreadsZ};");
         }
     }
 }

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.Syntax.cs
@@ -19,7 +19,7 @@ partial class ComputeShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly string global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.HlslSource =>");
+            writer.WriteLine($"static string global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.HlslSource =>");
             writer.IncreaseIndent();
             writer.WriteLine("\"\"\"");
             writer.Write(info.HlslInfoKey.HlslSource, isMultiline: true);

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.MetadataProperties.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.MetadataProperties.Syntax.cs
@@ -21,7 +21,7 @@ partial class ComputeShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ConstantBufferSize => {info.ConstantBufferSizeInBytes};");
+            writer.WriteLine($"static int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ConstantBufferSize => {info.ConstantBufferSizeInBytes};");
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ partial class ComputeShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly bool global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.IsStaticSamplerRequired => {info.IsSamplerUsed.ToString().ToLowerInvariant()};");
+            writer.WriteLine($"static bool global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.IsStaticSamplerRequired => {info.IsSamplerUsed.ToString().ToLowerInvariant()};");
         }
     }
 }

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.NumThreads.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.NumThreads.Syntax.cs
@@ -19,7 +19,7 @@ partial class ComputeShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsX => {info.ThreadsX};");
+            writer.WriteLine($"static int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsX => {info.ThreadsX};");
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ partial class ComputeShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsY => {info.ThreadsY};");
+            writer.WriteLine($"static int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsY => {info.ThreadsY};");
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ partial class ComputeShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.WriteLine($"readonly int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsZ => {info.ThreadsZ};");
+            writer.WriteLine($"static int global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ThreadsZ => {info.ThreadsZ};");
         }
     }
 }

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.ResourceDescriptorRanges.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.ResourceDescriptorRanges.Syntax.cs
@@ -19,7 +19,7 @@ partial class ComputeShaderDescriptorGenerator
         {
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
-            writer.Write($"readonly global::System.ReadOnlyMemory<global::ComputeSharp.Interop.ResourceDescriptorRange> global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ResourceDescriptorRanges => ");
+            writer.Write($"static global::System.ReadOnlyMemory<global::ComputeSharp.Interop.ResourceDescriptorRange> global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.ResourceDescriptorRanges => ");
 
             // If there are no declared resources, just return an empty collection
             if (info.ResourceDescriptors.IsEmpty)

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -144,9 +144,9 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
         {
             using ImmutableArrayBuilder<IndentedTextWriter.Callback<ShaderInfo>> declaredMembers = new();
 
-            declaredMembers.Add(HlslBytecode.WriteThreadsXSyntax);
-            declaredMembers.Add(HlslBytecode.WriteThreadsYSyntax);
-            declaredMembers.Add(HlslBytecode.WriteThreadsZSyntax);
+            declaredMembers.Add(NumThreads.WriteThreadsXSyntax);
+            declaredMembers.Add(NumThreads.WriteThreadsYSyntax);
+            declaredMembers.Add(NumThreads.WriteThreadsZSyntax);
             declaredMembers.Add(MetadataProperties.WriteConstantBufferSizeSyntax);
             declaredMembers.Add(MetadataProperties.WriteIsStaticSamplerRequiredSyntax);
             declaredMembers.Add(ResourceDescriptorRanges.WriteSyntax);

--- a/src/ComputeSharp/Core/Interfaces/Descriptors/IComputeShaderDescriptor{T}.cs
+++ b/src/ComputeSharp/Core/Interfaces/Descriptors/IComputeShaderDescriptor{T}.cs
@@ -13,19 +13,19 @@ public interface IComputeShaderDescriptor<T>
     where T : struct
 {
     /// <summary>
-    /// The number of threads in each thread group for the X axis.
+    /// Gets the number of threads in each thread group for the X axis.
     /// </summary>
-    int ThreadsX { get; }
+    static abstract int ThreadsX { get; }
 
     /// <summary>
-    /// The number of threads in each thread group for the Y axis.
+    /// Gets the number of threads in each thread group for the Y axis.
     /// </summary>
-    int ThreadsY { get; }
+    static abstract int ThreadsY { get; }
 
     /// <summary>
-    /// The number of threads in each thread group for the Z axis.
+    /// Gets the number of threads in each thread group for the Z axis.
     /// </summary>
-    int ThreadsZ { get; }
+    static abstract int ThreadsZ { get; }
 
     /// <summary>
     /// Gets the size in bytes of the constant buffer for the current shader.
@@ -35,7 +35,7 @@ public interface IComputeShaderDescriptor<T>
     /// <see href="https://learn.microsoft.com/windows/win32/api/d3d12/nf-d3d12-id3d12graphicscommandlist-setcomputeroot32bitconstants"><c>ID3D12GraphicsCommandList::SetComputeRoot32BitConstants</c></see>,
     /// so the size must be a multiple of the size of a DWORD value (ie. 4 bytes).
     /// </remarks>
-    int ConstantBufferSize { get; }
+    static abstract int ConstantBufferSize { get; }
 
     /// <summary>
     /// Gets whether the shader requires a static sampler being declared and initialized.
@@ -43,22 +43,22 @@ public interface IComputeShaderDescriptor<T>
     /// <remarks>
     /// When requested, a static sampler with linear sampling and mirror addressing will be bound to <c>register(s)</c>.
     /// </remarks>
-    bool IsStaticSamplerRequired { get; }
+    static abstract bool IsStaticSamplerRequired { get; }
 
     /// <summary>
     /// Gets the resource descriptor ranges for all resources that should be bound to this shader.
     /// </summary>
-    ReadOnlyMemory<ResourceDescriptorRange> ResourceDescriptorRanges { get; }
+    static abstract ReadOnlyMemory<ResourceDescriptorRange> ResourceDescriptorRanges { get; }
 
     /// <summary>
     /// Gets the HLSL source code for the current shader instance.
     /// </summary>
-    string HlslSource { get; }
+    static abstract string HlslSource { get; }
 
     /// <summary>
     /// Gets the HLSL bytecode for the current shader.
     /// </summary>
-    ReadOnlyMemory<byte> HlslBytecode { get; }
+    static abstract ReadOnlyMemory<byte> HlslBytecode { get; }
 
     /// <summary>
     /// Loads the constant buffer of a given input shader.
@@ -69,7 +69,7 @@ public interface IComputeShaderDescriptor<T>
     /// <param name="x">The number of iterations to run on the X axis.</param>
     /// <param name="y">The number of iterations to run on the Y axis.</param>
     /// <param name="z">The number of iterations to run on the Z axis.</param>
-    void LoadConstantBuffer<TLoader>(in T shader, ref TLoader loader, int x, int y, int z)
+    static abstract void LoadConstantBuffer<TLoader>(in T shader, ref TLoader loader, int x, int y, int z)
         where TLoader : struct, IConstantBufferLoader;
 
     /// <summary>
@@ -78,6 +78,6 @@ public interface IComputeShaderDescriptor<T>
     /// <typeparam name="TLoader">The type of graphics resource loader being used.</typeparam>
     /// <param name="shader">The input shader to load the graphics resources for.</param>
     /// <param name="loader">The <typeparamref name="TLoader"/> instance to use to load the data.</param>
-    void LoadGraphicsResources<TLoader>(in T shader, ref TLoader loader)
+    static abstract void LoadGraphicsResources<TLoader>(in T shader, ref TLoader loader)
         where TLoader : struct, IGraphicsResourceLoader;
 }

--- a/src/ComputeSharp/Shaders/ComputeContext.cs
+++ b/src/ComputeSharp/Shaders/ComputeContext.cs
@@ -157,9 +157,9 @@ public struct ComputeContext : IDisposable, IAsyncDisposable
         default(ArgumentOutOfRangeException).ThrowIfNegativeOrZero(y);
         default(ArgumentOutOfRangeException).ThrowIfNegativeOrZero(z);
 
-        int groupsX = Math.DivRem(x, shader.ThreadsX, out int modX) + (modX == 0 ? 0 : 1);
-        int groupsY = Math.DivRem(y, shader.ThreadsY, out int modY) + (modY == 0 ? 0 : 1);
-        int groupsZ = Math.DivRem(z, shader.ThreadsZ, out int modZ) + (modZ == 0 ? 0 : 1);
+        int groupsX = Math.DivRem(x, T.ThreadsX, out int modX) + (modX == 0 ? 0 : 1);
+        int groupsY = Math.DivRem(y, T.ThreadsY, out int modY) + (modY == 0 ? 0 : 1);
+        int groupsZ = Math.DivRem(z, T.ThreadsZ, out int modZ) + (modZ == 0 ? 0 : 1);
 
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(groupsX, 1, D3D11.D3D11_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION);
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(groupsY, 1, D3D11.D3D11_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION, nameof(groupsX));
@@ -173,11 +173,11 @@ public struct ComputeContext : IDisposable, IAsyncDisposable
 
         D3D12GraphicsCommandListConstantBufferLoader dataLoader = new(commandList.D3D12GraphicsCommandList);
 
-        shader.LoadConstantBuffer(in shader, ref dataLoader, x, y, z);
+        T.LoadConstantBuffer(in shader, ref dataLoader, x, y, z);
 
         D3D12GraphicsCommandListGraphicsResourceLoader graphicsResourceLoader = new(commandList.D3D12GraphicsCommandList, this.device, rootParameterOffset: 1);
 
-        shader.LoadGraphicsResources(in shader, ref graphicsResourceLoader);
+        T.LoadGraphicsResources(in shader, ref graphicsResourceLoader);
 
         commandList.D3D12GraphicsCommandList->Dispatch((uint)groupsX, (uint)groupsY, (uint)groupsZ);
     }
@@ -197,8 +197,8 @@ public struct ComputeContext : IDisposable, IAsyncDisposable
 
         int x = texture.Width;
         int y = texture.Height;
-        int groupsX = Math.DivRem(x, shader.ThreadsX, out int modX) + (modX == 0 ? 0 : 1);
-        int groupsY = Math.DivRem(y, shader.ThreadsY, out int modY) + (modY == 0 ? 0 : 1);
+        int groupsX = Math.DivRem(x, T.ThreadsX, out int modX) + (modX == 0 ? 0 : 1);
+        int groupsY = Math.DivRem(y, T.ThreadsY, out int modY) + (modY == 0 ? 0 : 1);
 
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(groupsX, 1, D3D11.D3D11_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION);
         default(ArgumentOutOfRangeException).ThrowIfNotBetweenOrEqual(groupsY, 1, D3D11.D3D11_CS_DISPATCH_MAX_THREAD_GROUPS_PER_DIMENSION, nameof(groupsX));
@@ -211,11 +211,11 @@ public struct ComputeContext : IDisposable, IAsyncDisposable
 
         D3D12GraphicsCommandListConstantBufferLoader constantBufferLoader = new(commandList.D3D12GraphicsCommandList);
 
-        shader.LoadConstantBuffer(in shader, ref constantBufferLoader, x, y, 1);
+        T.LoadConstantBuffer(in shader, ref constantBufferLoader, x, y, 1);
 
         D3D12GraphicsCommandListGraphicsResourceLoader graphicsResourceLoader = new(commandList.D3D12GraphicsCommandList, this.device, rootParameterOffset: 2);
 
-        shader.LoadGraphicsResources(in shader, ref graphicsResourceLoader);
+        T.LoadGraphicsResources(in shader, ref graphicsResourceLoader);
 
         // Load the implicit output texture
         commandList.D3D12GraphicsCommandList->SetComputeRootDescriptorTable(

--- a/src/ComputeSharp/Shaders/Loading/PipelineDataLoader{T}.cs
+++ b/src/ComputeSharp/Shaders/Loading/PipelineDataLoader{T}.cs
@@ -65,9 +65,7 @@ internal static unsafe class PipelineDataLoader<T>
     /// <param name="d3D12RootSignature">The allocated <see cref="ID3D12RootSignature"/> instance.</param>
     private static void CreateD3D12RootSignature(ID3D12Device* d3D12Device, ID3D12RootSignature** d3D12RootSignature)
     {
-        Unsafe.SkipInit(out T shader);
-
-        ReadOnlySpan<ResourceDescriptorRange> resourceDescriptorRanges = shader.ResourceDescriptorRanges.Span;
+        ReadOnlySpan<ResourceDescriptorRange> resourceDescriptorRanges = T.ResourceDescriptorRanges.Span;
 
         D3D12_DESCRIPTOR_RANGE1[]? d3D12DescriptorRangesArray = null;
 
@@ -94,13 +92,13 @@ internal static unsafe class PipelineDataLoader<T>
         }
 
         // Calculate the actual size of the constant buffer in DWORD values
-        int root32BitConstantCount = shader.ConstantBufferSize / sizeof(int);
+        int root32BitConstantCount = T.ConstantBufferSize / sizeof(int);
 
         // Create the D3D12 root signature
         d3D12Device->CreateRootSignature(
             root32BitConstantCount,
             d3D12DescriptorRanges,
-            shader.IsStaticSamplerRequired,
+            T.IsStaticSamplerRequired,
             d3D12RootSignature);
 
         // Return the array to the pool if no exceptions have been thrown
@@ -118,11 +116,9 @@ internal static unsafe class PipelineDataLoader<T>
     /// <param name="d3D12PipelineState">The resulting <see cref="ID3D12PipelineState"/> instance.</param>
     private static void CreateD3D12PipelineState(ID3D12Device* d3D12Device, ID3D12RootSignature* d3D12RootSignature, ID3D12PipelineState** d3D12PipelineState)
     {
-        Unsafe.SkipInit(out T shader);
-
-        fixed (byte* hlslBytecodePtr = shader.HlslBytecode.Span)
+        fixed (byte* hlslBytecodePtr = T.HlslBytecode.Span)
         {
-            D3D12_SHADER_BYTECODE d3D12ShaderBytecode = new(hlslBytecodePtr, (nuint)shader.HlslBytecode.Length);
+            D3D12_SHADER_BYTECODE d3D12ShaderBytecode = new(hlslBytecodePtr, (nuint)T.HlslBytecode.Length);
 
             d3D12Device->CreateComputePipelineState(d3D12RootSignature, d3D12ShaderBytecode, d3D12PipelineState);
         }

--- a/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Runtime.CompilerServices;
 using ComputeSharp.Descriptors;
+using ComputeSharp.Interop;
 using ComputeSharp.Tests.Internals.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -29,18 +31,18 @@ public partial class ShaderDataLoaderTests
         CapturedResourceShader shader = new(buffer);
         DebugDispatchDataLoader dataLoader = new();
 
-        ((IComputeShaderDescriptor<CapturedResourceShader>)shader).LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
+        LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
 
-        Assert.AreEqual(12, ((IComputeShaderDescriptor<CapturedResourceShader>)shader).ConstantBufferSize);
+        Assert.AreEqual(12, ConstantBufferSize<CapturedResourceShader>());
         Assert.IsNotNull(dataLoader.ConstantBuffer);
         Assert.AreEqual(12, dataLoader.ConstantBuffer.Length);
         Assert.AreEqual(111, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[0]));
         Assert.AreEqual(222, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[4]));
         Assert.AreEqual(333, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[8]));
 
-        ((IComputeShaderDescriptor<CapturedResourceShader>)shader).LoadGraphicsResources(in shader, ref dataLoader);
+        LoadGraphicsResources(in shader, ref dataLoader);
 
-        Assert.AreEqual(1, ((IComputeShaderDescriptor<CapturedResourceShader>)shader).ResourceDescriptorRanges.Length);
+        Assert.AreEqual(1, ResourceDescriptorRanges<CapturedResourceShader>().Length);
         Assert.AreSame(buffer, dataLoader.GraphicsResources[0].Resource);
         Assert.AreEqual(0u, dataLoader.GraphicsResources[0].Index);
     }
@@ -70,9 +72,9 @@ public partial class ShaderDataLoaderTests
         MultipleResourcesAndPrimitivesShader shader = new(buffer0, buffer1, 1, 22, 77);
         DebugDispatchDataLoader dataLoader = new();
 
-        ((IComputeShaderDescriptor<MultipleResourcesAndPrimitivesShader>)shader).LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
+        LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
 
-        Assert.AreEqual(24, ((IComputeShaderDescriptor<MultipleResourcesAndPrimitivesShader>)shader).ConstantBufferSize);
+        Assert.AreEqual(24, ConstantBufferSize<MultipleResourcesAndPrimitivesShader>());
         Assert.IsNotNull(dataLoader.ConstantBuffer);
         Assert.AreEqual(24, dataLoader.ConstantBuffer.Length);
         Assert.AreEqual(111, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[0]));
@@ -82,9 +84,9 @@ public partial class ShaderDataLoaderTests
         Assert.AreEqual(22, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[16]));
         Assert.AreEqual(77, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[20]));
 
-        ((IComputeShaderDescriptor<MultipleResourcesAndPrimitivesShader>)shader).LoadGraphicsResources(in shader, ref dataLoader);
+        LoadGraphicsResources(in shader, ref dataLoader);
 
-        Assert.AreEqual(2, ((IComputeShaderDescriptor<MultipleResourcesAndPrimitivesShader>)shader).ResourceDescriptorRanges.Length);
+        Assert.AreEqual(2, ResourceDescriptorRanges<MultipleResourcesAndPrimitivesShader>().Length);
         Assert.AreSame(buffer0, dataLoader.GraphicsResources[0].Resource);
         Assert.AreEqual(0u, dataLoader.GraphicsResources[0].Index);
         Assert.AreSame(buffer1, dataLoader.GraphicsResources[1].Resource);
@@ -117,9 +119,9 @@ public partial class ShaderDataLoaderTests
         ScalarAndVectorTypesShader shader = new(buffer, new(55, 44, 888), 22, 77, new(3.14, 6.28), 42, 9999);
         DebugDispatchDataLoader dataLoader = new();
 
-        ((IComputeShaderDescriptor<ScalarAndVectorTypesShader>)shader).LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
+        LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
 
-        Assert.AreEqual(72, ((IComputeShaderDescriptor<ScalarAndVectorTypesShader>)shader).ConstantBufferSize);
+        Assert.AreEqual(72, ConstantBufferSize<ScalarAndVectorTypesShader>());
         Assert.IsNotNull(dataLoader.ConstantBuffer);
         Assert.AreEqual(72, dataLoader.ConstantBuffer.Length);
         Assert.AreEqual(111, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[0]));
@@ -135,9 +137,9 @@ public partial class ShaderDataLoaderTests
         Assert.AreEqual(42, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[64]));
         Assert.AreEqual(9999, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[68]));
 
-        ((IComputeShaderDescriptor<ScalarAndVectorTypesShader>)shader).LoadGraphicsResources(in shader, ref dataLoader);
+        LoadGraphicsResources(in shader, ref dataLoader);
 
-        Assert.AreEqual(1, ((IComputeShaderDescriptor<ScalarAndVectorTypesShader>)shader).ResourceDescriptorRanges.Length);
+        Assert.AreEqual(1, ResourceDescriptorRanges<ScalarAndVectorTypesShader>().Length);
         Assert.AreSame(buffer, dataLoader.GraphicsResources[0].Resource);
         Assert.AreEqual(0u, dataLoader.GraphicsResources[0].Index);
     }
@@ -179,9 +181,9 @@ public partial class ShaderDataLoaderTests
             d: 9999);
         DebugDispatchDataLoader dataLoader = new();
 
-        ((IComputeShaderDescriptor<ScalarVectorAndMatrixTypesShader>)shader).LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
+        LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
 
-        Assert.AreEqual(124, ((IComputeShaderDescriptor<ScalarVectorAndMatrixTypesShader>)shader).ConstantBufferSize);
+        Assert.AreEqual(124, ConstantBufferSize<ScalarVectorAndMatrixTypesShader>());
         Assert.IsNotNull(dataLoader.ConstantBuffer);
         Assert.AreEqual(124, dataLoader.ConstantBuffer.Length);
         Assert.AreEqual(111, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[0]));
@@ -208,9 +210,9 @@ public partial class ShaderDataLoaderTests
         Assert.AreEqual(44, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[116]));
         Assert.AreEqual(9999, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[120]));
 
-        ((IComputeShaderDescriptor<ScalarVectorAndMatrixTypesShader>)shader).LoadGraphicsResources(in shader, ref dataLoader);
+        LoadGraphicsResources(in shader, ref dataLoader);
 
-        Assert.AreEqual(1, ((IComputeShaderDescriptor<ScalarVectorAndMatrixTypesShader>)shader).ResourceDescriptorRanges.Length);
+        Assert.AreEqual(1, ResourceDescriptorRanges<ScalarVectorAndMatrixTypesShader>().Length);
         Assert.AreSame(buffer, dataLoader.GraphicsResources[0].Resource);
         Assert.AreEqual(0u, dataLoader.GraphicsResources[0].Index);
     }
@@ -259,9 +261,9 @@ public partial class ShaderDataLoaderTests
                 d: 9999));
         DebugDispatchDataLoader dataLoader = new();
 
-        ((IComputeShaderDescriptor<FlatCustomTypeShader>)shader).LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
+        LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
 
-        Assert.AreEqual(124, ((IComputeShaderDescriptor<FlatCustomTypeShader>)shader).ConstantBufferSize);
+        Assert.AreEqual(124, ConstantBufferSize<FlatCustomTypeShader>());
         Assert.IsNotNull(dataLoader.ConstantBuffer);
         Assert.AreEqual(124, dataLoader.ConstantBuffer.Length);
         Assert.AreEqual(111, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[0]));
@@ -288,9 +290,9 @@ public partial class ShaderDataLoaderTests
         Assert.AreEqual(44, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[116]));
         Assert.AreEqual(9999, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[120]));
 
-        ((IComputeShaderDescriptor<FlatCustomTypeShader>)shader).LoadGraphicsResources(in shader, ref dataLoader);
+        LoadGraphicsResources(in shader, ref dataLoader);
 
-        Assert.AreEqual(1, ((IComputeShaderDescriptor<FlatCustomTypeShader>)shader).ResourceDescriptorRanges.Length);
+        Assert.AreEqual(1, ResourceDescriptorRanges<FlatCustomTypeShader>().Length);
         Assert.AreSame(buffer, dataLoader.GraphicsResources[0].Resource);
         Assert.AreEqual(0u, dataLoader.GraphicsResources[0].Index);
     }
@@ -363,9 +365,9 @@ public partial class ShaderDataLoaderTests
                     b: new(333.3f, 444.4f))));
         DebugDispatchDataLoader dataLoader = new();
 
-        ((IComputeShaderDescriptor<NestedCustomTypesShader>)shader).LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
+        LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
 
-        Assert.AreEqual(188, ((IComputeShaderDescriptor<NestedCustomTypesShader>)shader).ConstantBufferSize);
+        Assert.AreEqual(188, ConstantBufferSize<NestedCustomTypesShader>());
         Assert.IsNotNull(dataLoader.ConstantBuffer);
         Assert.AreEqual(188, dataLoader.ConstantBuffer.Length);
         Assert.AreEqual(111, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[0]));
@@ -405,9 +407,9 @@ public partial class ShaderDataLoaderTests
         Assert.AreEqual(333.3f, Unsafe.As<byte, float>(ref dataLoader.ConstantBuffer[180]));
         Assert.AreEqual(444.4f, Unsafe.As<byte, float>(ref dataLoader.ConstantBuffer[184]));
 
-        ((IComputeShaderDescriptor<NestedCustomTypesShader>)shader).LoadGraphicsResources(in shader, ref dataLoader);
+        LoadGraphicsResources(in shader, ref dataLoader);
 
-        Assert.AreEqual(1, ((IComputeShaderDescriptor<NestedCustomTypesShader>)shader).ResourceDescriptorRanges.Length);
+        Assert.AreEqual(1, ResourceDescriptorRanges<NestedCustomTypesShader>().Length);
         Assert.AreSame(buffer, dataLoader.GraphicsResources[0].Resource);
         Assert.AreEqual(0u, dataLoader.GraphicsResources[0].Index);
     }
@@ -445,9 +447,9 @@ public partial class ShaderDataLoaderTests
         AmbiguousNamesShader shader = new(a, b, c, x, y, z, 7777, 8888, 9999);
         DebugDispatchDataLoader dataLoader = new();
 
-        ((IComputeShaderDescriptor<AmbiguousNamesShader>)shader).LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
+        LoadConstantBuffer(in shader, ref dataLoader, 111, 222, 333);
 
-        Assert.AreEqual(24, ((IComputeShaderDescriptor<AmbiguousNamesShader>)shader).ConstantBufferSize);
+        Assert.AreEqual(24, ConstantBufferSize<AmbiguousNamesShader>());
         Assert.IsNotNull(dataLoader.ConstantBuffer);
         Assert.AreEqual(24, dataLoader.ConstantBuffer.Length);
         Assert.AreEqual(111, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[0]));
@@ -457,9 +459,9 @@ public partial class ShaderDataLoaderTests
         Assert.AreEqual(8888, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[16]));
         Assert.AreEqual(9999, Unsafe.As<byte, int>(ref dataLoader.ConstantBuffer[20]));
 
-        ((IComputeShaderDescriptor<AmbiguousNamesShader>)shader).LoadGraphicsResources(in shader, ref dataLoader);
+        LoadGraphicsResources(in shader, ref dataLoader);
 
-        Assert.AreEqual(6, ((IComputeShaderDescriptor<AmbiguousNamesShader>)shader).ResourceDescriptorRanges.Length);
+        Assert.AreEqual(6, ResourceDescriptorRanges<AmbiguousNamesShader>().Length);
         Assert.AreSame(a, dataLoader.GraphicsResources[0].Resource);
         Assert.AreEqual(0u, dataLoader.GraphicsResources[0].Index);
         Assert.AreSame(b, dataLoader.GraphicsResources[1].Resource);
@@ -472,5 +474,35 @@ public partial class ShaderDataLoaderTests
         Assert.AreEqual(4u, dataLoader.GraphicsResources[4].Index);
         Assert.AreSame(z, dataLoader.GraphicsResources[5].Resource);
         Assert.AreEqual(5u, dataLoader.GraphicsResources[5].Index);
+    }
+
+    /// <inheritdoc cref="IComputeShaderDescriptor{T}.ConstantBufferSize"/>
+    private static int ConstantBufferSize<T>()
+        where T : struct, IComputeShaderDescriptor<T>
+    {
+        return T.ConstantBufferSize;
+    }
+
+    /// <inheritdoc cref="IComputeShaderDescriptor{T}.ResourceDescriptorRanges"/>
+    private static ReadOnlyMemory<ResourceDescriptorRange> ResourceDescriptorRanges<T>()
+        where T : struct, IComputeShaderDescriptor<T>
+    {
+        return T.ResourceDescriptorRanges;
+    }
+
+    /// <inheritdoc cref="IComputeShaderDescriptor{T}.LoadConstantBuffer"/>
+    private static void LoadConstantBuffer<T, TLoader>(in T shader, ref TLoader loader, int x, int y, int z)
+        where T : struct, IComputeShaderDescriptor<T>
+        where TLoader : struct, IConstantBufferLoader
+    {
+        T.LoadConstantBuffer(in shader, ref loader, x, y, z);
+    }
+
+    /// <inheritdoc cref="IComputeShaderDescriptor{T}.LoadGraphicsResources"/>
+    private static void LoadGraphicsResources<T, TLoader>(in T shader, ref TLoader loader)
+        where T : struct, IComputeShaderDescriptor<T>
+        where TLoader : struct, IGraphicsResourceLoader
+    {
+        T.LoadGraphicsResources(in shader, ref loader);
     }
 }

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using ComputeSharp;
 using ComputeSharp.Descriptors;
 using ComputeSharp.Interop;
@@ -15,9 +16,15 @@ namespace ComputeSharp.Tests
         [TestMethod]
         public void ReflectionBytecode()
         {
+            static ReadOnlyMemory<byte> GetHlslBytecode<T>()
+            where T : struct, IComputeShaderDescriptor<T>
+            {
+                return T.HlslBytecode;
+            }
+
             ShaderInfo shaderInfo = ReflectionServices.GetShaderInfo<ReservedKeywordsShader>();
 
-            CollectionAssert.AreEqual(((IComputeShaderDescriptor<ReservedKeywordsShader>)default(ReservedKeywordsShader)).HlslBytecode.ToArray(), shaderInfo.HlslBytecode.ToArray());
+            CollectionAssert.AreEqual(GetHlslBytecode<ReservedKeywordsShader>().ToArray(), shaderInfo.HlslBytecode.ToArray());
         }
 
         [TestMethod]

--- a/tests/ComputeSharp.Tests/ThreadGroupSizeTests.cs
+++ b/tests/ComputeSharp.Tests/ThreadGroupSizeTests.cs
@@ -10,21 +10,16 @@ public partial class ThreadGroupSizeTests
     [TestMethod]
     public unsafe void Verify_ThreadGroupSize()
     {
-        Assert.AreEqual(64, ((IComputeShaderDescriptor<DispatchXShader>)default(DispatchXShader)).ThreadsX);
-        Assert.AreEqual(1, ((IComputeShaderDescriptor<DispatchXShader>)default(DispatchXShader)).ThreadsY);
-        Assert.AreEqual(1, ((IComputeShaderDescriptor<DispatchXShader>)default(DispatchXShader)).ThreadsZ);
+        static (int X, int Y, int Z) GetNumThreads<T>()
+            where T : struct, IComputeShaderDescriptor<T>
+        {
+            return (T.ThreadsX, T.ThreadsY, T.ThreadsZ);
+        }
 
-        Assert.AreEqual(8, ((IComputeShaderDescriptor<DispatchXYShader>)default(DispatchXYShader)).ThreadsX);
-        Assert.AreEqual(8, ((IComputeShaderDescriptor<DispatchXYShader>)default(DispatchXYShader)).ThreadsY);
-        Assert.AreEqual(1, ((IComputeShaderDescriptor<DispatchXYShader>)default(DispatchXYShader)).ThreadsZ);
-
-        Assert.AreEqual(4, ((IComputeShaderDescriptor<DispatchXYZShader>)default(DispatchXYZShader)).ThreadsX);
-        Assert.AreEqual(4, ((IComputeShaderDescriptor<DispatchXYZShader>)default(DispatchXYZShader)).ThreadsY);
-        Assert.AreEqual(4, ((IComputeShaderDescriptor<DispatchXYZShader>)default(DispatchXYZShader)).ThreadsZ);
-
-        Assert.AreEqual(11, ((IComputeShaderDescriptor<DispatchCustomShader>)default(DispatchCustomShader)).ThreadsX);
-        Assert.AreEqual(14, ((IComputeShaderDescriptor<DispatchCustomShader>)default(DispatchCustomShader)).ThreadsY);
-        Assert.AreEqual(6, ((IComputeShaderDescriptor<DispatchCustomShader>)default(DispatchCustomShader)).ThreadsZ);
+        Assert.AreEqual((64, 1, 1), GetNumThreads<DispatchXShader>());
+        Assert.AreEqual((8, 8, 1), GetNumThreads<DispatchXYShader>());
+        Assert.AreEqual((4, 4, 4), GetNumThreads<DispatchXYZShader>());
+        Assert.AreEqual((11, 14, 6), GetNumThreads<DispatchCustomShader>());
     }
 
     [AutoConstructor]


### PR DESCRIPTION
### Contributes to #598

### Description

This PR switches all shader descriptor APIs to static abstracts, and updates all callsites. In particular for all calls to `D2D1PixelShader` and `D2D1PixelShaderEffect` internal uses, the descriptor APIs can be invoked directly instead, which is nice (and potentially faster).