### PR TITLE
Add [CompileOptions] attribute for DX12 shaders

### DIFF
--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -107,8 +107,13 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
 
                     token.ThrowIfCancellationRequested();
 
+                    // Get the compile options as well
+                    CompileOptions compileOptions = HlslBytecode.GetCompileOptions(diagnostics, typeSymbol);
+
+                    token.ThrowIfCancellationRequested();
+
                     // Prepare the lookup key for the HLSL shader bytecode
-                    HlslBytecodeInfoKey hlslInfoKey = new(hlslSource, isCompilationEnabled);
+                    HlslBytecodeInfoKey hlslInfoKey = new(hlslSource, compileOptions, isCompilationEnabled);
 
                     // Try to get the HLSL bytecode
                     HlslBytecodeInfo hlslInfo = HlslBytecode.GetBytecode(ref hlslInfoKey, token);

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -55,6 +55,7 @@
 
     <!-- ComputeSharp APIs -->
     <Compile Include="..\ComputeSharp\Core\Attributes\EmbeddedBytecodeAttribute.cs" Link="ComputeSharp\Core\Attributes\EmbeddedBytecodeAttribute.cs" />
+    <Compile Include="..\ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" Link="ComputeSharp\Core\Attributes\Enums\CompileOptions.cs" />
     <Compile Include="..\ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" Link="ComputeSharp\Core\Attributes\GroupSharedAttribute.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchAxis.cs" Link="ComputeSharp\Core\Dispatch\DispatchAxis.cs" />
     <Compile Include="..\ComputeSharp\Core\Dispatch\DispatchSize.cs" Link="ComputeSharp\Core\Dispatch\DispatchSize.cs" />

--- a/src/ComputeSharp.SourceGenerators/Models/HlslBytecodeInfoKey.cs
+++ b/src/ComputeSharp.SourceGenerators/Models/HlslBytecodeInfoKey.cs
@@ -6,5 +6,9 @@ namespace ComputeSharp.SourceGenerators.Models;
 /// A model with info to be a unique key for <see cref="HlslBytecodeInfo"/> instances.
 /// </summary>
 /// <param name="HlslSource">The input HLSL source code.</param>
+/// <param name="CompileOptions">The compile options.</param>
 /// <param name="IsCompilationEnabled">Whether compilation should be attempted for the current info.</param>
-internal sealed record HlslBytecodeInfoKey(string HlslSource, bool IsCompilationEnabled);
+internal sealed record HlslBytecodeInfoKey(
+    string HlslSource,
+    CompileOptions CompileOptions,
+    bool IsCompilationEnabled);

--- a/src/ComputeSharp/Core/Attributes/CompileOptionsAttribute.cs
+++ b/src/ComputeSharp/Core/Attributes/CompileOptionsAttribute.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace ComputeSharp;
+
+/// <summary>
+/// An attribute that indicates the compile options that should be used when compiling a given compute shader.
+/// <para>
+/// This attribute can be used to annotate shader types as follows:
+/// <code>
+/// [CompileOptions(CompileOptions.IeeeStrictness | CompileOptions.OptimizationLevel3)]
+/// struct MyShader : IComputeShader
+/// {
+/// }
+/// </code>
+/// </para>
+/// <para>
+/// This attribute can also be added to a whole assembly, and will be used by default if not overridden by a shader type.
+/// </para>
+/// </summary>
+/// <param name="options">The compiler options to use to compile the shader.</param>
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = false)]
+public sealed class CompileOptionsAttribute(CompileOptions options) : Attribute
+{
+    /// <summary>
+    /// Gets the compile options to use to compile the shader.
+    /// </summary>
+    public CompileOptions Options { get; } = options;
+}

--- a/src/ComputeSharp/Core/Attributes/Enums/CompileOptions.cs
+++ b/src/ComputeSharp/Core/Attributes/Enums/CompileOptions.cs
@@ -1,0 +1,147 @@
+using System;
+
+namespace ComputeSharp;
+
+/// <summary>
+/// Flags to control the options that can be used to compile a compute shader.
+/// </summary>
+[Flags]
+public enum CompileOptions
+{
+    /// <summary>
+    /// Enables agressive flattening.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-all-resources-bound</c>.
+    /// </remarks>
+    AllResourcesBound = 1 << 0,
+
+    /// <summary>
+    /// Directs the compiler not to validate the generated code against known capabilities and constraints.
+    /// This option should only be used with shaders that have been successfully compiled in the past.
+    /// DirectX always validates shaders before it sets them to a device.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-Vd</c>.
+    /// </remarks>
+    DisableValidation = 1 << 1,
+
+    /// <summary>
+    /// Directs the compiler to skip optimization steps during code generation.
+    /// This option should only be used for debug purposes.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-Od</c>.
+    /// </remarks>
+    DisableOptimization = 1 << 2,
+
+    /// <summary>
+    /// Directs the compiler to not use flow-control constructs where possible.	
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-Gfa</c>.
+    /// </remarks>
+    AvoidFlowControl = 1 << 3,
+
+    /// <summary>
+    /// Directs the compiler to prefer using flow-control constructs where possible.	
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-Gfp</c>.
+    /// </remarks>
+    PreferFlowControl = 1 << 4,
+
+    /// <summary>
+    /// Forces strict compile, which might not allow for legacy syntax.
+    /// By default, the compiler disables strictness on deprecated syntax.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-Ges</c>.W
+    /// </remarks>
+    EnableStrictness = 1 << 5,
+
+    /// <summary>
+    /// Forces the IEEE strict compile which avoids optimizations that may break IEEE rules.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-Gis</c>.
+    /// </remarks>
+    IeeeStrictness = 1 << 6,
+
+    /// <summary>
+    /// Enables backward compatibility mode.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-Gec</c>.
+    /// </remarks>
+    EnableBackwardsCompatibility = 1 << 7,
+
+    /// <summary>
+    /// Directs the compiler to use the lowest optimization level. If this option is set, the compiler
+    /// might produce slower code but produces the code more quickly. This option should be set when
+    /// shaders are developed iteratively, as it can reduce compilation times.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-O0</c>.
+    /// </remarks>
+    OptimizationLevel0 = 1 << 8,
+
+    /// <summary>
+    /// Directs the compiler to use the second lowest optimization level.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-O1</c>.
+    /// </remarks>
+    OptimizationLevel1 = OptimizationLevel0 | (1 << 9),
+
+    /// <summary>
+    /// Directs the compiler to use the second highest optimization level.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-O2</c>.
+    /// </remarks>
+    OptimizationLevel2 = OptimizationLevel1 | (1 << 10),
+
+    /// <summary>
+    /// Directs the compiler to use the highest optimization level. If this option is set, the compiler
+    /// produces the best possible code but might take significantly longer to do so. This option should
+    /// be set for final builds of an application when performance is the most important factor.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-O3</c>.
+    /// </remarks>
+    OptimizationLevel3 = OptimizationLevel2 | (1 << 11),
+
+    /// <summary>
+    /// Directs the compiler to treat all warnings as errors when it compiles the shader code. This 
+    /// option is recommended for new shader code, so that warnings can be resolved and the
+    /// number of hard-to-find code defects can be minimized.	
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-WX</c>.
+    /// </remarks>
+    WarningsAreErrors = 1 << 12,
+
+    /// <summary>
+    /// Directs the compiler that UAVs (uniform access views) and SRVs (shader resource views) may alias.
+    /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-res-may-alias</c>.
+    /// </remarks>
+    ResourcesMayAlias = 1 << 13,
+
+    /// <summary>
+    /// Strips the reflection data from the generated shader bytecode. The bytecode size will be significantly lower,
+    /// but trying to perform reflection on the shader will fail at runtime. Recommend if not reflection is done.
+    /// </summary>
+    StripReflectionData = 1 << 14,
+
+    /// <summary>
+    /// The default options for shaders compiled by ComputeSharp.
+    /// </summary>
+    /// <remarks>
+    /// This option does not include a flag to pack matrices in column-major order on input and output from the shader,
+    /// as that is always enabled by default (it is necessary to ensure the constant buffer matches the managed layout).
+    /// </remarks>
+    Default = OptimizationLevel3 | WarningsAreErrors
+}

--- a/src/ComputeSharp/Core/Attributes/Enums/CompileOptions.cs
+++ b/src/ComputeSharp/Core/Attributes/Enums/CompileOptions.cs
@@ -131,8 +131,8 @@ public enum CompileOptions
     ResourcesMayAlias = 1 << 13,
 
     /// <summary>
-    /// Strips the reflection data from the generated shader bytecode. The bytecode size will be significantly lower,
-    /// but trying to perform reflection on the shader will fail at runtime. Recommend if not reflection is done.
+    /// Strips the reflection data from the generated shader bytecode. The bytecode size will be significantly lower, but
+    /// trying to perform reflection on the shader will return inaccurate results. Recommend if not reflection is done.
     /// </summary>
     /// <remarks>
     /// This flag maps to <c>-Qstrip_reflect</c>.

--- a/src/ComputeSharp/Core/Attributes/Enums/CompileOptions.cs
+++ b/src/ComputeSharp/Core/Attributes/Enums/CompileOptions.cs
@@ -56,7 +56,7 @@ public enum CompileOptions
     /// By default, the compiler disables strictness on deprecated syntax.
     /// </summary>
     /// <remarks>
-    /// This flag maps to <c>-Ges</c>.W
+    /// This flag maps to <c>-Ges</c>.
     /// </remarks>
     EnableStrictness = 1 << 5,
 
@@ -134,6 +134,9 @@ public enum CompileOptions
     /// Strips the reflection data from the generated shader bytecode. The bytecode size will be significantly lower,
     /// but trying to perform reflection on the shader will fail at runtime. Recommend if not reflection is done.
     /// </summary>
+    /// <remarks>
+    /// This flag maps to <c>-Qstrip_reflect</c>.
+    /// </remarks>
     StripReflectionData = 1 << 14,
 
     /// <summary>

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -559,6 +559,54 @@ namespace ComputeSharp.Tests
                 this.buffer[ThreadIds.X] *= x;
             }
         }
+
+        [TestMethod]
+        public void ShaderWithStrippedReflectionData()
+        {
+            ShaderInfo info1 = ReflectionServices.GetShaderInfo<ShaderWithStrippedReflectionData1>();
+
+            // With no reflection data available, the instruction count is just 0
+            Assert.AreEqual(0u, info1.InstructionCount);
+
+            ShaderInfo info2 = ReflectionServices.GetShaderInfo<ShaderWithStrippedReflectionData2>();
+
+            // Sanity check, here instead we should have some valid count
+            Assert.AreNotEqual(0u, info2.InstructionCount);
+
+            // Verify that the bytecode with stripped reflection is much smaller
+            Assert.IsTrue(info1.HlslBytecode.Length < 1800);
+            Assert.IsTrue(info2.HlslBytecode.Length > 3300);
+        }
+
+        [AutoConstructor]
+        [EmbeddedBytecode(DispatchAxis.X)]
+        [CompileOptions(CompileOptions.Default | CompileOptions.StripReflectionData)]
+        [GeneratedComputeShaderDescriptor]
+        internal readonly partial struct ShaderWithStrippedReflectionData1 : IComputeShader
+        {
+            public readonly ReadWriteBuffer<float> buffer;
+
+            /// <inheritdoc/>
+            public void Execute()
+            {
+                this.buffer[ThreadIds.X] = ThreadIds.X;
+            }
+        }
+
+        [AutoConstructor]
+        [EmbeddedBytecode(DispatchAxis.X)]
+        [CompileOptions(CompileOptions.Default)]
+        [GeneratedComputeShaderDescriptor]
+        internal readonly partial struct ShaderWithStrippedReflectionData2 : IComputeShader
+        {
+            public readonly ReadWriteBuffer<float> buffer;
+
+            /// <inheritdoc/>
+            public void Execute()
+            {
+                this.buffer[ThreadIds.X] = ThreadIds.X;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Contributes to #598

### Description

This PR adds a new `[CompileOptions]` attribute, analogous to `[D2DCompileOptions]`, but for DX12 compute shaders.
