### PR TITLE
Fix handling of suppressed D2D compilation warnings

### DIFF
--- a/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Translation/D3DCompiler.cs
@@ -169,12 +169,16 @@ internal static unsafe partial class D3DCompiler
                 ppErrorMsgs: d3DBlobErrors.GetAddressOf());
         }
 
-        // Throw if an error was retrieved, then also double check the HRESULT
-        if (d3DBlobErrors.Get() is not null)
+        // Throw an exception with the input messages, if the compilation fails.
+        // If compilation succeeds with warnings, we just ignore the messages.
+        if (hResult.Value < 0 && d3DBlobErrors.Get() is not null)
         {
             ThrowHslsCompilationException(d3DBlobErrors.Get());
         }
 
+        // Also just assert the HRESULT in general after checking messages. Not entirely
+        // clear if this is reachable in case the compilation fails (one would assume
+        // there would always be a message), but better safe than sorry.
         hResult.Assert();
 
         return d3DBlobBytecode.Move();

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -8,7 +8,7 @@ using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Tests.Effects;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-#pragma warning disable IDE0059, IDE0161, IDE0044
+#pragma warning disable IDE0044, IDE0059, IDE0161
 
 [D2DInputCount(0)]
 [D2DGeneratedPixelShaderDescriptor]
@@ -597,6 +597,28 @@ namespace ComputeSharp.D2D1.Tests
             public float4 Execute()
             {
                 return D2D.GetInput(0);
+            }
+        }
+
+        [TestMethod]
+        public void LoadBytecode_ShaderWithSuppressedFxcWarning()
+        {
+            ReadOnlyMemory<byte> hlslBytecode = D2D1PixelShader.LoadBytecode<ShaderWithSuppressedFxcWarning>(out _, out D2D1CompileOptions compileOptions);
+
+            Assert.AreEqual(D2D1CompileOptions.OptimizationLevel3 | D2D1CompileOptions.PackMatrixRowMajor, compileOptions);
+            Assert.IsTrue(hlslBytecode.Length > 0);
+        }
+
+        // See https://github.com/Sergio0694/ComputeSharp/issues/647
+        [D2DInputCount(0)]
+        [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+        [D2DGeneratedPixelShaderDescriptor]
+        [D2DCompileOptions(D2D1CompileOptions.Default & ~D2D1CompileOptions.WarningsAreErrors)]
+        public readonly partial struct ShaderWithSuppressedFxcWarning(int a) : ID2D1PixelShader
+        {
+            public float4 Execute()
+            {
+                return a / 4;
             }
         }
 

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
@@ -9,7 +9,7 @@ namespace ComputeSharp.D2D1.Tests;
 public partial class D2D1ShaderCompilerTests
 {
     [TestMethod]
-    public unsafe void CompileInvertEffectWithDefaultOptions()
+    public void CompileInvertEffectWithDefaultOptions()
     {
         const string source = """
             #define D2D_INPUT_COUNT 1
@@ -35,7 +35,7 @@ public partial class D2D1ShaderCompilerTests
     }
 
     [TestMethod]
-    public unsafe void CompileInvertEffectWithDefaultOptions_Utf8()
+    public void CompileInvertEffectWithDefaultOptions_Utf8()
     {
         ReadOnlySpan<byte> sourceUtf8 = """
             #define D2D_INPUT_COUNT 1
@@ -61,7 +61,7 @@ public partial class D2D1ShaderCompilerTests
     }
 
     [TestMethod]
-    public unsafe void CompileInvertEffectWithDefaultOptionsAndLinking()
+    public void CompileInvertEffectWithDefaultOptionsAndLinking()
     {
         const string source = """
             #define D2D_INPUT_COUNT 1
@@ -88,7 +88,7 @@ public partial class D2D1ShaderCompilerTests
 
     [TestMethod]
     [ExpectedException(typeof(FxcCompilationException))]
-    public unsafe void CompileInvertEffectWithInvalidEntryPoint()
+    public void CompileInvertEffectWithInvalidEntryPoint()
     {
         const string source = """
             #define D2D_INPUT_COUNT 1
@@ -104,18 +104,18 @@ public partial class D2D1ShaderCompilerTests
             }
             """;
 
-        ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
+        _ = D2D1ShaderCompiler.Compile(
             source.AsSpan(),
             "Execute".AsSpan(),
             D2D1ShaderProfile.PixelShader40Level93,
             D2D1CompileOptions.Default);
 
-        Assert.IsTrue(bytecode.Length > 0);
+        Assert.Fail();
     }
 
     [TestMethod]
     [ExpectedException(typeof(FxcCompilationException))]
-    public unsafe void CompileInvertEffectWithErrors()
+    public void CompileInvertEffectWithErrors()
     {
         const string source = """
             #define D2D_INPUT_COUNT 1
@@ -131,17 +131,17 @@ public partial class D2D1ShaderCompilerTests
             }
             """;
 
-        ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
+        _ = D2D1ShaderCompiler.Compile(
             source.AsSpan(),
             "PSMain".AsSpan(),
             D2D1ShaderProfile.PixelShader40Level93,
             D2D1CompileOptions.Default);
 
-        Assert.IsTrue(bytecode.Length > 0);
+        Assert.Fail();
     }
 
     [TestMethod]
-    public unsafe void CompilePixelateEffectWithDefaultOptions()
+    public void CompilePixelateEffectWithDefaultOptions()
     {
         const string source = """
             #define D2D_INPUT_COUNT 1
@@ -184,6 +184,70 @@ public partial class D2D1ShaderCompilerTests
             "PSMain".AsSpan(),
             D2D1ShaderProfile.PixelShader40,
             D2D1CompileOptions.Default);
+
+        Assert.IsTrue(bytecode.Length > 0);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(FxcCompilationException))]
+    public void CompileShaderWithWarning()
+    {
+        const string source = """
+            // ================================================
+            //                  AUTO GENERATED
+            // ================================================
+            // This shader was created by ComputeSharp.
+            // See: https://github.com/Sergio0694/ComputeSharp.
+
+            #define D2D_INPUT_COUNT 0
+
+            #include "d2d1effecthelpers.hlsli"
+
+            int a;
+
+            D2D_PS_ENTRY(Execute)
+            {
+                return a / 4;
+            }
+            """;
+
+        _ = D2D1ShaderCompiler.Compile(
+            source.AsSpan(),
+            "Execute".AsSpan(),
+            D2D1ShaderProfile.PixelShader40,
+            D2D1CompileOptions.Default);
+
+        Assert.Fail();
+    }
+
+    // See https://github.com/Sergio0694/ComputeSharp/issues/647
+    [TestMethod]
+    public void CompileShaderWithWarning_Suppressed()
+    {
+        const string source = """
+            // ================================================
+            //                  AUTO GENERATED
+            // ================================================
+            // This shader was created by ComputeSharp.
+            // See: https://github.com/Sergio0694/ComputeSharp.
+
+            #define D2D_INPUT_COUNT 0
+
+            #include "d2d1effecthelpers.hlsli"
+
+            int a;
+
+            D2D_PS_ENTRY(Execute)
+            {
+                return a / 4;
+            }
+            """;
+
+        ReadOnlyMemory<byte> bytecode = D2D1ShaderCompiler.Compile(
+            source.AsSpan(),
+            "Execute".AsSpan(),
+            D2D1ShaderProfile.PixelShader40,
+            D2D1CompileOptions.Default & ~D2D1CompileOptions.WarningsAreErrors);
 
         Assert.IsTrue(bytecode.Length > 0);
     }


### PR DESCRIPTION
### Closes #647, contributes to #598

### Description

This PR fixes the D2D compiler APIs incorrectly handling suppressed compilation warnings.