### PR TITLE
Update NuGet packages info

### DIFF
--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -113,6 +113,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/Sergio0694/ComputeSharp/</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIconUrl>https://user-images.githubusercontent.com/10199417/110238403-b8811080-7f41-11eb-8cfe-e47e7e58f05b.png</PackageIconUrl>
     <PackageTags>dotnet net netcore netstandard csharp library graphics directx shader hlsl compute gpu performance parallel windows</PackageTags>
 

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -96,6 +96,12 @@
     <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request' AND '$(IsCommitOnReleaseBranch)' != 'true'">pr</VersionSuffix>
   </PropertyGroup>
 
+  <!-- Source link and debug configuration -->
+  <PropertyGroup>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
   <!-- NuGet info and basic configuration -->
   <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_RUN_ID)' != ''">true</ContinuousIntegrationBuild>
@@ -105,6 +111,8 @@
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <ProjectUrl>https://github.com/Sergio0694/ComputeSharp/</ProjectUrl>
+    <RepositoryBranch Condition="$(GITHUB_REF.Contains('refs/heads/'))">$(GITHUB_REF.Replace('refs/heads/', ''))</RepositoryBranch>
+    <RepositoryBranch Condition="$(GITHUB_REF.Contains('refs/pull/'))">pr$(GITHUB_REF.Replace('refs/pull/', '').Replace('/merge', ''))</RepositoryBranch>
     <Authors>Sergio Pedri</Authors>
     <Owners>Sergio Pedri</Owners>
     <Company>Sergio Pedri</Company>
@@ -127,10 +135,6 @@
     -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="all" />
-  </ItemGroup>
 
   <!-- Needed for deterministic builds -->
   <ItemGroup>


### PR DESCRIPTION
### Description

This PR includes a few packaging tweaks:
- Removes the dependency on `DotNet.ReproducibleBuilds`
- Correctly sets `<RepositoryBranch>`
- Correctly sets `<PackageReadmeFile>`