### PR TITLE
Switch all TFMs to .NET 8 and enable C# 12

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -122,7 +122,7 @@ jobs:
     - name: Run ComputeSharp.D2D1.Tests.AssemblyLevelAttributes
       run: dotnet test tests\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes\ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj -c Release -v n -l "console;verbosity=detailed"
 
-      # Run the D2D1 source generators tests as well (only on .NET 7, like for the DX12 ones)
+      # Run the D2D1 source generators tests as well
     - name: Run ComputeSharp.D2D1.Tests.SourceGenerators
       run: dotnet test tests\ComputeSharp.D2D1.Tests.SourceGenerators\ComputeSharp.D2D1.Tests.SourceGenerators.csproj -v n -l "console;verbosity=detailed"
 
@@ -165,7 +165,7 @@ jobs:
       run: >
         $vs_path = vswhere -latest -products * -requires Microsoft.VisualStudio.Workload.ManagedDesktop -requiresAny -property installationPath;
         $vstest_path = join-path $vs_path 'Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe';
-        & $vstest_path /Platform:x64 tests\ComputeSharp.D2D1.WinUI.Tests\bin\x64\Release\net7.0-windows10.0.22621.0\win10-x64\ComputeSharp.D2D1.WinUI.Tests.build.appxrecipe
+        & $vstest_path /Platform:x64 tests\ComputeSharp.D2D1.WinUI.Tests\bin\x64\Release\net8.0-windows10.0.22621.0\win-x64\ComputeSharp.D2D1.WinUI.Tests.build.appxrecipe
 
   # Run all the local samples to ensure they build and run with no errors
   run-samples:
@@ -177,15 +177,15 @@ jobs:
     - name: Build and run ComputeSharp.Sample
       run: >
         dotnet build samples\ComputeSharp.Sample\ComputeSharp.Sample.csproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
-        samples\ComputeSharp.Sample\bin\x64\Release\net7.0\win-x64\ComputeSharp.Sample.exe
+        samples\ComputeSharp.Sample\bin\x64\Release\net8.0\win-x64\ComputeSharp.Sample.exe
     - name: Build and run ComputeSharp.Sample.FSharp
       run: >
         dotnet build samples\ComputeSharp.Sample.FSharp\ComputeSharp.Sample.FSharp.fsproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
-        samples\ComputeSharp.Sample.FSharp\bin\x64\Release\net7.0\win-x64\ComputeSharp.Sample.FSharp.exe
+        samples\ComputeSharp.Sample.FSharp\bin\x64\Release\net8.0\win-x64\ComputeSharp.Sample.FSharp.exe
     - name: Build and run ComputeSharp.ImageProcessing.csproj
       run: >
         dotnet build samples\ComputeSharp.ImageProcessing\ComputeSharp.ImageProcessing.csproj -c Release -r win-x64 --no-self-contained -p:Platform=x64 -v n;
-        samples\ComputeSharp.ImageProcessing\bin\x64\Release\net7.0\win-x64\ComputeSharp.ImageProcessing.exe
+        samples\ComputeSharp.ImageProcessing\bin\x64\Release\net8.0\win-x64\ComputeSharp.ImageProcessing.exe
 
   # Run the NativeAOT samples as well
   run-samples-aot:
@@ -215,7 +215,7 @@ jobs:
     - if: matrix.platform == 'x64'
       name: Run ComputeSharp.SwapChain.Cli (speed)
       run: >
-        $process = (Start-Process samples\ComputeSharp.SwapChain.Cli\bin\Release\net7.0\win-x64\publish\computesharp.cli.exe -PassThru);
+        $process = (Start-Process samples\ComputeSharp.SwapChain.Cli\bin\Release\net8.0\win-x64\publish\computesharp.cli.exe -PassThru);
         sleep -Seconds 2;
         $process.CloseMainWindow() | Out-Null;
         $process.WaitForExit();
@@ -228,7 +228,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: computesharp.cli.opt-speed.exe
-        path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net7.0\win-x64\publish\computesharp.cli.exe
+        path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net8.0\win-x64\publish\computesharp.cli.exe
         if-no-files-found: error
 
       # Publish the NativeAOT CLI sample (optimized for size, and reflection-free)
@@ -244,7 +244,7 @@ jobs:
     - if: matrix.platform == 'x64'
       name: Run ComputeSharp.SwapChain.Cli (size)
       run: >
-        $process = (Start-Process samples\ComputeSharp.SwapChain.Cli\bin\Release\net7.0\win-x64\publish\computesharp.cli.exe -PassThru);
+        $process = (Start-Process samples\ComputeSharp.SwapChain.Cli\bin\Release\net8.0\win-x64\publish\computesharp.cli.exe -PassThru);
         sleep -Seconds 2;
         $process.CloseMainWindow() | Out-Null;
         $process.WaitForExit();
@@ -257,21 +257,21 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: computesharp.cli.opt-size.exe
-        path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net7.0\win-x64\publish\computesharp.cli.exe
+        path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net8.0\win-x64\publish\computesharp.cli.exe
         if-no-files-found: error
 
-      # Also publish the Win2D sample on .NET 7 (without NativeAOT, see https://github.com/dotnet/runtime/issues/84908)
+      # Also publish the Win2D sample (without NativeAOT, see https://github.com/dotnet/runtime/issues/84908)
     - if: matrix.platform == 'x64'
       name: Publish ComputeSharp.SwapChain.D2D1.Cli
       run: >
         msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish /p:Configuration=Release
-        /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win10-${{matrix.platform}} /p:PublishSingleFile=True /p:SelfContained=True /p:PublishTrimmed=True
+        /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}} /p:PublishSingleFile=True /p:SelfContained=True /p:PublishTrimmed=True
       
       # Just like for the DX12 sample, run it on x64 to validate it works correctly
     - if: matrix.platform == 'x64'
       name: Run ComputeSharp.SwapChain.D2D1.Cli
       run: >
-        $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net7.0-windows10.0.22621\win10-x64\publish\computesharp.d2d1.cli.exe -PassThru);
+        $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net8.0-windows10.0.22621\win-x64\publish\computesharp.d2d1.cli.exe -PassThru);
         sleep -Seconds 2;
         $process.CloseMainWindow() | Out-Null;
         $process.WaitForExit();
@@ -285,7 +285,7 @@ jobs:
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT='true';
         git clean -fdx;
         msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish /p:Configuration=Release
-        /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win10-${{matrix.platform}}
+        /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
 
   # Download the NuGet packages generated in the previous job and use them
   # to build and run the sample project referencing them. This is used as
@@ -321,17 +321,17 @@ jobs:
       run: >
         $env:COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT='true';
         dotnet publish tests\ComputeSharp.NuGet\ComputeSharp.NuGet.csproj -c Release -r win-x64 -v n;
-        tests\ComputeSharp.NuGet\bin\Release\net7.0\win-x64\publish\ComputeSharp.NuGet.exe
+        tests\ComputeSharp.NuGet\bin\Release\net8.0\win-x64\publish\ComputeSharp.NuGet.exe
     - name: Publish and run ComputeSharp.Dxc.NuGet with NativeAOT
       run: >
         $env:COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT='true';
         dotnet publish tests\ComputeSharp.Dxc.NuGet\ComputeSharp.Dxc.NuGet.csproj -c Release -r win-x64 -v n;
-        tests\ComputeSharp.Dxc.NuGet\bin\Release\net7.0\win-x64\publish\ComputeSharp.Dxc.NuGet.exe
+        tests\ComputeSharp.Dxc.NuGet\bin\Release\net8.0\win-x64\publish\ComputeSharp.Dxc.NuGet.exe
     - name: Publish and run ComputeSharp.Pix.NuGet with NativeAOT
       run: >
         $env:COMPUTESHARP_NUGET_TESTS_PUBLISH_AOT='true';
         dotnet publish tests\ComputeSharp.Pix.NuGet\ComputeSharp.Pix.NuGet.csproj -c Release -r win-x64 -v n;
-        tests\ComputeSharp.Pix.NuGet\bin\Release\net7.0\win-x64\publish\ComputeSharp.Pix.NuGet.exe
+        tests\ComputeSharp.Pix.NuGet\bin\Release\net8.0\win-x64\publish\ComputeSharp.Pix.NuGet.exe
 
   # Publish the packages to GitHub packages
   publish-nightlies-github:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -265,8 +265,10 @@ jobs:
     - if: matrix.platform == 'x64'
       name: Publish ComputeSharp.SwapChain.D2D1.Cli
       run: >
-        msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish /p:Configuration=Release
-        /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}} /p:PublishSingleFile=True /p:SelfContained=True /p:PublishTrimmed=True
+        $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_R2R='true';
+        $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT='false';
+        msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish
+        /p:Configuration=Release /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
       
       # Just like for the DX12 sample, run it on x64 to validate it works correctly
     - if: matrix.platform == 'x64'
@@ -283,6 +285,7 @@ jobs:
     - if: matrix.platform == 'x64'
       name: Publish ComputeSharp.SwapChain.D2D1.Cli with NativeAOT
       run: >
+        $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_R2R='false';
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT='true';
         git clean -fdx;
         msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish /p:Configuration=Release

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -231,12 +231,13 @@ jobs:
         path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net8.0\win-x64\publish\computesharp.cli.exe
         if-no-files-found: error
 
-      # Publish the NativeAOT CLI sample (optimized for size, and reflection-free)
+      # Publish the NativeAOT CLI sample (optimized for size, and reflection-free).
+      # Temporarily skip COMPUTESHARP_SWAPCHAIN_CLI_DISABLE_REFLECTION unti code is
+      # refactored to replace typeof(T).GUID with hardcoded IIDs, or it won't work.
     - name: Publish ComputeSharp.SwapChain.Cli with NativeAOT (size)
       run: >
         $env:COMPUTESHARP_SWAPCHAIN_CLI_PUBLISH_AOT='true';
         $env:COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED='true';
-        $env:COMPUTESHARP_SWAPCHAIN_CLI_DISABLE_REFLECTION='true';
         git clean -fdx;
         dotnet publish samples\ComputeSharp.SwapChain.Cli\ComputeSharp.SwapChain.Cli.csproj -c Release -r win-${{matrix.platform}} -v n
       

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
@@ -46,7 +46,7 @@
       This is used eg. to replace Unsafe.SizeOf<T>() calls with just sizeof(T). The warning is not necessary
       since in order to use these APIs the caller already has to be in an unsafe context.
     -->
-    <NoWarn>$(NoWarn);CS8500</NoWarn>
+    <NoWarn>$(NoWarn);CS8500;IDE0290;IDE0305;IDE0028;IDE0300;IDE0301;IDE0302</NoWarn>
   </PropertyGroup>
 
   <!-- Centralized location for all generated artifacts -->

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2",
+    "version": "8.0.100",
     "rollForward": "latestFeature",
-    "allowPrerelease": true
+    "allowPrerelease": false
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,9 +1,7 @@
 {
-  "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "3.0.38"
-  },
   "sdk": {
-    "version": "7.0.202",
-    "rollForward": "latestFeature"
+    "version": "8.0.100-rc.2.23502.2",
+    "rollForward": "latestFeature",
+    "allowPrerelease": true
   }
 }

--- a/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
+++ b/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 

--- a/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
+++ b/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.9" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />
   </ItemGroup>

--- a/samples/ComputeSharp.Benchmark/Program.cs
+++ b/samples/ComputeSharp.Benchmark/Program.cs
@@ -6,6 +6,6 @@ using BenchmarkDotNet.Running;
 // ================
 // In order to run this benchmark, switch to Release mode and either run select
 // it as the startup project for the solution and run it without the debugger
-// (CTRL + F5), or compile it and then go to its bin\Release\net7.0 folder,
+// (CTRL + F5), or compile it and then go to its bin\Release\net8.0 folder,
 // open a cmd prompt and run "dotnet ComputeSharp.Benchmark.dll".
 BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);

--- a/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
+++ b/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/samples/ComputeSharp.Sample.FSharp.Shaders/ComputeSharp.Sample.FSharp.Shaders.csproj
+++ b/samples/ComputeSharp.Sample.FSharp.Shaders/ComputeSharp.Sample.FSharp.Shaders.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <LangVersion>5.0</LangVersion>
   </PropertyGroup>

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
-    <LangVersion>5.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="7.0.400" />
+    <PackageReference Update="FSharp.Core" Version="8.0.100" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.Sample/ComputeSharp.Sample.csproj
+++ b/samples/ComputeSharp.Sample/ComputeSharp.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>

--- a/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
@@ -26,14 +26,13 @@
   -->
   <PropertyGroup Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_PUBLISH_AOT)' == 'true'">
     <PublishAot>true</PublishAot>
-    <DebuggerSupport>false</DebuggerSupport>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <StackTraceSupport>false</StackTraceSupport>
+    <OptimizationPreference Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED)' == 'true'">Size</OptimizationPreference>
+    <OptimizationPreference Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED)' != 'true'">Speed</OptimizationPreference>
     <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
-    <IlcGenerateStackTraceData>false</IlcGenerateStackTraceData>
     <IlcDisableReflection Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_DISABLE_REFLECTION)' == 'true'">true</IlcDisableReflection>
-    <IlcOptimizationPreference Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED)' == 'true'">Size</IlcOptimizationPreference>
-    <IlcOptimizationPreference Condition="'$(COMPUTESHARP_SWAPCHAIN_CLI_SIZE_OPTIMIZED)' != 'true'">Speed</IlcOptimizationPreference>
   </PropertyGroup>
 
   <!--
@@ -49,7 +48,7 @@
 
   <!-- If requested, also reference the UPX compression package -->
   <ItemGroup Condition="'$(PUBLISH_AOT_COMPRESSED)' == 'true'">
-    <PackageReference Include="PublishAotCompressed" Version="1.0.0" />
+    <PackageReference Include="PublishAotCompressed" Version="1.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
@@ -8,7 +8,7 @@
     -->
     <OutputType Condition="'$(CI_RUNNER_SAMPLES_INTEGRATION_TESTS)' == 'true'">Exe</OutputType>
     <OutputType Condition="'$(CI_RUNNER_SAMPLES_INTEGRATION_TESTS)' != 'true'">WinExe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416</NoWarn>
     <AssemblyName>computesharp.cli</AssemblyName>

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -9,6 +9,9 @@
     <NoWarn>$(NoWarn);IDE0065</NoWarn>
     <AssemblyName>computesharp.d2d1.cli</AssemblyName>
     <ApplicationIcon>..\..\assets\icon.ico</ApplicationIcon>
+
+    <!-- Temporary workaround for RID graph change in .NET 8 (see https://github.com/microsoft/Win2D/issues/935) -->
+    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <OutputType Condition="'$(CI_RUNNER_SAMPLES_INTEGRATION_TESTS)' == 'true'">Exe</OutputType>
     <OutputType Condition="'$(CI_RUNNER_SAMPLES_INTEGRATION_TESTS)' != 'true'">WinExe</OutputType>
-    <TargetFramework>net7.0-windows10.0.22621</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621</TargetFramework>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x64;ARM64</Platforms>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <NoWarn>$(NoWarn);IDE0065</NoWarn>
     <AssemblyName>computesharp.d2d1.cli</AssemblyName>
     <ApplicationIcon>..\..\assets\icon.ico</ApplicationIcon>

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -22,7 +22,8 @@
     <PublishAot>true</PublishAot>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
     <InvariantGlobalization>true</InvariantGlobalization>
-    <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
+    <StackTraceSupport>false</StackTraceSupport>
+    <OptimizationPreference>Speed</OptimizationPreference>
 
     <!-- Workaround for WinRT.Runtime and System.Linq.Expressions producing trim warnings -->
     <NoWarn>$(NoWarn);IL3053</NoWarn>

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -20,6 +20,14 @@
     <NoWarn>$(NoWarn);IL2104;IL2026</NoWarn>
   </PropertyGroup>
 
+  <!-- Options for R2R publishing -->
+  <PropertyGroup Condition="'$(COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_R2R)' == 'true'">
+    <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
   <!-- Same optional NativeAOT property group as in ComputeSharp.SwapChain.Cli -->
   <PropertyGroup Condition="'$(COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT)' == 'true'">
     <PublishAot>true</PublishAot>

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -3,13 +3,15 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <RootNamespace>ComputeSharp.SwapChain.WinUI</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x64;arm64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+
+    <!-- Temporary workaround for RID graph change in .NET 8 (see https://github.com/microsoft/Win2D/issues/935) -->
+    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,12 +28,23 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Manifest Include="$(ApplicationManifest)" />
+  </ItemGroup>
+
+  <ItemGroup>
+
+    <!--
+      The Win2D package is directly referenced as a temporary workaround for the native binaries
+      using the non-portable RID (ie. "win10-"). If this is only pulled in transitively by the
+      ComputeSharp.WinUI dependency, <UseRidGraph> will not actually work correctly. So, using
+      an explicit reference until Win2D is updated to use the portable RID instead (ie. "win-").
+    -->
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.1.0" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Media" Version="7.1.2" />
-    <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 
   <!-- 

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>ComputeSharp.SwapChain.WinUI</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x64;arm64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>

--- a/samples/ComputeSharp.SwapChain.WinUI/Properties/PublishProfiles/win-arm64.pubxml
+++ b/samples/ComputeSharp.SwapChain.WinUI/Properties/PublishProfiles/win-arm64.pubxml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://go.microsoft.com/fwlink/?LinkID=208121 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>arm64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/samples/ComputeSharp.SwapChain.WinUI/Properties/PublishProfiles/win-x64.pubxml
+++ b/samples/ComputeSharp.SwapChain.WinUI/Properties/PublishProfiles/win-x64.pubxml
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://go.microsoft.com/fwlink/?LinkID=208121 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>False</PublishSingleFile>

--- a/samples/ComputeSharp.SwapChain/ComputeSharp.SwapChain.csproj
+++ b/samples/ComputeSharp.SwapChain/ComputeSharp.SwapChain.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
     <NoWarn>$(NoWarn);CA1416;IDE0210</NoWarn>
   </PropertyGroup>

--- a/src/ComputeSharp.Core/ComputeSharp.Core.csproj
+++ b/src/ComputeSharp.Core/ComputeSharp.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
+++ b/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.csproj
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SupportedOSVersion>windows6.1</SupportedOSVersion>
   </PropertyGroup>
 

--- a/src/ComputeSharp.D3D12MemoryAllocator/ComputeSharp.D3D12MemoryAllocator.csproj
+++ b/src/ComputeSharp.D3D12MemoryAllocator/ComputeSharp.D3D12MemoryAllocator.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SupportedOSVersion>windows6.2</SupportedOSVersion>
   </PropertyGroup>
   

--- a/src/ComputeSharp.Dxc/ComputeSharp.Dxc.csproj
+++ b/src/ComputeSharp.Dxc/ComputeSharp.Dxc.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <SupportedOSVersion>windows6.2</SupportedOSVersion>
   </PropertyGroup>

--- a/src/ComputeSharp.Pix/ComputeSharp.Pix.csproj
+++ b/src/ComputeSharp.Pix/ComputeSharp.Pix.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <SupportedOSVersion>windows6.2</SupportedOSVersion>
   </PropertyGroup>

--- a/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
+++ b/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <Platforms>x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.WinUI/Helpers/SwapChainManager.cs
+++ b/src/ComputeSharp.WinUI/Helpers/SwapChainManager.cs
@@ -223,9 +223,9 @@ internal sealed unsafe partial class SwapChainManager<TOwner> : ReferenceTracked
 
             swapChainPanel.Attach((IUnknown*)((IWinRTObject)owner).NativeObject.GetRef());
 
-            swapChainPanel.CopyTo(
-                (Guid*)Unsafe.AsPointer(ref Unsafe.AsRef(new Guid(0x63AAD0B8, 0x7C24, 0x40FF, 0x85, 0xA8, 0x64, 0x0D, 0x94, 0x4C, 0xC3, 0x25))),
-                (void**)swapChainPanelNative).Assert();
+            Guid guid = new(0x63AAD0B8, 0x7C24, 0x40FF, 0x85, 0xA8, 0x64, 0x0D, 0x94, 0x4C, 0xC3, 0x25);
+
+            swapChainPanel.CopyTo(&guid, (void**)swapChainPanelNative).Assert();
         }
 
         // Get the underlying ID3D12Device in use

--- a/src/ComputeSharp/ComputeSharp.csproj
+++ b/src/ComputeSharp/ComputeSharp.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <SupportedOSVersion>windows6.2</SupportedOSVersion>
   </PropertyGroup>
 

--- a/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Dispatching.cs
+++ b/src/ComputeSharp/Graphics/Extensions/GraphicsDeviceExtensions.Dispatching.cs
@@ -80,7 +80,9 @@ public static partial class GraphicsDeviceExtensions
 
         using ComputeContext context = device.CreateComputeContext();
 
-        context.Run(texture, ref Unsafe.AsRef(default(T)));
+        Unsafe.SkipInit(out T shader);
+
+        context.Run(texture, ref shader);
     }
 
     /// <summary>

--- a/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
@@ -532,7 +532,9 @@ public static class ComputeContextExtensions
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
-        context.Run(texture, ref Unsafe.AsRef(default(T)));
+        Unsafe.SkipInit(out T shader);
+
+        context.Run(texture, ref shader);
     }
 
     /// <summary>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -43,16 +43,13 @@
   </ItemGroup>
 
   <!--
-    Enable trimming support on .NET 7 (we need to use StartsWith since it
+    Enable trimming support on .NET 8 (we need to use StartsWith since it
     could be a Windows TFM too). This can't be in a target unlike the other
     properties set below, because if that is the case the trimmable attribute
     will be set but the analyzers will not run, so warnings will be skipped.
   -->
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
-    <IsTrimmable>true</IsTrimmable>
-    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <EnableAotAnalyzer>true</EnableAotAnalyzer>
-    <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- Emit the [DisableRuntimeMarshalling] attribute for all .NET 8 projects -->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -48,15 +48,15 @@
     properties set below, because if that is the case the trimmable attribute
     will be set but the analyzers will not run, so warnings will be skipped.
   -->
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net7.0'))">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
     <EnableSingleFileAnalyzer>true</EnableSingleFileAnalyzer>
   </PropertyGroup>
 
-  <!-- Emit the [DisableRuntimeMarshalling] attribute for all .NET 7 projects -->
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net7.0'))">
+  <!-- Emit the [DisableRuntimeMarshalling] attribute for all .NET 8 projects -->
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute" />
   </ItemGroup>
 
@@ -71,7 +71,7 @@
   </Target>
 
   <!-- Emit the [ComVisible(false)] attribute for WinUI targets -->
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net7.0-windows'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0-windows'))">
     <AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">
       <_Parameter1>false</_Parameter1>
     </AssemblyAttribute>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2-beta1.23509.1" />

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer.cs
@@ -40,7 +40,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -101,7 +101,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -135,7 +135,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -193,7 +193,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -233,7 +233,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -285,7 +285,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);
@@ -349,7 +349,7 @@ public class Test_MissingPixelShaderDescriptorOnPixelShaderCodeFixer
         {
             TestCode = original,
             FixedCode = @fixed,
-            ReferenceAssemblies = ReferenceAssemblies.Net.Net70
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80
         };
 
         test.TestState.AdditionalReferences.Add(typeof(Core::ComputeSharp.Float4).Assembly);

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x64;ARM64</Platforms>
-    <RuntimeIdentifiers>win10-x64;win10-arm64</RuntimeIdentifiers>
-    <PublishProfile>win10-$(Platform).pubxml</PublishProfile>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+    <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" ExcludeAssets="build" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" ExcludeAssets="build" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.22621.2" />

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -9,6 +9,9 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+
+    <!-- Temporary workaround for RID graph change in .NET 8 (see https://github.com/microsoft/Win2D/issues/935) -->
+    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -56,6 +59,9 @@
   </ItemGroup>
 
   <ItemGroup>
+
+    <!-- Temporary Win2D package reference (see notes in the WinUI sample app .csproj file) -->
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" ExcludeAssets="build" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Properties/PublishProfiles/win-arm64.pubxml
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Properties/PublishProfiles/win-arm64.pubxml
@@ -2,8 +2,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>x64</Platform>
-    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
+    <Platform>ARM64</Platform>
+    <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Properties/PublishProfiles/win-x64.pubxml
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Properties/PublishProfiles/win-x64.pubxml
@@ -2,8 +2,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <Platform>ARM64</Platform>
-    <RuntimeIdentifier>win10-arm64</RuntimeIdentifier>
+    <Platform>x64</Platform>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishDir>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishDir>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/CanvasEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/CanvasEffectTests.cs
@@ -90,9 +90,11 @@ public partial class CanvasEffectTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidOperationException))]
+    [ExpectedException(typeof(Exception), AllowDerivedTypes = true)]
     public void CanvasEffect_EffectNotRegisteringAnOutputNode()
     {
+        const int COR_E_INVALIDOPERATION = unchecked((int)0x80131509);
+
         EffectNotRegisteringAnOutputNode effect = new();
 
         try
@@ -102,8 +104,14 @@ public partial class CanvasEffectTests
 
             drawingSession.DrawImage(effect);
         }
-        catch
+        catch (Exception e)
         {
+            // Note: this test should ideally expect and catch an InvalidOperationException, as that's the exception
+            // type thrown by CanvasEffect. But it seems that CsWinRT isn't correctly forwarding the exception type
+            // in this case, and it ends up only throwing a COMException on the managed side. To work around this in
+            // this test, we can just catch a generic Exception and manually verify that the HRESULT is a match.
+            // See https://github.com/microsoft/CsWinRT/issues/1393 (and ideally update the test once that's fixed).
+            Assert.AreEqual(COR_E_INVALIDOPERATION, e.HResult);
             Assert.IsTrue(effect.WasConfigureEffectGraphCalled);
 
             throw;

--- a/tests/ComputeSharp.Dxc.NuGet/ComputeSharp.Dxc.NuGet.csproj
+++ b/tests/ComputeSharp.Dxc.NuGet/ComputeSharp.Dxc.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <NoWarn>$(NoWarn);IL2026</NoWarn>

--- a/tests/ComputeSharp.NuGet/ComputeSharp.NuGet.csproj
+++ b/tests/ComputeSharp.NuGet/ComputeSharp.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <NoWarn>$(NoWarn);IL2026</NoWarn>

--- a/tests/ComputeSharp.Pix.NuGet/ComputeSharp.Pix.NuGet.csproj
+++ b/tests/ComputeSharp.Pix.NuGet/ComputeSharp.Pix.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <NoWarn>$(NoWarn);IL2026</NoWarn>

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.22621.2" />

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
+++ b/tests/ComputeSharp.Tests.GlobalStatements/ComputeSharp.Tests.GlobalStatements.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/Helpers/NativeLibrariesResolverTestsBase.cs
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/Helpers/NativeLibrariesResolverTestsBase.cs
@@ -55,7 +55,7 @@ public abstract class NativeLibrariesResolverTestsBase
         CleanSampleProject(configuration, rid);
         BuildSampleProject(configuration, rid);
 
-        string realtivePathToDll = Path.Combine("bin", $"{configuration}", "net7.0", $"{ToDirectory(rid)}", $"{SampleProjectName}.dll");
+        string realtivePathToDll = Path.Combine("bin", $"{configuration}", "net8.0", $"{ToDirectory(rid)}", $"{SampleProjectName}.dll");
 
         Assert.AreEqual(0, Exec(SampleProjectDirectory, "dotnet", realtivePathToDll));
     }
@@ -70,7 +70,7 @@ public abstract class NativeLibrariesResolverTestsBase
         CleanSampleProject(configuration, rid);
         BuildSampleProject(configuration, rid);
 
-        string pathToDllDirectory = Path.Combine(SampleProjectDirectory, "bin", $"{configuration}", "net7.0", $"{ToDirectory(rid)}");
+        string pathToDllDirectory = Path.Combine(SampleProjectDirectory, "bin", $"{configuration}", "net8.0", $"{ToDirectory(rid)}");
 
         Assert.AreEqual(0, Exec(pathToDllDirectory, "dotnet", $"{SampleProjectName}.dll"));
     }
@@ -85,7 +85,7 @@ public abstract class NativeLibrariesResolverTestsBase
         CleanSampleProject(configuration, rid);
         BuildSampleProject(configuration, rid);
 
-        string relativePathToAppHost = Path.Combine("bin", $"{configuration}", "net7.0", $"{ToDirectory(rid)}", $"{SampleProjectName}.exe");
+        string relativePathToAppHost = Path.Combine("bin", $"{configuration}", "net8.0", $"{ToDirectory(rid)}", $"{SampleProjectName}.exe");
 
         Assert.AreEqual(0, Exec(SampleProjectDirectory, relativePathToAppHost, ""));
     }
@@ -100,7 +100,7 @@ public abstract class NativeLibrariesResolverTestsBase
         CleanSampleProject(configuration, rid);
         BuildSampleProject(configuration, rid);
 
-        string pathToAppHostDirectory = Path.Combine(SampleProjectDirectory, "bin", $"{configuration}", "net7.0", $"{ToDirectory(rid)}");
+        string pathToAppHostDirectory = Path.Combine(SampleProjectDirectory, "bin", $"{configuration}", "net8.0", $"{ToDirectory(rid)}");
 
         Assert.AreEqual(0, Exec(pathToAppHostDirectory, $"{SampleProjectName}.exe", ""));
     }
@@ -120,7 +120,7 @@ public abstract class NativeLibrariesResolverTestsBase
 
         _ = Exec(SampleProjectDirectory, "dotnet", $"publish -c Release -r win-x64 {ToOption(publishMode)} {ToOption(deploymentMode)} {ToOption(nativeLibsDeploymentMode)} /bl");
 
-        string pathToAppHost = Path.Combine("bin", $"Release", "net7.0", "win-x64", "publish", $"{SampleProjectName}.exe");
+        string pathToAppHost = Path.Combine("bin", $"Release", "net8.0", "win-x64", "publish", $"{SampleProjectName}.exe");
 
         Assert.AreEqual(0, Exec(SampleProjectDirectory, pathToAppHost, ""));
     }
@@ -278,8 +278,8 @@ public enum PublishMode
 }
 
 /// <summary>
-/// Indicates how should the application be packaged. Notably, these tests employ .NET 7 style SingleFile,
-/// aka SuperHost. It does not affect native libraries packaging in .NET 7, but may in the future.
+/// Indicates how should the application be packaged. Notably, these tests employ .NET 8 style SingleFile,
+/// aka SuperHost. It does not affect native libraries packaging in .NET 8, but may in the future.
 /// </summary>
 public enum DeploymentMode
 {

--- a/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="1.4.5" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.4.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />

--- a/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.4.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2-beta1.23509.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1433,7 +1433,7 @@ public class DiagnosticsTests
         };
 
         // Get all assembly references for the loaded assemblies (easy way to pull in all necessary dependencies)
-        IEnumerable<MetadataReference> metadataReferences = Net70.References.All.Concat(additionalReferences);
+        IEnumerable<MetadataReference> metadataReferences = Net80.References.All.Concat(additionalReferences);
 
         // Parse the source text (C# 11)
         SyntaxTree sourceTree = CSharpSyntaxTree.ParseText(

--- a/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
@@ -46,7 +46,7 @@ internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpA
     {
         CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> test = new(languageVersion) { TestCode = source };
 
-        test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net70;
+        test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Core::ComputeSharp.Hlsl).Assembly.Location));
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(D3D12::ComputeSharp.IComputeShader).Assembly.Location));
 

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
     <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.0.2" />

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
   </PropertyGroup>
 


### PR DESCRIPTION
### Contributes to #598

### Description

This PR bumps the TFM for all projects to .NET 8 and enables C# 12.
No actual code changes done yet (they're in separate follow up PRs).