### PR TITLE
Detect and warn on annotated generic shader types

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -39,8 +39,9 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
                         return default;
                     }
 
-                    // If the type symbol doesn't have at least one interface, it can't possibly be a shader type
-                    if (context.TargetSymbol is not INamedTypeSymbol { AllInterfaces.Length: > 0 } typeSymbol)
+                    // If the type symbol doesn't have at least one interface, it can't possibly be a shader type.
+                    // Also check for generic types, just like with DX12 shaders (including nesting inside generics).
+                    if (context.TargetSymbol is not INamedTypeSymbol { AllInterfaces.Length: > 0, IsGenericType: false } typeSymbol)
                     {
                         return default;
                     }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer.cs
@@ -38,9 +38,14 @@ public sealed class InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnaly
                     return;
                 }
 
-                // Emit a diagnostic if the target type is using [D2DGeneratedPixelShaderDescriptor] but does not implement ID2D1PixelShader
-                if (typeSymbol.TryGetAttributeWithType(d2DGeneratedPixelShaderDescriptorAttributeSymbol, out AttributeData? attribute) &&
-                    !typeSymbol.HasInterfaceWithType(d2D1PixelShaderSymbol))
+                // If the type does not have [D2DGeneratedPixelShaderDescriptor], we can stop here
+                if (!typeSymbol.TryGetAttributeWithType(d2DGeneratedPixelShaderDescriptorAttributeSymbol, out AttributeData? attribute))
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if the target type is generic or does not implement ID2D1PixelShader
+                if (typeSymbol.IsGenericType || !typeSymbol.HasInterfaceWithType(d2D1PixelShaderSymbol))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         InvalidD2DGeneratedPixelShaderDescriptorAttributeTarget,

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -978,17 +978,17 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[D2DGeneratedPixelShaderDescriptor]</c> attribute is being used on an invalid target type.
     /// <para>
-    /// Format: <c>"The type {0} is not a valid target for the [D2DGeneratedPixelShaderDescriptor] attribute (only types implementing the ID2D1PixelShader interface are valid)"</c>.
+    /// Format: <c>"The type {0} is not a valid target for the [D2DGeneratedPixelShaderDescriptor] attribute (only non generic types implementing the ID2D1PixelShader interface are valid)"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidD2DGeneratedPixelShaderDescriptorAttributeTarget = new(
         id: "CMPSD2D0066",
         title: "Invalid [D2DGeneratedPixelShaderDescriptor] attribute target",
-        messageFormat: "The type {0} is not a valid target for the [D2DGeneratedPixelShaderDescriptor] attribute (only types implementing ID2D1PixelShader interface are valid)",
+        messageFormat: "The type {0} is not a valid target for the [D2DGeneratedPixelShaderDescriptor] attribute (only non generic types implementing ID2D1PixelShader interface are valid)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The [D2DGeneratedPixelShaderDescriptor] attribute must be used on types that implement the ID2D1PixelShader interface.",
+        description: "The [D2DGeneratedPixelShaderDescriptor] attribute must be used on non generic types that implement the ID2D1PixelShader interface.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -39,8 +39,9 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                         return default;
                     }
 
-                    // If the type symbol doesn't have at least one interface, it can't possibly be a shader type
-                    if (context.TargetSymbol is not INamedTypeSymbol { AllInterfaces.Length: > 0 } typeSymbol)
+                    // If the type symbol doesn't have at least one interface, it can't possibly be a shader type.
+                    // Additionally, shader types cannot be generic (including nested inside generic types).
+                    if (context.TargetSymbol is not INamedTypeSymbol { AllInterfaces.Length: > 0, IsGenericType: false } typeSymbol)
                     {
                         return default;
                     }

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer.cs
@@ -45,13 +45,14 @@ public sealed class InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyz
                     return;
                 }
 
-                // If the type doesn't implement IComputeShader nor IComputeShader<TPixel>, we can emit a diagnostic
-                if (!MissingComputeShaderDescriptorOnComputeShaderAnalyzer.IsComputeShaderType(typeSymbol, computeShaderSymbol, pixelShaderSymbol))
+                // If the type is generic or it doesn't implement IComputeShader nor IComputeShader<TPixel>, we emit a diagnostic
+                if (typeSymbol.IsGenericType ||
+                    !MissingComputeShaderDescriptorOnComputeShaderAnalyzer.IsComputeShaderType(typeSymbol, computeShaderSymbol, pixelShaderSymbol))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
-                    InvalidGeneratedComputeShaderDescriptorAttributeTarget,
-                    attribute.GetLocation(),
-                    typeSymbol));
+                        InvalidGeneratedComputeShaderDescriptorAttributeTarget,
+                        attribute.GetLocation(),
+                        typeSymbol));
                 }
             }, SymbolKind.NamedType);
         });

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -754,17 +754,17 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>[GeneratedComputeShaderDescriptor]</c> attribute is being used on an invalid target type.
     /// <para>
-    /// Format: <c>"The type {0} is not a valid target for the [GeneratedComputeShaderDescriptor] attribute (only types implementing the IComputeShader or IComputeShader&lt;TPixel&gt; interface are valid)"</c>.
+    /// Format: <c>"The type {0} is not a valid target for the [GeneratedComputeShaderDescriptor] attribute (only non generic types implementing the IComputeShader or IComputeShader&lt;TPixel&gt; interface are valid)"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidGeneratedComputeShaderDescriptorAttributeTarget = new(
         id: "CMPS0054",
         title: "Invalid [GeneratedComputeShaderDescriptor] attribute target",
-        messageFormat: "The type {0} is not a valid target for the [GeneratedComputeShaderDescriptor] attribute (only types implementing the IComputeShader or IComputeShader<TPixel> interface are valid)",
+        messageFormat: "The type {0} is not a valid target for the [GeneratedComputeShaderDescriptor] attribute (only non generic types implementing the IComputeShader or IComputeShader<TPixel> interface are valid)",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The [GeneratedComputeShaderDescriptor] attribute must be used on types that implement the IComputeShader or IComputeShader<TPixel> interfaces.",
+        description: "The [GeneratedComputeShaderDescriptor] attribute must be used on non generic types that implement the IComputeShader or IComputeShader<TPixel> interfaces.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -138,4 +138,62 @@ public class Test_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<NotReadOnlyPixelShaderTypeWithFieldsAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task InvalidD2DGeneratedPixelShaderDescriptorAttributeTarget_NoInterface()
+    {
+        const string source = """
+            using ComputeSharp.D2D1;
+
+            [{|CMPSD2D0066:D2DGeneratedPixelShaderDescriptor|}]
+            internal partial struct MyType
+            {
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task InvalidD2DGeneratedPixelShaderDescriptorAttributeTarget_GenericType()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [{|CMPSD2D0066:D2DGeneratedPixelShaderDescriptor|}]
+            internal partial struct MyType<T> : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task InvalidD2DGeneratedPixelShaderDescriptorAttributeTarget_TypeNestedInsideGenericType()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            internal partial class Foo<T>
+            {
+                [{|CMPSD2D0066:D2DGeneratedPixelShaderDescriptor|}]
+                internal partial struct MyType : ID2D1PixelShader
+                {
+                    public Float4 Execute()
+                    {
+                        return 0;
+                    }
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_Analyzers.cs
@@ -337,4 +337,58 @@ public class Test_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<InvalidGroupSharedFieldDeclarationAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task InvalidGeneratedComputeShaderDescriptorAttributeTarget_NoInterface()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            [{|CMPS0054:GeneratedComputeShaderDescriptor|}]
+            internal partial struct MyType
+            {
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task InvalidGeneratedComputeShaderDescriptorAttributeTarget_GenericType()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            [{|CMPS0054:GeneratedComputeShaderDescriptor|}]
+            internal partial struct MyType<T> : IComputeShader
+            {
+                public void Execute()
+                {
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task InvalidGeneratedComputeShaderDescriptorAttributeTarget_TypeNestedInsideGenericType()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            internal partial class Foo<T>
+            {
+                [{|CMPS0054:GeneratedComputeShaderDescriptor|}]
+                internal partial struct MyType : IComputeShader
+                {
+                    public void Execute()
+                    {
+                    }
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }


### PR DESCRIPTION
### Description

This PR updates the analyzers for `[GeneratedComputeShaderDescriptor]` and `[D2DGeneratedPixelShaderDescriptor]` to also detect and warn on generic shader types, and it updates the generators to skip processing generic shader types entirely.