### PR TITLE
Update Win2D dependency, remove RID graph workaround

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -261,9 +261,10 @@ jobs:
         path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net8.0\win-x64\publish\computesharp.cli.exe
         if-no-files-found: error
 
-      # Also publish the Win2D sample (with R2R)
+      # Also publish the Win2D sample (with R2R).
+      # Only doing this on x64 (to avoid a Roslyn issue).
     - if: matrix.platform == 'x64'
-      name: Publish ComputeSharp.SwapChain.D2D1.Cli
+      name: Publish ComputeSharp.SwapChain.D2D1.Cli (R2R)
       run: >
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_R2R='true';
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT='false';
@@ -272,7 +273,8 @@ jobs:
         /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
       
       # Just like for the DX12 sample, run it on x64 to validate it works correctly
-    - name: Run ComputeSharp.SwapChain.D2D1.Cli
+    - if: matrix.platform == 'x64'
+      name: Run ComputeSharp.SwapChain.D2D1.Cli
       run: >
         $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net8.0-windows10.0.22621\win-x64\publish\computesharp.d2d1.cli.exe -PassThru);
         sleep -Seconds 2;
@@ -283,7 +285,7 @@ jobs:
       
       # Publish the Win2D sample again (with NativeAOT)
     - if: matrix.platform == 'x64'
-      name: Publish ComputeSharp.SwapChain.D2D1.Cli with NativeAOT
+      name: Publish ComputeSharp.SwapChain.D2D1.Cli (NativeAOT)
       run: >
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_R2R='false';
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT='true';
@@ -292,7 +294,8 @@ jobs:
         /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
         
       # Verify that the Win2D NativeAOT sample also runs correctly
-    - name: Run ComputeSharp.SwapChain.D2D1.Cli
+    - if: matrix.platform == 'x64'
+      name: Run ComputeSharp.SwapChain.D2D1.Cli
       run: >
         $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net8.0-windows10.0.22621\win-x64\publish\computesharp.d2d1.cli.exe -PassThru);
         sleep -Seconds 2;

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -261,16 +261,17 @@ jobs:
         path: samples\ComputeSharp.SwapChain.Cli\bin\Release\net8.0\win-x64\publish\computesharp.cli.exe
         if-no-files-found: error
 
-      # Also publish the Win2D sample (without NativeAOT, see https://github.com/dotnet/runtime/issues/84908)
+      # Also publish the Win2D sample (with R2R)
     - if: matrix.platform == 'x64'
       name: Publish ComputeSharp.SwapChain.D2D1.Cli
       run: >
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_R2R='true';
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT='false';
+        git clean -fdx;
         msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish
         /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
       
-      # Just like for the DX12 sample, run it on x64 to validate it works correctly.
+      # Just like for the DX12 sample, run it on x64 to validate it works correctly
     - name: Run ComputeSharp.SwapChain.D2D1.Cli
       run: >
         $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net8.0-windows10.0.22621\win-x64\publish\computesharp.d2d1.cli.exe -PassThru);
@@ -280,7 +281,7 @@ jobs:
         if ($process.ExitCode -lt 0 -and $process.ExitCode -ne -1073741510) { throw $process.ExitCode; }
         return $process.ExitCode;
       
-      # Publish the Win2D sample with NativeAOT (just verifying the build, can't run this yet, see above)
+      # Publish the Win2D sample again (with NativeAOT)
     - if: matrix.platform == 'x64'
       name: Publish ComputeSharp.SwapChain.D2D1.Cli with NativeAOT
       run: >
@@ -289,6 +290,16 @@ jobs:
         git clean -fdx;
         msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish
         /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
+        
+      # Verify that the Win2D NativeAOT sample also runs correctly
+    - name: Run ComputeSharp.SwapChain.D2D1.Cli
+      run: >
+        $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net8.0-windows10.0.22621\win-x64\publish\computesharp.d2d1.cli.exe -PassThru);
+        sleep -Seconds 2;
+        $process.CloseMainWindow() | Out-Null;
+        $process.WaitForExit();
+        if ($process.ExitCode -lt 0 -and $process.ExitCode -ne -1073741510) { throw $process.ExitCode; }
+        return $process.ExitCode;
 
       # Publish the native library as a NativeAOT shared library
     - name: Publish ComputeSharp.NativeLibrary

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -271,9 +271,7 @@ jobs:
         /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
       
       # Just like for the DX12 sample, run it on x64 to validate it works correctly.
-      # Temporarily disabled due to https://github.com/microsoft/Win2D/issues/935.
-    - if: false # matrix.platform == 'x64'
-      name: Run ComputeSharp.SwapChain.D2D1.Cli
+    - name: Run ComputeSharp.SwapChain.D2D1.Cli
       run: >
         $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net8.0-windows10.0.22621\win-x64\publish\computesharp.d2d1.cli.exe -PassThru);
         sleep -Seconds 2;

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -270,11 +270,11 @@ jobs:
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT='false';
         git clean -fdx;
         msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish
-        /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
+        /p:Configuration=Release /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
       
       # Just like for the DX12 sample, run it on x64 to validate it works correctly
     - if: matrix.platform == 'x64'
-      name: Run ComputeSharp.SwapChain.D2D1.Cli
+      name: Run ComputeSharp.SwapChain.D2D1.Cli (R2R)
       run: >
         $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net8.0-windows10.0.22621\win-x64\publish\computesharp.d2d1.cli.exe -PassThru);
         sleep -Seconds 2;
@@ -291,11 +291,11 @@ jobs:
         $env:COMPUTESHARP_SWAPCHAIN_D2D1_PUBLISH_AOT='true';
         git clean -fdx;
         msbuild samples\ComputeSharp.SwapChain.D2D1.Cli\ComputeSharp.SwapChain.D2D1.Cli.csproj /restore -t:publish
-        /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
+        /p:Configuration=Release /p:Platform=${{matrix.platform}} /p:RuntimeIdentifier=win-${{matrix.platform}}
         
       # Verify that the Win2D NativeAOT sample also runs correctly
     - if: matrix.platform == 'x64'
-      name: Run ComputeSharp.SwapChain.D2D1.Cli
+      name: Run ComputeSharp.SwapChain.D2D1.Cli (NativeAOT)
       run: >
         $process = (Start-Process samples\ComputeSharp.SwapChain.D2D1.Cli\bin\x64\Release\net8.0-windows10.0.22621\win-x64\publish\computesharp.d2d1.cli.exe -PassThru);
         sleep -Seconds 2;

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -9,9 +9,6 @@
     <NoWarn>$(NoWarn);IDE0065</NoWarn>
     <AssemblyName>computesharp.d2d1.cli</AssemblyName>
     <ApplicationIcon>..\..\assets\icon.ico</ApplicationIcon>
-
-    <!-- Temporary workaround for RID graph change in .NET 8 (see https://github.com/microsoft/Win2D/issues/935) -->
-    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -9,9 +9,6 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
-
-    <!-- Temporary workaround for RID graph change in .NET 8 (see https://github.com/microsoft/Win2D/issues/935) -->
-    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,15 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-
-    <!--
-      The Win2D package is directly referenced as a temporary workaround for the native binaries
-      using the non-portable RID (ie. "win10-"). If this is only pulled in transitively by the
-      ComputeSharp.WinUI dependency, <UseRidGraph> will not actually work correctly. So, using
-      an explicit reference until Win2D is updated to use the portable RID instead (ie. "win-").
-    -->
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.1.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />

--- a/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
+++ b/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
+++ b/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231008000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -9,9 +9,6 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
-
-    <!-- Temporary workaround for RID graph change in .NET 8 (see https://github.com/microsoft/Win2D/issues/935) -->
-    <UseRidGraph>true</UseRidGraph>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -59,9 +56,6 @@
   </ItemGroup>
 
   <ItemGroup>
-
-    <!-- Temporary Win2D package reference (see notes in the WinUI sample app .csproj file) -->
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" ExcludeAssets="build" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />


### PR DESCRIPTION
### Description

This PR updates Win2D to 1.1.1, which includes a fix for the RID graph in .NET 8, and removes the workarounds.
It also restores the R2R test in the CI script, and enables running the NAOT one as well.