### PR TITLE
Add diagnostic for invalid linking D2D compile option

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -75,3 +75,4 @@ CMPSD2D0065 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://gith
 CMPSD2D0066 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0067 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0068 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0069 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -145,7 +145,7 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
                     token.ThrowIfCancellationRequested();
 
                     // Get the shader profile and linking info for LoadBytecode()
-                    bool isLinkingSupported = HlslBytecode.IsSimpleInputShader(typeSymbol, inputCount);
+                    bool isLinkingSupported = HlslBytecode.IsSimpleInputShader(context.SemanticModel.Compilation, typeSymbol, inputCount);
                     D2D1ShaderProfile? requestedShaderProfile = HlslBytecode.GetRequestedShaderProfile(typeSymbol);
                     D2D1CompileOptions? requestedCompileOptions = HlslBytecode.GetRequestedCompileOptions(diagnostics, typeSymbol);
                     D2D1ShaderProfile effectiveShaderProfile = HlslBytecode.GetEffectiveShaderProfile(requestedShaderProfile, out bool isCompilationEnabled);

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer.cs
@@ -1,0 +1,67 @@
+using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error whenever [D2DCompileOptions] is used on a shader type to request linking when not supported.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidD2D1CompileOptionsEnableLinkingOnShaderType);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the [D2DCompileOptions], [D2DInputCount] and [D2DInputSimple] symbols
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute") is not { } d2DCompileOptionsAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DInputCountAttribute") is not { } d2DInputCountAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DInputSimpleAttribute") is not { } d2DInputSimpleAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only struct types are possible targets
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // If the type is not using [D2DCompileOptions] with D2D1CompileOptions.EnableLinking, there's nothing to do
+                if (!typeSymbol.TryGetAttributeWithType(d2DCompileOptionsAttributeSymbol, out AttributeData? compileOptionsAttribute) ||
+                    !((D2D1CompileOptions)compileOptionsAttribute.ConstructorArguments[0].Value!).HasFlag(D2D1CompileOptions.EnableLinking))
+                {
+                    return;
+                }
+
+                // Make sure we have the [D2DInputCount] (if not present, the shader is invalid anyway) and with a valid value
+                if (!typeSymbol.TryGetAttributeWithType(d2DInputCountAttributeSymbol, out AttributeData? inputCountAttribute) ||
+                    inputCountAttribute.ConstructorArguments is not [{ Value: >= 0 and < 8 and int inputCount }])
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if the compile options are not valid for the shader type
+                if (!D2DPixelShaderDescriptorGenerator.HlslBytecode.IsSimpleInputShader(typeSymbol, d2DInputSimpleAttributeSymbol, inputCount))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InvalidD2D1CompileOptionsEnableLinkingOnShaderType,
+                        compileOptionsAttribute.GetLocation(),
+                        typeSymbol));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1022,4 +1022,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "The [D2DGeneratedPixelShaderDescriptor] attribute requires the type of all fields of target types to be accessible from their containing assembly.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an invalid use of <c>[D2DCompileOptions]</c> requesting to enable linking.
+    /// <para>
+    /// Format: <c>"The D2D1 shader of type {0} cannot use D2D1CompileOptions.EnableLinking in its [D2DCompileOptions] attribute, as it doesn't support linking (only D2D1 shaders with no complex inputs can use this option)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidD2D1CompileOptionsEnableLinkingOnShaderType = new(
+        id: "CMPSD2D0069",
+        title: "Invalid [D2DResourceTextureIndex] use",
+        messageFormat: """The D2D1 shader of type {0} cannot use D2D1CompileOptions.EnableLinking in its [D2DCompileOptions] attribute, as it doesn't support linking (only D2D1 shaders with no complex inputs can use this option)""",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A D2D1 shader cannot use D2D1CompileOptions.EnableLinking in its [D2DCompileOptions] attribute if it doesn't support linking (only D2D1 shaders with no complex inputs can use this option).",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
@@ -5,6 +5,7 @@
       https://api.nuget.org/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
     </RestoreSources>
+    <DefineConstants>$(DefineConstants);D2D1_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,5 +23,9 @@
     <ProjectReference Include="..\..\src\ComputeSharp.D2D1\ComputeSharp.D2D1.csproj" Aliases="D2D1" />
     <ProjectReference Include="..\..\src\ComputeSharp.D2D1.CodeFixers\ComputeSharp.D2D1.CodeFixers.csproj" />
     <ProjectReference Include="..\..\src\ComputeSharp.D2D1.SourceGenerators\ComputeSharp.D2D1.SourceGenerators.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\ComputeSharp.Tests.SourceGenerators\Helpers\CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs" Link="Helpers\CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs" />
   </ItemGroup>
 </Project>

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer.cs
@@ -1,0 +1,117 @@
+using System.Threading.Tasks;
+using ComputeSharp.D2D1.SourceGenerators;
+using ComputeSharp.Tests.SourceGenerators.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.D2D1.Tests.SourceGenerators;
+
+[TestClass]
+public class Test_InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer
+{
+    [TestMethod]
+    public async Task NoCompileOptionsDoesNotWarn()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            public partial class Foo
+            {
+                [D2DInputCount(0)]
+                private partial struct MyShader : ID2D1PixelShader
+                {
+                    public Float4 Execute() => 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ValidCompileOptionsDoesNotWarn()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            public partial class Foo
+            {
+                [D2DInputCount(0)]
+                [D2DCompileOptions(D2D1CompileOptions.PackMatrixRowMajor)]
+                private partial struct MyShader : ID2D1PixelShader
+                {
+                    public Float4 Execute() => 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task EnableLinkingWithNoInputCountDoesNotWarn()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            public partial class Foo
+            {
+                [D2DInputComplex(0)]
+                [D2DCompileOptions(D2D1CompileOptions.EnableLinking)]
+                private partial struct MyShader : ID2D1PixelShader
+                {
+                    public Float4 Execute() => 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task EnableLinkingWithImplicitComplexInputWarns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            public partial class Foo
+            {
+                [D2DInputCount(2)]
+                [D2DInputSimple(1)]
+                [{|CMPSD2D0069:D2DCompileOptions(D2D1CompileOptions.Default | D2D1CompileOptions.EnableLinking)|}]
+                private partial struct MyShader : ID2D1PixelShader
+                {
+                    public Float4 Execute() => 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task EnableLinkingWithExplicitComplexInputWarns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            public partial class Foo
+            {
+                [D2DInputCount(2)]
+                [D2DInputSimple(0)]
+                [D2DInputComplex(1)]
+                [{|CMPSD2D0069:D2DCompileOptions(D2D1CompileOptions.Default | D2D1CompileOptions.EnableLinking)|}]
+                private partial struct MyShader : ID2D1PixelShader
+                {
+                    public Float4 Execute() => 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+}

--- a/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
@@ -1,5 +1,9 @@
 extern alias Core;
+#if D2D1_TESTS
+extern alias D2D1;
+#else
 extern alias D3D12;
+#endif
 
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,7 +52,11 @@ internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpA
 
         test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Core::ComputeSharp.Hlsl).Assembly.Location));
+#if D2D1_TESTS
+        test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(D2D1::ComputeSharp.D2D1.ID2D1PixelShader).Assembly.Location));
+#else
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(D3D12::ComputeSharp.IComputeShader).Assembly.Location));
+#endif
 
         return test.RunAsync(CancellationToken.None);
     }


### PR DESCRIPTION
### Closes #462 (and contributes to #598)

### Description

This PR adds a diagnostic (warning) when a D2D shader has the `EnableLinking` option set, but has any complex inputs.