### PR TITLE
Unify more HLSL rewriting logic

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
@@ -12,7 +12,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace ComputeSharp.D2D1.SourceGenerators;
 
@@ -44,8 +43,8 @@ partial class D2DPixelShaderDescriptorGenerator
             ImmutableArray<int> inputSimpleIndices,
             ImmutableArray<int> inputComplexIndices)
         {
-            // Properties are not supported
-            DetectAndReportInvalidPropertyDeclarations(diagnostics, structDeclarationSymbol);
+            // Detect any invalid properties
+            HlslDefinitionsSyntaxProcessor.DetectAndReportInvalidPropertyDeclarations(diagnostics, structDeclarationSymbol);
 
             // We need to sets to track all discovered custom types and static methods
             HashSet<INamedTypeSymbol> discoveredTypes = new(SymbolEqualityComparer.Default);
@@ -67,8 +66,8 @@ partial class D2DPixelShaderDescriptorGenerator
             ImmutableArray<(string Name, string TypeDeclaration, string? Assignment)> staticFields = GetStaticFields(diagnostics, semanticModelProvider, structDeclaration, structDeclarationSymbol, discoveredTypes, constantDefinitions, out bool fieldsNeedD2D1RequiresScenePosition);
 
             // Process the discovered types and constants
-            ImmutableArray<(string Name, string Definition)> declaredTypes = GetDeclaredTypes(diagnostics, structDeclarationSymbol, discoveredTypes, instanceMethods);
-            ImmutableArray<(string Name, string Value)> definedConstants = GetDefinedConstants(constantDefinitions);
+            ImmutableArray<(string Name, string Definition)> declaredTypes = HlslDefinitionsSyntaxProcessor.GetDeclaredTypes(diagnostics, structDeclarationSymbol, discoveredTypes, instanceMethods);
+            ImmutableArray<(string Name, string Value)> definedConstants = HlslDefinitionsSyntaxProcessor.GetDefinedConstants(constantDefinitions);
 
             // Check whether the scene position is required
             bool requiresScenePosition = GetD2DRequiresScenePositionInfo(structDeclarationSymbol);
@@ -356,132 +355,6 @@ partial class D2DPixelShaderDescriptorGenerator
             }
 
             return (entryPoint!, methods.ToImmutable());
-        }
-
-        /// <summary>
-        /// Gets a sequence of discovered constants.
-        /// </summary>
-        /// <param name="constantDefinitions">The collection of discovered constant definitions.</param>
-        /// <returns>A sequence of discovered constants to declare in the shader.</returns>
-        private static ImmutableArray<(string Name, string Value)> GetDefinedConstants(IReadOnlyDictionary<IFieldSymbol, string> constantDefinitions)
-        {
-            using ImmutableArrayBuilder<(string, string)> builder = new();
-
-            foreach (KeyValuePair<IFieldSymbol, string> constant in constantDefinitions)
-            {
-                string ownerTypeName = ((INamedTypeSymbol)constant.Key.ContainingSymbol).ToDisplayString().ToHlslIdentifierName();
-                string constantName = $"__{ownerTypeName}__{constant.Key.Name}";
-
-                builder.Add((constantName, constant.Value));
-            }
-
-            return builder.ToImmutable();
-        }
-
-        /// <summary>
-        /// Gets the sequence of processed discovered custom types.
-        /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
-        /// <param name="structDeclarationSymbol">The type symbol for the shader type.</param>
-        /// <param name="types">The sequence of discovered custom types.</param>
-        /// <param name="instanceMethods">The collection of discovered instance methods for custom struct types.</param>
-        /// <returns>A sequence of custom type definitions to add to the shader source.</returns>
-        private static ImmutableArray<(string Name, string Definition)> GetDeclaredTypes(
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
-            INamedTypeSymbol structDeclarationSymbol,
-            IEnumerable<INamedTypeSymbol> types,
-            IReadOnlyDictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods)
-        {
-            using ImmutableArrayBuilder<(string, string)> builder = new();
-
-            IReadOnlyCollection<INamedTypeSymbol> invalidTypes;
-
-            // Process the discovered types
-            foreach (INamedTypeSymbol type in HlslKnownTypes.GetCustomTypes(types, out invalidTypes))
-            {
-                string structType = type.GetFullyQualifiedMetadataName().ToHlslIdentifierName();
-                StructDeclarationSyntax structDeclaration = StructDeclaration(structType);
-
-                // Declare the fields of the current type
-                foreach (ISymbol memberSymbol in type.GetMembers())
-                {
-                    // Once again, skip constants and staticv fields
-                    if (memberSymbol is not IFieldSymbol { IsConst: false, IsStatic: false } fieldSymbol)
-                    {
-                        continue;
-                    }
-
-                    // Try to get the actual field name
-                    if (!ConstantBufferSyntaxProcessor.TryGetFieldAccessorName(fieldSymbol, out string? fieldName, out _))
-                    {
-                        continue;
-                    }
-
-                    INamedTypeSymbol fieldType = (INamedTypeSymbol)fieldSymbol.Type;
-
-                    // Convert the name to the fully qualified HLSL version
-                    if (!HlslKnownTypes.TryGetMappedName(fieldType.GetFullyQualifiedMetadataName(), out string? mappedType))
-                    {
-                        mappedType = fieldType.GetFullyQualifiedMetadataName().ToHlslIdentifierName();
-                    }
-
-                    // Get the field name as a valid HLSL identifier
-                    if (!HlslKnownKeywords.TryGetMappedName(fieldName, out string? mappedName))
-                    {
-                        mappedName = fieldName;
-                    }
-
-                    structDeclaration = structDeclaration.AddMembers(
-                        FieldDeclaration(VariableDeclaration(
-                            IdentifierName(mappedType!)).AddVariables(
-                            VariableDeclarator(Identifier(mappedName!)))));
-                }
-
-                // Declare the methods of the current type
-                foreach (KeyValuePair<IMethodSymbol, MethodDeclarationSyntax> method in instanceMethods.Where(pair => SymbolEqualityComparer.Default.Equals(pair.Key.ContainingType, type)))
-                {
-                    structDeclaration = structDeclaration.AddMembers(method.Value);
-                }
-
-                // Insert the trailing ; right after the closing bracket (after normalization)
-                builder.Add((
-                    structType,
-                    structDeclaration
-                        .NormalizeWhitespace(eol: "\n")
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
-                        .ToFullString()));
-            }
-
-            // Process the invalid types
-            foreach (INamedTypeSymbol invalidType in invalidTypes)
-            {
-                diagnostics.Add(InvalidDiscoveredType, structDeclarationSymbol, structDeclarationSymbol, invalidType);
-            }
-
-            return builder.ToImmutable();
-        }
-
-        /// <summary>
-        /// Finds and reports all invalid declared properties in a shader.
-        /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
-        /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
-        private static void DetectAndReportInvalidPropertyDeclarations(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, INamedTypeSymbol structDeclarationSymbol)
-        {
-            foreach (ISymbol memberSymbol in structDeclarationSymbol.GetMembers())
-            {
-                // Detect properties that are not explicit interface implementations
-                if (memberSymbol is IPropertySymbol { ExplicitInterfaceImplementations.IsEmpty: true })
-                {
-                    diagnostics.Add(InvalidPropertyDeclaration, memberSymbol, structDeclarationSymbol, memberSymbol);
-                }
-
-                // Detect properties causing a field to be generated
-                if (memberSymbol is IFieldSymbol { AssociatedSymbol: IPropertySymbol associatedProperty })
-                {
-                    diagnostics.Add(InvalidPropertyDeclaration, associatedProperty, structDeclarationSymbol, associatedProperty);
-                }
-            }
         }
 
         /// <summary>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\HlslBytecodeInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Interfaces\IConstantBufferInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\ConstantBufferSyntaxProcessor.Generation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\HlslDefinitionsSyntaxProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\HlslSourceRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\HlslSourceRewriter.Diagnostics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\ShaderSourceRewriter.cs" />

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslDefinitionsSyntaxProcessor.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslDefinitionsSyntaxProcessor.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Helpers;
+using ComputeSharp.SourceGeneration.Mappings;
+using ComputeSharp.SourceGeneration.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace ComputeSharp.SourceGeneration.SyntaxProcessors;
+
+/// <summary>
+/// A processor responsible for extracting definitions from shader types
+/// </summary>
+internal static class HlslDefinitionsSyntaxProcessor
+{
+    /// <summary>
+    /// Gets a sequence of discovered constants.
+    /// </summary>
+    /// <param name="constantDefinitions">The collection of discovered constant definitions.</param>
+    /// <returns>A sequence of discovered constants to declare in the shader.</returns>
+    public static ImmutableArray<(string Name, string Value)> GetDefinedConstants(IReadOnlyDictionary<IFieldSymbol, string> constantDefinitions)
+    {
+        using ImmutableArrayBuilder<(string, string)> builder = new();
+
+        foreach (KeyValuePair<IFieldSymbol, string> constant in constantDefinitions)
+        {
+            string ownerTypeName = ((INamedTypeSymbol)constant.Key.ContainingSymbol).ToDisplayString().ToHlslIdentifierName();
+            string constantName = $"__{ownerTypeName}__{constant.Key.Name}";
+
+            builder.Add((constantName, constant.Value));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Gets the sequence of processed discovered custom types.
+    /// </summary>
+    /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
+    /// <param name="structDeclarationSymbol">The type symbol for the shader type.</param>
+    /// <param name="types">The sequence of discovered custom types.</param>
+    /// <param name="instanceMethods">The collection of discovered instance methods for custom struct types.</param>
+    /// <returns>A sequence of custom type definitions to add to the shader source.</returns>
+    public static ImmutableArray<(string Name, string Definition)> GetDeclaredTypes(
+        ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
+        INamedTypeSymbol structDeclarationSymbol,
+        IEnumerable<INamedTypeSymbol> types,
+        IReadOnlyDictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods)
+    {
+        using ImmutableArrayBuilder<(string, string)> builder = new();
+
+        IReadOnlyCollection<INamedTypeSymbol> invalidTypes;
+
+        // Process the discovered types
+        foreach (INamedTypeSymbol type in HlslKnownTypes.GetCustomTypes(types, out invalidTypes))
+        {
+            string structType = type.GetFullyQualifiedMetadataName().ToHlslIdentifierName();
+            StructDeclarationSyntax structDeclaration = StructDeclaration(structType);
+
+            // Declare the fields of the current type
+            foreach (ISymbol memberSymbol in type.GetMembers())
+            {
+                // Once again, skip constants and static fields
+                if (memberSymbol is not IFieldSymbol { IsConst: false, IsStatic: false } fieldSymbol)
+                {
+                    continue;
+                }
+
+                // Try to get the actual field name
+                if (!ConstantBufferSyntaxProcessor.TryGetFieldAccessorName(fieldSymbol, out string? fieldName, out _))
+                {
+                    continue;
+                }
+
+                INamedTypeSymbol fieldType = (INamedTypeSymbol)fieldSymbol.Type;
+
+                // Convert the name to the fully qualified HLSL version
+                if (!HlslKnownTypes.TryGetMappedName(fieldType.GetFullyQualifiedMetadataName(), out string? mappedType))
+                {
+                    mappedType = fieldType.GetFullyQualifiedMetadataName().ToHlslIdentifierName();
+                }
+
+                // Get the field name as a valid HLSL identifier
+                if (!HlslKnownKeywords.TryGetMappedName(fieldName, out string? mappedName))
+                {
+                    mappedName = fieldName;
+                }
+
+                structDeclaration = structDeclaration.AddMembers(
+                    FieldDeclaration(VariableDeclaration(
+                        IdentifierName(mappedType!)).AddVariables(
+                        VariableDeclarator(Identifier(mappedName!)))));
+            }
+
+            // Declare the methods of the current type
+            foreach (KeyValuePair<IMethodSymbol, MethodDeclarationSyntax> method in instanceMethods.Where(pair => SymbolEqualityComparer.Default.Equals(pair.Key.ContainingType, type)))
+            {
+                structDeclaration = structDeclaration.AddMembers(method.Value);
+            }
+
+            // Insert the trailing ; right after the closing bracket (after normalization)
+            builder.Add((
+                structType,
+                structDeclaration
+                    .NormalizeWhitespace(eol: "\n")
+                    .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
+                    .ToFullString()));
+        }
+
+        // Process the invalid types
+        foreach (INamedTypeSymbol invalidType in invalidTypes)
+        {
+            diagnostics.Add(InvalidDiscoveredType, structDeclarationSymbol, structDeclarationSymbol, invalidType);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Finds and reports all invalid declared properties in a shader.
+    /// </summary>
+    /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
+    /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
+    public static void DetectAndReportInvalidPropertyDeclarations(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, INamedTypeSymbol structDeclarationSymbol)
+    {
+        foreach (ISymbol memberSymbol in structDeclarationSymbol.GetMembers())
+        {
+            // Detect properties that are not explicit interface implementations
+            if (memberSymbol is IPropertySymbol { ExplicitInterfaceImplementations.IsEmpty: true })
+            {
+                diagnostics.Add(InvalidPropertyDeclaration, memberSymbol, structDeclarationSymbol, memberSymbol);
+            }
+
+            // Detect properties causing a field to be generated
+            if (memberSymbol is IFieldSymbol { AssociatedSymbol: IPropertySymbol associatedProperty })
+            {
+                diagnostics.Add(InvalidPropertyDeclaration, associatedProperty, structDeclarationSymbol, associatedProperty);
+            }
+        }
+    }
+}

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
@@ -97,20 +97,40 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
     {
         ObjectCreationExpressionSyntax updatedNode = (ObjectCreationExpressionSyntax)base.VisitObjectCreationExpression(node)!;
 
+        updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.Type, node, SemanticModel.For(node), DiscoveredTypes);
+
+        return VisitObjectCreationExpression(node, updatedNode, updatedNode.Type);
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxNode VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
+    {
+        ImplicitObjectCreationExpressionSyntax updatedNode = (ImplicitObjectCreationExpressionSyntax)base.VisitImplicitObjectCreationExpression(node)!;
+        TypeSyntax explicitType = IdentifierName("").ReplaceAndTrackType(node, SemanticModel.For(node), DiscoveredTypes);
+
+        return VisitObjectCreationExpression(node, updatedNode, explicitType);
+    }
+
+    /// <inheritdoc cref="VisitObjectCreationExpression(ObjectCreationExpressionSyntax)"/>
+    /// <param name="node">The original input <see cref="BaseObjectCreationExpressionSyntax"/> instance.</param>
+    /// <param name="updatedNode">The updated <see cref="BaseObjectCreationExpressionSyntax"/> instance with tweaked syntax.</param>
+    /// <param name="targetType">The <see cref="TypeSyntax"/> for the object being created.</param>
+    /// <returns>The rewritten <see cref="SyntaxNode"/> for the object creation expression.</returns>
+    private SyntaxNode VisitObjectCreationExpression(BaseObjectCreationExpressionSyntax node, BaseObjectCreationExpressionSyntax updatedNode, TypeSyntax targetType)
+    {
+        // Emit a diagnostic if the object being created is not valid (ie. it's a managed type)
         if (SemanticModel.For(node).GetTypeInfo(node).Type is ITypeSymbol { IsUnmanagedType: false } type)
         {
             Diagnostics.Add(InvalidObjectCreationExpression, node, type);
         }
 
-        updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.Type, node, SemanticModel.For(node), DiscoveredTypes);
-
-        // New objects use the default HLSL cast syntax, eg. (float4)0
+        // Mutate the syntax like with explicit object creation expressions
         if (updatedNode.ArgumentList!.Arguments.Count == 0)
         {
-            return CastExpression(updatedNode.Type, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)));
+            return CastExpression(targetType, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)));
         }
 
-        // Add explicit casts for matrix constructors to help the overload resolution
+        // Add explicit casts like with the explicit object creation expressions above
         if (SemanticModel.For(node).GetTypeInfo(node).Type is ITypeSymbol matrixType &&
             HlslKnownTypes.IsMatrixType(matrixType.GetFullyQualifiedMetadataName()))
         {
@@ -125,43 +145,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
             }
         }
 
-        return InvocationExpression(updatedNode.Type, updatedNode.ArgumentList!);
-    }
-
-    /// <inheritdoc/>
-    public override SyntaxNode VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
-    {
-        ImplicitObjectCreationExpressionSyntax updatedNode = (ImplicitObjectCreationExpressionSyntax)base.VisitImplicitObjectCreationExpression(node)!;
-
-        if (SemanticModel.For(node).GetTypeInfo(node).Type is ITypeSymbol { IsUnmanagedType: false } type)
-        {
-            Diagnostics.Add(InvalidObjectCreationExpression, node, type);
-        }
-
-        TypeSyntax explicitType = IdentifierName("").ReplaceAndTrackType(node, SemanticModel.For(node), DiscoveredTypes);
-
-        // Mutate the syntax like with explicit object creation expressions
-        if (updatedNode.ArgumentList!.Arguments.Count == 0)
-        {
-            return CastExpression(explicitType, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)));
-        }
-
-        // Add explicit casts like with the explicit object creation expressions above
-        if (SemanticModel.For(node).GetTypeInfo(node).Type is ITypeSymbol matrixType &&
-            HlslKnownTypes.IsMatrixType(matrixType.GetFullyQualifiedMetadataName()))
-        {
-            for (int i = 0; i < node.ArgumentList.Arguments.Count; i++)
-            {
-                IArgumentOperation argumentOperation = (IArgumentOperation)SemanticModel.For(node).GetOperation(node.ArgumentList.Arguments[i])!;
-                INamedTypeSymbol elementType = (INamedTypeSymbol)argumentOperation.Parameter!.Type;
-
-                updatedNode = updatedNode.ReplaceNode(
-                    updatedNode.ArgumentList.Arguments[i].Expression,
-                    CastExpression(IdentifierName(HlslKnownTypes.GetMappedName(elementType)), updatedNode.ArgumentList.Arguments[i].Expression));
-            }
-        }
-
-        return InvocationExpression(explicitType, updatedNode.ArgumentList);
+        return InvocationExpression(targetType, updatedNode.ArgumentList!);
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
-using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace ComputeSharp.SourceGenerators;
 
@@ -50,8 +49,8 @@ partial class ComputeShaderDescriptorGenerator
             out bool isSamplerUsed,
             out string hlslSource)
         {
-            // Detect invalid properties
-            DetectAndReportInvalidPropertyDeclarations(diagnostics, structDeclarationSymbol);
+            // Detect any invalid properties
+            HlslDefinitionsSyntaxProcessor.DetectAndReportInvalidPropertyDeclarations(diagnostics, structDeclarationSymbol);
 
             // We need to sets to track all discovered custom types and static methods
             HashSet<INamedTypeSymbol> discoveredTypes = new(SymbolEqualityComparer.Default);
@@ -77,8 +76,8 @@ partial class ComputeShaderDescriptorGenerator
             ImmutableArray<(string Name, string TypeDeclaration, string? Assignment)> staticFields = GetStaticFields(diagnostics, semanticModelProvider, structDeclaration, structDeclarationSymbol, discoveredTypes, constantDefinitions);
 
             // Process the discovered types and constants
-            ImmutableArray<(string Name, string Definition)> declaredTypes = GetDeclaredTypes(diagnostics, structDeclarationSymbol, discoveredTypes, instanceMethods);
-            ImmutableArray<(string Name, string Value)> definedConstants = GetDefinedConstants(constantDefinitions);
+            ImmutableArray<(string Name, string Definition)> declaredTypes = HlslDefinitionsSyntaxProcessor.GetDeclaredTypes(diagnostics, structDeclarationSymbol, discoveredTypes, instanceMethods);
+            ImmutableArray<(string Name, string Value)> definedConstants = HlslDefinitionsSyntaxProcessor.GetDefinedConstants(constantDefinitions);
 
             // Check whether an implicit texture is used in the shader
             isImplicitTextureUsed = implicitTextureType is not null;
@@ -418,125 +417,6 @@ partial class ComputeShaderDescriptorGenerator
             }
 
             return (entryPoint!, methods.ToImmutable(), isSamplerUsed);
-        }
-
-        /// <summary>
-        /// Gets a sequence of discovered constants.
-        /// </summary>
-        /// <param name="constantDefinitions">The collection of discovered constant definitions.</param>
-        /// <returns>A sequence of discovered constants to declare in the shader.</returns>
-        private static ImmutableArray<(string Name, string Value)> GetDefinedConstants(IReadOnlyDictionary<IFieldSymbol, string> constantDefinitions)
-        {
-            using ImmutableArrayBuilder<(string, string)> builder = new();
-
-            foreach (KeyValuePair<IFieldSymbol, string> constant in constantDefinitions)
-            {
-                string ownerTypeName = ((INamedTypeSymbol)constant.Key.ContainingSymbol).ToDisplayString().ToHlslIdentifierName();
-                string constantName = $"__{ownerTypeName}__{constant.Key.Name}";
-
-                builder.Add((constantName, constant.Value));
-            }
-
-            return builder.ToImmutable();
-        }
-
-        /// <summary>
-        /// Gets the sequence of processed discovered custom types.
-        /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
-        /// <param name="sourceSymbol">The symbol for the current object being processed.</param>
-        /// <param name="types">The sequence of discovered custom types.</param>
-        /// <param name="instanceMethods">The collection of discovered instance methods for custom struct types.</param>
-        /// <returns>A sequence of custom type definitions to add to the shader source.</returns>
-        private static ImmutableArray<(string Name, string Definition)> GetDeclaredTypes(
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
-            ISymbol sourceSymbol,
-            IEnumerable<INamedTypeSymbol> types,
-            IReadOnlyDictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods)
-        {
-            using ImmutableArrayBuilder<(string, string)> builder = new();
-
-            IReadOnlyCollection<INamedTypeSymbol> invalidTypes;
-
-            // Process the discovered types
-            foreach (INamedTypeSymbol type in HlslKnownTypes.GetCustomTypes(types, out invalidTypes))
-            {
-                string structType = type.GetFullyQualifiedMetadataName().ToHlslIdentifierName();
-                StructDeclarationSyntax structDeclaration = StructDeclaration(structType);
-
-                // Declare the fields of the current type
-                foreach (IFieldSymbol field in type.GetMembers().OfType<IFieldSymbol>())
-                {
-                    if (field.IsStatic)
-                    {
-                        continue;
-                    }
-
-                    INamedTypeSymbol fieldType = (INamedTypeSymbol)field.Type;
-
-                    // Convert the name to the fully qualified HLSL version
-                    if (!HlslKnownTypes.TryGetMappedName(fieldType.GetFullyQualifiedMetadataName(), out string? mappedType))
-                    {
-                        mappedType = fieldType.GetFullyQualifiedMetadataName().ToHlslIdentifierName();
-                    }
-
-                    // Get the field name as a valid HLSL identifier
-                    if (!HlslKnownKeywords.TryGetMappedName(field.Name, out string? mappedName))
-                    {
-                        mappedName = field.Name;
-                    }
-
-                    structDeclaration = structDeclaration.AddMembers(
-                        FieldDeclaration(VariableDeclaration(
-                            IdentifierName(mappedType!)).AddVariables(
-                            VariableDeclarator(Identifier(mappedName!)))));
-                }
-
-                // Declare the methods of the current type
-                foreach (KeyValuePair<IMethodSymbol, MethodDeclarationSyntax> method in instanceMethods.Where(pair => SymbolEqualityComparer.Default.Equals(pair.Key.ContainingType, type)))
-                {
-                    structDeclaration = structDeclaration.AddMembers(method.Value);
-                }
-
-                // Insert the trailing ; right after the closing bracket (after normalization)
-                builder.Add((
-                    structType,
-                    structDeclaration
-                        .NormalizeWhitespace(eol: "\n")
-                        .WithSemicolonToken(Token(SyntaxKind.SemicolonToken))
-                        .ToFullString()));
-            }
-
-            // Process the invalid types
-            foreach (INamedTypeSymbol invalidType in invalidTypes)
-            {
-                diagnostics.Add(InvalidDiscoveredType, sourceSymbol, sourceSymbol, invalidType);
-            }
-
-            return builder.ToImmutable();
-        }
-
-        /// <summary>
-        /// Finds and reports all invalid declared properties in a shader.
-        /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
-        /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
-        private static void DetectAndReportInvalidPropertyDeclarations(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, INamedTypeSymbol structDeclarationSymbol)
-        {
-            foreach (ISymbol memberSymbol in structDeclarationSymbol.GetMembers())
-            {
-                // Detect properties that are not explicit interface implementations
-                if (memberSymbol is IPropertySymbol { ExplicitInterfaceImplementations.IsEmpty: true })
-                {
-                    diagnostics.Add(InvalidPropertyDeclaration, memberSymbol, structDeclarationSymbol, memberSymbol);
-                }
-
-                // Detect properties causing a field to be generated
-                if (memberSymbol is IFieldSymbol { AssociatedSymbol: IPropertySymbol associatedProperty })
-                {
-                    diagnostics.Add(InvalidPropertyDeclaration, associatedProperty, structDeclarationSymbol, associatedProperty);
-                }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Contributes to #48

### Description

This PR unifies more HLSL rewriting logic, in particular that handling object initializers as well.