### PR TITLE
Improve throw path in ReferenceTracker

### DIFF
--- a/src/ComputeSharp/Graphics/Interop/ReferenceTracker.cs
+++ b/src/ComputeSharp/Graphics/Interop/ReferenceTracker.cs
@@ -115,15 +115,7 @@ internal struct ReferenceTracker : IDisposable
     {
         Lease lease = TryGetLease(out bool leaseTaken);
 
-        if (!leaseTaken)
-        {
-            // We can't use a throw helper here as we only want to invoke ToString if we
-            // are about to throw an exception. The JIT will recognize this pattern
-            // as this method has a single basic block that always throws an exception.
-            static void Throw(object trackedObject) => throw new ObjectDisposedException(trackedObject.ToString());
-
-            Throw(this);
-        }
+        default(ObjectDisposedException).ThrowIf(!leaseTaken, this.trackedObject);
 
         return lease;
     }


### PR DESCRIPTION
### Description

This PR tweaks the throw path in `ReferenceTracker` to make it more compact, a bit faster, and also fixing the error message. The code was accidentally boxing the `ReferenceTracker` instance and passing that, instead of passing the actual tracked object.