### PR TITLE
Replace [AutoConstructor] with primary constructors in samples

### DIFF
--- a/samples/ComputeSharp.Benchmark/Dispatching/DispatchingBenchmark.cs
+++ b/samples/ComputeSharp.Benchmark/Dispatching/DispatchingBenchmark.cs
@@ -108,12 +108,11 @@ public partial class DispatchingBenchmark : IDisposable
         context.For(64, new TestShader(this.buffer!));
     }
 
-    [AutoConstructor]
     [ThreadGroupSize(DefaultThreadGroupSizes.X)]
     [GeneratedComputeShaderDescriptor]
-    internal readonly partial struct TestShader : IComputeShader
+    internal readonly partial struct TestShader(ReadWriteBuffer<float> buffer) : IComputeShader
     {
-        private readonly ReadWriteBuffer<float> buffer;
+        private readonly ReadWriteBuffer<float> buffer = buffer;
 
         /// <inheritdoc/>
         public void Execute()

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.Implementation.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.Implementation.cs
@@ -117,68 +117,64 @@ public sealed partial class HlslGaussianBlurProcessor
         /// <summary>
         /// Kernel for the vertical convolution pass.
         /// </summary>
-        [AutoConstructor]
         [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
         [GeneratedComputeShaderDescriptor]
-        internal readonly partial struct VerticalConvolutionProcessor : IComputeShader
+        internal readonly partial struct VerticalConvolutionProcessor(
+            IReadWriteNormalizedTexture2D<float4> source,
+            IReadWriteNormalizedTexture2D<float4> target,
+            ReadOnlyBuffer<float> kernel) : IComputeShader
         {
-            private readonly IReadWriteNormalizedTexture2D<float4> source;
-            private readonly IReadWriteNormalizedTexture2D<float4> target;
-            private readonly ReadOnlyBuffer<float> kernel;
-
             /// <inheritdoc/>
             public void Execute()
             {
                 float4 result = float4.Zero;
-                int maxY = this.source.Height - 1;
-                int maxX = this.source.Width - 1;
-                int kernelLength = this.kernel.Length;
+                int maxY = source.Height - 1;
+                int maxX = source.Width - 1;
+                int kernelLength = kernel.Length;
                 int radiusY = kernelLength >> 1;
 
                 for (int i = 0; i < kernelLength; i++)
                 {
                     int offsetY = Hlsl.Clamp(ThreadIds.Y + i - radiusY, 0, maxY);
                     int offsetX = Hlsl.Clamp(ThreadIds.X, 0, maxX);
-                    float4 color = this.source[offsetX, offsetY];
+                    float4 color = source[offsetX, offsetY];
 
-                    result += this.kernel[i] * color;
+                    result += kernel[i] * color;
                 }
 
-                this.target[ThreadIds.XY] = result;
+                target[ThreadIds.XY] = result;
             }
         }
 
         /// <summary>
         /// Kernel for the horizontal convolution pass.
         /// </summary>
-        [AutoConstructor]
         [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
         [GeneratedComputeShaderDescriptor]
-        internal readonly partial struct HorizontalConvolutionProcessor : IComputeShader
+        internal readonly partial struct HorizontalConvolutionProcessor(
+            IReadWriteNormalizedTexture2D<float4> source,
+            IReadWriteNormalizedTexture2D<float4> target,
+            ReadOnlyBuffer<float> kernel) : IComputeShader
         {
-            private readonly IReadWriteNormalizedTexture2D<float4> source;
-            private readonly IReadWriteNormalizedTexture2D<float4> target;
-            private readonly ReadOnlyBuffer<float> kernel;
-
             /// <inheritdoc/>
             public void Execute()
             {
                 float4 result = float4.Zero;
-                int maxY = this.source.Height - 1;
-                int maxX = this.source.Width - 1;
-                int kernelLength = this.kernel.Length;
+                int maxY = source.Height - 1;
+                int maxX = source.Width - 1;
+                int kernelLength = kernel.Length;
                 int radiusX = kernelLength >> 1;
                 int offsetY = Hlsl.Clamp(ThreadIds.Y, 0, maxY);
 
                 for (int i = 0; i < kernelLength; i++)
                 {
                     int offsetX = Hlsl.Clamp(ThreadIds.X + i - radiusX, 0, maxX);
-                    float4 color = this.source[offsetX, offsetY];
+                    float4 color = source[offsetX, offsetY];
 
-                    result += this.kernel[i] * color;
+                    result += kernel[i] * color;
                 }
 
-                this.target[ThreadIds.XY] = result;
+                target[ThreadIds.XY] = result;
             }
         }
     }

--- a/samples/ComputeSharp.Sample.FSharp.Shaders/MultiplyByTwo.cs
+++ b/samples/ComputeSharp.Sample.FSharp.Shaders/MultiplyByTwo.cs
@@ -3,16 +3,13 @@ namespace ComputeSharp.Sample.FSharp.Shaders;
 /// <summary>
 /// A sample shader thaat just multiplies items in a buffer by two.
 /// </summary>
-[AutoConstructor]
 [ThreadGroupSize(DefaultThreadGroupSizes.X)]
 [GeneratedComputeShaderDescriptor]
-public readonly partial struct MultiplyByTwo : IComputeShader
+public readonly partial struct MultiplyByTwo(ReadWriteBuffer<float> buffer) : IComputeShader
 {
-    private readonly ReadWriteBuffer<float> buffer;
-
     /// <inheritdoc/>
     public void Execute()
     {
-        this.buffer[ThreadIds.X] *= 2;
+        buffer[ThreadIds.X] *= 2;
     }
 }

--- a/samples/ComputeSharp.Sample/Program.cs
+++ b/samples/ComputeSharp.Sample/Program.cs
@@ -23,16 +23,13 @@ Formatting.PrintMatrix(array, 10, 10, "AFTER");
 /// <summary>
 /// The sample kernel that multiples all items by two.
 /// </summary>
-[AutoConstructor]
 [ThreadGroupSize(DefaultThreadGroupSizes.X)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct MultiplyByTwo : IComputeShader
+internal readonly partial struct MultiplyByTwo(ReadWriteBuffer<float> buffer) : IComputeShader
 {
-    private readonly ReadWriteBuffer<float> buffer;
-
     /// <inheritdoc/>
     public void Execute()
     {
-        this.buffer[ThreadIds.X] *= 2;
+        buffer[ThreadIds.X] *= 2;
     }
 }

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/ColorfulInfinity.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/ColorfulInfinity.cs
@@ -8,23 +8,14 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// <para>Created by Benoit Marini.</para>
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct ColorfulInfinity : ID2D1PixelShader
+internal readonly partial struct ColorfulInfinity(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     /// <summary>
     /// The total number of layers for the final animation.
     /// </summary>
@@ -40,7 +31,7 @@ internal readonly partial struct ColorfulInfinity : ID2D1PixelShader
     /// </summary>
     private float4 Tex(float3 p)
     {
-        float t = this.time + 78.0f;
+        float t = time + 78.0f;
         float4 o = new(p.X, p.Y, p.Z, 3.0f * Hlsl.Sin(t * 0.1f));
         float4 dec =
             new float4(1.0f, 0.9f, 0.1f, 0.15f) +
@@ -58,9 +49,9 @@ internal readonly partial struct ColorfulInfinity : ID2D1PixelShader
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        float2 uv = (xy - ((float2)this.dispatchSize * 0.5f)) / this.dispatchSize.Y;
+        float2 uv = (xy - ((float2)dispatchSize * 0.5f)) / dispatchSize.Y;
         float3 col = 0;
-        float t = this.time * 0.3f;
+        float t = time * 0.3f;
 
         for (float i = 0.0f; i <= 1.0f; i += 1.0f / NumberOfLayers)
         {

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/ContouredLayers.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/ContouredLayers.cs
@@ -7,23 +7,14 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// Ported from <see href="https://www.shadertoy.com/view/3lj3zt"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct ContouredLayers : ID2D1PixelShader
+internal readonly partial struct ContouredLayers(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time Hlsl.Since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     /// <summary>
     /// The background texture to sample.
     /// </summary>
@@ -43,7 +34,7 @@ internal readonly partial struct ContouredLayers : ID2D1PixelShader
 
         p = Hlsl.Frac(new float2(262144, 32768) * n);
 
-        return Hlsl.Sin((p * 6.2831853f) + this.time);
+        return Hlsl.Sin((p * 6.2831853f) + time);
     }
 
     // float2 to float2 hash.
@@ -154,10 +145,10 @@ internal readonly partial struct ContouredLayers : ID2D1PixelShader
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        float2 fragCoord = new(xy.X, this.dispatchSize.Y - xy.Y);
-        float res = Hlsl.Min(this.dispatchSize.Y, 700.0f);
-        float2 uv = (fragCoord - ((float2)this.dispatchSize * 0.5f)) / res;
-        float sf = 1.0f / this.dispatchSize.Y;
+        float2 fragCoord = new(xy.X, dispatchSize.Y - xy.Y);
+        float res = Hlsl.Min(dispatchSize.Y, 700.0f);
+        float2 uv = (fragCoord - ((float2)dispatchSize * 0.5f)) / res;
+        float sf = 1.0f / dispatchSize.Y;
         float3 col = GetColor(uv, 0.0f, 0.0f);
         float pL = 0.0f;
         float hatch = Hatch(uv, res);
@@ -199,11 +190,11 @@ internal readonly partial struct ContouredLayers : ID2D1PixelShader
 
         col *= Hlsl.Lerp(new float3(1.8f, 1, 0.7f).ZYX, new float3(1.8f, 1, 0.7f).XZY, Noise2D(uv * 2.0f));
 
-        float3 rn3 = Noise2D((uv * this.dispatchSize.Y / 1.0f) + 1.7f) - Noise2D((uv * this.dispatchSize.Y / 1.0f) + 3.4f);
+        float3 rn3 = Noise2D((uv * dispatchSize.Y / 1.0f) + 1.7f) - Noise2D((uv * dispatchSize.Y / 1.0f) + 3.4f);
 
         col *= 0.93f + (0.07f * rn3.XYZ) + (0.07f * Hlsl.Dot(rn3, new float3(0.299f, 0.587f, 0.114f)));
 
-        uv = fragCoord / this.dispatchSize.XY;
+        uv = fragCoord / dispatchSize.XY;
 
         col *= Hlsl.Pow(Hlsl.Abs(16.0f * uv.X * uv.Y * (1.0f - uv.X) * (1.0f - uv.Y)), 0.0625f);
 

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/FractalTiling.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/FractalTiling.cs
@@ -8,28 +8,19 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// <para>Created by Inigo Quilez.</para>
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct FractalTiling : ID2D1PixelShader
+internal readonly partial struct FractalTiling(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     /// <inheritdoc/>
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        float2 position = (((float2)(256 * xy)) / this.dispatchSize.X) + this.time;
+        float2 position = (((float2)(256 * xy)) / dispatchSize.X) + time;
         float4 color = 0;
 
         for (int i = 0; i < 6; i++)
@@ -37,7 +28,7 @@ internal readonly partial struct FractalTiling : ID2D1PixelShader
             float2 a = Hlsl.Floor(position);
             float2 b = Hlsl.Frac(position);
             float4 w = Hlsl.Frac(
-                (Hlsl.Sin((a.X * 7) + (31.0f * a.Y) + (0.01f * this.time)) +
+                (Hlsl.Sin((a.X * 7) + (31.0f * a.Y) + (0.01f * time)) +
                  new float4(0.035f, 0.01f, 0, 0.7f))
                  * 13.545317f);
 

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/HelloWorld.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/HelloWorld.cs
@@ -6,33 +6,24 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// A simple shader to get started with based on shadertoy new shader template.
 /// Ported from <see href="https://www.shadertoy.com/new"/>.
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct HelloWorld : ID2D1PixelShader
+internal readonly partial struct HelloWorld(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     /// <inheritdoc/>
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
 
         // Normalized screen space UV coordinates from 0.0 to 1.0
-        float2 uv = xy / (float2)this.dispatchSize;
+        float2 uv = xy / (float2)dispatchSize;
 
         // Time varying pixel color
-        float3 col = 0.5f + (0.5f * Hlsl.Cos(this.time + new float3(uv, uv.X) + new float3(0, 2, 4)));
+        float3 col = 0.5f + (0.5f * Hlsl.Cos(time + new float3(uv, uv.X) + new float3(0, 2, 4)));
 
         // Output to screen
         return new(col, 1f);

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/Octagrams.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/Octagrams.cs
@@ -7,23 +7,14 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// Ported from <see href="https://www.shadertoy.com/view/tlVGDt"/>.
 /// <para>Created by whisky_shusuky.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct Octagrams : ID2D1PixelShader
+internal readonly partial struct Octagrams(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     private static float2x2 Rotate(float a)
     {
         float c = Hlsl.Cos(a);
@@ -98,12 +89,12 @@ internal readonly partial struct Octagrams : ID2D1PixelShader
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        float2 p = (((float2)xy * 2.0f) - this.dispatchSize) / Hlsl.Min(this.dispatchSize.X, this.dispatchSize.Y);
-        float3 ro = new(0.0f, -0.2f, this.time * 4.0f);
+        float2 p = (((float2)xy * 2.0f) - dispatchSize) / Hlsl.Min(dispatchSize.X, dispatchSize.Y);
+        float3 ro = new(0.0f, -0.2f, time * 4.0f);
         float3 ray = Hlsl.Normalize(new float3(p, 1.5f));
 
-        ray.XY = Hlsl.Mul(ray.XY, Rotate(Hlsl.Sin(this.time * 0.03f) * 5.0f));
-        ray.YZ = Hlsl.Mul(ray.YZ, Rotate(Hlsl.Sin(this.time * 0.05f) * 0.2f));
+        ray.XY = Hlsl.Mul(ray.XY, Rotate(Hlsl.Sin(time * 0.03f) * 5.0f));
+        ray.YZ = Hlsl.Mul(ray.YZ, Rotate(Hlsl.Sin(time * 0.05f) * 0.2f));
 
         float t = 0.1f;
         float ac = 0.0f;
@@ -119,7 +110,7 @@ internal readonly partial struct Octagrams : ID2D1PixelShader
 
             pos = Mod(pos - 2.0f, 4.0f) - 2.0f;
 
-            float gTime = this.time - (i * 0.01f);
+            float gTime = time - (i * 0.01f);
             float d = BoxSet(pos, gTime);
 
             d = Hlsl.Max(Hlsl.Abs(d), 0.01f);
@@ -127,7 +118,7 @@ internal readonly partial struct Octagrams : ID2D1PixelShader
             t += d * 0.55f;
         }
 
-        float3 col = (ac * 0.02f) + new float3(0.0f, 0.2f * Hlsl.Abs(Hlsl.Sin(this.time)), 0.5f + (Hlsl.Sin(this.time) * 0.2f));
+        float3 col = (ac * 0.02f) + new float3(0.0f, 0.2f * Hlsl.Abs(Hlsl.Sin(time)), 0.5f + (Hlsl.Sin(time) * 0.2f));
         float4 color = new(col, 1);
 
         return color;

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/ProteanClouds.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/ProteanClouds.cs
@@ -8,23 +8,14 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// <para>Created by nimitz (twitter: @stormoid).</para>
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct ProteanClouds : ID2D1PixelShader
+internal readonly partial struct ProteanClouds(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time Hlsl.Since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     private static readonly float3x3 M3 = new float3x3(0.33338f, 0.56034f, -0.71817f, -0.87887f, 0.32651f, -0.15323f, 0.15162f, 0.69596f, 0.61339f) * 1.93f;
 
     private static float2x2 Rotate(in float a)
@@ -50,7 +41,7 @@ internal readonly partial struct ProteanClouds : ID2D1PixelShader
         float3 p2 = p;
 
         p2.XY -= Disp(p.Z).XY;
-        p.XY = Hlsl.Mul(p.XY, Rotate((Hlsl.Sin(p.Z + this.time) * (0.1f + (prm1 * 0.05f))) + (this.time * 0.09f)));
+        p.XY = Hlsl.Mul(p.XY, Rotate((Hlsl.Sin(p.Z + time) * (0.1f + (prm1 * 0.05f))) + (time * 0.09f)));
 
         float cl = Hlsl.Dot(p2.XY, p2.XY);
         float d = 0.0f;
@@ -63,7 +54,7 @@ internal readonly partial struct ProteanClouds : ID2D1PixelShader
 
         for (int i = 0; i < 5; i++)
         {
-            p += Hlsl.Sin((p.ZXY * 0.75f * trk) + (this.time * trk * 0.8f)) * dspAmp;
+            p += Hlsl.Sin((p.ZXY * 0.75f * trk) + (time * trk * 0.8f)) * dspAmp;
             d -= Hlsl.Abs(Hlsl.Dot(Hlsl.Cos(p), Hlsl.Sin(p.YZX)) * z);
             z *= 0.57f;
             trk *= 1.4f;
@@ -144,13 +135,13 @@ internal readonly partial struct ProteanClouds : ID2D1PixelShader
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        float2 q = (float2)xy / this.dispatchSize;
-        float2 p = (xy - (0.5f * (float2)this.dispatchSize)) / this.dispatchSize.Y;
-        float2 bsMo = -0.5f * (float2)this.dispatchSize / this.dispatchSize.Y;
-        float scaledTime = this.time * 3.0f;
+        float2 q = (float2)xy / dispatchSize;
+        float2 p = (xy - (0.5f * (float2)dispatchSize)) / dispatchSize.Y;
+        float2 bsMo = -0.5f * (float2)dispatchSize / dispatchSize.Y;
+        float scaledTime = time * 3.0f;
         float3 ro = new(0, 0, scaledTime);
 
-        ro += new float3(Hlsl.Sin(this.time) * 0.5f, Hlsl.Sin(this.time * 1.0f) * 0.0f, 0);
+        ro += new float3(Hlsl.Sin(time) * 0.5f, Hlsl.Sin(time * 1.0f) * 0.0f, 0);
 
         float dspAmp = 0.85f;
 
@@ -170,7 +161,7 @@ internal readonly partial struct ProteanClouds : ID2D1PixelShader
 
         rd.XY = Hlsl.Mul(rd.XY, Rotate((-Disp(scaledTime + 3.5f).X * 0.2f) + bsMo.X));
 
-        float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(this.time * 0.3f));
+        float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(time * 0.3f));
         float4 scn = Render(ro, rd, scaledTime, prm1, bsMo);
         float3 col = scn.RGB;
 

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/PyramidPattern.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/PyramidPattern.cs
@@ -8,23 +8,14 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// Ported from <see href="https://www.shadertoy.com/view/wlscWX"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct PyramidPattern : ID2D1PixelShader
+internal readonly partial struct PyramidPattern(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time Hlsl.Since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     // Standard 2D rotation formula.
     private static float2x2 Rotate2x2(in float a)
     {
@@ -92,7 +83,7 @@ internal readonly partial struct PyramidPattern : ID2D1PixelShader
 
         p -= ip + 0.5f;
 
-        float ang = (-3.14159f * 3.0f / 5.0f) + (FBM((ip / 8.0f) + (this.time / 3.0f)) * 6.2831f * 2.0f);
+        float ang = (-3.14159f * 3.0f / 5.0f) + (FBM((ip / 8.0f) + (time / 3.0f)) * 6.2831f * 2.0f);
 
         float2 offs = new float2(Hlsl.Cos(ang), Hlsl.Sin(ang)) * 0.35f;
 
@@ -158,12 +149,12 @@ internal readonly partial struct PyramidPattern : ID2D1PixelShader
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        int2 coordinate = new(xy.X, this.dispatchSize.Y - xy.Y);
-        float iRes = Hlsl.Min(this.dispatchSize.Y, 800.0f);
-        float2 uv = (coordinate - ((float2)this.dispatchSize * 0.5f)) / iRes;
+        int2 coordinate = new(xy.X, dispatchSize.Y - xy.Y);
+        float iRes = Hlsl.Min(dispatchSize.Y, 800.0f);
+        float2 uv = (coordinate - ((float2)dispatchSize * 0.5f)) / iRes;
         float3 rd = Hlsl.Normalize(new float3(uv, 0.5f));
         const float gSc = 10.0f;
-        float2 p = (uv * gSc) + new float2(0, this.time / 2.0f);
+        float2 p = (uv * gSc) + new float2(0, time / 2.0f);
         float2 oP = p;
         float m = BMap(p);
         float3 n = new(0, 0, -1);
@@ -172,7 +163,7 @@ internal readonly partial struct PyramidPattern : ID2D1PixelShader
 
         n = DoBumpMap(p, n, bumpFactor, ref edge);
 
-        float3 lp = new float3(-0.0f + (Hlsl.Sin(this.time) * 0.3f), 0.0f + (Hlsl.Cos(this.time * 1.3f) * 0.3f), -1) - new float3(uv, 0);
+        float3 lp = new float3(-0.0f + (Hlsl.Sin(time) * 0.3f), 0.0f + (Hlsl.Cos(time * 1.3f) * 0.3f), -1) - new float3(uv, 0);
         float lDist = Hlsl.Max(Hlsl.Length(lp), 0.001f);
         float3 ld = lp / lDist;
         float diff = Hlsl.Max(Hlsl.Dot(n, ld), 0.0f);

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TerracedHills.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TerracedHills.cs
@@ -7,23 +7,14 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// Ported from <see href="https://www.shadertoy.com/view/MtdSRn"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct TerracedHills : ID2D1PixelShader
+internal readonly partial struct TerracedHills(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     // 2x2 matrix rotation. Angle vector, courtesy of Fabrice
     private static float2x2 Rot2(float th)
     {
@@ -96,13 +87,13 @@ internal readonly partial struct TerracedHills : ID2D1PixelShader
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        int2 coordinate = new(xy.X, this.dispatchSize.Y - xy.Y);
+        int2 coordinate = new(xy.X, dispatchSize.Y - xy.Y);
 
-        float3 rd = Hlsl.Normalize(new float3((float2)coordinate - (this.dispatchSize.Y * 0.5f), this.dispatchSize.Y));
+        float3 rd = Hlsl.Normalize(new float3((float2)coordinate - (dispatchSize.Y * 0.5f), dispatchSize.Y));
 
         rd.YZ = Rot2(0.35f) * rd.YZ;
 
-        float3 ro = new(this.time * 0.4f, 0.5f, this.time * 0.2f);
+        float3 ro = new(time * 0.4f, 0.5f, time * 0.2f);
 
         float t = 0, d;
         for (int i = 0; i < 96; i++)
@@ -120,7 +111,7 @@ internal readonly partial struct TerracedHills : ID2D1PixelShader
         float3 sp = ro + (rd * t);
         float3 ld = new(-0.676f, 0.408f, 0.613f);
         float edge = 0;
-        float3 n = Normal(sp, ref edge, this.dispatchSize.Y);
+        float3 n = Normal(sp, ref edge, dispatchSize.Y);
         float dif = Hlsl.Max(Hlsl.Dot(ld, n), 0.0f);
         float spe = Hlsl.Pow(Hlsl.Max(Hlsl.Dot(Hlsl.Reflect(rd, n), ld), 0.0f), 16.0f);
         float sh = HMap(sp.XZ);

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TriangleGridContouring.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TriangleGridContouring.cs
@@ -7,23 +7,14 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// Ported from <see href="https://www.shadertoy.com/view/WtfGDX"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct TriangleGridContouring : ID2D1PixelShader
+internal readonly partial struct TriangleGridContouring(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time Hlsl.Since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     // Standard 2D rotation formula.
     private static float2x2 Rotate2x2(in float a)
     {
@@ -40,7 +31,7 @@ internal readonly partial struct TriangleGridContouring : ID2D1PixelShader
 
         p = Hlsl.Frac(new float2(262144, 32768) * n);
 
-        return Hlsl.Sin((p * 6.2831853f) + this.time);
+        return Hlsl.Sin((p * 6.2831853f) + time);
     }
 
     // Based on IQ's gradient noise formula.
@@ -298,12 +289,12 @@ internal readonly partial struct TriangleGridContouring : ID2D1PixelShader
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        int2 coordinate = new(xy.X, this.dispatchSize.Y - xy.Y);
-        float2 uv = (coordinate - ((float2)this.dispatchSize * 0.5f)) / Hlsl.Min(650.0f, this.dispatchSize.Y);
-        float2 p = Hlsl.Mul(Rotate2x2(3.14159f / 12.0f), uv) + (new float2(0.8660254f, 0.5f) * this.time / 16.0f);
+        int2 coordinate = new(xy.X, dispatchSize.Y - xy.Y);
+        float2 uv = (coordinate - ((float2)dispatchSize * 0.5f)) / Hlsl.Min(650.0f, dispatchSize.Y);
+        float2 p = Hlsl.Mul(Rotate2x2(3.14159f / 12.0f), uv) + (new float2(0.8660254f, 0.5f) * time / 16.0f);
         float3 col = SimplexContour(p);
 
-        uv = coordinate / (float2)this.dispatchSize;
+        uv = coordinate / (float2)dispatchSize;
         col *= Hlsl.Pow(Hlsl.Abs(16.0f * uv.X * uv.Y * (1.0f - uv.X) * (1.0f - uv.Y)), 0.0625f) + 0.1f;
 
         return new(Hlsl.Sqrt(Hlsl.Max(col, 0.0f)), 1);

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TwoTiledTruchet.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1.Shared/TwoTiledTruchet.cs
@@ -7,23 +7,14 @@ namespace ComputeSharp.SwapChain.Shaders.D2D1;
 /// Ported from <see href="https://www.shadertoy.com/view/tsSfWK"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
+/// <param name="time">The current time since the start of the application.</param>
+/// <param name="dispatchSize">The dispatch size for the current output.</param>
 [D2DInputCount(0)]
 [D2DRequiresScenePosition]
 [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
 [D2DGeneratedPixelShaderDescriptor]
-[AutoConstructor]
-internal readonly partial struct TwoTiledTruchet : ID2D1PixelShader
+internal readonly partial struct TwoTiledTruchet(float time, int2 dispatchSize) : ID2D1PixelShader
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The dispatch size for the current output.
-    /// </summary>
-    private readonly int2 dispatchSize;
-
     /// <summary>
     /// Calculates the Truchet distance field.
     /// </summary>
@@ -114,7 +105,7 @@ internal readonly partial struct TwoTiledTruchet : ID2D1PixelShader
             ang *= 2.0f;
         }
 
-        ang = Hlsl.Frac(ang + (this.time / 4.0f));
+        ang = Hlsl.Frac(ang + (time / 4.0f));
 
         return d;
     }
@@ -123,10 +114,10 @@ internal readonly partial struct TwoTiledTruchet : ID2D1PixelShader
     public float4 Execute()
     {
         int2 xy = (int2)D2D.GetScenePosition().XY;
-        float2 uv = (xy - ((float2)this.dispatchSize * 0.5f)) / this.dispatchSize.Y;
+        float2 uv = (xy - ((float2)dispatchSize * 0.5f)) / dispatchSize.Y;
         float gSc = 7.0f;
-        float2 p = (uv * gSc) - (new float2(-1, -0.5f) * this.time / 2.0f);
-        float sf = 2.0f / this.dispatchSize.Y * gSc;
+        float2 p = (uv * gSc) - (new float2(-1, -0.5f) * time / 2.0f);
+        float sf = 2.0f / dispatchSize.Y * gSc;
         float lSc = 6.0f;
         float lw = 1.0f / lSc / gSc;
         float2 d = DistanceField(p, out float2 ang) - (2.5f / lSc);
@@ -135,7 +126,7 @@ internal readonly partial struct TwoTiledTruchet : ID2D1PixelShader
         for (int i = 0; i < 2; i++)
         {
             float di = d[i] - (lw / 4.0f);
-            float tracks = Hlsl.Clamp(Hlsl.Sin((ang[i] * 6.2831f) + (this.time * 6.0f)) * 4.0f, 0.0f, 1.0f);
+            float tracks = Hlsl.Clamp(Hlsl.Sin((ang[i] * 6.2831f) + (time * 6.0f)) * 4.0f, 0.0f, 1.0f);
             float gap = 1.0f + lw;
 
             col = Hlsl.Lerp(col, 0, (1.0f - Hlsl.SmoothStep(0.0f, sf * 6.0f, di)) * 0.35f);

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ColorfulInfinity.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ColorfulInfinity.cs
@@ -6,16 +6,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Benoit Marini.</para>
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct ColorfulInfinity : IComputeShader<float4>
+internal readonly partial struct ColorfulInfinity(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     /// <summary>
     /// The total number of layers for the final animation.
     /// </summary>
@@ -31,7 +26,7 @@ internal readonly partial struct ColorfulInfinity : IComputeShader<float4>
     /// </summary>
     private float4 Tex(float3 p)
     {
-        float t = this.time + 78.0f;
+        float t = time + 78.0f;
         float4 o = new(p.X, p.Y, p.Z, 3.0f * Hlsl.Sin(t * 0.1f));
         float4 dec =
             new float4(1.0f, 0.9f, 0.1f, 0.15f) +
@@ -50,7 +45,7 @@ internal readonly partial struct ColorfulInfinity : IComputeShader<float4>
     {
         float2 uv = (ThreadIds.XY - ((float2)DispatchSize.XY * 0.5f)) / DispatchSize.Y;
         float3 col = 0;
-        float t = this.time * 0.3f;
+        float t = time * 0.3f;
 
         for (float i = 0.0f; i <= 1.0f; i += 1.0f / NumberOfLayers)
         {

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ContouredLayers.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ContouredLayers.cs
@@ -5,21 +5,14 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/view/3lj3zt"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time Hlsl.Since the start of the application.</param>
+/// <param name="texture">The background texture to sample.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct ContouredLayers : IComputeShader<float4>
+internal readonly partial struct ContouredLayers(
+    float time,
+    IReadOnlyNormalizedTexture2D<float4> texture) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time Hlsl.Since the start of the application.
-    /// </summary>
-    private readonly float time;
-
-    /// <summary>
-    /// The background texture to sample.
-    /// </summary>
-    private readonly IReadOnlyNormalizedTexture2D<float4> texture;
-
     // float3 to float hash.
     private static float Hash21(float2 p)
     {
@@ -33,7 +26,7 @@ internal readonly partial struct ContouredLayers : IComputeShader<float4>
 
         p = Hlsl.Frac(new float2(262144, 32768) * n);
 
-        return Hlsl.Sin((p * 6.2831853f) + this.time);
+        return Hlsl.Sin((p * 6.2831853f) + time);
     }
 
     // float2 to float2 hash.
@@ -110,7 +103,7 @@ internal readonly partial struct ContouredLayers : IComputeShader<float4>
     // Layer color. Based on the shade, layer number and smoothing factor.
     private float3 GetColor(float2 p, float sh, float fi)
     {
-        float3 tx = this.texture.Sample(p + Hash21(new float2(sh, fi))).XYZ;
+        float3 tx = texture.Sample(p + Hash21(new float2(sh, fi))).XYZ;
 
         tx *= tx;
 

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ExtrudedTruchetPattern.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ExtrudedTruchetPattern.cs
@@ -5,16 +5,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/view/ttVBzd"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct ExtrudedTruchetPattern : IComputeShader<float4>
+internal readonly partial struct ExtrudedTruchetPattern(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     /// <summary>
     /// Curve shape - Round: 0, Semi-round: 1, Octagonal: 2, Superellipse: 3, Straight: 4.
     /// </summary>
@@ -169,7 +164,7 @@ internal readonly partial struct ExtrudedTruchetPattern : IComputeShader<float4>
         float sca = 2.0f;
         float occ = 0.0f;
 
-        for (int i = (int)Hlsl.Min(this.time, 0f); i < 5; i++)
+        for (int i = (int)Hlsl.Min(time, 0f); i < 5; i++)
         {
             float hr = (i + 1f) * 0.15f / 5.0f;
             float d = M(p + (n * hr));
@@ -203,15 +198,15 @@ internal readonly partial struct ExtrudedTruchetPattern : IComputeShader<float4>
         int2 coords = new(ThreadIds.X, DispatchSize.Y - ThreadIds.Y);
         float2 u = (coords - ((float2)DispatchSize.XY * 0.5f)) / DispatchSize.Y;
         float3 r = Hlsl.Normalize(new float3(u, 1));
-        float3 o = new(0, this.time / 2.0f, -3);
+        float3 o = new(0, time / 2.0f, -3);
         float3 l = o + new float3(0.25f, 0.25f, 2.0f);
 
         r.YZ = Hlsl.Mul(Rotate2x2(0.15f), r.YZ);
-        r.XZ = Hlsl.Mul(Rotate2x2(-Hlsl.Cos(this.time * 3.14159f / 32.0f) / 8.0f), r.XZ);
-        r.XY = Hlsl.Mul(Rotate2x2(Hlsl.Sin(this.time * 3.14159f / 32.0f) / 8.0f), r.XY);
+        r.XZ = Hlsl.Mul(Rotate2x2(-Hlsl.Cos(time * 3.14159f / 32.0f) / 8.0f), r.XZ);
+        r.XY = Hlsl.Mul(Rotate2x2(Hlsl.Sin(time * 3.14159f / 32.0f) / 8.0f), r.XY);
 
         float d;
-        float t = Hash21((r.XY * 57.0f) + Hlsl.Frac(this.time)) * 0.5f;
+        float t = Hash21((r.XY * 57.0f) + Hlsl.Frac(time)) * 0.5f;
         float glow = 0;
 
         for (int i = 0; i < 96; i++)

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/FourColorGradient.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/FourColorGradient.cs
@@ -6,16 +6,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Inigo Quilez.</para>
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct FourColorGradient : IComputeShader<float4>
+internal readonly partial struct FourColorGradient(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     // Colors to blend together
     private static readonly float3 ColorOne = new(0.999f, 0.999f, 0.999f);
     private static readonly float3 ColorTwo = new(0.999f, 0f, 0f);
@@ -82,7 +77,7 @@ internal readonly partial struct FourColorGradient : IComputeShader<float4>
         tuv -= 0.5f;
 
         // Rotate with noise
-        float degree = Noise(new float2(this.time * 0.1f, tuv.X * tuv.Y));
+        float degree = Noise(new float2(time * 0.1f, tuv.X * tuv.Y));
 
         tuv.Y *= 1.0f / ratio;
         tuv.XY = Hlsl.Mul(tuv.XY, Rotate(Hlsl.Radians(((degree - 0.5f) * 720.0f) + 180.0f)));
@@ -91,7 +86,7 @@ internal readonly partial struct FourColorGradient : IComputeShader<float4>
         // Wave warp with sin
         float frequency = 5.0f;
         float amplitude = 30.0f;
-        float speed = this.time * 2.0f;
+        float speed = time * 2.0f;
 
         tuv.X += Hlsl.Sin((tuv.Y * frequency) + speed) / amplitude;
         tuv.Y += Hlsl.Sin((tuv.X * frequency * 1.5f) + speed) / (amplitude * 0.5f);

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/FractalTiling.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/FractalTiling.cs
@@ -6,20 +6,15 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by Inigo Quilez.</para>
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct FractalTiling : IComputeShader<float4>
+internal readonly partial struct FractalTiling(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     /// <inheritdoc/>
     public float4 Execute()
     {
-        float2 position = (((float2)(256 * ThreadIds.XY)) / DispatchSize.X) + this.time;
+        float2 position = (((float2)(256 * ThreadIds.XY)) / DispatchSize.X) + time;
         float4 color = 0;
 
         for (int i = 0; i < 6; i++)
@@ -27,7 +22,7 @@ internal readonly partial struct FractalTiling : IComputeShader<float4>
             float2 a = Hlsl.Floor(position);
             float2 b = Hlsl.Frac(position);
             float4 w = Hlsl.Frac(
-                (Hlsl.Sin((a.X * 7) + (31.0f * a.Y) + (0.01f * this.time)) +
+                (Hlsl.Sin((a.X * 7) + (31.0f * a.Y) + (0.01f * time)) +
                  new float4(0.035f, 0.01f, 0, 0.7f))
                  * 13.545317f);
 

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/HelloWorld.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/HelloWorld.cs
@@ -4,16 +4,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// A simple shader to get started with based on shadertoy new shader template.
 /// Ported from <see href="https://www.shadertoy.com/new"/>.
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct HelloWorld : IComputeShader<float4>
+internal readonly partial struct HelloWorld(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     /// <inheritdoc/>
     public float4 Execute()
     {
@@ -21,7 +16,7 @@ internal readonly partial struct HelloWorld : IComputeShader<float4>
         float2 uv = ThreadIds.Normalized.XY;
 
         // Time varying pixel color
-        float3 col = 0.5f + (0.5f * Hlsl.Cos(this.time + new float3(uv, uv.X) + new float3(0, 2, 4)));
+        float3 col = 0.5f + (0.5f * Hlsl.Cos(time + new float3(uv, uv.X) + new float3(0, 2, 4)));
 
         // Output to screen
         return new(col, 1f);

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/MengerJourney.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/MengerJourney.cs
@@ -5,16 +5,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/view/Mdf3z7"/>.
 /// <para>Created by Syntopia.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct MengerJourney : IComputeShader<float4>
+internal readonly partial struct MengerJourney(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     private const int MaxSteps = 30;
     private const float MinimumDistance = 0.0009f;
     private const float NormalDistance = 0.0002f;
@@ -76,7 +71,7 @@ internal readonly partial struct MengerJourney : IComputeShader<float4>
 
         for (int n = 0; n < Iterations; n++)
         {
-            z.XY = Rotate(z.XY, 4.0f + (2.0f * Hlsl.Cos(this.time / 8.0f)));
+            z.XY = Rotate(z.XY, 4.0f + (2.0f * Hlsl.Cos(time / 8.0f)));
             z = Hlsl.Abs(z);
 
             if (z.X < z.Y) { z.XY = z.YX; }
@@ -122,7 +117,7 @@ internal readonly partial struct MengerJourney : IComputeShader<float4>
             return Hlsl.Frac(Hlsl.Cos(Hlsl.Dot(co, new float2(4.898f, 7.23f))) * 23421.631f);
         }
 
-        float totalDistance = Jitter * Rand(fragCoord.XY + this.time);
+        float totalDistance = Jitter * Rand(fragCoord.XY + time);
         float3 dir2 = dir;
         float distance = 0;
         int steps = 0;
@@ -130,7 +125,7 @@ internal readonly partial struct MengerJourney : IComputeShader<float4>
 
         for (int i = 0; i < MaxSteps; i++)
         {
-            dir.ZY = Rotate(dir2.ZY, totalDistance * Hlsl.Cos(this.time / 4.0f) * NonLinearPerspective);
+            dir.ZY = Rotate(dir2.ZY, totalDistance * Hlsl.Cos(time / 4.0f) * NonLinearPerspective);
             pos = from + (totalDistance * dir);
             distance = DE(pos) * FudgeFactor;
             totalDistance += distance;
@@ -157,8 +152,8 @@ internal readonly partial struct MengerJourney : IComputeShader<float4>
     /// <inheritdoc/>
     public float4 Execute()
     {
-        float3 camPos = 0.5f * this.time * new float3(1.0f, 0.0f, 0.0f);
-        float3 target = camPos + new float3(1.0f, 0.0f * Hlsl.Cos(this.time), 0.0f * Hlsl.Sin(0.4f * this.time));
+        float3 camPos = 0.5f * time * new float3(1.0f, 0.0f, 0.0f);
+        float3 target = camPos + new float3(1.0f, 0.0f * Hlsl.Cos(time), 0.0f * Hlsl.Sin(0.4f * time));
         float3 camDir = Hlsl.Normalize(target - camPos);
         float3 camUp = new(0.0f, 1.0f, 0.0f);
 

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/Octagrams.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/Octagrams.cs
@@ -5,16 +5,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/view/tlVGDt"/>.
 /// <para>Created by whisky_shusuky.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct Octagrams : IComputeShader<float4>
+internal readonly partial struct Octagrams(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     private static float2x2 Rotate(float a)
     {
         float c = Hlsl.Cos(a);
@@ -89,11 +84,11 @@ internal readonly partial struct Octagrams : IComputeShader<float4>
     public float4 Execute()
     {
         float2 p = (((float2)ThreadIds.XY * 2.0f) - DispatchSize.XY) / Hlsl.Min(DispatchSize.X, DispatchSize.Y);
-        float3 ro = new(0.0f, -0.2f, this.time * 4.0f);
+        float3 ro = new(0.0f, -0.2f, time * 4.0f);
         float3 ray = Hlsl.Normalize(new float3(p, 1.5f));
 
-        ray.XY = Hlsl.Mul(ray.XY, Rotate(Hlsl.Sin(this.time * 0.03f) * 5.0f));
-        ray.YZ = Hlsl.Mul(ray.YZ, Rotate(Hlsl.Sin(this.time * 0.05f) * 0.2f));
+        ray.XY = Hlsl.Mul(ray.XY, Rotate(Hlsl.Sin(time * 0.03f) * 5.0f));
+        ray.YZ = Hlsl.Mul(ray.YZ, Rotate(Hlsl.Sin(time * 0.05f) * 0.2f));
 
         float t = 0.1f;
         float ac = 0.0f;
@@ -109,7 +104,7 @@ internal readonly partial struct Octagrams : IComputeShader<float4>
 
             pos = Mod(pos - 2.0f, 4.0f) - 2.0f;
 
-            float gTime = this.time - (i * 0.01f);
+            float gTime = time - (i * 0.01f);
             float d = BoxSet(pos, gTime);
 
             d = Hlsl.Max(Hlsl.Abs(d), 0.01f);
@@ -117,7 +112,7 @@ internal readonly partial struct Octagrams : IComputeShader<float4>
             t += d * 0.55f;
         }
 
-        float3 col = (ac * 0.02f) + new float3(0.0f, 0.2f * Hlsl.Abs(Hlsl.Sin(this.time)), 0.5f + (Hlsl.Sin(this.time) * 0.2f));
+        float3 col = (ac * 0.02f) + new float3(0.0f, 0.2f * Hlsl.Abs(Hlsl.Sin(time)), 0.5f + (Hlsl.Sin(time) * 0.2f));
         float4 color = new(col, 1);
 
         return color;

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/ProteanClouds.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/ProteanClouds.cs
@@ -6,16 +6,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// <para>Created by nimitz (twitter: @stormoid).</para>
 /// <para>License Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time Hlsl.Since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct ProteanClouds : IComputeShader<float4>
+internal readonly partial struct ProteanClouds(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time Hlsl.Since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     private static readonly float3x3 M3 = new float3x3(0.33338f, 0.56034f, -0.71817f, -0.87887f, 0.32651f, -0.15323f, 0.15162f, 0.69596f, 0.61339f) * 1.93f;
 
     private static float2x2 Rotate(in float a)
@@ -41,7 +36,7 @@ internal readonly partial struct ProteanClouds : IComputeShader<float4>
         float3 p2 = p;
 
         p2.XY -= Disp(p.Z).XY;
-        p.XY = Hlsl.Mul(p.XY, Rotate((Hlsl.Sin(p.Z + this.time) * (0.1f + (prm1 * 0.05f))) + (this.time * 0.09f)));
+        p.XY = Hlsl.Mul(p.XY, Rotate((Hlsl.Sin(p.Z + time) * (0.1f + (prm1 * 0.05f))) + (time * 0.09f)));
 
         float cl = Hlsl.Dot(p2.XY, p2.XY);
         float d = 0.0f;
@@ -54,7 +49,7 @@ internal readonly partial struct ProteanClouds : IComputeShader<float4>
 
         for (int i = 0; i < 5; i++)
         {
-            p += Hlsl.Sin((p.ZXY * 0.75f * trk) + (this.time * trk * 0.8f)) * dspAmp;
+            p += Hlsl.Sin((p.ZXY * 0.75f * trk) + (time * trk * 0.8f)) * dspAmp;
             d -= Hlsl.Abs(Hlsl.Dot(Hlsl.Cos(p), Hlsl.Sin(p.YZX)) * z);
             z *= 0.57f;
             trk *= 1.4f;
@@ -137,10 +132,10 @@ internal readonly partial struct ProteanClouds : IComputeShader<float4>
         float2 q = (float2)ThreadIds.XY / DispatchSize.XY;
         float2 p = (ThreadIds.XY - (0.5f * (float2)DispatchSize.XY)) / DispatchSize.Y;
         float2 bsMo = -0.5f * (float2)DispatchSize.XY / DispatchSize.Y;
-        float scaledTime = this.time * 3.0f;
+        float scaledTime = time * 3.0f;
         float3 ro = new(0, 0, scaledTime);
 
-        ro += new float3(Hlsl.Sin(this.time) * 0.5f, Hlsl.Sin(this.time * 1.0f) * 0.0f, 0);
+        ro += new float3(Hlsl.Sin(time) * 0.5f, Hlsl.Sin(time * 1.0f) * 0.0f, 0);
 
         float dspAmp = 0.85f;
 
@@ -160,7 +155,7 @@ internal readonly partial struct ProteanClouds : IComputeShader<float4>
 
         rd.XY = Hlsl.Mul(rd.XY, Rotate((-Disp(scaledTime + 3.5f).X * 0.2f) + bsMo.X));
 
-        float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(this.time * 0.3f));
+        float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(time * 0.3f));
         float4 scn = Render(ro, rd, scaledTime, prm1, bsMo);
         float3 col = scn.RGB;
 

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/PyramidPattern.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/PyramidPattern.cs
@@ -6,16 +6,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/view/wlscWX"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time Hlsl.Since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct PyramidPattern : IComputeShader<float4>
+internal readonly partial struct PyramidPattern(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time Hlsl.Since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     // Standard 2D rotation formula.
     private static float2x2 Rotate2x2(in float a)
     {
@@ -83,7 +78,7 @@ internal readonly partial struct PyramidPattern : IComputeShader<float4>
 
         p -= ip + 0.5f;
 
-        float ang = (-3.14159f * 3.0f / 5.0f) + (FBM((ip / 8.0f) + (this.time / 3.0f)) * 6.2831f * 2.0f);
+        float ang = (-3.14159f * 3.0f / 5.0f) + (FBM((ip / 8.0f) + (time / 3.0f)) * 6.2831f * 2.0f);
 
         float2 offs = new float2(Hlsl.Cos(ang), Hlsl.Sin(ang)) * 0.35f;
 
@@ -153,7 +148,7 @@ internal readonly partial struct PyramidPattern : IComputeShader<float4>
         float2 uv = (coordinate - ((float2)DispatchSize.XY * 0.5f)) / iRes;
         float3 rd = Hlsl.Normalize(new float3(uv, 0.5f));
         const float gSc = 10.0f;
-        float2 p = (uv * gSc) + new float2(0, this.time / 2.0f);
+        float2 p = (uv * gSc) + new float2(0, time / 2.0f);
         float2 oP = p;
         float m = BMap(p);
         float3 n = new(0, 0, -1);
@@ -162,7 +157,7 @@ internal readonly partial struct PyramidPattern : IComputeShader<float4>
 
         n = DoBumpMap(p, n, bumpFactor, ref edge);
 
-        float3 lp = new float3(-0.0f + (Hlsl.Sin(this.time) * 0.3f), 0.0f + (Hlsl.Cos(this.time * 1.3f) * 0.3f), -1) - new float3(uv, 0);
+        float3 lp = new float3(-0.0f + (Hlsl.Sin(time) * 0.3f), 0.0f + (Hlsl.Cos(time * 1.3f) * 0.3f), -1) - new float3(uv, 0);
         float lDist = Hlsl.Max(Hlsl.Length(lp), 0.001f);
         float3 ld = lp / lDist;
         float diff = Hlsl.Max(Hlsl.Dot(n, ld), 0.0f);

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TerracedHills.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TerracedHills.cs
@@ -5,16 +5,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/view/MtdSRn"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct TerracedHills : IComputeShader<float4>
+internal readonly partial struct TerracedHills(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     // 2x2 matrix rotation. Angle vector, courtesy of Fabrice
     private static float2x2 Rot2(float th)
     {
@@ -91,7 +86,7 @@ internal readonly partial struct TerracedHills : IComputeShader<float4>
 
         rd.YZ = Rot2(0.35f) * rd.YZ;
 
-        float3 ro = new(this.time * 0.4f, 0.5f, this.time * 0.2f);
+        float3 ro = new(time * 0.4f, 0.5f, time * 0.2f);
 
         float t = 0, d;
         for (int i = 0; i < 96; i++)

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TriangleGridContouring.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TriangleGridContouring.cs
@@ -5,16 +5,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/view/WtfGDX"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time Hlsl.Since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct TriangleGridContouring : IComputeShader<float4>
+internal readonly partial struct TriangleGridContouring(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time Hlsl.Since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     // Standard 2D rotation formula.
     private static float2x2 Rotate2x2(in float a)
     {
@@ -31,7 +26,7 @@ internal readonly partial struct TriangleGridContouring : IComputeShader<float4>
 
         p = Hlsl.Frac(new float2(262144, 32768) * n);
 
-        return Hlsl.Sin((p * 6.2831853f) + this.time);
+        return Hlsl.Sin((p * 6.2831853f) + time);
     }
 
     // Based on IQ's gradient noise formula.
@@ -290,7 +285,7 @@ internal readonly partial struct TriangleGridContouring : IComputeShader<float4>
     {
         int2 coordinate = new(ThreadIds.X, DispatchSize.Y - ThreadIds.Y);
         float2 uv = (coordinate - ((float2)DispatchSize.XY * 0.5f)) / Hlsl.Min(650.0f, DispatchSize.Y);
-        float2 p = Hlsl.Mul(Rotate2x2(3.14159f / 12.0f), uv) + (new float2(0.8660254f, 0.5f) * this.time / 16.0f);
+        float2 p = Hlsl.Mul(Rotate2x2(3.14159f / 12.0f), uv) + (new float2(0.8660254f, 0.5f) * time / 16.0f);
         float3 col = SimplexContour(p);
 
         uv = coordinate / (float2)DispatchSize.XY;

--- a/samples/ComputeSharp.SwapChain.Shaders.Shared/TwoTiledTruchet.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.Shared/TwoTiledTruchet.cs
@@ -5,16 +5,11 @@ namespace ComputeSharp.SwapChain.Shaders;
 /// Ported from <see href="https://www.shadertoy.com/view/tsSfWK"/>.
 /// <para>Created by Shane.</para>
 /// </summary>
-[AutoConstructor]
+/// <param name="time">The current time since the start of the application.</param>
 [ThreadGroupSize(DefaultThreadGroupSizes.XY)]
 [GeneratedComputeShaderDescriptor]
-internal readonly partial struct TwoTiledTruchet : IComputeShader<float4>
+internal readonly partial struct TwoTiledTruchet(float time) : IComputeShader<float4>
 {
-    /// <summary>
-    /// The current time since the start of the application.
-    /// </summary>
-    private readonly float time;
-
     /// <summary>
     /// Calculates the Truchet distance field.
     /// </summary>
@@ -105,7 +100,7 @@ internal readonly partial struct TwoTiledTruchet : IComputeShader<float4>
             ang *= 2.0f;
         }
 
-        ang = Hlsl.Frac(ang + (this.time / 4.0f));
+        ang = Hlsl.Frac(ang + (time / 4.0f));
 
         return d;
     }
@@ -115,7 +110,7 @@ internal readonly partial struct TwoTiledTruchet : IComputeShader<float4>
     {
         float2 uv = (ThreadIds.XY - ((float2)DispatchSize.XY * 0.5f)) / DispatchSize.Y;
         float gSc = 7.0f;
-        float2 p = (uv * gSc) - (new float2(-1, -0.5f) * this.time / 2.0f);
+        float2 p = (uv * gSc) - (new float2(-1, -0.5f) * time / 2.0f);
         float sf = 2.0f / DispatchSize.Y * gSc;
         float lSc = 6.0f;
         float lw = 1.0f / lSc / gSc;
@@ -125,7 +120,7 @@ internal readonly partial struct TwoTiledTruchet : IComputeShader<float4>
         for (int i = 0; i < 2; i++)
         {
             float di = d[i] - (lw / 4.0f);
-            float tracks = Hlsl.Clamp(Hlsl.Sin((ang[i] * 6.2831f) + (this.time * 6.0f)) * 4.0f, 0.0f, 1.0f);
+            float tracks = Hlsl.Clamp(Hlsl.Sin((ang[i] * 6.2831f) + (time * 6.0f)) * 4.0f, 0.0f, 1.0f);
             float gap = 1.0f + lw;
 
             col = Hlsl.Lerp(col, 0, (1.0f - Hlsl.SmoothStep(0.0f, sf * 6.0f, di)) * 0.35f);


### PR DESCRIPTION
### Contributes to #598

### Description

This PR replaces all uses of `[AutoConstructor]` in samples to use primary constructors instead.
This first refactoring is to make the rest of the work to remove `[AutoConstructor]` easier.