### PR TITLE
Use ImmutableCollectionsMarshal for fast ImmutableArray<T> creation

### DIFF
--- a/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.Properties.ResourceTextureManagerCollection.cs
+++ b/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.Properties.ResourceTextureManagerCollection.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.WinUI.Buffers;
 using ComputeSharp.D2D1.WinUI.Collections;
@@ -254,7 +254,7 @@ partial class PixelShaderEffect<T>
                 indices[i] = descriptions[i].Index;
             }
 
-            return Unsafe.As<int[], ImmutableArray<int>>(ref indices);
+            return ImmutableCollectionsMarshal.AsImmutableArray(indices);
         }
     }
 }

--- a/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.Properties.SourceCollection.cs
+++ b/src/ComputeSharp.D2D1.WinUI/PixelShaderEffect{T}.Properties.SourceCollection.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using ComputeSharp.D2D1.WinUI.Buffers;
 using ComputeSharp.D2D1.WinUI.Collections;
 using Windows.Graphics.Effects;
@@ -223,7 +224,7 @@ partial class PixelShaderEffect<T>
                 indices[i] = i;
             }
 
-            return Unsafe.As<int[], ImmutableArray<int>>(ref indices);
+            return ImmutableCollectionsMarshal.AsImmutableArray(indices);
         }
     }
 }


### PR DESCRIPTION
### Contributes to #598

### Description

This PR switches to `ImmutableCollectionsMarshal` now that it's available on .NET 8, instead of `Unsafe.As`.