### PR TITLE
Fix XML docs in generated unsafe accessors

### DIFF
--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/ConstantBufferSyntaxProcessor.Generation.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/ConstantBufferSyntaxProcessor.Generation.cs
@@ -284,7 +284,7 @@ partial class ConstantBufferSyntaxProcessor
                         {
                             writer.WriteLine($"""
                                 /// <inheritdoc cref="{containingTypeName}.{pathPart.Name}"/>
-                                /// <param name="shader">The input <see cref="{containingTypeName}"/> value.</param>
+                                /// <param name="value">The input <see cref="{containingTypeName}"/> value.</param>
                                 /// <returns>A mutable reference to <see cref="{containingTypeName}.{pathPart.Name}"/>.</returns>
                                 [UnsafeAccessor(UnsafeAccessorKind.Field)]
                                 private static extern ref {typeName} {pathPart.Name}(this ref readonly {containingTypeName} value);
@@ -294,7 +294,7 @@ partial class ConstantBufferSyntaxProcessor
                         {
                             writer.WriteLine($"""
                                 /// <summary>Gets a reference to the unspeakable field "{pathPart.Name}" of type <see cref="{containingTypeName}"/>.</summary>
-                                /// <param name="shader">The input <see cref="{containingTypeName}"/> value.</param>
+                                /// <param name="value">The input <see cref="{containingTypeName}"/> value.</param>
                                 /// <returns>A mutable reference to the unspeakable field "{pathPart.Name}".</returns>
                                 [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "{pathPart.UnspeakableName}")]
                                 private static extern ref {typeName} {pathPart.Name}(this ref readonly {containingTypeName} value);

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.Resources.Syntax.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.Resources.Syntax.cs
@@ -98,7 +98,7 @@ partial class ComputeShaderDescriptorGenerator
                         {
                             writer.WriteLine($"""
                                 /// <inheritdoc cref="{fullyQualifiedTypeName}.{resourceInfo.FieldName}"/>
-                                /// <param name="shader">The input <see cref="{fullyQualifiedTypeName}"/> value.</param>
+                                /// <param name="value">The input <see cref="{fullyQualifiedTypeName}"/> value.</param>
                                 /// <returns>A reference to <see cref="{fullyQualifiedTypeName}.{resourceInfo.FieldName}"/>.</returns>
                                 [UnsafeAccessor(UnsafeAccessorKind.Field)]
                                 private static extern ref readonly {resourceInfo.FieldType} {resourceInfo.FieldName}(this ref readonly {fullyQualifiedTypeName} value);
@@ -108,7 +108,7 @@ partial class ComputeShaderDescriptorGenerator
                         {
                             writer.WriteLine($"""
                                 /// <summary>Gets a reference to the unspeakable field "{resourceInfo.FieldName}" of type <see cref="{fullyQualifiedTypeName}"/>.</summary>
-                                /// <param name="shader">The input <see cref="{fullyQualifiedTypeName}"/> value.</param>
+                                /// <param name="value">The input <see cref="{fullyQualifiedTypeName}"/> value.</param>
                                 /// <returns>A reference to the unspeakable field "{resourceInfo.FieldName}".</returns>
                                 [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "{resourceInfo.UnspeakableName}")]
                                 private static extern ref readonly {resourceInfo.FieldType} {resourceInfo.FieldName}(this ref readonly {fullyQualifiedTypeName} value);


### PR DESCRIPTION
### Description

This PR just fixes some incorrect XML docs in the generated unsafe accessors for fields and resources.