### PR TITLE
Rename [EmbeddedBytecode] attribute

### DIFF
--- a/samples/ComputeSharp.Benchmark/Blas/BlasHelpers.cs
+++ b/samples/ComputeSharp.Benchmark/Blas/BlasHelpers.cs
@@ -81,7 +81,7 @@ internal static partial class BlasHelpers
     /// Kernel for <see cref="FullyConnectedForwardGpu"/>.
     /// </summary>
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct FullyConnectedForwardKernel : IComputeShader
     {

--- a/samples/ComputeSharp.Benchmark/Blas/BlasHelpers.cs
+++ b/samples/ComputeSharp.Benchmark/Blas/BlasHelpers.cs
@@ -81,7 +81,7 @@ internal static partial class BlasHelpers
     /// Kernel for <see cref="FullyConnectedForwardGpu"/>.
     /// </summary>
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct FullyConnectedForwardKernel : IComputeShader
     {

--- a/samples/ComputeSharp.Benchmark/Dispatching/DispatchingBenchmark.cs
+++ b/samples/ComputeSharp.Benchmark/Dispatching/DispatchingBenchmark.cs
@@ -109,7 +109,7 @@ public partial class DispatchingBenchmark : IDisposable
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct TestShader : IComputeShader
     {

--- a/samples/ComputeSharp.Benchmark/Dispatching/DispatchingBenchmark.cs
+++ b/samples/ComputeSharp.Benchmark/Dispatching/DispatchingBenchmark.cs
@@ -109,7 +109,7 @@ public partial class DispatchingBenchmark : IDisposable
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct TestShader : IComputeShader
     {

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.Implementation.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.Implementation.cs
@@ -308,7 +308,7 @@ public sealed partial class HlslBokehBlurProcessor
         /// Kernel for the vertical convolution pass.
         /// </summary>
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.XY)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct VerticalConvolutionProcessor : IComputeShader
         {
@@ -347,7 +347,7 @@ public sealed partial class HlslBokehBlurProcessor
         /// Kernel for the horizontal convolution pass.
         /// </summary>
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.XY)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct HorizontalConvolutionAndAccumulatePartialsProcessor : IComputeShader
         {
@@ -388,7 +388,7 @@ public sealed partial class HlslBokehBlurProcessor
         /// Kernel for the gamma highlight pass.
         /// </summary>
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct GammaHighlightProcessor : IComputeShader
         {
@@ -414,7 +414,7 @@ public sealed partial class HlslBokehBlurProcessor
         /// Kernel for the inverse gamma highlight pass.
         /// </summary>
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct InverseGammaHighlightProcessor : IComputeShader
         {

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.Implementation.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.Implementation.cs
@@ -308,7 +308,7 @@ public sealed partial class HlslBokehBlurProcessor
         /// Kernel for the vertical convolution pass.
         /// </summary>
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.XY)]
+        [ThreadGroupSize(DispatchAxis.XY)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct VerticalConvolutionProcessor : IComputeShader
         {
@@ -347,7 +347,7 @@ public sealed partial class HlslBokehBlurProcessor
         /// Kernel for the horizontal convolution pass.
         /// </summary>
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.XY)]
+        [ThreadGroupSize(DispatchAxis.XY)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct HorizontalConvolutionAndAccumulatePartialsProcessor : IComputeShader
         {
@@ -388,7 +388,7 @@ public sealed partial class HlslBokehBlurProcessor
         /// Kernel for the gamma highlight pass.
         /// </summary>
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct GammaHighlightProcessor : IComputeShader
         {
@@ -414,7 +414,7 @@ public sealed partial class HlslBokehBlurProcessor
         /// Kernel for the inverse gamma highlight pass.
         /// </summary>
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct InverseGammaHighlightProcessor : IComputeShader
         {

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.Implementation.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.Implementation.cs
@@ -118,7 +118,7 @@ public sealed partial class HlslGaussianBlurProcessor
         /// Kernel for the vertical convolution pass.
         /// </summary>
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.XY)]
+        [ThreadGroupSize(DispatchAxis.XY)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct VerticalConvolutionProcessor : IComputeShader
         {
@@ -152,7 +152,7 @@ public sealed partial class HlslGaussianBlurProcessor
         /// Kernel for the horizontal convolution pass.
         /// </summary>
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.XY)]
+        [ThreadGroupSize(DispatchAxis.XY)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct HorizontalConvolutionProcessor : IComputeShader
         {

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.Implementation.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.Implementation.cs
@@ -118,7 +118,7 @@ public sealed partial class HlslGaussianBlurProcessor
         /// Kernel for the vertical convolution pass.
         /// </summary>
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.XY)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct VerticalConvolutionProcessor : IComputeShader
         {
@@ -152,7 +152,7 @@ public sealed partial class HlslGaussianBlurProcessor
         /// Kernel for the horizontal convolution pass.
         /// </summary>
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.XY)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct HorizontalConvolutionProcessor : IComputeShader
         {

--- a/samples/ComputeSharp.Sample.FSharp.Shaders/MultiplyByTwo.cs
+++ b/samples/ComputeSharp.Sample.FSharp.Shaders/MultiplyByTwo.cs
@@ -4,7 +4,7 @@ namespace ComputeSharp.Sample.FSharp.Shaders;
 /// A sample shader thaat just multiplies items in a buffer by two.
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.X)]
+[ThreadGroupSize(DispatchAxis.X)]
 [GeneratedComputeShaderDescriptor]
 public readonly partial struct MultiplyByTwo : IComputeShader
 {

--- a/samples/ComputeSharp.Sample.FSharp.Shaders/MultiplyByTwo.cs
+++ b/samples/ComputeSharp.Sample.FSharp.Shaders/MultiplyByTwo.cs
@@ -4,7 +4,7 @@ namespace ComputeSharp.Sample.FSharp.Shaders;
 /// A sample shader thaat just multiplies items in a buffer by two.
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.X)]
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
 [GeneratedComputeShaderDescriptor]
 public readonly partial struct MultiplyByTwo : IComputeShader
 {

--- a/samples/ComputeSharp.Sample/Program.cs
+++ b/samples/ComputeSharp.Sample/Program.cs
@@ -24,7 +24,7 @@ Formatting.PrintMatrix(array, 10, 10, "AFTER");
 /// The sample kernel that multiples all items by two.
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.X)]
+[ThreadGroupSize(DispatchAxis.X)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct MultiplyByTwo : IComputeShader
 {

--- a/samples/ComputeSharp.Sample/Program.cs
+++ b/samples/ComputeSharp.Sample/Program.cs
@@ -24,7 +24,7 @@ Formatting.PrintMatrix(array, 10, 10, "AFTER");
 /// The sample kernel that multiples all items by two.
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.X)]
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct MultiplyByTwo : IComputeShader
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ColorfulInfinity.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ColorfulInfinity.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ColorfulInfinity : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ColorfulInfinity.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ColorfulInfinity.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ColorfulInfinity : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ContouredLayers.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ContouredLayers.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ContouredLayers : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ContouredLayers.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ContouredLayers.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ContouredLayers : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ExtrudedTruchetPattern.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ExtrudedTruchetPattern.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ExtrudedTruchetPattern : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ExtrudedTruchetPattern.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ExtrudedTruchetPattern.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ExtrudedTruchetPattern : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/FourColorGradient.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/FourColorGradient.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct FourColorGradient : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/FourColorGradient.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/FourColorGradient.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct FourColorGradient : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/FractalTiling.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/FractalTiling.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct FractalTiling : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/FractalTiling.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/FractalTiling.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct FractalTiling : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/HelloWorld.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/HelloWorld.cs
@@ -5,7 +5,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/new"/>.
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct HelloWorld : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/HelloWorld.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/HelloWorld.cs
@@ -5,7 +5,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/new"/>.
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct HelloWorld : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/MengerJourney.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/MengerJourney.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Syntopia.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct MengerJourney : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/MengerJourney.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/MengerJourney.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Syntopia.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct MengerJourney : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/Octagrams.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/Octagrams.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by whisky_shusuky.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct Octagrams : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/Octagrams.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/Octagrams.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by whisky_shusuky.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct Octagrams : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ProteanClouds.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ProteanClouds.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ProteanClouds : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ProteanClouds.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ProteanClouds.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ProteanClouds : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/PyramidPattern.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/PyramidPattern.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct PyramidPattern : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/PyramidPattern.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/PyramidPattern.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct PyramidPattern : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TerracedHills.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TerracedHills.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TerracedHills : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TerracedHills.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TerracedHills.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TerracedHills : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TriangleGridContouring.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TriangleGridContouring.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TriangleGridContouring : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TriangleGridContouring.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TriangleGridContouring.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TriangleGridContouring : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TwoTiledTruchet.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TwoTiledTruchet.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TwoTiledTruchet : IComputeShader<float4>
 {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TwoTiledTruchet.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TwoTiledTruchet.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TwoTiledTruchet : IComputeShader<float4>
 {

--- a/src/ComputeSharp.CodeFixers/MissingComputeShaderDescriptorOnComputeShaderCodeFixer.cs
+++ b/src/ComputeSharp.CodeFixers/MissingComputeShaderDescriptorOnComputeShaderCodeFixer.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 
-namespace ComputeSharp.D2D1.CodeFixers;
+namespace ComputeSharp.CodeFixers;
 
 /// <summary>
 /// A code fixer that adds the <c>[GeneratedComputeShaderDescriptor]</c> to compute shader types with no descriptor.

--- a/src/ComputeSharp.CodeFixers/MissingComputeShaderDescriptorOnComputeShaderCodeFixer.cs
+++ b/src/ComputeSharp.CodeFixers/MissingComputeShaderDescriptorOnComputeShaderCodeFixer.cs
@@ -16,9 +16,9 @@ public sealed class MissingComputeShaderDescriptorOnComputeShaderCodeFixer : Mis
     /// <summary>
     /// The set of type names for all attributes that can be over shader types.
     /// </summary>
-    private static readonly string[] D2DAttributeTypeNames =
+    private static readonly string[] AttributeTypeNames =
     [
-        "ComputeSharp.EmbeddedBytecodeAttribute",
+        "ComputeSharp.ThreadGroupSizeAttribute",
         "ComputeSharp.GroupSharedAttribute"
     ];
 
@@ -30,7 +30,7 @@ public sealed class MissingComputeShaderDescriptorOnComputeShaderCodeFixer : Mis
             diagnosticId: MissingComputeShaderDescriptorOnComputeShaderTypeId,
             codeActionTitle: "Add [GeneratedComputeShaderDescriptor] attribute",
             attributeFullyQualifiedMetadataName: "ComputeSharp.GeneratedComputeShaderDescriptorAttribute",
-            leadingAttributeFullyQualifiedMetadataNames: D2DAttributeTypeNames)
+            leadingAttributeFullyQualifiedMetadataNames: AttributeTypeNames)
     {
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.cs
@@ -250,14 +250,14 @@ partial class D2DPixelShaderDescriptorGenerator
             if (info is HlslBytecodeInfo.Win32Error win32Error)
             {
                 diagnostic = DiagnosticInfo.Create(
-                    EmbeddedBytecodeFailedWithWin32Exception,
+                    HlslBytecodeFailedWithWin32Exception,
                     structDeclarationSymbol,
                     [structDeclarationSymbol, win32Error.HResult, win32Error.Message]);
             }
             else if (info is HlslBytecodeInfo.CompilerError fxcError)
             {
                 diagnostic = DiagnosticInfo.Create(
-                    EmbeddedBytecodeFailedWithFxcCompilationException,
+                    HlslBytecodeFailedWithFxcCompilationException,
                     structDeclarationSymbol,
                     [structDeclarationSymbol, fxcError.Message]);
             }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -445,14 +445,14 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode shader failed due to a Win32 exception.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for HLSL bytecode shader failed due to a Win32 exception.
     /// <para>
     /// Format: <c>"The shader of type {0} failed to compile due to a Win32 exception (HRESULT: {1:X8}, Message: "{2}")"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor EmbeddedBytecodeFailedWithWin32Exception = new(
+    public static readonly DiagnosticDescriptor HlslBytecodeFailedWithWin32Exception = new(
         id: "CMPSD2D0033",
-        title: "Embedded bytecode compilation failed due to Win32 exception",
+        title: "HLSL bytecode compilation failed due to Win32 exception",
         messageFormat: """The shader of type {0} failed to compile due to a Win32 exception (HRESULT: {1:X8}, Message: "{2}")""",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
@@ -461,14 +461,14 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode shader failed due to an HLSL compilation exception.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for HLSL bytecode shader failed due to an HLSL compilation exception.
     /// <para>
     /// Format: <c>"The shader of type {0} failed to compile due to an HLSL compiler error (Message: "{1}")"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor EmbeddedBytecodeFailedWithFxcCompilationException = new(
+    public static readonly DiagnosticDescriptor HlslBytecodeFailedWithFxcCompilationException = new(
         id: "CMPSD2D0034",
-        title: "Embedded bytecode compilation failed due to an HLSL compiler error",
+        title: "HLSL bytecode compilation failed due to an HLSL compiler error",
         messageFormat: """The shader of type {0} failed to compile due to an HLSL compiler error (Message: "{1}")""",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
@@ -106,14 +106,14 @@ partial class ComputeShaderDescriptorGenerator
             if (info is HlslBytecodeInfo.Win32Error win32Error)
             {
                 diagnostic = DiagnosticInfo.Create(
-                    EmbeddedBytecodeFailedWithWin32Exception,
+                    HlslBytecodeFailedWithWin32Exception,
                     structDeclarationSymbol,
                     [structDeclarationSymbol, win32Error.HResult, win32Error.Message]);
             }
             else if (info is HlslBytecodeInfo.CompilerError dxcError)
             {
                 diagnostic = DiagnosticInfo.Create(
-                    EmbeddedBytecodeFailedWithDxcCompilationException,
+                    HlslBytecodeFailedWithDxcCompilationException,
                     structDeclarationSymbol,
                     [structDeclarationSymbol, dxcError.Message]);
             }

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -129,7 +129,7 @@ partial class ComputeShaderDescriptorGenerator
                     continue;
                 }
 
-                AttributeData? attribute = fieldSymbol.GetAttributes().FirstOrDefault(static a => a.AttributeClass?.ToDisplayString() == typeof(GroupSharedAttribute).FullName);
+                AttributeData? attribute = fieldSymbol.GetAttributes().FirstOrDefault(static a => a.AttributeClass?.ToDisplayString() == "ComputeSharp.GroupSharedAttribute");
 
                 // Group shared fields must be static
                 if (attribute is not null)
@@ -224,7 +224,7 @@ partial class ComputeShaderDescriptorGenerator
                         continue;
                     }
 
-                    AttributeData? attribute = fieldSymbol.GetAttributes().FirstOrDefault(static a => a.AttributeClass?.ToDisplayString() == typeof(GroupSharedAttribute).FullName);
+                    AttributeData? attribute = fieldSymbol.GetAttributes().FirstOrDefault(static a => a.AttributeClass?.ToDisplayString() == "ComputeSharp.GroupSharedAttribute");
 
                     if (attribute is not null)
                     {
@@ -284,7 +284,7 @@ partial class ComputeShaderDescriptorGenerator
                     continue;
                 }
 
-                AttributeData? attribute = fieldSymbol.GetAttributes().FirstOrDefault(static a => a.AttributeClass?.ToDisplayString() == typeof(GroupSharedAttribute).FullName);
+                AttributeData? attribute = fieldSymbol.GetAttributes().FirstOrDefault(static a => a.AttributeClass?.ToDisplayString() == "ComputeSharp.GroupSharedAttribute");
 
                 if (attribute is null)
                 {

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.NumThreads.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.NumThreads.cs
@@ -46,24 +46,24 @@ partial class ComputeShaderDescriptorGenerator
             // Check for a dispatch axis argument first
             if (attribute.ConstructorArguments.Length == 1)
             {
-                int dispatchAxis = (int)attribute.ConstructorArguments[0].Value!;
+                int defaultSize = (int)attribute.ConstructorArguments[0].Value!;
 
-                (threadsX, threadsY, threadsZ) = (DispatchAxis)dispatchAxis switch
+                (threadsX, threadsY, threadsZ) = (DefaultThreadGroupSizes)defaultSize switch
                 {
-                    DispatchAxis.X => (64, 1, 1),
-                    DispatchAxis.Y => (1, 64, 1),
-                    DispatchAxis.Z => (1, 1, 64),
-                    DispatchAxis.XY => (8, 8, 1),
-                    DispatchAxis.XZ => (8, 1, 8),
-                    DispatchAxis.YZ => (1, 8, 8),
-                    DispatchAxis.XYZ => (4, 4, 4),
+                    DefaultThreadGroupSizes.X => (64, 1, 1),
+                    DefaultThreadGroupSizes.Y => (1, 64, 1),
+                    DefaultThreadGroupSizes.Z => (1, 1, 64),
+                    DefaultThreadGroupSizes.XY => (8, 8, 1),
+                    DefaultThreadGroupSizes.XZ => (8, 1, 8),
+                    DefaultThreadGroupSizes.YZ => (1, 8, 8),
+                    DefaultThreadGroupSizes.XYZ => (4, 4, 4),
                     _ => (0, 0, 0)
                 };
 
                 // Validate the dispatch axis argument
                 if ((threadsX, threadsY, threadsZ) is (0, 0, 0))
                 {
-                    diagnostics.Add(InvalidThreadGroupSizeAttributeDefaultThreadGroupSize, structDeclarationSymbol, structDeclarationSymbol);
+                    diagnostics.Add(InvalidThreadGroupSizeAttributeDefaultThreadGroupSizes, structDeclarationSymbol, structDeclarationSymbol);
 
                     threadsX = threadsY = threadsZ = 0;
                     isCompilationEnabled = false;

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.NumThreads.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.NumThreads.cs
@@ -33,7 +33,7 @@ partial class ComputeShaderDescriptorGenerator
             out bool isCompilationEnabled)
         {
             // Try to get the attribute that controls shader precompilation (this is always required)
-            if (!structDeclarationSymbol.TryGetAttributeWithFullyQualifiedMetadataName(typeof(ThreadGroupSizeAttribute).FullName, out AttributeData? attribute))
+            if (!structDeclarationSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.ThreadGroupSizeAttribute", out AttributeData? attribute))
             {
                 diagnostics.Add(MissingThreadGroupSizeAttribute, structDeclarationSymbol, structDeclarationSymbol);
 

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.NumThreads.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.NumThreads.cs
@@ -33,10 +33,9 @@ partial class ComputeShaderDescriptorGenerator
             out bool isCompilationEnabled)
         {
             // Try to get the attribute that controls shader precompilation (this is always required)
-            if (!structDeclarationSymbol.TryGetAttributeWithFullyQualifiedMetadataName(typeof(EmbeddedBytecodeAttribute).FullName, out AttributeData? attribute))
+            if (!structDeclarationSymbol.TryGetAttributeWithFullyQualifiedMetadataName(typeof(ThreadGroupSizeAttribute).FullName, out AttributeData? attribute))
             {
-                // Emit the diagnostics if dynamic shaders are not supported
-                diagnostics.Add(MissingEmbeddedBytecodeAttributeWhenDynamicShaderCompilationIsNotSupported, structDeclarationSymbol, structDeclarationSymbol);
+                diagnostics.Add(MissingThreadGroupSizeAttribute, structDeclarationSymbol, structDeclarationSymbol);
 
                 threadsX = threadsY = threadsZ = 0;
                 isCompilationEnabled = false;
@@ -64,7 +63,7 @@ partial class ComputeShaderDescriptorGenerator
                 // Validate the dispatch axis argument
                 if ((threadsX, threadsY, threadsZ) is (0, 0, 0))
                 {
-                    diagnostics.Add(InvalidEmbeddedBytecodeDispatchAxis, structDeclarationSymbol, structDeclarationSymbol);
+                    diagnostics.Add(InvalidThreadGroupSizeAttributeDefaultThreadGroupSize, structDeclarationSymbol, structDeclarationSymbol);
 
                     threadsX = threadsY = threadsZ = 0;
                     isCompilationEnabled = false;
@@ -84,7 +83,7 @@ partial class ComputeShaderDescriptorGenerator
                 explicitThreadsZ is < 1 or > 64)
             {
                 // Failed to validate the thread number arguments
-                diagnostics.Add(InvalidEmbeddedBytecodeThreadIds, structDeclarationSymbol, structDeclarationSymbol);
+                diagnostics.Add(InvalidThreadGroupSizeAttributeValues, structDeclarationSymbol, structDeclarationSymbol);
 
                 threadsX = threadsY = threadsZ = 0;
                 isCompilationEnabled = false;

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -59,9 +59,9 @@
     <Compile Include="..\ComputeSharp.Core\Primitives\MatrixIndex.cs" Link="ComputeSharp.Core\Primitives\MatrixIndex.cs" />
 
     <!-- ComputeSharp APIs -->
-    <Compile Include="..\ComputeSharp\Core\Attributes\EmbeddedBytecodeAttribute.cs" Link="ComputeSharp\Core\Attributes\EmbeddedBytecodeAttribute.cs" />
     <Compile Include="..\ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" Link="ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" />
     <Compile Include="..\ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" Link="ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" />
+    <Compile Include="..\ComputeSharp\Core\Attributes\ThreadGroupSizeAttribute.cs" Link="ComputeSharp\Core\Attributes\ThreadGroupSizeAttribute.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchAxis.cs" Link="ComputeSharp\Core\Dispatch\DispatchAxis.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchSize.cs" Link="ComputeSharp\Core\Dispatch\DispatchSize.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\GridIds.cs" Link="ComputeSharp\Core\Dispatch\GridIds.cs" />

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -60,9 +60,9 @@
 
     <!-- ComputeSharp APIs -->
     <Compile Include="..\ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" Link="ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" />
+    <Compile Include="..\ComputeSharp\Core\Attributes\Enums\DefaultThreadGroupSizes.cs" Link="ComputeSharp\Core\Attributes\Enums\DefaultThreadGroupSizes.cs" />
     <Compile Include="..\ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" Link="ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" />
     <Compile Include="..\ComputeSharp\Core\Attributes\ThreadGroupSizeAttribute.cs" Link="ComputeSharp\Core\Attributes\ThreadGroupSizeAttribute.cs" />
-    <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchAxis.cs" Link="ComputeSharp\Core\Dispatch\DispatchAxis.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchSize.cs" Link="ComputeSharp\Core\Dispatch\DispatchSize.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\GridIds.cs" Link="ComputeSharp\Core\Dispatch\GridIds.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\GroupIds.cs" Link="ComputeSharp\Core\Dispatch\GroupIds.cs" />

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -61,7 +61,6 @@
     <!-- ComputeSharp APIs -->
     <Compile Include="..\ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" Link="ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" />
     <Compile Include="..\ComputeSharp\Core\Attributes\Enums\DefaultThreadGroupSizes.cs" Link="ComputeSharp\Core\Attributes\Enums\DefaultThreadGroupSizes.cs" />
-    <Compile Include="..\ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" Link="ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchSize.cs" Link="ComputeSharp\Core\Dispatch\DispatchSize.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\GridIds.cs" Link="ComputeSharp\Core\Dispatch\GridIds.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\GroupIds.cs" Link="ComputeSharp\Core\Dispatch\GroupIds.cs" />

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -62,7 +62,6 @@
     <Compile Include="..\ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" Link="ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" />
     <Compile Include="..\ComputeSharp\Core\Attributes\Enums\DefaultThreadGroupSizes.cs" Link="ComputeSharp\Core\Attributes\Enums\DefaultThreadGroupSizes.cs" />
     <Compile Include="..\ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" Link="ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" />
-    <Compile Include="..\ComputeSharp\Core\Attributes\ThreadGroupSizeAttribute.cs" Link="ComputeSharp\Core\Attributes\ThreadGroupSizeAttribute.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchSize.cs" Link="ComputeSharp\Core\Dispatch\DispatchSize.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\GridIds.cs" Link="ComputeSharp\Core\Dispatch\GridIds.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\GroupIds.cs" Link="ComputeSharp\Core\Dispatch\GroupIds.cs" />

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -654,19 +654,19 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode shader with an invalid dispatch axis value.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for shaders shader with an invalid DefaultThreadGroupSizes value.
     /// <para>
-    /// Format: <c>"The shader of type {0} is using an invalid DefaultThreadGroupSize value in its [ThreadGroupSize] attribute"</c>.
+    /// Format: <c>"The shader of type {0} is using an invalid DefaultThreadGroupSizes value in its [ThreadGroupSize] attribute"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor InvalidThreadGroupSizeAttributeDefaultThreadGroupSize = new(
+    public static readonly DiagnosticDescriptor InvalidThreadGroupSizeAttributeDefaultThreadGroupSizes = new(
         id: "CMPS0048",
-        title: "Invalid DefaultThreadGroupSize value for [ThreadGroupSize] use",
-        messageFormat: "The shader of type {0} is using an invalid DefaultThreadGroupSize value in its [ThreadGroupSize] attribute",
+        title: "Invalid DefaultThreadGroupSizes value for [ThreadGroupSize] use",
+        messageFormat: "The shader of type {0} is using an invalid DefaultThreadGroupSizes value in its [ThreadGroupSize] attribute",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The DefaultThreadGroupSize value for [ThreadGroupSize] attributes have to be valid.",
+        description: "The DefaultThreadGroupSizes value for [ThreadGroupSize] attributes have to be valid.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -590,83 +590,83 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode shader with invalid thread ids values.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for invalid thread group sizes.
     /// <para>
-    /// Format: <c>"The shader of type {0} is annotated with invalid thread ids values"</c>.
+    /// Format: <c>"The shader of type {0} is annotated with invalid [ThreadGroupSize] values"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor InvalidEmbeddedBytecodeThreadIds = new(
+    public static readonly DiagnosticDescriptor InvalidThreadGroupSizeAttributeValues = new(
         id: "CMPS0044",
-        title: "Invalid thread ids for shader with embedded bytecode",
-        messageFormat: "The shader of type {0} is annotated with invalid thread ids values",
+        title: "Invalid values for [ThreadGroupSize] attribute",
+        messageFormat: "The shader of type {0} is annotated with invalid [ThreadGroupSize] values",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The thread ids values for a shader marked as embedded bytecode have to be in the valid range.",
+        description: "The thread group sizes for [ThreadGroupSize] have to be in the valid range.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode shader failed due to a Win32 exception.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for HLSL bytecode shader failed due to a Win32 exception.
     /// <para>
     /// Format: <c>"The shader of type {0} failed to compile due to a Win32 exception (HRESULT: {1:X8}, Message: "{2}")"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor EmbeddedBytecodeFailedWithWin32Exception = new(
+    public static readonly DiagnosticDescriptor HlslBytecodeFailedWithWin32Exception = new(
         id: "CMPS0045",
-        title: "Embedded bytecode compilation failed due to Win32 exception",
+        title: "HLSL bytecode compilation failed due to Win32 exception",
         messageFormat: """The shader of type {0} failed to compile due to a Win32 exception (HRESULT: {1:X8}, Message: "{2}")""",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The embedded bytecode for a shader failed to be compiled due to a Win32 exception.",
+        description: "The HLSL bytecode for a shader failed to be compiled due to a Win32 exception.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode shader failed due to an HLSL compilation exception.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for HLSL bytecode shader failed due to an HLSL compilation exception.
     /// <para>
-    /// Format: <c>"The shader of type {{0}} failed to compile due to an HLSL compiler error (Message: "{1}")"</c>.
+    /// Format: <c>"The shader of type {0} failed to compile due to an HLSL compiler error (Message: "{1}")"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor EmbeddedBytecodeFailedWithDxcCompilationException = new(
+    public static readonly DiagnosticDescriptor HlslBytecodeFailedWithDxcCompilationException = new(
         id: "CMPS0046",
-        title: "Embedded bytecode compilation failed due to an HLSL compiler error",
+        title: "HLSL bytecode compilation failed due to an HLSL compiler error",
         messageFormat: """The shader of type {0} failed to compile due to an HLSL compiler error (Message: "{1}")""",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The embedded bytecode for a shader failed to be compiled due to an HLSL compiler error.",
+        description: "The HLSL bytecode for a shader failed to be compiled due to an HLSL compiler error.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader without the embedded bytecode attribute,.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader without the thread group size attribute.
     /// <para>
-    /// Format: <c>"The shader of type {0} needs to be annotated as having embedded bytecode (using the [EmbeddedBytecode] attribute), as dynamic shader compilation is not supported"</c>.
+    /// Format: <c>"The shader of type {0} needs to be annotated with [ThreadGroupSize], as dynamic shader compilation is not supported"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor MissingEmbeddedBytecodeAttributeWhenDynamicShaderCompilationIsNotSupported = new(
+    public static readonly DiagnosticDescriptor MissingThreadGroupSizeAttribute = new(
         id: "CMPS0047",
-        title: "Embedded bytecode compilation failed due to an HLSL compiler error",
-        messageFormat: "The shader of type {0} needs to be annotated as having embedded bytecode (using the [EmbeddedBytecode] attribute), as dynamic shader compilation is not supported",
+        title: "Missing [ThreadGroupSize] attribute on shader type",
+        messageFormat: "The shader of type {0} needs to be annotated with [ThreadGroupSize] to be compiled at build time, as dynamic shader compilation is not supported",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "All shaders need to be annotated as having embedded bytecode (using the [EmbeddedBytecode] attribute).",
+        description: "All shaders need to be annotated with the [ThreadGroupSize] attribute to be compiled at build time.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for an embedded bytecode shader with an invalid dispatch axis value.
     /// <para>
-    /// Format: <c>"The shader of type {0} is annotated with an invalid dispatch axis value"</c>.
+    /// Format: <c>"The shader of type {0} is using an invalid DefaultThreadGroupSize value in its [ThreadGroupSize] attribute"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor InvalidEmbeddedBytecodeDispatchAxis = new(
+    public static readonly DiagnosticDescriptor InvalidThreadGroupSizeAttributeDefaultThreadGroupSize = new(
         id: "CMPS0048",
-        title: "Invalid dispatch axis for shader with embedded bytecode",
-        messageFormat: "The shader of type {0} is annotated with with an invalid dispatch axis value",
+        title: "Invalid DefaultThreadGroupSize value for [ThreadGroupSize] use",
+        messageFormat: "The shader of type {0} is using an invalid DefaultThreadGroupSize value in its [ThreadGroupSize] attribute",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The dispatch axis value for a shader marked as embedded bytecode have to be valid (flags are not supported).",
+        description: "The DefaultThreadGroupSize value for [ThreadGroupSize] attributes have to be valid.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp/Core/Attributes/Enums/DefaultThreadGroupSizes.cs
+++ b/src/ComputeSharp/Core/Attributes/Enums/DefaultThreadGroupSizes.cs
@@ -1,9 +1,12 @@
+using System;
+
 namespace ComputeSharp;
 
 /// <summary>
-/// A <see langword="enum"/> to be used with <see cref="ThreadGroupSizeAttribute"/> to indicate the dispatch axis to precompile a shader for.
+/// A <see langword="enum"/> to be used with <see cref="ThreadGroupSizeAttribute"/> to more easily set default values for the thread group size.
 /// </summary>
-public enum DispatchAxis
+[Flags]
+public enum DefaultThreadGroupSizes
 {
     /// <summary>
     /// Indicates a shader dispatch only along the X axis.
@@ -11,7 +14,7 @@ public enum DispatchAxis
     /// <remarks>
     /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, in T)"/>.
     /// </remarks>
-    X,
+    X = 1 << 0,
 
     /// <summary>
     /// Indicates a shader dispatch only along the Y axis.
@@ -20,7 +23,7 @@ public enum DispatchAxis
     /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>,
     /// but only as long as the input dispatch size on both the X and Z axes is <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
-    Y,
+    Y = 1 << 1,
 
     /// <summary>
     /// Indicates a shader dispatch only along the Z axis.
@@ -29,7 +32,7 @@ public enum DispatchAxis
     /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>,
     /// but only as long as the input dispatch size on both the X and Y axes is <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
-    Z,
+    Z = 1 << 2,
 
     /// <summary>
     /// Indicates a shader dispatch along the X and Y axes.
@@ -39,7 +42,7 @@ public enum DispatchAxis
     /// <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>, <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, in T)"/>,
     /// <see cref="ComputeContextExtensions.ForEach{T, TPixel}(in ComputeContext, IReadWriteNormalizedTexture2D{TPixel})"/> or <see cref="ComputeContextExtensions.ForEach{T, TPixel}(in ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>.
     /// </remarks>
-    XY,
+    XY = X | Y,
 
     /// <summary>
     /// Indicates a shader dispatch along the X and Z axes.
@@ -48,7 +51,7 @@ public enum DispatchAxis
     /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>,
     /// but only as long as the input dispatch size on the Y axis <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
-    XZ,
+    XZ = X | Z,
 
     /// <summary>
     /// Indicates a shader dispatch along the Y and Z axes.
@@ -57,7 +60,7 @@ public enum DispatchAxis
     /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>,
     /// but only as long as the input dispatch size on the X axis <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
-    YZ,
+    YZ = Y | Z,
 
     /// <summary>
     /// Indicates a shader dispatch along the X, Y and Z axes.
@@ -65,5 +68,5 @@ public enum DispatchAxis
     /// <remarks>
     /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>.
     /// </remarks>
-    XYZ
+    XYZ = X | Y | Z
 }

--- a/src/ComputeSharp/Core/Attributes/ThreadGroupSizeAttribute.cs
+++ b/src/ComputeSharp/Core/Attributes/ThreadGroupSizeAttribute.cs
@@ -3,21 +3,20 @@ using System;
 namespace ComputeSharp;
 
 /// <summary>
-/// An attribute that indicates that a given shader should be precompiled at build time and embedded
-/// directly into the containing assembly as static bytecode, to avoid compiling it at runtime.
+/// An attribute that indicates the size of the thread groups to use to dispatch a given compute shader.
 /// <para>
 /// This attribute can be used to annotate shader types as follows:
 /// <code>
 /// // A compute shader that is dispatched on a target buffer
-/// [EmbeddedBytecode(DispatchAxis.X)]
+/// [ThreadGroupSize(DispatchAxis.X)]
 /// struct MyShader : IComputeShader
 /// {
 /// }
 /// </code>
-/// Or similarly, for a pixel shader:
+/// Or similarly, for a pixel-like compute shader:
 /// <code>
-/// // A pixel shader that is dispatched on a target texture
-/// [EmbeddedBytecode(DispatchAxis.XY)]
+/// // A compute shader that is dispatched on a target texture
+/// [ThreadGroupSize(DispatchAxis.XY)]
 /// struct MyShader : IComputeShader&lt;float4&gt;
 /// {
 /// }
@@ -25,31 +24,17 @@ namespace ComputeSharp;
 /// </para>
 /// <para>
 /// Using <see cref="DispatchAxis"/> is an easier way to precompile shaders when dispatching them over known dimensions. For more
-/// fine grained control over the thread size values when dispatching, use <see cref="EmbeddedBytecodeAttribute(int, int, int)"/>.
+/// fine grained control over the thread size values when dispatching, use <see cref="ThreadGroupSizeAttribute(int, int, int)"/>.
 /// </para>
-/// <para>
-/// </para>
-/// The runtime compilation will automatically be skipped if the shader is invoked using matching thread count values,
-/// otherwise the usual runtime compilation will be used as fallback if the <c>ComputeSharp.Dxc</c> library is
-/// referenced. If not, <see cref="NotSupportedException"/> will be thrown when trying to dispatch the shader.
 /// </summary>
-/// <remarks>
-/// <para>
-/// Using this attribute is mandatory when not referencing <c>ComputeSharp.Dxc</c>.
-/// </para>
-/// <para>
-/// This attribute can only be used when the shader type being annotated does not require dynamic
-/// features. Specifically, this attribute is not supported if the shader captures any delegates.
-/// </para>
-/// </remarks>
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
-public sealed class EmbeddedBytecodeAttribute : Attribute
+public sealed class ThreadGroupSizeAttribute : Attribute
 {
     /// <summary>
-    /// Creates a new <see cref="EmbeddedBytecodeAttribute"/> instance with the specified parameters.
+    /// Creates a new <see cref="ThreadGroupSizeAttribute"/> instance with the specified parameters.
     /// </summary>
     /// <param name="dispatchAxis">The target dispatch axes for the shader to run.</param>
-    public EmbeddedBytecodeAttribute(DispatchAxis dispatchAxis)
+    public ThreadGroupSizeAttribute(DispatchAxis dispatchAxis)
     {
 #if !SOURCE_GENERATOR
         (ThreadsX, ThreadsY, ThreadsZ) = dispatchAxis switch
@@ -67,12 +52,12 @@ public sealed class EmbeddedBytecodeAttribute : Attribute
     }
 
     /// <summary>
-    /// Creates a new <see cref="EmbeddedBytecodeAttribute"/> instance with the specified parameters.
+    /// Creates a new <see cref="ThreadGroupSizeAttribute"/> instance with the specified parameters.
     /// </summary>
     /// <param name="threadsX">The number of threads in each thread group for the X axis.</param>
     /// <param name="threadsY">The number of threads in each thread group for the Y axis.</param>
     /// <param name="threadsZ">The number of threads in each thread group for the Z axis.</param>
-    public EmbeddedBytecodeAttribute(int threadsX, int threadsY, int threadsZ)
+    public ThreadGroupSizeAttribute(int threadsX, int threadsY, int threadsZ)
     {
         ThreadsX = threadsX;
         ThreadsY = threadsY;
@@ -80,17 +65,17 @@ public sealed class EmbeddedBytecodeAttribute : Attribute
     }
 
     /// <summary>
-    /// Gets the number of threads in each thread group for the X axis
+    /// Gets the number of threads in each thread group for the X axis.
     /// </summary>
     public int ThreadsX { get; }
 
     /// <summary>
-    /// Gets the number of threads in each thread group for the Y axis
+    /// Gets the number of threads in each thread group for the Y axis.
     /// </summary>
     public int ThreadsY { get; }
 
     /// <summary>
-    /// Gets the number of threads in each thread group for the Z axis
+    /// Gets the number of threads in each thread group for the Z axis.
     /// </summary>
     public int ThreadsZ { get; }
 }

--- a/src/ComputeSharp/Core/Attributes/ThreadGroupSizeAttribute.cs
+++ b/src/ComputeSharp/Core/Attributes/ThreadGroupSizeAttribute.cs
@@ -36,7 +36,6 @@ public sealed class ThreadGroupSizeAttribute : Attribute
     /// <param name="size">The default thread group size to use.</param>
     public ThreadGroupSizeAttribute(DefaultThreadGroupSizes size)
     {
-#if !SOURCE_GENERATOR
         (ThreadsX, ThreadsY, ThreadsZ) = size switch
         {
             DefaultThreadGroupSizes.X => (64, 1, 1),
@@ -48,7 +47,6 @@ public sealed class ThreadGroupSizeAttribute : Attribute
             DefaultThreadGroupSizes.XYZ => (4, 4, 4),
             _ => default(ArgumentException).Throw<(int, int, int)>(nameof(size))
         };
-#endif
     }
 
     /// <summary>

--- a/src/ComputeSharp/Core/Attributes/ThreadGroupSizeAttribute.cs
+++ b/src/ComputeSharp/Core/Attributes/ThreadGroupSizeAttribute.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp;
 /// This attribute can be used to annotate shader types as follows:
 /// <code>
 /// // A compute shader that is dispatched on a target buffer
-/// [ThreadGroupSize(DispatchAxis.X)]
+/// [ThreadGroupSize(DefaultThreadGroupSizes.X)]
 /// struct MyShader : IComputeShader
 /// {
 /// }
@@ -16,14 +16,14 @@ namespace ComputeSharp;
 /// Or similarly, for a pixel-like compute shader:
 /// <code>
 /// // A compute shader that is dispatched on a target texture
-/// [ThreadGroupSize(DispatchAxis.XY)]
+/// [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 /// struct MyShader : IComputeShader&lt;float4&gt;
 /// {
 /// }
 /// </code>
 /// </para>
 /// <para>
-/// Using <see cref="DispatchAxis"/> is an easier way to precompile shaders when dispatching them over known dimensions. For more
+/// Using <see cref="DefaultThreadGroupSizes"/> is an easier way to precompile shaders when dispatching them over known dimensions. For more
 /// fine grained control over the thread size values when dispatching, use <see cref="ThreadGroupSizeAttribute(int, int, int)"/>.
 /// </para>
 /// </summary>
@@ -33,20 +33,20 @@ public sealed class ThreadGroupSizeAttribute : Attribute
     /// <summary>
     /// Creates a new <see cref="ThreadGroupSizeAttribute"/> instance with the specified parameters.
     /// </summary>
-    /// <param name="dispatchAxis">The target dispatch axes for the shader to run.</param>
-    public ThreadGroupSizeAttribute(DispatchAxis dispatchAxis)
+    /// <param name="size">The default thread group size to use.</param>
+    public ThreadGroupSizeAttribute(DefaultThreadGroupSizes size)
     {
 #if !SOURCE_GENERATOR
-        (ThreadsX, ThreadsY, ThreadsZ) = dispatchAxis switch
+        (ThreadsX, ThreadsY, ThreadsZ) = size switch
         {
-            DispatchAxis.X => (64, 1, 1),
-            DispatchAxis.Y => (1, 64, 1),
-            DispatchAxis.Z => (1, 1, 64),
-            DispatchAxis.XY => (8, 8, 1),
-            DispatchAxis.XZ => (8, 1, 8),
-            DispatchAxis.YZ => (1, 8, 8),
-            DispatchAxis.XYZ => (4, 4, 4),
-            _ => default(ArgumentException).Throw<(int, int, int)>(nameof(dispatchAxis))
+            DefaultThreadGroupSizes.X => (64, 1, 1),
+            DefaultThreadGroupSizes.Y => (1, 64, 1),
+            DefaultThreadGroupSizes.Z => (1, 1, 64),
+            DefaultThreadGroupSizes.XY => (8, 8, 1),
+            DefaultThreadGroupSizes.XZ => (8, 1, 8),
+            DefaultThreadGroupSizes.YZ => (1, 8, 8),
+            DefaultThreadGroupSizes.XYZ => (4, 4, 4),
+            _ => default(ArgumentException).Throw<(int, int, int)>(nameof(size))
         };
 #endif
     }

--- a/src/ComputeSharp/Core/Dispatch/DispatchAxis.cs
+++ b/src/ComputeSharp/Core/Dispatch/DispatchAxis.cs
@@ -1,7 +1,7 @@
 namespace ComputeSharp;
 
 /// <summary>
-/// A <see langword="enum"/> to be used with <see cref="EmbeddedBytecodeAttribute"/> to indicate the dispatch axis to precompile a shader for.
+/// A <see langword="enum"/> to be used with <see cref="ThreadGroupSizeAttribute"/> to indicate the dispatch axis to precompile a shader for.
 /// </summary>
 public enum DispatchAxis
 {

--- a/tests/ComputeSharp.Dxc.NuGet/Program.cs
+++ b/tests/ComputeSharp.Dxc.NuGet/Program.cs
@@ -34,7 +34,7 @@ Trace.Assert(shaderInfo.BoundResourceCount == 2);
 /// A sample kernel that requires dynamic compilation, as it's not precompiled.
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.X)]
+[ThreadGroupSize(DispatchAxis.X)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct MultiplyByTwo : IComputeShader
 {

--- a/tests/ComputeSharp.Dxc.NuGet/Program.cs
+++ b/tests/ComputeSharp.Dxc.NuGet/Program.cs
@@ -34,7 +34,7 @@ Trace.Assert(shaderInfo.BoundResourceCount == 2);
 /// A sample kernel that requires dynamic compilation, as it's not precompiled.
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.X)]
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct MultiplyByTwo : IComputeShader
 {

--- a/tests/ComputeSharp.NuGet/Program.cs
+++ b/tests/ComputeSharp.NuGet/Program.cs
@@ -25,7 +25,7 @@ for (int i = 0; i < array.Length; i++)
 /// <summary>
 /// A sample kernel that is precompiled.
 /// </summary>
-[ThreadGroupSize(DispatchAxis.X)]
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
 [GeneratedComputeShaderDescriptor]
 [AutoConstructor]
 internal readonly partial struct MultiplyByTwo : IComputeShader

--- a/tests/ComputeSharp.NuGet/Program.cs
+++ b/tests/ComputeSharp.NuGet/Program.cs
@@ -25,7 +25,7 @@ for (int i = 0; i < array.Length; i++)
 /// <summary>
 /// A sample kernel that is precompiled.
 /// </summary>
-[EmbeddedBytecode(DispatchAxis.X)]
+[ThreadGroupSize(DispatchAxis.X)]
 [GeneratedComputeShaderDescriptor]
 [AutoConstructor]
 internal readonly partial struct MultiplyByTwo : IComputeShader

--- a/tests/ComputeSharp.Pix.NuGet/Program.cs
+++ b/tests/ComputeSharp.Pix.NuGet/Program.cs
@@ -31,7 +31,7 @@ for (int i = 0; i < array.Length; i++)
 /// <summary>
 /// A sample kernel that is precompiled.
 /// </summary>
-[EmbeddedBytecode(DispatchAxis.X)]
+[ThreadGroupSize(DispatchAxis.X)]
 [GeneratedComputeShaderDescriptor]
 [AutoConstructor]
 internal readonly partial struct MultiplyByTwo : IComputeShader

--- a/tests/ComputeSharp.Pix.NuGet/Program.cs
+++ b/tests/ComputeSharp.Pix.NuGet/Program.cs
@@ -31,7 +31,7 @@ for (int i = 0; i < array.Length; i++)
 /// <summary>
 /// A sample kernel that is precompiled.
 /// </summary>
-[ThreadGroupSize(DispatchAxis.X)]
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
 [GeneratedComputeShaderDescriptor]
 [AutoConstructor]
 internal readonly partial struct MultiplyByTwo : IComputeShader

--- a/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
@@ -143,7 +143,7 @@ public partial class DeviceDisposalTests
         Assert.AreEqual(1u, GraphicsDeviceHelper.GetD3D12DeviceRefCount(d3D12Device));
     }
 
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     [AutoConstructor]
     internal readonly partial struct InitializeShader : IComputeShader
@@ -177,7 +177,7 @@ public partial class DeviceDisposalTests
         Assert.AreEqual(1u, GraphicsDeviceHelper.GetD3D12DeviceRefCount(d3D12Device));
     }
 
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal partial struct HelloWorldShader : IComputeShader<float4>
     {

--- a/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
@@ -143,7 +143,7 @@ public partial class DeviceDisposalTests
         Assert.AreEqual(1u, GraphicsDeviceHelper.GetD3D12DeviceRefCount(d3D12Device));
     }
 
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     [AutoConstructor]
     internal readonly partial struct InitializeShader : IComputeShader
@@ -177,7 +177,7 @@ public partial class DeviceDisposalTests
         Assert.AreEqual(1u, GraphicsDeviceHelper.GetD3D12DeviceRefCount(d3D12Device));
     }
 
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal partial struct HelloWorldShader : IComputeShader<float4>
     {

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/DispatchTests.cs
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/DispatchTests.cs
@@ -31,7 +31,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(32, 1, 1)]
+    [ThreadGroupSize(32, 1, 1)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ComputeShader : IComputeShader
     {
@@ -76,7 +76,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(8, 8, 1)]
+    [ThreadGroupSize(8, 8, 1)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct PixelShader : IComputeShader<float4>
     {

--- a/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
+++ b/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
@@ -22,7 +22,7 @@ if (!numbers.SequenceEqual(result))
 Console.WriteLine("Test passed successfully!");
 
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.X)]
+[ThreadGroupSize(DispatchAxis.X)]
 [GeneratedComputeShaderDescriptor]
 public readonly partial struct ApplyFunctionShader : IComputeShader
 {

--- a/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
+++ b/tests/ComputeSharp.Tests.GlobalStatements/Program.cs
@@ -22,7 +22,7 @@ if (!numbers.SequenceEqual(result))
 Console.WriteLine("Test passed successfully!");
 
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.X)]
+[ThreadGroupSize(DefaultThreadGroupSizes.X)]
 [GeneratedComputeShaderDescriptor]
 public readonly partial struct ApplyFunctionShader : IComputeShader
 {

--- a/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
@@ -12,7 +12,7 @@ namespace ComputeSharp.Tests.Internals;
 public partial class ShaderDataLoaderTests
 {
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct CapturedResourceShader : IComputeShader
     {
@@ -48,7 +48,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct MultipleResourcesAndPrimitivesShader : IComputeShader
     {
@@ -94,7 +94,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct ScalarAndVectorTypesShader : IComputeShader
     {
@@ -145,7 +145,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct ScalarVectorAndMatrixTypesShader : IComputeShader
     {
@@ -231,7 +231,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct FlatCustomTypeShader : IComputeShader
     {
@@ -323,7 +323,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct NestedCustomTypesShader : IComputeShader
     {
@@ -415,7 +415,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct AmbiguousNamesShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
@@ -12,7 +12,7 @@ namespace ComputeSharp.Tests.Internals;
 public partial class ShaderDataLoaderTests
 {
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct CapturedResourceShader : IComputeShader
     {
@@ -48,7 +48,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct MultipleResourcesAndPrimitivesShader : IComputeShader
     {
@@ -94,7 +94,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct ScalarAndVectorTypesShader : IComputeShader
     {
@@ -145,7 +145,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct ScalarVectorAndMatrixTypesShader : IComputeShader
     {
@@ -231,7 +231,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct FlatCustomTypeShader : IComputeShader
     {
@@ -323,7 +323,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct NestedCustomTypesShader : IComputeShader
     {
@@ -415,7 +415,7 @@ public partial class ShaderDataLoaderTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public partial struct AmbiguousNamesShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1242,7 +1242,7 @@ public class DiagnosticsTests
 
             namespace MyFancyApp.Sample;
 
-            [ThreadGroupSize(DispatchAxis.XYZ | DispatchAxis.Y)]
+            [ThreadGroupSize(default)]
             [GeneratedComputeShaderDescriptor]
             public partial struct MyShader : IComputeShader
             {
@@ -1266,7 +1266,7 @@ public class DiagnosticsTests
 
             namespace MyFancyApp.Sample;
 
-            [ThreadGroupSize((DispatchAxis)243712)]
+            [ThreadGroupSize((DefaultThreadGroupSizes)243712)]
             [GeneratedComputeShaderDescriptor]
             public partial struct MyShader : IComputeShader
             {
@@ -1290,7 +1290,7 @@ public class DiagnosticsTests
 
             namespace MyFancyApp.Sample;
 
-            [ThreadGroupSize((DispatchAxis)(-289))]
+            [ThreadGroupSize((DefaultThreadGroupSizes)(-289))]
             [GeneratedComputeShaderDescriptor]
             public partial struct MyShader : IComputeShader
             {

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1210,7 +1210,7 @@ public class DiagnosticsTests
     [DataRow(1050, 1, 1)]
     [DataRow(1, 1050, 1)]
     [DataRow(1, 1, 70)]
-    public void InvalidEmbeddedBytecodeThreadIds(int threadsX, int threadsY, int threadsZ)
+    public void InvalidThreadGroupSizeValues(int threadsX, int threadsY, int threadsZ)
     {
         string source = $$"""
             using System;
@@ -1218,7 +1218,7 @@ public class DiagnosticsTests
 
             namespace MyFancyApp.Sample;
 
-            [EmbeddedBytecode({{threadsX}}, {{threadsY}}, {{threadsZ}})]
+            [ThreadGroupSize({{threadsX}}, {{threadsY}}, {{threadsZ}})]
             [GeneratedComputeShaderDescriptor]
             public partial struct MyShader : IComputeShader
             {
@@ -1234,7 +1234,7 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
-    public void InvalidEmbeddedBytecodeDispatchSize_Flags()
+    public void InvalidThreadGroupSizeDispatchSize_Flags()
     {
         const string source = """
             using System;
@@ -1242,7 +1242,7 @@ public class DiagnosticsTests
 
             namespace MyFancyApp.Sample;
 
-            [EmbeddedBytecode(DispatchAxis.XYZ | DispatchAxis.Y)]
+            [ThreadGroupSize(DispatchAxis.XYZ | DispatchAxis.Y)]
             [GeneratedComputeShaderDescriptor]
             public partial struct MyShader : IComputeShader
             {
@@ -1258,7 +1258,7 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
-    public void InvalidEmbeddedBytecodeDispatchSize_ExplicitValue()
+    public void InvalidThreadGroupSizeDispatchSize_ExplicitValue()
     {
         const string source = """
             using System;
@@ -1266,7 +1266,7 @@ public class DiagnosticsTests
 
             namespace MyFancyApp.Sample;
 
-            [EmbeddedBytecode((DispatchAxis)243712)]
+            [ThreadGroupSize((DispatchAxis)243712)]
             [GeneratedComputeShaderDescriptor]
             public partial struct MyShader : IComputeShader
             {
@@ -1282,7 +1282,7 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
-    public void InvalidEmbeddedBytecodeDispatchSize_ExplicitValue_Negative()
+    public void InvalidThreadGroupSizeDispatchSize_ExplicitValue_Negative()
     {
         const string source = """
             using System;
@@ -1290,7 +1290,7 @@ public class DiagnosticsTests
 
             namespace MyFancyApp.Sample;
 
-            [EmbeddedBytecode((DispatchAxis)(-289))]
+            [ThreadGroupSize((DispatchAxis)(-289))]
             [GeneratedComputeShaderDescriptor]
             public partial struct MyShader : IComputeShader
             {

--- a/tests/ComputeSharp.Tests/BufferTests.cs
+++ b/tests/ComputeSharp.Tests/BufferTests.cs
@@ -278,7 +278,7 @@ public partial class BufferTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ConstantBufferKernel : IComputeShader
     {
@@ -308,7 +308,7 @@ public partial class BufferTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyBufferKernel : IComputeShader
     {
@@ -338,7 +338,7 @@ public partial class BufferTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteBufferKernel : IComputeShader
     {
@@ -375,7 +375,7 @@ public partial class BufferTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct DoublePrecisionSupportShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/BufferTests.cs
+++ b/tests/ComputeSharp.Tests/BufferTests.cs
@@ -278,7 +278,7 @@ public partial class BufferTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ConstantBufferKernel : IComputeShader
     {
@@ -308,7 +308,7 @@ public partial class BufferTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyBufferKernel : IComputeShader
     {
@@ -338,7 +338,7 @@ public partial class BufferTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteBufferKernel : IComputeShader
     {
@@ -375,7 +375,7 @@ public partial class BufferTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct DoublePrecisionSupportShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ComputeContextTests.cs
+++ b/tests/ComputeSharp.Tests/ComputeContextTests.cs
@@ -1294,7 +1294,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct OffsetComputeShader : IComputeShader
     {
@@ -1309,7 +1309,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ClearPixelShader : IComputeShader<float4>
     {
@@ -1321,7 +1321,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ColorPixelShader : IComputeShader<float4>
     {
@@ -1335,7 +1335,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct LinearSampling2DPixelShader : IComputeShader<float4>
     {
@@ -1349,7 +1349,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct LinearSampling3DComputeShader : IComputeShader
     {
@@ -1369,7 +1369,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct LinearSamplingFromNormalized2DPixelShader : IComputeShader<float4>
     {
@@ -1383,7 +1383,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct CopyToOutputPixelShader : IComputeShader<float4>
     {
@@ -1397,7 +1397,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct InvertPixelShader : IComputeShader<float4>
     {
@@ -1411,7 +1411,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct LinearSamplingFromNormalized3DComputeShader : IComputeShader
     {
@@ -1431,7 +1431,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Dotted2DPixelShader : IComputeShader
     {
@@ -1461,7 +1461,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Dotted3DPixelShader : IComputeShader
     {
@@ -1491,7 +1491,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ConvertToNonNormalized2DShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ComputeContextTests.cs
+++ b/tests/ComputeSharp.Tests/ComputeContextTests.cs
@@ -1294,7 +1294,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct OffsetComputeShader : IComputeShader
     {
@@ -1309,7 +1309,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ClearPixelShader : IComputeShader<float4>
     {
@@ -1321,7 +1321,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ColorPixelShader : IComputeShader<float4>
     {
@@ -1335,7 +1335,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct LinearSampling2DPixelShader : IComputeShader<float4>
     {
@@ -1349,7 +1349,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct LinearSampling3DComputeShader : IComputeShader
     {
@@ -1369,7 +1369,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct LinearSamplingFromNormalized2DPixelShader : IComputeShader<float4>
     {
@@ -1383,7 +1383,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct CopyToOutputPixelShader : IComputeShader<float4>
     {
@@ -1397,7 +1397,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct InvertPixelShader : IComputeShader<float4>
     {
@@ -1411,7 +1411,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct LinearSamplingFromNormalized3DComputeShader : IComputeShader
     {
@@ -1431,7 +1431,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Dotted2DPixelShader : IComputeShader
     {
@@ -1461,7 +1461,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Dotted3DPixelShader : IComputeShader
     {
@@ -1491,7 +1491,7 @@ public partial class ComputeContextTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ConvertToNonNormalized2DShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/DispatchTests.cs
+++ b/tests/ComputeSharp.Tests/DispatchTests.cs
@@ -57,7 +57,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ThreadIdsShader : IComputeShader
     {
@@ -113,7 +113,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ThreadIdsNormalizedShader : IComputeShader
     {
@@ -156,7 +156,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct GroupIdsShader : IComputeShader
     {
@@ -188,7 +188,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(4, 15, 7)]
+    [ThreadGroupSize(4, 15, 7)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct GroupSizeShader : IComputeShader
     {
@@ -222,7 +222,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(32, 1, 1)]
+    [ThreadGroupSize(32, 1, 1)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct GridIdsShader : IComputeShader
     {
@@ -255,7 +255,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchSizeShader : IComputeShader
     {
@@ -296,7 +296,7 @@ public partial class DispatchTests
         }
     }
 
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchPixelShader : IComputeShader<float4>
     {
@@ -327,7 +327,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct FixedGroupSharedPixelShader : IComputeShader
     {
@@ -372,7 +372,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(32, 1, 1)]
+    [ThreadGroupSize(32, 1, 1)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DynamicGroupSharedPixelShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/DispatchTests.cs
+++ b/tests/ComputeSharp.Tests/DispatchTests.cs
@@ -57,7 +57,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ThreadIdsShader : IComputeShader
     {
@@ -113,7 +113,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ThreadIdsNormalizedShader : IComputeShader
     {
@@ -156,7 +156,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct GroupIdsShader : IComputeShader
     {
@@ -255,7 +255,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchSizeShader : IComputeShader
     {
@@ -296,7 +296,7 @@ public partial class DispatchTests
         }
     }
 
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchPixelShader : IComputeShader<float4>
     {
@@ -327,7 +327,7 @@ public partial class DispatchTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct FixedGroupSharedPixelShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/IPixelShaderTests.cs
+++ b/tests/ComputeSharp.Tests/IPixelShaderTests.cs
@@ -35,7 +35,7 @@ public partial class IPixelShaderTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct EarlyReturnShader : IComputeShader<float4>
     {

--- a/tests/ComputeSharp.Tests/IPixelShaderTests.cs
+++ b/tests/ComputeSharp.Tests/IPixelShaderTests.cs
@@ -35,7 +35,7 @@ public partial class IPixelShaderTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct EarlyReturnShader : IComputeShader<float4>
     {

--- a/tests/ComputeSharp.Tests/InitializationTests.cs
+++ b/tests/ComputeSharp.Tests/InitializationTests.cs
@@ -73,7 +73,7 @@ public partial class InitializationTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct SampleShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/InitializationTests.cs
+++ b/tests/ComputeSharp.Tests/InitializationTests.cs
@@ -73,7 +73,7 @@ public partial class InitializationTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct SampleShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
@@ -29,7 +29,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyBuffer_T1_AsReadOnlyBufferShader : IComputeShader
     {
@@ -63,7 +63,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteBuffer_T1_AsReadWriteBufferShader : IComputeShader
     {
@@ -97,7 +97,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture1D_T1_AsReadOnlyTexture1DShader : IComputeShader
     {
@@ -131,7 +131,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1D_T1_AsReadWriteTexture1DShader : IComputeShader
     {
@@ -169,7 +169,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1D_T1_AsIReadOnlyTexture1DShader : IComputeShader
     {
@@ -203,7 +203,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture1D_T2_AsReadOnlyTexture1DShader : IComputeShader
     {
@@ -237,7 +237,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture1D_T2_AsIReadOnlyNormalizedTexture1DShader : IComputeShader
     {
@@ -271,7 +271,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1D_T2_AsReadWriteTexture1DShader : IComputeShader
     {
@@ -305,7 +305,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1D_T2_AsIReadWriteNormalizedTexture1DShader : IComputeShader
     {
@@ -339,7 +339,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture2D_T1_AsReadOnlyTexture2DShader : IComputeShader
     {
@@ -374,7 +374,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2D_T1_AsReadWriteTexture2DShader : IComputeShader
     {
@@ -413,7 +413,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2D_T1_AsIReadOnlyTexture2DShader : IComputeShader
     {
@@ -448,7 +448,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture2D_T2_AsReadOnlyTexture2DShader : IComputeShader
     {
@@ -483,7 +483,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture2D_T2_AsIReadOnlyNormalizedTexture2DShader : IComputeShader
     {
@@ -518,7 +518,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2D_T2_AsReadWriteTexture2DShader : IComputeShader
     {
@@ -553,7 +553,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2D_T2_AsIReadWriteNormalizedTexture2DShader : IComputeShader
     {
@@ -588,7 +588,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture3D_T1_AsReadOnlyTexture3DShader : IComputeShader
     {
@@ -624,7 +624,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3D_T1_AsReadWriteTexture3DShader : IComputeShader
     {
@@ -664,7 +664,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3D_T1_AsIReadOnlyTexture3DShader : IComputeShader
     {
@@ -700,7 +700,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture3D_T2_AsReadOnlyTexture3DShader : IComputeShader
     {
@@ -736,7 +736,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture3D_T2_AsIReadOnlyNormalizedTexture3DShader : IComputeShader
     {
@@ -772,7 +772,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3D_T2_AsReadWriteTexture3DShader : IComputeShader
     {
@@ -808,7 +808,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3D_T2_AsIReadWriteNormalizedTexture3DShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
@@ -29,7 +29,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyBuffer_T1_AsReadOnlyBufferShader : IComputeShader
     {
@@ -63,7 +63,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteBuffer_T1_AsReadWriteBufferShader : IComputeShader
     {
@@ -97,7 +97,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture1D_T1_AsReadOnlyTexture1DShader : IComputeShader
     {
@@ -131,7 +131,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1D_T1_AsReadWriteTexture1DShader : IComputeShader
     {
@@ -169,7 +169,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1D_T1_AsIReadOnlyTexture1DShader : IComputeShader
     {
@@ -203,7 +203,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture1D_T2_AsReadOnlyTexture1DShader : IComputeShader
     {
@@ -237,7 +237,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture1D_T2_AsIReadOnlyNormalizedTexture1DShader : IComputeShader
     {
@@ -271,7 +271,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1D_T2_AsReadWriteTexture1DShader : IComputeShader
     {
@@ -305,7 +305,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1D_T2_AsIReadWriteNormalizedTexture1DShader : IComputeShader
     {
@@ -339,7 +339,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture2D_T1_AsReadOnlyTexture2DShader : IComputeShader
     {
@@ -374,7 +374,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2D_T1_AsReadWriteTexture2DShader : IComputeShader
     {
@@ -413,7 +413,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2D_T1_AsIReadOnlyTexture2DShader : IComputeShader
     {
@@ -448,7 +448,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture2D_T2_AsReadOnlyTexture2DShader : IComputeShader
     {
@@ -483,7 +483,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture2D_T2_AsIReadOnlyNormalizedTexture2DShader : IComputeShader
     {
@@ -518,7 +518,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2D_T2_AsReadWriteTexture2DShader : IComputeShader
     {
@@ -553,7 +553,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2D_T2_AsIReadWriteNormalizedTexture2DShader : IComputeShader
     {
@@ -588,7 +588,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture3D_T1_AsReadOnlyTexture3DShader : IComputeShader
     {
@@ -624,7 +624,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3D_T1_AsReadWriteTexture3DShader : IComputeShader
     {
@@ -664,7 +664,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3D_T1_AsIReadOnlyTexture3DShader : IComputeShader
     {
@@ -700,7 +700,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture3D_T2_AsReadOnlyTexture3DShader : IComputeShader
     {
@@ -736,7 +736,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture3D_T2_AsIReadOnlyNormalizedTexture3DShader : IComputeShader
     {
@@ -772,7 +772,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3D_T2_AsReadWriteTexture3DShader : IComputeShader
     {
@@ -808,7 +808,7 @@ public partial class ResourceDimensionsTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3D_T2_AsIReadWriteNormalizedTexture3DShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
@@ -132,7 +132,7 @@ foreach (var pair in typesMap)
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct <#=testMethodName#>Shader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
@@ -132,7 +132,7 @@ foreach (var pair in typesMap)
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct <#=testMethodName#>Shader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -34,7 +34,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ReservedKeywordsShader : IComputeShader
         {
@@ -71,7 +71,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ReservedKeywordsInCustomTypesShader : IComputeShader
         {
@@ -100,7 +100,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ReservedKeywordsFromHlslTypesAndBuiltInValuesShader : IComputeShader
         {
@@ -143,7 +143,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ReservedKeywordsPrecompiledShader : IComputeShader
         {
@@ -181,7 +181,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct SpecialTypeAsReturnTypeShader : IComputeShader
         {
@@ -204,7 +204,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct LocalFunctionInExternalMethodsShader : IComputeShader
         {
@@ -237,7 +237,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct CapturedNestedStructTypeShader : IComputeShader
         {
@@ -258,7 +258,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ExternalStructTypeShader : IComputeShader
         {
@@ -281,7 +281,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct OutOfOrderMethodsShader : IComputeShader
         {
@@ -318,7 +318,7 @@ namespace ComputeSharp.Tests
             Assert.AreEqual(info.BoundResourceCount, 2u);
         }
 
-        [EmbeddedBytecode(DispatchAxis.XY)]
+        [ThreadGroupSize(DispatchAxis.XY)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct StatelessPixelShader : IComputeShader<float4>
         {
@@ -330,7 +330,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct LoopWithVarCounterShader : IComputeShader
         {
@@ -361,7 +361,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct DoublePrecisionSupportShader : IComputeShader
         {
@@ -382,7 +382,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct FieldAccessWithThisExpressionShader : IComputeShader
         {
@@ -410,7 +410,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct ComputeShaderWithInheritedShaderInterfaceShader : IMyBaseShader
         {
@@ -445,7 +445,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct PixelShaderWithInheritedShaderInterfaceShader : IMyBaseShader<float4>
         {
@@ -495,7 +495,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct StructInstanceMethodsShader : IComputeShader
         {
@@ -530,7 +530,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct PixelShaderWithScopedParameterInMethodsShader : IComputeShader
         {
@@ -579,7 +579,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [CompileOptions(CompileOptions.Default | CompileOptions.StripReflectionData)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct ShaderWithStrippedReflectionData1 : IComputeShader
@@ -594,7 +594,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [CompileOptions(CompileOptions.Default)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct ShaderWithStrippedReflectionData2 : IComputeShader
@@ -617,7 +617,7 @@ namespace ExternalNamespace
     public partial class ShaderCompilerTestsInExternalNamespace
     {
         [AutoConstructor]
-        [EmbeddedBytecode(DispatchAxis.X)]
+        [ThreadGroupSize(DispatchAxis.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct UserDefinedTypeShader : IComputeShader
         {

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -34,7 +34,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ReservedKeywordsShader : IComputeShader
         {
@@ -71,7 +71,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ReservedKeywordsInCustomTypesShader : IComputeShader
         {
@@ -100,7 +100,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ReservedKeywordsFromHlslTypesAndBuiltInValuesShader : IComputeShader
         {
@@ -143,7 +143,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ReservedKeywordsPrecompiledShader : IComputeShader
         {
@@ -181,7 +181,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct SpecialTypeAsReturnTypeShader : IComputeShader
         {
@@ -204,7 +204,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct LocalFunctionInExternalMethodsShader : IComputeShader
         {
@@ -237,7 +237,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct CapturedNestedStructTypeShader : IComputeShader
         {
@@ -258,7 +258,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct ExternalStructTypeShader : IComputeShader
         {
@@ -281,7 +281,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct OutOfOrderMethodsShader : IComputeShader
         {
@@ -318,7 +318,7 @@ namespace ComputeSharp.Tests
             Assert.AreEqual(info.BoundResourceCount, 2u);
         }
 
-        [ThreadGroupSize(DispatchAxis.XY)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct StatelessPixelShader : IComputeShader<float4>
         {
@@ -330,7 +330,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct LoopWithVarCounterShader : IComputeShader
         {
@@ -361,7 +361,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct DoublePrecisionSupportShader : IComputeShader
         {
@@ -382,7 +382,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct FieldAccessWithThisExpressionShader : IComputeShader
         {
@@ -410,7 +410,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct ComputeShaderWithInheritedShaderInterfaceShader : IMyBaseShader
         {
@@ -445,7 +445,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct PixelShaderWithInheritedShaderInterfaceShader : IMyBaseShader<float4>
         {
@@ -495,7 +495,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct StructInstanceMethodsShader : IComputeShader
         {
@@ -530,7 +530,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct PixelShaderWithScopedParameterInMethodsShader : IComputeShader
         {
@@ -579,7 +579,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [CompileOptions(CompileOptions.Default | CompileOptions.StripReflectionData)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct ShaderWithStrippedReflectionData1 : IComputeShader
@@ -594,7 +594,7 @@ namespace ComputeSharp.Tests
         }
 
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [CompileOptions(CompileOptions.Default)]
         [GeneratedComputeShaderDescriptor]
         internal readonly partial struct ShaderWithStrippedReflectionData2 : IComputeShader
@@ -617,7 +617,7 @@ namespace ExternalNamespace
     public partial class ShaderCompilerTestsInExternalNamespace
     {
         [AutoConstructor]
-        [ThreadGroupSize(DispatchAxis.X)]
+        [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct UserDefinedTypeShader : IComputeShader
         {

--- a/tests/ComputeSharp.Tests/ShaderMembersTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderMembersTests.cs
@@ -31,7 +31,7 @@ public partial class ShaderMembersTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct StaticConstantsShader : IComputeShader
     {
@@ -72,7 +72,7 @@ public partial class ShaderMembersTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct GlobalVariableShader : IComputeShader
     {
@@ -108,7 +108,7 @@ public partial class ShaderMembersTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct BoolInstanceFieldsShader : IComputeShader
     {
@@ -173,7 +173,7 @@ public partial class ShaderMembersTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct BoolInstanceFieldInCustomStructShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ShaderMembersTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderMembersTests.cs
@@ -31,7 +31,7 @@ public partial class ShaderMembersTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct StaticConstantsShader : IComputeShader
     {
@@ -72,7 +72,7 @@ public partial class ShaderMembersTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct GlobalVariableShader : IComputeShader
     {
@@ -108,7 +108,7 @@ public partial class ShaderMembersTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct BoolInstanceFieldsShader : IComputeShader
     {
@@ -173,7 +173,7 @@ public partial class ShaderMembersTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct BoolInstanceFieldInCustomStructShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -52,7 +52,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct NanAndInfiniteShader : IComputeShader
     {
@@ -114,7 +114,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ModAndComparisonOperatorsShader : IComputeShader
     {
@@ -177,7 +177,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct BitwiseOperatorsShader : IComputeShader
     {
@@ -231,7 +231,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct BooleanOperatorsShader : IComputeShader
     {
@@ -282,7 +282,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ToBooleanConversionIntrinsicsShader : IComputeShader
     {
@@ -367,7 +367,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct FromBooleanConversionIntrinsicsShader : IComputeShader
     {
@@ -451,7 +451,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ConstantsInShaderConstantFieldsShader : IComputeShader
     {
@@ -530,7 +530,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DoubleConstantsInShaderConstantFieldsShader : IComputeShader
     {
@@ -593,7 +593,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct InterlockedOperationsShader : IComputeShader
     {
@@ -639,7 +639,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct GlslStyleMulOperatorsShader : IComputeShader
     {
@@ -781,7 +781,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct CustomStructTypeShader : IComputeShader
     {
@@ -820,7 +820,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct MiscHlslIntrinsicsShader : IComputeShader
     {
@@ -864,7 +864,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadonlyModifierInMethodsShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -52,7 +52,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct NanAndInfiniteShader : IComputeShader
     {
@@ -114,7 +114,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ModAndComparisonOperatorsShader : IComputeShader
     {
@@ -177,7 +177,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct BitwiseOperatorsShader : IComputeShader
     {
@@ -231,7 +231,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct BooleanOperatorsShader : IComputeShader
     {
@@ -282,7 +282,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ToBooleanConversionIntrinsicsShader : IComputeShader
     {
@@ -367,7 +367,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct FromBooleanConversionIntrinsicsShader : IComputeShader
     {
@@ -451,7 +451,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ConstantsInShaderConstantFieldsShader : IComputeShader
     {
@@ -530,7 +530,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DoubleConstantsInShaderConstantFieldsShader : IComputeShader
     {
@@ -593,7 +593,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct InterlockedOperationsShader : IComputeShader
     {
@@ -639,7 +639,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct GlslStyleMulOperatorsShader : IComputeShader
     {
@@ -781,7 +781,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct CustomStructTypeShader : IComputeShader
     {
@@ -820,7 +820,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct MiscHlslIntrinsicsShader : IComputeShader
     {
@@ -864,7 +864,7 @@ public partial class ShaderRewriterTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadonlyModifierInMethodsShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ColorfulInfinity.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ColorfulInfinity.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ColorfulInfinity : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ColorfulInfinity.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ColorfulInfinity.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ColorfulInfinity : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ContouredLayers.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ContouredLayers.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ContouredLayers : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ContouredLayers.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ContouredLayers.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ContouredLayers : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ExtrudedTruchetPattern.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ExtrudedTruchetPattern.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ExtrudedTruchetPattern : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ExtrudedTruchetPattern.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ExtrudedTruchetPattern.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ExtrudedTruchetPattern : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/FourColorGradient.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/FourColorGradient.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct FourColorGradient : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/FourColorGradient.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/FourColorGradient.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct FourColorGradient : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/FractalTiling.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/FractalTiling.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct FractalTiling : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/FractalTiling.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/FractalTiling.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct FractalTiling : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/HelloWorld.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/HelloWorld.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// Ported from <see href="https://www.shadertoy.com/new"/>.
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct HelloWorld : IComputeShader<float4>
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/HelloWorld.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/HelloWorld.cs
@@ -7,7 +7,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// Ported from <see href="https://www.shadertoy.com/new"/>.
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct HelloWorld : IComputeShader<float4>
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/MengerJourney.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/MengerJourney.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Syntopia.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct MengerJourney : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/MengerJourney.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/MengerJourney.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Syntopia.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct MengerJourney : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/Octagrams.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/Octagrams.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by whisky_shusuky.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct Octagrams : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/Octagrams.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/Octagrams.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by whisky_shusuky.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct Octagrams : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ProteanClouds : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct ProteanClouds : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/PyramidPattern.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/PyramidPattern.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct PyramidPattern : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/PyramidPattern.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/PyramidPattern.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct PyramidPattern : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/TerracedHills.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/TerracedHills.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TerracedHills : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/TerracedHills.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/TerracedHills.cs
@@ -6,7 +6,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TerracedHills : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/TriangleGridContouring.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/TriangleGridContouring.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TriangleGridContouring : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/TriangleGridContouring.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/TriangleGridContouring.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TriangleGridContouring : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/TwoTiledTruchet.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/TwoTiledTruchet.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[EmbeddedBytecode(DispatchAxis.XY)]
+[ThreadGroupSize(DispatchAxis.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TwoTiledTruchet : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/TwoTiledTruchet.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/TwoTiledTruchet.cs
@@ -8,7 +8,7 @@ namespace ComputeSharp.SwapChain.Shaders.Compute;
 /// <para>Created by Shane.</para>
 /// </summary>
 [AutoConstructor]
-[ThreadGroupSize(DispatchAxis.XY)]
+[ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
 internal readonly partial struct TwoTiledTruchet : IComputeShader
 {

--- a/tests/ComputeSharp.Tests/Texture1DTests.Pixels.cs
+++ b/tests/ComputeSharp.Tests/Texture1DTests.Pixels.cs
@@ -89,7 +89,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct SamplingComputeShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture1DTests.Pixels.cs
+++ b/tests/ComputeSharp.Tests/Texture1DTests.Pixels.cs
@@ -89,7 +89,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct SamplingComputeShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture1DTests.Pixels.g.cs
+++ b/tests/ComputeSharp.Tests/Texture1DTests.Pixels.g.cs
@@ -69,7 +69,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Bgra32_Float4 : IComputeShader
     {
@@ -83,7 +83,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R16_float : IComputeShader
     {
@@ -97,7 +97,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R8_float : IComputeShader
     {
@@ -111,7 +111,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg16_Float2 : IComputeShader
     {
@@ -125,7 +125,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg32_Float2 : IComputeShader
     {
@@ -139,7 +139,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba32_Float4 : IComputeShader
     {
@@ -153,7 +153,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba64_Float4 : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture1DTests.Pixels.g.cs
+++ b/tests/ComputeSharp.Tests/Texture1DTests.Pixels.g.cs
@@ -69,7 +69,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Bgra32_Float4 : IComputeShader
     {
@@ -83,7 +83,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R16_float : IComputeShader
     {
@@ -97,7 +97,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R8_float : IComputeShader
     {
@@ -111,7 +111,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg16_Float2 : IComputeShader
     {
@@ -125,7 +125,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg32_Float2 : IComputeShader
     {
@@ -139,7 +139,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba32_Float4 : IComputeShader
     {
@@ -153,7 +153,7 @@ partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba64_Float4 : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture1DTests.Pixels.tt
+++ b/tests/ComputeSharp.Tests/Texture1DTests.Pixels.tt
@@ -65,7 +65,7 @@ foreach (var (t, tPixel) in EnumerateTypes())
 #>
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_<#=t#>_<#=tPixel#> : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture1DTests.Pixels.tt
+++ b/tests/ComputeSharp.Tests/Texture1DTests.Pixels.tt
@@ -65,7 +65,7 @@ foreach (var (t, tPixel) in EnumerateTypes())
 #>
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_<#=t#>_<#=tPixel#> : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture1DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture1DTests.cs
@@ -363,7 +363,7 @@ public partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture1DKernel : IComputeShader
     {
@@ -395,7 +395,7 @@ public partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1DKernel : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture1DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture1DTests.cs
@@ -363,7 +363,7 @@ public partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture1DKernel : IComputeShader
     {
@@ -395,7 +395,7 @@ public partial class Texture1DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture1DKernel : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture2DTests.Pixels.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.Pixels.cs
@@ -72,7 +72,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct SamplingComputeShader : IComputeShader
     {
@@ -107,7 +107,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct SamplingPixelShader : IComputeShader<float4>
     {

--- a/tests/ComputeSharp.Tests/Texture2DTests.Pixels.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.Pixels.cs
@@ -72,7 +72,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct SamplingComputeShader : IComputeShader
     {
@@ -107,7 +107,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct SamplingPixelShader : IComputeShader<float4>
     {

--- a/tests/ComputeSharp.Tests/Texture2DTests.Pixels.g.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.Pixels.g.cs
@@ -69,7 +69,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Bgra32_Float4 : IComputeShader
     {
@@ -83,7 +83,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R16_float : IComputeShader
     {
@@ -97,7 +97,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R8_float : IComputeShader
     {
@@ -111,7 +111,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg16_Float2 : IComputeShader
     {
@@ -125,7 +125,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg32_Float2 : IComputeShader
     {
@@ -139,7 +139,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba32_Float4 : IComputeShader
     {
@@ -153,7 +153,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba64_Float4 : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture2DTests.Pixels.g.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.Pixels.g.cs
@@ -69,7 +69,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Bgra32_Float4 : IComputeShader
     {
@@ -83,7 +83,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R16_float : IComputeShader
     {
@@ -97,7 +97,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R8_float : IComputeShader
     {
@@ -111,7 +111,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg16_Float2 : IComputeShader
     {
@@ -125,7 +125,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg32_Float2 : IComputeShader
     {
@@ -139,7 +139,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba32_Float4 : IComputeShader
     {
@@ -153,7 +153,7 @@ partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba64_Float4 : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture2DTests.Pixels.tt
+++ b/tests/ComputeSharp.Tests/Texture2DTests.Pixels.tt
@@ -65,7 +65,7 @@ foreach (var (t, tPixel) in EnumerateTypes())
 #>
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_<#=t#>_<#=tPixel#> : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture2DTests.Pixels.tt
+++ b/tests/ComputeSharp.Tests/Texture2DTests.Pixels.tt
@@ -65,7 +65,7 @@ foreach (var (t, tPixel) in EnumerateTypes())
 #>
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_<#=t#>_<#=tPixel#> : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture2DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.cs
@@ -428,7 +428,7 @@ public partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture2DKernel : IComputeShader
     {
@@ -460,7 +460,7 @@ public partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2DKernel : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture2DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.cs
@@ -428,7 +428,7 @@ public partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture2DKernel : IComputeShader
     {
@@ -460,7 +460,7 @@ public partial class Texture2DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture2DKernel : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture3DTests.Pixels.g.cs
+++ b/tests/ComputeSharp.Tests/Texture3DTests.Pixels.g.cs
@@ -69,7 +69,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Bgra32_Float4 : IComputeShader
     {
@@ -83,7 +83,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R16_float : IComputeShader
     {
@@ -97,7 +97,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R8_float : IComputeShader
     {
@@ -111,7 +111,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg16_Float2 : IComputeShader
     {
@@ -125,7 +125,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg32_Float2 : IComputeShader
     {
@@ -139,7 +139,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba32_Float4 : IComputeShader
     {
@@ -153,7 +153,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba64_Float4 : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture3DTests.Pixels.g.cs
+++ b/tests/ComputeSharp.Tests/Texture3DTests.Pixels.g.cs
@@ -69,7 +69,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Bgra32_Float4 : IComputeShader
     {
@@ -83,7 +83,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R16_float : IComputeShader
     {
@@ -97,7 +97,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_R8_float : IComputeShader
     {
@@ -111,7 +111,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg16_Float2 : IComputeShader
     {
@@ -125,7 +125,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rg32_Float2 : IComputeShader
     {
@@ -139,7 +139,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba32_Float4 : IComputeShader
     {
@@ -153,7 +153,7 @@ partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_Rgba64_Float4 : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture3DTests.Pixels.tt
+++ b/tests/ComputeSharp.Tests/Texture3DTests.Pixels.tt
@@ -65,7 +65,7 @@ foreach (var (t, tPixel) in EnumerateTypes())
 #>
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_<#=t#>_<#=tPixel#> : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture3DTests.Pixels.tt
+++ b/tests/ComputeSharp.Tests/Texture3DTests.Pixels.tt
@@ -65,7 +65,7 @@ foreach (var (t, tPixel) in EnumerateTypes())
 #>
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct Shader_Unorm_<#=t#>_<#=tPixel#> : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture3DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture3DTests.cs
@@ -533,7 +533,7 @@ public partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture3DKernel : IComputeShader
     {
@@ -565,7 +565,7 @@ public partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3DKernel : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/Texture3DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture3DTests.cs
@@ -533,7 +533,7 @@ public partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadOnlyTexture3DKernel : IComputeShader
     {
@@ -565,7 +565,7 @@ public partial class Texture3DTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct ReadWriteTexture3DKernel : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ThreadGroupSizeTests.cs
+++ b/tests/ComputeSharp.Tests/ThreadGroupSizeTests.cs
@@ -23,7 +23,7 @@ public partial class ThreadGroupSizeTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.X)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchXShader : IComputeShader
     {
@@ -36,7 +36,7 @@ public partial class ThreadGroupSizeTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XY)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchXYShader : IComputeShader
     {
@@ -49,7 +49,7 @@ public partial class ThreadGroupSizeTests
     }
 
     [AutoConstructor]
-    [ThreadGroupSize(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DefaultThreadGroupSizes.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchXYZShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ThreadGroupSizeTests.cs
+++ b/tests/ComputeSharp.Tests/ThreadGroupSizeTests.cs
@@ -23,7 +23,7 @@ public partial class ThreadGroupSizeTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.X)]
+    [ThreadGroupSize(DispatchAxis.X)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchXShader : IComputeShader
     {
@@ -36,7 +36,7 @@ public partial class ThreadGroupSizeTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XY)]
+    [ThreadGroupSize(DispatchAxis.XY)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchXYShader : IComputeShader
     {
@@ -49,7 +49,7 @@ public partial class ThreadGroupSizeTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(DispatchAxis.XYZ)]
+    [ThreadGroupSize(DispatchAxis.XYZ)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchXYZShader : IComputeShader
     {
@@ -62,7 +62,7 @@ public partial class ThreadGroupSizeTests
     }
 
     [AutoConstructor]
-    [EmbeddedBytecode(11, 14, 6)]
+    [ThreadGroupSize(11, 14, 6)]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DispatchCustomShader : IComputeShader
     {


### PR DESCRIPTION
### Contributes to #598

### Description

This PR renames `[EmbeddedBytecode]` to `[ThreadGroupSize]`. This is more consistent with the actual names used by DX12 APIs, and it also jut makes more sense in general. Additionally, it more closely matches what the values are actually doing.
