### PR TITLE
Use more static abstracts directly instead of helper methods

### DIFF
--- a/src/ComputeSharp.D2D1.WinUI/Extensions/ID2D1EffectExtensions.cs
+++ b/src/ComputeSharp.D2D1.WinUI/Extensions/ID2D1EffectExtensions.cs
@@ -47,7 +47,7 @@ internal static unsafe class ID2D1EffectExtensions
                 dataSize: (uint)constantBufferSize).Assert();
         }
 
-        T shader = D2D1PixelShader.CreateFromConstantBuffer<T>(buffer);
+        T shader = T.CreateFromConstantBuffer(buffer);
 
         ArrayPool<byte>.Shared.Return(buffer);
 

--- a/src/ComputeSharp.D2D1/Interfaces/Descriptors/ID2D1PixelShaderDescriptor{T}.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/Descriptors/ID2D1PixelShaderDescriptor{T}.cs
@@ -130,7 +130,9 @@ public interface ID2D1PixelShaderDescriptor<T>
     /// Creates a new <typeparamref name="T"/> shader instance from a constant buffer.
     /// </summary>
     /// <param name="buffer">The input constant buffer to read.</param>
+    /// <returns>The resulting <typeparamref name="T"/> instance.</returns>
     /// <remarks>The input buffer must be retrieved from <see cref="LoadConstantBuffer"/>.</remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="buffer"/> is not large enough for the current shader type.</exception>
     static abstract T CreateFromConstantBuffer(ReadOnlySpan<byte> buffer);
 
     /// <summary>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShader.cs
@@ -441,17 +441,11 @@ public static class D2D1PixelShader
     /// <typeparam name="T">The type of D2D1 pixel shader value to create.</typeparam>
     /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> with the constant buffer data.</param>
     /// <returns>The resulting <typeparamref name="T"/> instance.</returns>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="span"/> is not large enough to contain the constant buffer.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="span"/> is not large enough for the current shader type.</exception>
     public static T CreateFromConstantBuffer<T>(ReadOnlySpan<byte> span)
         where T : unmanaged, ID2D1PixelShader, ID2D1PixelShaderDescriptor<T>
     {
-        if (!TryCreateFromConstantBuffer(span, out T shader))
-        {
-            default(ArgumentException).Throw(nameof(span));
-        }
-
-        return shader;
-
+        return T.CreateFromConstantBuffer(span);
     }
 
     /// <summary>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/D2D1PixelShaderEffect.cs
@@ -176,7 +176,7 @@ public static unsafe class D2D1PixelShaderEffect
             d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager14].setFunction = &PixelShaderEffect.SetResourceTextureManager14Impl;
             d2D1PropertyBinding[D2D1PixelShaderEffectProperty.ResourceTextureManager15].setFunction = &PixelShaderEffect.SetResourceTextureManager15Impl;
 
-            fixed (Guid* pGuid = &GetEffectId<T>())
+            fixed (Guid* pGuid = &T.EffectId)
             {
                 // Register the effect
                 ((ID2D1Factory1*)d2D1Factory1)->RegisterEffectFromString(
@@ -187,7 +187,7 @@ public static unsafe class D2D1PixelShaderEffect
                     effectFactory: PixelShaderEffect.Globals<T>.Instance.Factory).Assert();
             }
 
-            effectId = GetEffectId<T>();
+            effectId = T.EffectId;
         }
     }
 
@@ -383,7 +383,7 @@ public static unsafe class D2D1PixelShaderEffect
         writer.Dispose();
 
         // Extract the effect id (the same that was encoded in the registration blob)
-        effectId = GetEffectId<T>();
+        effectId = T.EffectId;
 
         return registrationBlob;
     }
@@ -407,7 +407,7 @@ public static unsafe class D2D1PixelShaderEffect
         default(ArgumentNullException).ThrowIfNull(d2D1DeviceContext);
         default(ArgumentNullException).ThrowIfNull(d2D1Effect);
 
-        fixed (Guid* pGuid = &GetEffectId<T>())
+        fixed (Guid* pGuid = &T.EffectId)
         {
             ((ID2D1DeviceContext*)d2D1DeviceContext)->CreateEffect(
                 effectId: pGuid,

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -738,7 +738,7 @@ namespace ComputeSharp.D2D1.Tests
         [DataRow(0)]
         [DataRow(4)]
         [DataRow(27)]
-        [ExpectedException(typeof(ArgumentException))]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void GetConstantBuffer_BufferTooShort(int size)
         {
             byte[] buffer = new byte[size];


### PR DESCRIPTION
### Contributes to #598

### Description

This PR is a follow up to #630, and updates internal library code to invoke the static abstracts directly, rather than going through the helper methods. This is equivalent and can make the JIT life a little bit easier (especially when inlining). Additionally, it adds exception docs to the public `CreateFromConstantBuffer` method, and updates the public helper too to match the same exception type, for consistency. Lastly, it makes that method just call the generated static abstract directly instead.