### PR TITLE
Fix analyzer for missing shader descriptors when manually implemented

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingPixelShaderDescriptorOnPixelShaderAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingPixelShaderDescriptorOnPixelShaderAnalyzer.cs
@@ -47,7 +47,7 @@ public sealed class MissingPixelShaderDescriptorOnPixelShaderAnalyzer : Diagnost
                 }
 
                 // Emit a diagnostic if the descriptor is missing for the shader type
-                if (!typeSymbol.HasInterfaceWithType(d2D1PixelShaderDescriptorSymbol) &&
+                if (!HasD2D1PixelShaderDescriptorInterface(typeSymbol, d2D1PixelShaderDescriptorSymbol) &&
                     !typeSymbol.HasAttributeWithType(d2DGeneratedPixelShaderDescriptorAttributeSymbol))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
@@ -57,5 +57,24 @@ public sealed class MissingPixelShaderDescriptorOnPixelShaderAnalyzer : Diagnost
                 }
             }, SymbolKind.NamedType);
         });
+    }
+
+    /// <summary>
+    /// Checks whether a given type implements the shader descriptor interface.
+    /// </summary>
+    /// <param name="typeSymbol">The type to check.</param>
+    /// <param name="d2D1PixelShaderDescriptorSymbol">The type symbol for <c>ID2D1PixelShaderDescriptor&lt;T&gt;</c>.</param>
+    /// <returns></returns>
+    private static bool HasD2D1PixelShaderDescriptorInterface(INamedTypeSymbol typeSymbol, INamedTypeSymbol d2D1PixelShaderDescriptorSymbol)
+    {
+        foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(interfaceSymbol.ConstructedFrom, d2D1PixelShaderDescriptorSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/MissingComputeShaderDescriptorOnComputeShaderAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/MissingComputeShaderDescriptorOnComputeShaderAnalyzer.cs
@@ -48,7 +48,7 @@ public sealed class MissingComputeShaderDescriptorOnComputeShaderAnalyzer : Diag
                 }
 
                 // Emit a diagnostic if the descriptor is missing for the shader type
-                if (!typeSymbol.HasInterfaceWithType(computeShaderDescriptorSymbol) &&
+                if (!HasComputeShaderDescriptorInterface(typeSymbol, computeShaderDescriptorSymbol) &&
                     !typeSymbol.HasAttributeWithType(generatedComputeShaderDescriptorAttributeSymbol))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
@@ -76,6 +76,25 @@ public sealed class MissingComputeShaderDescriptorOnComputeShaderAnalyzer : Diag
         {
             if (SymbolEqualityComparer.Default.Equals(interfaceSymbol, computeShaderSymbol) ||
                 SymbolEqualityComparer.Default.Equals(interfaceSymbol.ConstructedFrom, pixelShaderSymbol))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Checks whether a given type implements the shader descriptor interface.
+    /// </summary>
+    /// <param name="typeSymbol">The type to check.</param>
+    /// <param name="computeShaderDescriptorSymbol">The type symbol for <c>IComputeShaderDescriptor&lt;T&gt;</c>.</param>
+    /// <returns></returns>
+    private static bool HasComputeShaderDescriptorInterface(INamedTypeSymbol typeSymbol, INamedTypeSymbol computeShaderDescriptorSymbol)
+    {
+        foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(interfaceSymbol.ConstructedFrom, computeShaderDescriptorSymbol))
             {
                 return true;
             }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -9,6 +9,93 @@ namespace ComputeSharp.D2D1.Tests.SourceGenerators;
 public class Test_Analyzers
 {
     [TestMethod]
+    public async Task MissingComputeShaderDescriptor_ComputeShader()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            internal partial struct {|CMPSD2D0065:MyShader|} : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingPixelShaderDescriptorOnPixelShaderAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task MissingComputeShaderDescriptor_ManuallyImplemented_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+            using ComputeSharp.D2D1.Descriptors;
+            using ComputeSharp.D2D1.Interop;
+
+            internal partial struct MyShader : ID2D1PixelShader, ID2D1PixelShaderDescriptor<MyShader>
+            {
+                public static ref readonly Guid EffectId => throw new NotImplementedException();
+
+                public static string? EffectDisplayName => throw new NotImplementedException();
+
+                public static string? EffectDescription => throw new NotImplementedException();
+
+                public static string? EffectCategory => throw new NotImplementedException();
+
+                public static string? EffectAuthor => throw new NotImplementedException();
+
+                public static int ConstantBufferSize => throw new NotImplementedException();
+
+                public static int InputCount => throw new NotImplementedException();
+
+                public static int ResourceTextureCount => throw new NotImplementedException();
+
+                public static ReadOnlyMemory<D2D1PixelShaderInputType> InputTypes => throw new NotImplementedException();
+
+                public static ReadOnlyMemory<D2D1InputDescription> InputDescriptions => throw new NotImplementedException();
+
+                public static ReadOnlyMemory<D2D1ResourceTextureDescription> ResourceTextureDescriptions => throw new NotImplementedException();
+
+                public static D2D1PixelOptions PixelOptions => throw new NotImplementedException();
+
+                public static D2D1BufferPrecision BufferPrecision => throw new NotImplementedException();
+
+                public static D2D1ChannelDepth ChannelDepth => throw new NotImplementedException();
+
+                public static D2D1ShaderProfile ShaderProfile => throw new NotImplementedException();
+
+                public static D2D1CompileOptions CompileOptions => throw new NotImplementedException();
+
+                public static string HlslSource => throw new NotImplementedException();
+
+                public static ReadOnlyMemory<byte> HlslBytecode => throw new NotImplementedException();
+
+                public static MyShader CreateFromConstantBuffer(ReadOnlySpan<byte> buffer)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public static void LoadConstantBuffer<TLoader>(in MyShader shader, ref TLoader loader) where TLoader : struct, ID2D1ConstantBufferLoader
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingPixelShaderDescriptorOnPixelShaderAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
     public async Task NotReadOnlyShaderType_WithFields_Warns()
     {
         const string source = """

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_Analyzers.cs
@@ -10,6 +10,90 @@ namespace ComputeSharp.Tests.SourceGenerators;
 public class Test_Analyzers
 {
     [TestMethod]
+    public async Task MissingComputeShaderDescriptor_ComputeShader()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            internal partial struct {|CMPS0053:MyShader|} : IComputeShader
+            {
+                public ReadWriteBuffer<float> buffer;
+
+                public void Execute()
+                {
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingComputeShaderDescriptorOnComputeShaderAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task MissingComputeShaderDescriptor_ComputeShaderOfT()
+    {
+        const string source = """
+            using ComputeSharp;
+            using float4 = ComputeSharp.Float4;
+
+            internal partial struct {|CMPS0053:MyShader|} : IComputeShader<float4>
+            {
+                public float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingComputeShaderDescriptorOnComputeShaderAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task MissingComputeShaderDescriptor_ManuallyImplemented_DoesNotWarn()
+    {
+        const string source = """
+            using System;
+            using ComputeSharp;
+            using ComputeSharp.Descriptors;
+            using ComputeSharp.Interop;
+
+            internal partial struct MyShader : IComputeShader, IComputeShaderDescriptor<MyShader>
+            {
+                public static int ThreadsX => throw new NotImplementedException();
+
+                public static int ThreadsY => throw new NotImplementedException();
+
+                public static int ThreadsZ => throw new NotImplementedException();
+
+                public static int ConstantBufferSize => throw new NotImplementedException();
+
+                public static bool IsStaticSamplerRequired => throw new NotImplementedException();
+
+                public static ReadOnlyMemory<ResourceDescriptorRange> ResourceDescriptorRanges => throw new NotImplementedException();
+
+                public static string HlslSource => throw new NotImplementedException();
+
+                public static ReadOnlyMemory<byte> HlslBytecode => throw new NotImplementedException();
+
+                public static void LoadConstantBuffer<TLoader>(in MyShader shader, ref TLoader loader, int x, int y, int z) where TLoader : struct, IConstantBufferLoader
+                {
+                    throw new NotImplementedException();
+                }
+
+                public static void LoadGraphicsResources<TLoader>(in MyShader shader, ref TLoader loader) where TLoader : struct, IGraphicsResourceLoader
+                {
+                    throw new NotImplementedException();
+                }
+
+                public void Execute()
+                {
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingComputeShaderDescriptorOnComputeShaderAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
     public async Task NotAccessibleNestedShaderType()
     {
         const string source = """


### PR DESCRIPTION
### Closes #684

### Description

This PR fixes the two analyzers for missing shader descriptors when manually implemented on shader types.