### PR TITLE
Add analyzers for shader types being less accessible than internal

### DIFF
--- a/src/ComputeSharp.CodeFixing/MissingAttributeCodeFixer.cs
+++ b/src/ComputeSharp.CodeFixing/MissingAttributeCodeFixer.cs
@@ -40,7 +40,7 @@ public abstract class MissingAttributeCodeFixer : CodeFixProvider
     /// <param name="codeActionTitle">The title to display for the code fixer.</param>
     /// <param name="attributeFullyQualifiedMetadataName">The fully qualified type name of the attribute to add.</param>
     /// <param name="leadingAttributeFullyQualifiedMetadataNames">The fully qualified type names of leading attributes to skip.</param>
-    protected MissingAttributeCodeFixer(
+    private protected MissingAttributeCodeFixer(
         string diagnosticId,
         string codeActionTitle,
         string attributeFullyQualifiedMetadataName,

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -73,3 +73,4 @@ CMPSD2D0063 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0064 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0065 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0066 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0067 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -43,6 +43,12 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
                         return default;
                     }
 
+                    // Immediately bail if the target type doesn't have internal accessibility
+                    if (!typeSymbol.IsAccessibleFromContainingAssembly(context.SemanticModel.Compilation))
+                    {
+                        return default;
+                    }
+
                     // Check that the shader implements the ID2D1PixelShader interface
                     if (!typeSymbol.HasInterfaceWithType(context.SemanticModel.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.ID2D1PixelShader")!))
                     {

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
@@ -1,33 +1,19 @@
-using System.Collections.Immutable;
-using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 
 namespace ComputeSharp.D2D1.SourceGenerators;
 
-/// <summary>
-/// A diagnostic analyzer that generates an error if the <c>AllowUnsafeBlocks</c> compilation option is not set.
-/// </summary>
+/// <inheritdoc/>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class MissingAllowUnsafeBlocksCompilationOptionAnalyzer : DiagnosticAnalyzer
+public sealed class MissingAllowUnsafeBlocksCompilationOptionAnalyzer : MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase
 {
-    /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MissingAllowUnsafeBlocksOption);
-
-    /// <inheritdoc/>
-    public override void Initialize(AnalysisContext context)
+    /// <summary>
+    /// Creates a new <see cref="MissingAllowUnsafeBlocksCompilationOptionAnalyzer"/> instance.
+    /// </summary>
+    public MissingAllowUnsafeBlocksCompilationOptionAnalyzer()
+        : base(MissingAllowUnsafeBlocksOption)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationAction(static context =>
-        {
-            // Check whether unsafe blocks are available, and emit an error if they are not
-            if (!context.Compilation.IsAllowUnsafeBlocksEnabled())
-            {
-                context.ReportDiagnostic(Diagnostic.Create(MissingAllowUnsafeBlocksOption, location: null));
-            }
-        });
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer.cs
@@ -1,0 +1,19 @@
+using ComputeSharp.SourceGeneration.Diagnostics;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer : NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase
+{
+    /// <summary>
+    /// Creates a new <see cref="NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer"/> instance.
+    /// </summary>
+    public NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer()
+        : base(NotAccessibleTargetTypeForD2DGeneratedPixelShaderDescriptorAttribute, "ComputeSharp.D2D1.D2DGeneratedPixelShaderDescriptorAttribute")
+    {
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -992,4 +992,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "The [D2DGeneratedPixelShaderDescriptor] attribute must be used on types that implement the ID2D1PixelShader interface.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[D2DGeneratedPixelShaderDescriptor]</c> attribute is being used on a type that is not accessible from its containing assembly.
+    /// <para>
+    /// Format: <c>"The [D2DGeneratedPixelShaderDescriptor] attribute requires target types to be accessible from their containing assembly (type {0} has less effective accessibility than internal)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor NotAccessibleTargetTypeForD2DGeneratedPixelShaderDescriptorAttribute = new DiagnosticDescriptor(
+        id: "CMPSD2D0067",
+        title: "Invalid [D2DGeneratedPixelShaderDescriptor] attribute target",
+        messageFormat: "The [D2DGeneratedPixelShaderDescriptor] attribute requires target types to be accessible from their containing assembly (type {0} has less effective accessibility than internal)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [D2DGeneratedPixelShaderDescriptor] attribute requires target types to be accessible from their containing assembly.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>ComputeSharp.SourceGeneration.Hlsl</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\DiagnosticDescriptors.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\StringExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SyntaxNodeExtensions.cs" />

--- a/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>ComputeSharp.SourceGeneration.Hlsl</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\DiagnosticDescriptors.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\StringExtensions.cs" />

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase.cs
@@ -1,0 +1,47 @@
+using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ComputeSharp.SourceGeneration.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error if the <c>AllowUnsafeBlocks</c> compilation option is not set.
+/// </summary>
+public abstract class MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The <see cref="DiagnosticDescriptor"/> instance to use.
+    /// </summary>
+    private readonly DiagnosticDescriptor diagnosticDescriptor;
+
+    /// <summary>
+    /// Creates a new <see cref="MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase"/> instance with the specified arguments.
+    /// </summary>
+    /// <param name="diagnosticDescriptor">The <see cref="DiagnosticDescriptor"/> instance to use.</param>
+    protected MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase(DiagnosticDescriptor diagnosticDescriptor)
+    {
+        this.diagnosticDescriptor = diagnosticDescriptor;
+
+        SupportedDiagnostics = ImmutableArray.Create(diagnosticDescriptor);
+    }
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+    /// <inheritdoc/>
+    public sealed override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationAction(context =>
+        {
+            // Check whether unsafe blocks are available, and emit an error if they are not
+            if (!context.Compilation.IsAllowUnsafeBlocksEnabled())
+            {
+                context.ReportDiagnostic(Diagnostic.Create(this.diagnosticDescriptor, location: null));
+            }
+        });
+    }
+}

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase.cs
@@ -19,7 +19,7 @@ public abstract class MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase : Di
     /// Creates a new <see cref="MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase"/> instance with the specified arguments.
     /// </summary>
     /// <param name="diagnosticDescriptor">The <see cref="DiagnosticDescriptor"/> instance to use.</param>
-    protected MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase(DiagnosticDescriptor diagnosticDescriptor)
+    private protected MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase(DiagnosticDescriptor diagnosticDescriptor)
     {
         this.diagnosticDescriptor = diagnosticDescriptor;
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/Analyzers/NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/Analyzers/NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase.cs
@@ -1,0 +1,75 @@
+using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace ComputeSharp.SourceGeneration.Diagnostics;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error if a target shader type is not accessible from its containing assembly.
+/// </summary>
+public abstract class NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The <see cref="DiagnosticDescriptor"/> instance to use.
+    /// </summary>
+    private readonly DiagnosticDescriptor diagnosticDescriptor;
+
+    /// <summary>
+    /// The fully qualified type name of the target attribute.
+    /// </summary>
+    private readonly string generatedShaderDescriptorFullyQualifiedTypeName;
+
+    /// <summary>
+    /// Creates a new <see cref="NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase"/> instance with the specified arguments.
+    /// </summary>
+    /// <param name="diagnosticDescriptor">The <see cref="DiagnosticDescriptor"/> instance to use.</param>
+    /// <param name="generatedShaderDescriptorFullyQualifiedTypeName">The fully qualified type name of the target attribute.</param>
+    private protected NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase(
+        DiagnosticDescriptor diagnosticDescriptor,
+        string generatedShaderDescriptorFullyQualifiedTypeName)
+    {
+        this.diagnosticDescriptor = diagnosticDescriptor;
+        this.generatedShaderDescriptorFullyQualifiedTypeName = generatedShaderDescriptorFullyQualifiedTypeName;
+
+        SupportedDiagnostics = ImmutableArray.Create(diagnosticDescriptor);
+    }
+
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+    /// <inheritdoc/>
+    public sealed override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(context =>
+        {
+            // Get the symbol for the target attribute type
+            if (context.Compilation.GetTypeByMetadataName(this.generatedShaderDescriptorFullyQualifiedTypeName) is not { } generatedShaderDescriptorAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only struct types are possible targets
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if the target type is using the attribute but is not accessible
+                if (typeSymbol.TryGetAttributeWithType(generatedShaderDescriptorAttributeSymbol, out AttributeData? attribute) &&
+                    !typeSymbol.IsAccessibleFromContainingAssembly(context.Compilation))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        this.diagnosticDescriptor,
+                        attribute.GetLocation(),
+                        typeSymbol));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/ComputeSharp.SourceGeneration/Extensions/ISymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/ISymbolExtensions.cs
@@ -18,6 +18,23 @@ internal static class ISymbolExtensions
         miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers);
 
     /// <summary>
+    /// Checks whether a given symbol is accessible from its containing assembly (including eg. through nested types).
+    /// </summary>
+    /// <param name="symbol">The input <see cref="ISymbol"/> instance.</param>
+    /// <param name="compilation">The <see cref="Compilation"/> instance currently in use.</param>
+    /// <returns>Whether <paramref name="symbol"/> is accessible from its containing assembly.</returns>
+    public static bool IsAccessibleFromContainingAssembly(this ISymbol symbol, Compilation compilation)
+    {
+        // If the symbol is associated across multiple assemblies, it must be accessible
+        if (symbol.ContainingAssembly is not IAssemblySymbol assemblySymbol)
+        {
+            return true;
+        }
+
+        return compilation.IsSymbolAccessibleWithin(symbol, assemblySymbol);
+    }
+
+    /// <summary>
     /// Gets the fully qualified name for a given symbol.
     /// </summary>
     /// <param name="symbol">The input <see cref="ISymbol"/> instance.</param>

--- a/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -60,3 +60,4 @@ CMPS0051 | ComputeSharp | Error | [Documentation](https://github.com/Sergio0694/
 CMPS0052 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0053 | ComputeSharp.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0054 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPS0055 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -43,6 +43,12 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                         return default;
                     }
 
+                    // Immediately bail if the target type doesn't have internal accessibility
+                    if (!typeSymbol.IsAccessibleFromContainingAssembly(context.SemanticModel.Compilation))
+                    {
+                        return default;
+                    }
+
                     // Check whether type is a compute shader, and if so, if it's pixel shader like
                     if (!TryGetIsPixelShaderLike(typeSymbol, context.SemanticModel.Compilation, out bool isPixelShaderLike))
                     {

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer.cs
@@ -13,7 +13,7 @@ namespace ComputeSharp.SourceGenerators;
 public sealed class InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer : DiagnosticAnalyzer
 {
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidGeneratedPixelShaderDescriptorAttributeTarget);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidGeneratedComputeShaderDescriptorAttributeTarget);
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -49,7 +49,7 @@ public sealed class InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyz
                 if (!MissingComputeShaderDescriptorOnComputeShaderAnalyzer.IsComputeShaderType(typeSymbol, computeShaderSymbol, pixelShaderSymbol))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
-                    InvalidGeneratedPixelShaderDescriptorAttributeTarget,
+                    InvalidGeneratedComputeShaderDescriptorAttributeTarget,
                     attribute.GetLocation(),
                     typeSymbol));
                 }

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
@@ -1,33 +1,19 @@
-using System.Collections.Immutable;
-using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Diagnostics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 
 namespace ComputeSharp.SourceGenerators;
 
-/// <summary>
-/// A diagnostic analyzer that generates an error if the <c>AllowUnsafeBlocks</c> compilation option is not set.
-/// </summary>
+/// <inheritdoc/>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class MissingAllowUnsafeBlocksCompilationOptionAnalyzer : DiagnosticAnalyzer
+public sealed class MissingAllowUnsafeBlocksCompilationOptionAnalyzer : MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase
 {
-    /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MissingAllowUnsafeBlocksOption);
-
-    /// <inheritdoc/>
-    public override void Initialize(AnalysisContext context)
+    /// <summary>
+    /// Creates a new <see cref="MissingAllowUnsafeBlocksCompilationOptionAnalyzer"/> instance.
+    /// </summary>
+    public MissingAllowUnsafeBlocksCompilationOptionAnalyzer()
+        : base(MissingAllowUnsafeBlocksOption)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationAction(static context =>
-        {
-            // Check whether unsafe blocks are available, and emit an error if they are not
-            if (!context.Compilation.IsAllowUnsafeBlocksEnabled())
-            {
-                context.ReportDiagnostic(Diagnostic.Create(MissingAllowUnsafeBlocksOption, location: null));
-            }
-        });
     }
 }

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer.cs
@@ -1,0 +1,19 @@
+using ComputeSharp.SourceGeneration.Diagnostics;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.SourceGenerators;
+
+/// <inheritdoc/>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer : NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase
+{
+    /// <summary>
+    /// Creates a new <see cref="NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer"/> instance.
+    /// </summary>
+    public NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer()
+        : base(NotAccessibleTargetTypeForGeneratedComputeShaderDescriptorAttribute, "ComputeSharp.GeneratedComputeShaderDescriptorAttribute")
+    {
+    }
+}

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -759,7 +759,7 @@ partial class DiagnosticDescriptors
     /// Format: <c>"The type {0} is not a valid target for the [GeneratedComputeShaderDescriptor] attribute (only types implementing the IComputeShader or IComputeShader&lt;TPixel&gt; interface are valid)"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor InvalidGeneratedPixelShaderDescriptorAttributeTarget = new DiagnosticDescriptor(
+    public static readonly DiagnosticDescriptor InvalidGeneratedComputeShaderDescriptorAttributeTarget = new DiagnosticDescriptor(
         id: "CMPS0054",
         title: "Invalid [GeneratedComputeShaderDescriptor] attribute target",
         messageFormat: "The type {0} is not a valid target for the [GeneratedComputeShaderDescriptor] attribute (only types implementing the IComputeShader or IComputeShader<TPixel> interface are valid)",
@@ -767,5 +767,21 @@ partial class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "The [GeneratedComputeShaderDescriptor] attribute must be used on types that implement the IComputeShader or IComputeShader<TPixel> interfaces.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[GeneratedComputeShaderDescriptor]</c> attribute is being used on a type that is not accessible from its containing assembly.
+    /// <para>
+    /// Format: <c>"The [GeneratedComputeShaderDescriptor] attribute requires target types to be accessible from their containing assembly (type {0} has less effective accessibility than internal)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor NotAccessibleTargetTypeForGeneratedComputeShaderDescriptorAttribute = new DiagnosticDescriptor(
+        id: "CMPS0055",
+        title: "Invalid [GeneratedComputeShaderDescriptor] attribute target",
+        messageFormat: "The [GeneratedComputeShaderDescriptor] attribute requires target types to be accessible from their containing assembly (type {0} has less effective accessibility than internal)",
+        category: "ComputeSharp.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The [GeneratedComputeShaderDescriptor] attribute requires target types to be accessible from their containing assembly.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
@@ -50,7 +50,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(1)]
     [D2DInputSimple(2)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithNoCompileAttributes : ID2D1PixelShader
+    internal readonly partial struct ShaderWithNoCompileAttributes : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -96,7 +96,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(2)]
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithOverriddenProfile : ID2D1PixelShader
+    internal readonly partial struct ShaderWithOverriddenProfile : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -142,7 +142,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(2)]
     [D2DCompileOptions(D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithOverriddenOptions : ID2D1PixelShader
+    internal readonly partial struct ShaderWithOverriddenOptions : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -179,7 +179,7 @@ public partial class D2D1PixelShaderTests
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DCompileOptions(D2D1CompileOptions.Debug | D2D1CompileOptions.AvoidFlowControl | D2D1CompileOptions.PartialPrecision)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithOverriddenProfileAndOptions : ID2D1PixelShader
+    internal readonly partial struct ShaderWithOverriddenProfileAndOptions : ID2D1PixelShader
     {
         public float4 Execute()
         {

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
@@ -1,15 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+    <RestoreSources>
+      https://api.nuget.org/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
+    </RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2-beta1.23509.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
   </ItemGroup>
 

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer.cs
@@ -2,6 +2,7 @@ extern alias Core;
 extern alias D2D1;
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CSharpCodeFixTest = Microsoft.CodeAnalysis.CSharp.Testing.CSharpCodeFixTest<
     ComputeSharp.D2D1.SourceGenerators.MissingPixelShaderDescriptorOnPixelShaderAnalyzer,
@@ -14,7 +15,6 @@ namespace ComputeSharp.D2D1.Tests.SourceGenerators;
 public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
 {
     [TestMethod]
-    [Ignore("Missing .NET 7 reference assemblies.")]
     public async Task FileContainsComputeSharpD2D1UsingDirective()
     {
         string original = """
@@ -40,7 +40,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            //ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -51,7 +51,6 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
     }
 
     [TestMethod]
-    [Ignore("Missing .NET 7 reference assemblies.")]
     public async Task FileContainsComputeSharpD2D1UsingDirective_MultipleOccurrences()
     {
         string original = """
@@ -102,7 +101,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            //ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -113,7 +112,6 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
     }
 
     [TestMethod]
-    [Ignore("Missing .NET 7 reference assemblies.")]
     public async Task FileDoesNotContainComputeSharpD2D1UsingDirective()
     {
         string original = """
@@ -137,7 +135,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            //ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -148,7 +146,6 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
     }
 
     [TestMethod]
-    [Ignore("Missing .NET 7 reference assemblies.")]
     public async Task FileDoesNotContainComputeSharpD2D1UsingDirective_MultipleOccurrences()
     {
         string original = """
@@ -196,7 +193,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            //ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -207,7 +204,6 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
     }
 
     [TestMethod]
-    [Ignore("Missing .NET 7 reference assemblies.")]
     public async Task InsertsAttributeAfterAllOtherD2DAttributes()
     {
         string original = """
@@ -237,7 +233,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            //ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -248,7 +244,6 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
     }
 
     [TestMethod]
-    [Ignore("Missing .NET 7 reference assemblies.")]
     public async Task InsertsAttributeAfterAllOtherD2DAttributes_WithOtherNonD2DAttribute()
     {
         string original = """
@@ -290,7 +285,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            //ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -301,7 +296,6 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
     }
 
     [TestMethod]
-    [Ignore("Missing .NET 7 reference assemblies.")]
     public async Task InsertsAttributeAfterAllOtherD2DAttributes_WithFakeAttributes()
     {
         string original = """
@@ -355,7 +349,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            //ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);

--- a/tests/ComputeSharp.D2D1.Tests/D2D1EffectRegistrationDataTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1EffectRegistrationDataTests.cs
@@ -53,7 +53,7 @@ public partial class D2D1EffectRegistrationDataTests
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private readonly partial struct TestRegistrationBlobShader : ID2D1PixelShader
+    internal readonly partial struct TestRegistrationBlobShader : ID2D1PixelShader
     {
         private readonly float a;
 
@@ -99,7 +99,7 @@ public partial class D2D1EffectRegistrationDataTests
     [D2DEffectAuthor("Bob Ross")]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private readonly partial struct TestRegistrationBlobWithCustomMetadataShader : ID2D1PixelShader
+    internal readonly partial struct TestRegistrationBlobWithCustomMetadataShader : ID2D1PixelShader
     {
         private readonly float a;
 
@@ -196,7 +196,7 @@ public partial class D2D1EffectRegistrationDataTests
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private readonly partial struct TestRegistrationBlobWithResourceTextures : ID2D1PixelShader
+    internal readonly partial struct TestRegistrationBlobWithResourceTextures : ID2D1PixelShader
     {
         [D2DResourceTextureIndex(0)]
         public readonly D2D1ResourceTexture1D<float> t0;

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -122,7 +122,7 @@ public partial class D2D1PixelShaderEffectTests
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct NullConstantBufferShader : ID2D1PixelShader
+    internal partial struct NullConstantBufferShader : ID2D1PixelShader
     {
         private float dummy;
 
@@ -154,7 +154,7 @@ public partial class D2D1PixelShaderEffectTests
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct ConstantBufferSizeTestShader : ID2D1PixelShader
+    internal partial struct ConstantBufferSizeTestShader : ID2D1PixelShader
     {
         private float a;
         private float b;
@@ -188,7 +188,7 @@ public partial class D2D1PixelShaderEffectTests
 
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWithDefaultEffectId : ID2D1PixelShader
+    internal partial struct ShaderWithDefaultEffectId : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -198,7 +198,7 @@ public partial class D2D1PixelShaderEffectTests
 
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWithDefaultEffectId2 : ID2D1PixelShader
+    internal partial struct ShaderWithDefaultEffectId2 : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -222,7 +222,7 @@ public partial class D2D1PixelShaderEffectTests
     [D2DInputCount(0)]
     [D2DEffectId("8E1F7F49-EF0D-4242-8912-08ADA36AB4EC")]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWithExplicitEffectId : ID2D1PixelShader
+    internal partial struct ShaderWithExplicitEffectId : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -241,7 +241,7 @@ public partial class D2D1PixelShaderEffectTests
 
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWithDefaultEffectDisplayName : ID2D1PixelShader
+    internal partial struct ShaderWithDefaultEffectDisplayName : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -261,7 +261,7 @@ public partial class D2D1PixelShaderEffectTests
     [D2DInputCount(0)]
     [D2DEffectDisplayName("Fancy blur")]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWithExplicitEffectDisplayName1 : ID2D1PixelShader
+    internal partial struct ShaderWithExplicitEffectDisplayName1 : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -284,7 +284,7 @@ public partial class D2D1PixelShaderEffectTests
     [D2DEffectCategory("Test effects!")]
     [D2DEffectAuthor("Bob \r\nRoss")]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWithExplicitEffectDisplayName2 : ID2D1PixelShader
+    internal partial struct ShaderWithExplicitEffectDisplayName2 : ID2D1PixelShader
     {
         public float4 Execute()
         {

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -67,7 +67,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputComplex(5)]
     [D2DInputSimple(6)]
     [D2DGeneratedPixelShaderDescriptor]
-    partial struct ShaderWithMultipleInputs : ID2D1PixelShader
+    internal partial struct ShaderWithMultipleInputs : ID2D1PixelShader
     {
         public Float4 Execute()
         {
@@ -95,7 +95,7 @@ public partial class D2D1PixelShaderTests
 
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
-    partial struct EmptyShader : ID2D1PixelShader
+    internal partial struct EmptyShader : ID2D1PixelShader
     {
         public Float4 Execute()
         {
@@ -106,7 +106,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputCount(0)]
     [D2DOutputBuffer(D2D1BufferPrecision.UInt16Normalized)]
     [D2DGeneratedPixelShaderDescriptor]
-    partial struct OnlyBufferPrecisionShader : ID2D1PixelShader
+    internal partial struct OnlyBufferPrecisionShader : ID2D1PixelShader
     {
         public Float4 Execute()
         {
@@ -117,7 +117,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputCount(0)]
     [D2DOutputBuffer(D2D1ChannelDepth.Four)]
     [D2DGeneratedPixelShaderDescriptor]
-    partial struct OnlyChannelDepthShader : ID2D1PixelShader
+    internal partial struct OnlyChannelDepthShader : ID2D1PixelShader
     {
         public Float4 Execute()
         {
@@ -128,7 +128,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputCount(0)]
     [D2DOutputBuffer(D2D1BufferPrecision.UInt8NormalizedSrgb, D2D1ChannelDepth.One)]
     [D2DGeneratedPixelShaderDescriptor]
-    partial struct CustomBufferOutputShader : ID2D1PixelShader
+    internal partial struct CustomBufferOutputShader : ID2D1PixelShader
     {
         public Float4 Execute()
         {
@@ -195,7 +195,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputDescription(5, D2D1Filter.MinMagPointMipLinear)]
     [D2DInputDescription(6, D2D1Filter.MinPointMagMipLinear, LevelOfDetailCount = 3)]
     [D2DGeneratedPixelShaderDescriptor]
-    partial struct ShaderWithInputDescriptions : ID2D1PixelShader
+    internal partial struct ShaderWithInputDescriptions : ID2D1PixelShader
     {
         public Float4 Execute()
         {
@@ -257,7 +257,7 @@ public partial class D2D1PixelShaderTests
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    partial struct ShaderWithoutResourceTextures : ID2D1PixelShader
+    internal partial struct ShaderWithoutResourceTextures : ID2D1PixelShader
     {
         public Float4 Execute()
         {
@@ -269,7 +269,7 @@ public partial class D2D1PixelShaderTests
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    partial struct ShaderWithJustOneResourceTextures : ID2D1PixelShader
+    internal partial struct ShaderWithJustOneResourceTextures : ID2D1PixelShader
     {
         [D2DResourceTextureIndex(0)]
         D2D1ResourceTexture1D<float> myTexture;
@@ -288,7 +288,7 @@ public partial class D2D1PixelShaderTests
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    partial struct ShaderWithResourceTextures : ID2D1PixelShader
+    internal partial struct ShaderWithResourceTextures : ID2D1PixelShader
     {
         float number;
 
@@ -332,7 +332,7 @@ public partial class D2D1PixelShaderTests
 
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithoutEmbeddedBytecode : ID2D1PixelShader
+    internal readonly partial struct ShaderWithoutEmbeddedBytecode : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -404,7 +404,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(2)]
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader40Level91)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithEmbeddedBytecode : ID2D1PixelShader
+    internal readonly partial struct ShaderWithEmbeddedBytecode : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -454,7 +454,7 @@ public partial class D2D1PixelShaderTests
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader40Level91)]
     [D2DCompileOptions(D2D1CompileOptions.IeeeStrictness | D2D1CompileOptions.OptimizationLevel2)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithEmbeddedBytecodeAndCompileOptions : ID2D1PixelShader
+    internal readonly partial struct ShaderWithEmbeddedBytecodeAndCompileOptions : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -486,7 +486,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(0)]
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader40Level91)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct SimpleShaderWithExplicitShaderProfileAndNoCompileOptions : ID2D1PixelShader
+    internal readonly partial struct SimpleShaderWithExplicitShaderProfileAndNoCompileOptions : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -498,7 +498,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputComplex(0)]
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader40Level91)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ComplexShaderWithExplicitShaderProfileAndNoCompileOptions : ID2D1PixelShader
+    internal readonly partial struct ComplexShaderWithExplicitShaderProfileAndNoCompileOptions : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -524,7 +524,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputSimple(0)]
     [D2DCompileOptions(D2D1CompileOptions.OptimizationLevel2 | D2D1CompileOptions.IeeeStrictness)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithExplicitCompileOptionsAndNoShaderProfile : ID2D1PixelShader
+    internal readonly partial struct ShaderWithExplicitCompileOptionsAndNoShaderProfile : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -573,7 +573,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputDescription(0, D2D1Filter.MinMagMipPoint)]
     [D2DPixelOptions(D2D1PixelOptions.TrivialSampling)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ShaderWithNoCapturedValues : ID2D1PixelShader
+    internal readonly partial struct ShaderWithNoCapturedValues : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -822,7 +822,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private readonly partial struct ShaderWithScalarVectorAndMatrixTypes : ID2D1PixelShader
+    internal readonly partial struct ShaderWithScalarVectorAndMatrixTypes : ID2D1PixelShader
     {
         public readonly int x;
         public readonly int y;
@@ -915,7 +915,7 @@ public partial class D2D1PixelShaderTests
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private readonly partial struct ShaderWithScalarVectorAndMatrixTypesInNestedStructs : ID2D1PixelShader
+    internal readonly partial struct ShaderWithScalarVectorAndMatrixTypesInNestedStructs : ID2D1PixelShader
     {
         public readonly int x;
         public readonly int y;

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
@@ -64,7 +64,7 @@ public partial class D2D1ReflectionServicesTests
     [D2DRequiresScenePosition]
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader41)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ReflectedShader : ID2D1PixelShader
+    internal readonly partial struct ReflectedShader : ID2D1PixelShader
     {
         private readonly float2 offset;
 
@@ -127,7 +127,7 @@ public partial class D2D1ReflectionServicesTests
     [D2DInputCount(1)]
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DGeneratedPixelShaderDescriptor]
-    private readonly partial struct ReflectedShaderWithDoubleOperations : ID2D1PixelShader
+    internal readonly partial struct ReflectedShaderWithDoubleOperations : ID2D1PixelShader
     {
         private readonly double amount;
 

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
@@ -171,7 +171,7 @@ public partial class D2D1ResourceTextureManagerTests
     [D2DInputCount(0)]
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct DummyShaderWithResourceTexture : ID2D1PixelShader
+    internal partial struct DummyShaderWithResourceTexture : ID2D1PixelShader
     {
         [D2DResourceTextureIndex(0)]
         private D2D1ResourceTexture2D<float4> source;
@@ -460,7 +460,7 @@ public partial class D2D1ResourceTextureManagerTests
     [D2DInputCount(0)]
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct IndexFrom2DResourceTextureShader : ID2D1PixelShader
+    internal partial struct IndexFrom2DResourceTextureShader : ID2D1PixelShader
     {
         [D2DResourceTextureIndex(0)]
         private D2D1ResourceTexture2D<float4> source;
@@ -536,7 +536,7 @@ public partial class D2D1ResourceTextureManagerTests
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct IndexFrom3DResourceTextureShader : ID2D1PixelShader
+    internal partial struct IndexFrom3DResourceTextureShader : ID2D1PixelShader
     {
         private int height;
 
@@ -624,7 +624,7 @@ public partial class D2D1ResourceTextureManagerTests
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct CopyFromResourceTexture1DShader : ID2D1PixelShader
+    internal partial struct CopyFromResourceTexture1DShader : ID2D1PixelShader
     {
         private int width;
 
@@ -794,7 +794,7 @@ public partial class D2D1ResourceTextureManagerTests
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct CopyFromResourceTexture2DShader : ID2D1PixelShader
+    internal partial struct CopyFromResourceTexture2DShader : ID2D1PixelShader
     {
         private int width;
         private int height;
@@ -901,7 +901,7 @@ public partial class D2D1ResourceTextureManagerTests
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct CopyFromResourceTexture3DShader : ID2D1PixelShader
+    internal partial struct CopyFromResourceTexture3DShader : ID2D1PixelShader
     {
         private int width;
         private int height;
@@ -946,7 +946,7 @@ public partial class D2D1ResourceTextureManagerTests
     [D2DInputCount(0)]
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct NullResourceTextureShader : ID2D1PixelShader
+    internal partial struct NullResourceTextureShader : ID2D1PixelShader
     {
         [D2DResourceTextureIndex(0)]
         private D2D1ResourceTexture2D<float4> source;

--- a/tests/ComputeSharp.D2D1.Tests/D2D1TransformMapperTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1TransformMapperTests.cs
@@ -195,7 +195,7 @@ public partial class D2D1TransformMapperTests
 
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct DummyShader : ID2D1PixelShader
+    internal partial struct DummyShader : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -286,7 +286,7 @@ public partial class D2D1TransformMapperTests
     [D2DRequiresScenePosition]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct ShaderWithDispatchArea : ID2D1PixelShader
+    internal partial struct ShaderWithDispatchArea : ID2D1PixelShader
     {
         public int Width;
         public int Height;

--- a/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
@@ -482,7 +482,7 @@ public sealed partial class BokehBlurEffect
     /// <summary>
     /// The vertical convolution shader and transform.
     /// </summary>
-    private sealed partial class VerticalConvolution
+    internal sealed partial class VerticalConvolution
     {
         /// <summary>
         /// The <see cref="D2D1TransformMapper{T}"/> for the shader.
@@ -530,7 +530,7 @@ public sealed partial class BokehBlurEffect
     /// <summary>
     /// The horizontal convolutin and partial accumulation effect and transform.
     /// </summary>
-    private sealed partial class HorizontalConvolutionAndAccumulatePartials
+    internal sealed partial class HorizontalConvolutionAndAccumulatePartials
     {
         /// <summary>
         /// The <see cref="D2D1TransformMapper{T}"/> for the shader.

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/CanvasEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/CanvasEffectTests.cs
@@ -693,7 +693,7 @@ public partial class CanvasEffectTests
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct ShaderWithNoInputs : ID2D1PixelShader
+    internal partial struct ShaderWithNoInputs : ID2D1PixelShader
     {
         public int Value;
 

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/PixelShaderEffectTests.cs
@@ -456,7 +456,7 @@ public partial class PixelShaderEffectTests
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct ShaderWithSomeProperties : ID2D1PixelShader
+    internal partial struct ShaderWithSomeProperties : ID2D1PixelShader
     {
         public float A;
         public int B;
@@ -473,7 +473,7 @@ public partial class PixelShaderEffectTests
     [D2DInputCount(1)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
-    private partial struct ShaderWithSomePropertiesAndInputs : ID2D1PixelShader
+    internal partial struct ShaderWithSomePropertiesAndInputs : ID2D1PixelShader
     {
         public int Number;
 
@@ -485,7 +485,7 @@ public partial class PixelShaderEffectTests
 
     [D2DInputCount(0)]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWith0Inputs : ID2D1PixelShader
+    internal partial struct ShaderWith0Inputs : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -496,7 +496,7 @@ public partial class PixelShaderEffectTests
     [D2DInputCount(1)]
     [D2DInputSimple(0)]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWith1Input : ID2D1PixelShader
+    internal partial struct ShaderWith1Input : ID2D1PixelShader
     {
         public float4 Execute()
         {
@@ -508,7 +508,7 @@ public partial class PixelShaderEffectTests
     [D2DInputSimple(0)]
     [D2DInputSimple(1)]
     [D2DGeneratedPixelShaderDescriptor]
-    private partial struct ShaderWith2Inputs : ID2D1PixelShader
+    internal partial struct ShaderWith2Inputs : ID2D1PixelShader
     {
         public float4 Execute()
         {

--- a/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
@@ -146,7 +146,7 @@ public partial class DeviceDisposalTests
     [EmbeddedBytecode(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     [AutoConstructor]
-    private readonly partial struct InitializeShader : IComputeShader
+    internal readonly partial struct InitializeShader : IComputeShader
     {
         private readonly ReadWriteBuffer<float> buffer;
 
@@ -179,7 +179,7 @@ public partial class DeviceDisposalTests
 
     [EmbeddedBytecode(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
-    private partial struct HelloWorldShader : IComputeShader<float4>
+    internal partial struct HelloWorldShader : IComputeShader<float4>
     {
         public float4 Execute()
         {

--- a/tests/ComputeSharp.Tests.SourceGenerators/AnalyzerTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/AnalyzerTests.cs
@@ -1,0 +1,36 @@
+using System.Threading.Tasks;
+using ComputeSharp.SourceGenerators;
+using ComputeSharp.Tests.SourceGenerators.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.Tests.SourceGenerators;
+
+[TestClass]
+[TestCategory("Analyzers")]
+public class AnalyzerTests
+{
+    [TestMethod]
+    public async Task InvalidShaderField()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            namespace MyFancyApp.Sample;
+
+            public partial class Foo
+            {
+                [{|CMPS0055:GeneratedComputeShaderDescriptor|}]
+                private partial struct MyShader : IComputeShader
+                {
+                    public ReadWriteBuffer<float> buffer;
+
+                    public void Execute()
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+}

--- a/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
@@ -1,10 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+    <RestoreSources>
+      https://api.nuget.org/v3/index.json;
+      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
+    </RestoreSources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="1.4.5" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />

--- a/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
@@ -1,0 +1,55 @@
+extern alias Core;
+extern alias D3D12;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis;
+
+namespace ComputeSharp.Tests.SourceGenerators.Helpers;
+
+/// <summary>
+/// A custom <see cref="CSharpAnalyzerTest{TAnalyzer, TVerifier}"/> that uses a specific C# language version to parse code.
+/// </summary>
+/// <typeparam name="TAnalyzer">The type of the analyzer to test.</typeparam>
+internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, MSTestVerifier>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+{
+    /// <summary>
+    /// The C# language version to use to parse code.
+    /// </summary>
+    private readonly LanguageVersion languageVersion;
+
+    /// <summary>
+    /// Creates a new <see cref="CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}"/> instance with the specified paramaters.
+    /// </summary>
+    /// <param name="languageVersion">The C# language version to use to parse code.</param>
+    private CSharpAnalyzerWithLanguageVersionTest(LanguageVersion languageVersion)
+    {
+        this.languageVersion = languageVersion;
+    }
+
+    /// <inheritdoc/>
+    protected override ParseOptions CreateParseOptions()
+    {
+        return new CSharpParseOptions(this.languageVersion, DocumentationMode.Diagnose);
+    }
+
+    /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync"/>
+    /// <param name="source">The source code to analyze.</param>
+    /// <param name="languageVersion">The language version to use to run the test.</param>
+    public static Task VerifyAnalyzerAsync(string source, LanguageVersion languageVersion = LanguageVersion.CSharp11)
+    {
+        CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> test = new(languageVersion) { TestCode = source };
+
+        test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Core::ComputeSharp.Hlsl).Assembly.Location));
+        test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(D3D12::ComputeSharp.IComputeShader).Assembly.Location));
+
+        return test.RunAsync(CancellationToken.None);
+    }
+}


### PR DESCRIPTION
### Description

As part of the work to centralize the generation logic (so that it becomes reasonable to add more complicated logic as well, such as support for primary constructor, support for fields that are not publicly visible, etc.), all constant buffer marshalling logic will be shared across the D2D1 and D3D12 generator, and specifically it will also go into a new `ConstantBufferMarshaller` generated type, which will reference the shader type and the constant buffer. For this to work (as well as for the ability to interact with all fields as well), the shader types must have at least internal accessibility, or the generated code would be invalid.

This PR adds a new analyzer to emit an error when that is not the case (for both the D3D12 and D2D1 generators). Additionally, it disable the generator if the annotated type is not accessible. As precedent, the COM interop generator does exactly the same.