### PR TITLE
Use collection expressions in generated code

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectId.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectId.Syntax.cs
@@ -28,8 +28,8 @@ partial class D2DPixelShaderDescriptorGenerator
 
                 using (writer.WriteBlock())
                 {
-                    writer.WriteLine("global::System.ReadOnlySpan<byte> bytes = new byte[]");
-                    writer.WriteLine("{");
+                    writer.WriteLine("global::System.ReadOnlySpan<byte> bytes =");
+                    writer.WriteLine("[");
                     writer.IncreaseIndent();
 
                     // Write the bytes like so:
@@ -60,7 +60,7 @@ partial class D2DPixelShaderDescriptorGenerator
                     writer.WriteLine($"{SyntaxFormattingHelper.GetByteExpression(info.EffectId[14])},");
                     writer.WriteLine(SyntaxFormattingHelper.GetByteExpression(info.EffectId[15]));
                     writer.DecreaseIndent();
-                    writer.WriteLine("};");
+                    writer.WriteLine("];");
 
                     writer.WriteLine();
                     writer.WriteLine("return ref global::System.Runtime.CompilerServices.Unsafe.As<byte, global::System.Guid>(ref global::System.Runtime.InteropServices.MemoryMarshal.GetReference(bytes));");

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.Syntax.cs
@@ -111,11 +111,11 @@ partial class D2DPixelShaderDescriptorGenerator
                     // RVA field (with the compiled HLSL bytecode, on a single line)
                     writer.WriteLine();
                     writer.WriteLine("/// <summary>The RVA data with the HLSL bytecode.</summary>");
-                    writer.Write("private static ReadOnlySpan<byte> Data => new byte[] { ");
+                    writer.Write("private static ReadOnlySpan<byte> Data => [");
 
                     SyntaxFormattingHelper.WriteByteArrayInitializationExpressions(((HlslBytecodeInfo.Success)info.HlslInfo).Bytecode.AsSpan(), writer);
 
-                    writer.WriteLine(" };");
+                    writer.WriteLine("];");
                     writer.WriteLine();
 
                     // Add the remaining members for the memory manager

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.Syntax.cs
@@ -124,8 +124,8 @@ partial class D2DPixelShaderDescriptorGenerator
             static void Callback(D2D1ShaderInfo info, IndentedTextWriter writer)
             {
                 writer.WriteLine("""/// <summary>The singleton <see cref="D2D1InputDescription"/> array instance.</summary>""");
-                writer.WriteLine("""public static readonly D2D1InputDescription[] InputDescriptions = """);
-                writer.WriteLine("""{""");
+                writer.WriteLine("""public static readonly D2D1InputDescription[] InputDescriptions =""");
+                writer.WriteLine("""[""");
                 writer.IncreaseIndent();
 
                 // Initialize all input descriptions
@@ -136,7 +136,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
                 writer.DecreaseIndent();
                 writer.WriteLine();
-                writer.WriteLine("};");
+                writer.WriteLine("];");
             }
 
             callbacks.Add(Callback);

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.Syntax.cs
@@ -77,8 +77,8 @@ partial class D2DPixelShaderDescriptorGenerator
                     // RVA field
                     writer.WriteLine();
                     writer.WriteLine("/// <summary>The RVA data with the input type info.</summary>");
-                    writer.WriteLine("private static ReadOnlySpan<D2D1PixelShaderInputType> Data => new[]");
-                    writer.WriteLine("{");
+                    writer.WriteLine("private static ReadOnlySpan<D2D1PixelShaderInputType> Data =>");
+                    writer.WriteLine("[");
                     writer.IncreaseIndent();
 
                     // Input types, one per line in the RVA field initializer
@@ -90,7 +90,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
                     writer.DecreaseIndent();
                     writer.WriteLine();
-                    writer.WriteLine("};");
+                    writer.WriteLine("];");
                     writer.WriteLine();
 
                     // Add the remaining members for the memory manager

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.Syntax.cs
@@ -76,8 +76,8 @@ partial class D2DPixelShaderDescriptorGenerator
 
                     // RVA field
                     writer.WriteLine();
-                    writer.WriteLine("/// <summary>The data with the input type info.</summary>");
-                    writer.WriteLine("private static D2D1PixelShaderInputType[] Data = new[]");
+                    writer.WriteLine("/// <summary>The RVA data with the input type info.</summary>");
+                    writer.WriteLine("private static ReadOnlySpan<D2D1PixelShaderInputType> Data => new[]");
                     writer.WriteLine("{");
                     writer.IncreaseIndent();
 
@@ -98,7 +98,7 @@ partial class D2DPixelShaderDescriptorGenerator
                         /// <inheritdoc/>
                         public override unsafe Span<D2D1PixelShaderInputType> GetSpan()
                         {
-                            return Data;
+                            return new(Unsafe.AsPointer(ref MemoryMarshal.GetReference(Data)), Data.Length);
                         }
 
                         /// <inheritdoc/>
@@ -111,9 +111,7 @@ partial class D2DPixelShaderDescriptorGenerator
                         /// <inheritdoc/>
                         public override unsafe MemoryHandle Pin(int elementIndex)
                         {
-                            GCHandle handle = GCHandle.Alloc(Data, GCHandleType.Pinned);
-
-                            return new(Unsafe.AsPointer(ref Data[elementIndex]), handle);
+                            return new(Unsafe.AsPointer(ref Unsafe.AsRef(in Data[elementIndex])), pinnable: this);
                         }
 
                         /// <inheritdoc/>

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ResourceTextureDescriptions.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ResourceTextureDescriptions.Syntax.cs
@@ -68,7 +68,7 @@ partial class D2DPixelShaderDescriptorGenerator
             {
                 writer.WriteLine("""/// <summary>The singleton <see cref="D2D1ResourceTextureDescription"/> array instance.</summary>""");
                 writer.WriteLine("""public static readonly D2D1ResourceTextureDescription[] ResourceTextureDescriptions =""");
-                writer.WriteLine("""{""");
+                writer.WriteLine("""[""");
                 writer.IncreaseIndent();
 
                 // Initialize all resource texture descriptions
@@ -79,7 +79,7 @@ partial class D2DPixelShaderDescriptorGenerator
 
                 writer.DecreaseIndent();
                 writer.WriteLine();
-                writer.WriteLine("};");
+                writer.WriteLine("];");
             }
 
             callbacks.Add(Callback);

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -25,13 +25,13 @@ partial class D2DPixelShaderSourceGenerator
         /// <returns>The HLSL source to compile, if present.</returns>
         public static string? GetInvalidReturnType(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, IMethodSymbol methodSymbol)
         {
-            if (!(methodSymbol.ReturnType is INamedTypeSymbol
+            if (methodSymbol.ReturnType is not INamedTypeSymbol
                 {
                     Name: "ReadOnlySpan",
                     ContainingNamespace.Name: "System",
                     IsGenericType: true,
-                    TypeParameters.Length: 1
-                } returnType && returnType.TypeArguments[0].SpecialType == SpecialType.System_Byte))
+                    TypeArguments: [{ SpecialType: SpecialType.System_Byte }]
+                })
             {
                 diagnostics.Add(
                     InvalidD2DPixelShaderSourceMethodReturnType,
@@ -191,11 +191,11 @@ partial class D2DPixelShaderSourceGenerator
             {
                 if (info.HlslInfo is HlslBytecodeInfo.Success success)
                 {
-                    writer.Write("return new byte[] { ");
+                    writer.Write("return [");
 
                     SyntaxFormattingHelper.WriteByteArrayInitializationExpressions(success.Bytecode.AsSpan(), writer);
 
-                    writer.WriteLine(" };");
+                    writer.WriteLine("];");
                 }
                 else
                 {

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.Syntax.cs
@@ -76,11 +76,11 @@ partial class ComputeShaderDescriptorGenerator
                     // RVA field (with the compiled HLSL bytecode, on a single line)
                     writer.WriteLine();
                     writer.WriteLine("/// <summary>The RVA data with the HLSL bytecode.</summary>");
-                    writer.Write("private static ReadOnlySpan<byte> Data => new byte[] { ");
+                    writer.Write("private static ReadOnlySpan<byte> Data => [");
 
                     SyntaxFormattingHelper.WriteByteArrayInitializationExpressions(((HlslBytecodeInfo.Success)info.HlslInfo).Bytecode.AsSpan(), writer);
 
-                    writer.WriteLine(" };");
+                    writer.WriteLine("];");
                     writer.WriteLine();
 
                     // Add the remaining members for the memory manager

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.ResourceDescriptorRanges.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.ResourceDescriptorRanges.Syntax.cs
@@ -67,7 +67,7 @@ partial class ComputeShaderDescriptorGenerator
                 {
                     writer.WriteLine("""/// <summary>The singleton <see cref="ResourceDescriptorRange"/> array instance.</summary>""");
                     writer.WriteLine("""public static readonly ResourceDescriptorRange[] ResourceDescriptorRanges =""");
-                    writer.WriteLine("""{""");
+                    writer.WriteLine("""[""");
                     writer.IncreaseIndent();
 
                     // Initialize all resource descriptor ranges
@@ -85,7 +85,7 @@ partial class ComputeShaderDescriptorGenerator
 
                     writer.DecreaseIndent();
                     writer.WriteLine();
-                    writer.WriteLine("};");
+                    writer.WriteLine("];");
                 }
             }
 


### PR DESCRIPTION
### Contributes to #598

### Description

This PR includes the following changes:
- Restores use of RVA fields for the generated input types
- Switches all source generators to emit collection expressions