### PR TITLE
Correctly handle and error on initializer expressions and collection expressions

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -77,3 +77,4 @@ CMPSD2D0067 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0068 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0069 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0070 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0071 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -78,3 +78,4 @@ CMPSD2D0068 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0069 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0070 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0071 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0072 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1067,4 +1067,17 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "An initializer expression cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a collection expression.
+    /// </summary>
+    public static readonly DiagnosticDescriptor CollectionExpression = new(
+        id: "CMPSD2D0072",
+        title: "Collection expression",
+        messageFormat: "A collection expression cannot be used in a pixel shader",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A collection expression cannot be used in a pixel shader.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1054,4 +1054,17 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Shader types should be readonly (shaders cannot mutate their instance state while running, so shader types not being readonly makes them error prone).",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an initializer expression.
+    /// </summary>
+    public static readonly DiagnosticDescriptor InitializerExpression = new(
+        id: "CMPSD2D0071",
+        title: "Initializer expression",
+        messageFormat: "An initializer expression cannot be used in a pixel shader",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "An initializer expression cannot be used in a pixel shader.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -13,33 +13,33 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for an invalid shader field.
     /// <para>
-    /// Format: <c>"The compute shader of type {0} contains a field "{1}" of an invalid type {2}"</c>.
+    /// Format: <c>"The pixel shader of type {0} contains a field "{1}" of an invalid type {2}"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidShaderField = new(
         id: "CMPSD2D0001",
         title: "Invalid shader field",
-        messageFormat: """The compute shader of type {0} contains a field "{1}" of an invalid type {2}""",
+        messageFormat: """The pixel shader of type {0} contains a field "{1}" of an invalid type {2}""",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A type representing a compute shader contains a field of a type that is not supported in HLSL.",
+        description: "A type representing a pixel shader contains a field of a type that is not supported in HLSL.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for an invalid object creation expression.
     /// <para>
-    /// Format: <c>"The type {0} cannot be created in a compute shader"</c>.
+    /// Format: <c>"The type {0} cannot be created in a pixel shader"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidObjectCreationExpression = new(
         id: "CMPSD2D0002",
         title: "Invalid object creation expression",
-        messageFormat: "The type {0} cannot be created in a compute shader (only unmanaged types are supported)",
+        messageFormat: "The type {0} cannot be created in a pixel shader (only unmanaged types are supported)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Only unmanaged value type objects can be created in a compute shader.",
+        description: "Only unmanaged value type objects can be created in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -48,11 +48,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor AnonymousObjectCreationExpression = new(
         id: "CMPSD2D0003",
         title: "Anonymous object creation expression",
-        messageFormat: "An anonymous object cannot be created in a compute shader",
+        messageFormat: "An anonymous object cannot be created in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "An anonymous object cannot be created in a compute shader.",
+        description: "An anonymous object cannot be created in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -61,11 +61,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor AsyncModifierOnMethodOrFunction = new(
         id: "CMPSD2D0004",
         title: "Async modifier on method or function",
-        messageFormat: "The async modifier cannot be used in methods or functions used in a compute shader",
+        messageFormat: "The async modifier cannot be used in methods or functions used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The async modifier cannot be used in methods or functions used in a compute shader.",
+        description: "The async modifier cannot be used in methods or functions used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -74,11 +74,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor AwaitExpression = new(
         id: "CMPSD2D0005",
         title: "Await expression",
-        messageFormat: "The await expression cannot be used in a compute shader",
+        messageFormat: "The await expression cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The await expression cannot be used in a compute shader.",
+        description: "The await expression cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -87,11 +87,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor CheckedExpression = new(
         id: "CMPSD2D0006",
         title: "Checked expression",
-        messageFormat: "A checked expression cannot be used in a compute shader",
+        messageFormat: "A checked expression cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A checked expression cannot be used in a compute shader.",
+        description: "A checked expression cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -100,11 +100,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor CheckedStatement = new(
         id: "CMPSD2D0007",
         title: "Checked statement",
-        messageFormat: "A checked statement cannot be used in a compute shader",
+        messageFormat: "A checked statement cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A checked statement cannot be used in a compute shader.",
+        description: "A checked statement cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -113,11 +113,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor FixedStatement = new(
         id: "CMPSD2D0008",
         title: "Fixed statement",
-        messageFormat: "A fixed statement cannot be used in a compute shader",
+        messageFormat: "A fixed statement cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A fixed statement cannot be used in a compute shader.",
+        description: "A fixed statement cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -126,11 +126,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor ForEachStatement = new(
         id: "CMPSD2D0009",
         title: "Foreach statement",
-        messageFormat: "A foreach statement cannot be used in a compute shader",
+        messageFormat: "A foreach statement cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A foreach statement cannot be used in a compute shader.",
+        description: "A foreach statement cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -139,11 +139,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor LockStatement = new(
         id: "CMPSD2D0010",
         title: "Foreach statement",
-        messageFormat: "A lock statement cannot be used in a compute shader",
+        messageFormat: "A lock statement cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A lock statement cannot be used in a compute shader.",
+        description: "A lock statement cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -152,11 +152,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor QueryExpression = new(
         id: "CMPSD2D0011",
         title: "Foreach statement",
-        messageFormat: "A LINQ query expression cannot be used in a compute shader",
+        messageFormat: "A LINQ query expression cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A LINQ query expression cannot be used in a compute shader.",
+        description: "A LINQ query expression cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -165,11 +165,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor RangeExpression = new(
         id: "CMPSD2D0012",
         title: "Range expression",
-        messageFormat: "A range expression cannot be used in a compute shader",
+        messageFormat: "A range expression cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A range expression cannot be used in a compute shader.",
+        description: "A range expression cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -178,11 +178,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor RecursivePattern = new(
         id: "CMPSD2D0013",
         title: "Recursive pattern",
-        messageFormat: "A recursive pattern cannot be used in a compute shader",
+        messageFormat: "A recursive pattern cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A recursive pattern cannot be used in a compute shader.",
+        description: "A recursive pattern cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -191,11 +191,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor RefType = new(
         id: "CMPSD2D0014",
         title: "Ref type",
-        messageFormat: "A compute shader cannot have a ref type declaration",
+        messageFormat: "A pixel shader cannot have a ref type declaration",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A compute shader cannot have a ref type declaration.",
+        description: "A pixel shader cannot have a ref type declaration.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -204,11 +204,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor RelationalPattern = new(
         id: "CMPSD2D0015",
         title: "Relational pattern",
-        messageFormat: "A relational pattern cannot be used in a compute shader",
+        messageFormat: "A relational pattern cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A relational pattern cannot be used in a compute shader.",
+        description: "A relational pattern cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -217,11 +217,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor SizeOfExpression = new(
         id: "CMPSD2D0016",
         title: "Sizeof expression",
-        messageFormat: "A sizeof expression cannot be used in a compute shader",
+        messageFormat: "A sizeof expression cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A sizeof expression cannot be used in a compute shader.",
+        description: "A sizeof expression cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -230,11 +230,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor StackAllocArrayCreationExpression = new(
         id: "CMPSD2D0017",
         title: "Stackalloc expression",
-        messageFormat: "A stackalloc expression cannot be used in a compute shader",
+        messageFormat: "A stackalloc expression cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A stackalloc expression cannot be used in a compute shader.",
+        description: "A stackalloc expression cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -243,11 +243,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor ThrowExpressionOrStatement = new(
         id: "CMPSD2D0018",
         title: "Throw expression or statement",
-        messageFormat: "Throw expressions and statements cannot be used in a compute shader",
+        messageFormat: "Throw expressions and statements cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Throw expressions and statements cannot be used in a compute shader.",
+        description: "Throw expressions and statements cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -256,11 +256,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor TryStatement = new(
         id: "CMPSD2D0019",
         title: "Try statement",
-        messageFormat: "A try statement cannot be used in a compute shader",
+        messageFormat: "A try statement cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A try statement cannot be used in a compute shader.",
+        description: "A try statement cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -269,11 +269,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor TupleType = new(
         id: "CMPSD2D0020",
         title: "Tuple type",
-        messageFormat: "A compute shader cannot have a tuple type declaration",
+        messageFormat: "A pixel shader cannot have a tuple type declaration",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A compute shader cannot have a tuple type declaration.",
+        description: "A pixel shader cannot have a tuple type declaration.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -282,11 +282,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor UsingStatementOrDeclaration = new(
         id: "CMPSD2D0021",
         title: "Using statement or declaration",
-        messageFormat: "Using statements and declarations cannot be used in a compute shader",
+        messageFormat: "Using statements and declarations cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Using statements and declarations cannot be used in a compute shader.",
+        description: "Using statements and declarations cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -295,27 +295,27 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor YieldStatement = new(
         id: "CMPSD2D0022",
         title: "Yield statement",
-        messageFormat: "A yield statement cannot be used in a compute shader",
+        messageFormat: "A yield statement cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A yield statement cannot be used in a compute shader.",
+        description: "A yield statement cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for an invalid object declaration.
     /// <para>
-    /// Format: <c>"A variable of type {0} cannot be declared in a compute shader"</c>.
+    /// Format: <c>"A variable of type {0} cannot be declared in a pixel shader"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidObjectDeclaration = new(
         id: "CMPSD2D0023",
         title: "Invalid object declaration",
-        messageFormat: "A variable of type {0} cannot be declared in a compute shader (only unmanaged types are supported)",
+        messageFormat: "A variable of type {0} cannot be declared in a pixel shader (only unmanaged types are supported)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Only unmanaged value type objects can be declared in a compute shader.",
+        description: "Only unmanaged value type objects can be declared in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -324,11 +324,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor PointerType = new(
         id: "CMPSD2D0024",
         title: "Pointer type",
-        messageFormat: "A compute shader cannot have a pointer type declaration",
+        messageFormat: "A pixel shader cannot have a pointer type declaration",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A compute shader cannot have a pointer type declaration.",
+        description: "A pixel shader cannot have a pointer type declaration.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -337,11 +337,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor FunctionPointer = new(
         id: "CMPSD2D0025",
         title: "Function pointer type",
-        messageFormat: "A compute shader cannot have a function pointer type declaration",
+        messageFormat: "A pixel shader cannot have a function pointer type declaration",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A compute shader cannot have a function pointer type declaration.",
+        description: "A pixel shader cannot have a function pointer type declaration.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -350,11 +350,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor UnsafeStatement = new(
         id: "CMPSD2D0026",
         title: "Unsafe statement",
-        messageFormat: "A compute shader cannot have an unsafe statement",
+        messageFormat: "A pixel shader cannot have an unsafe statement",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A compute shader cannot have an unsafe statement.",
+        description: "A pixel shader cannot have an unsafe statement.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -363,11 +363,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor UnsafeModifierOnMethodOrFunction = new(
         id: "CMPSD2D0027",
         title: "Unsafe modifier on method or function",
-        messageFormat: "The unsafe modifier cannot be used in methods or functions used in a compute shader",
+        messageFormat: "The unsafe modifier cannot be used in methods or functions used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The unsafe modifier cannot be used in methods or functions used in a compute shader.",
+        description: "The unsafe modifier cannot be used in methods or functions used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -376,11 +376,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor StringLiteralExpression = new(
         id: "CMPSD2D0028",
         title: "String literal expression",
-        messageFormat: "String literal expressions cannot be used in a compute shader",
+        messageFormat: "String literal expressions cannot be used in a pixel shader",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "String literal expressions cannot be used in a compute shader.",
+        description: "String literal expressions cannot be used in a pixel shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
@@ -399,17 +399,17 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for an invalid shader static readonly field type.
     /// <para>
-    /// Format: <c>"The compute shader of type {0} contains a static readonly field "{1}" of an invalid type {2} (only primitive, vector and matrix types are supported)"</c>.
+    /// Format: <c>"The pixel shader of type {0} contains a static readonly field "{1}" of an invalid type {2} (only primitive, vector and matrix types are supported)"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidShaderStaticFieldType = new(
         id: "CMPSD2D0030",
         title: "Invalid shader static readonly field type",
-        messageFormat: """The compute shader of type {0} contains a static readonly field "{1}" of an invalid type {2} (only primitive, vector and matrix types are supported)""",
+        messageFormat: """The pixel shader of type {0} contains a static readonly field "{1}" of an invalid type {2} (only primitive, vector and matrix types are supported)""",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "A type representing a compute shader contains a static readonly field of a type that is not supported.",
+        description: "A type representing a pixel shader contains a static readonly field of a type that is not supported.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Extensions/SyntaxNodeExtensions.cs
@@ -78,6 +78,7 @@ internal static class SyntaxNodeExtensions
         {
             RefTypeSyntax refType => semanticModel.GetTypeInfo(refType.Type).Type!,
             PointerTypeSyntax pointerType => semanticModel.GetTypeInfo(pointerType.ElementType).Type!,
+            ArrayTypeSyntax arrayType => semanticModel.GetTypeInfo(arrayType.ElementType).Type!,
             _ => semanticModel.GetTypeInfo(sourceType).Type!
         };
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Diagnostics.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Diagnostics.cs
@@ -11,11 +11,17 @@ partial class HlslSourceRewriter
     /// <inheritdoc/>
     public override SyntaxNode? VisitAnonymousObjectCreationExpression(AnonymousObjectCreationExpressionSyntax node)
     {
-        AnonymousObjectCreationExpressionSyntax updatedNode = (AnonymousObjectCreationExpressionSyntax)base.VisitAnonymousObjectCreationExpression(node)!;
-
         Diagnostics.Add(AnonymousObjectCreationExpression, node);
 
-        return updatedNode;
+        return base.VisitAnonymousObjectCreationExpression(node);
+    }
+
+    /// <inheritdoc/>
+    public override SyntaxNode? VisitInitializerExpression(InitializerExpressionSyntax node)
+    {
+        Diagnostics.Add(InitializerExpression, node);
+
+        return base.VisitInitializerExpression(node);
     }
 
     /// <inheritdoc/>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Diagnostics.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Diagnostics.cs
@@ -25,6 +25,14 @@ partial class HlslSourceRewriter
     }
 
     /// <inheritdoc/>
+    public override SyntaxNode? VisitCollectionExpression(CollectionExpressionSyntax node)
+    {
+        Diagnostics.Add(CollectionExpression, node);
+
+        return base.VisitCollectionExpression(node);
+    }
+
+    /// <inheritdoc/>
     public override SyntaxNode? VisitAwaitExpression(AwaitExpressionSyntax node)
     {
         Diagnostics.Add(AwaitExpression, node);

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
@@ -124,8 +124,11 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
             Diagnostics.Add(InvalidObjectCreationExpression, node, type);
         }
 
-        // Mutate the syntax like with explicit object creation expressions
-        if (updatedNode.ArgumentList!.Arguments.Count == 0)
+        // Mutate the syntax like with explicit object creation expressions. This also handles object
+        // initializer expressions. If those are used, the HLSL will just contain a default expression.
+        // There is a diagnostic being emitted to inform the users if that path is hit. If users want
+        // to create an object and immediately set some values, they should use a factory method.
+        if (updatedNode is not { ArgumentList.Arguments.Count: > 0, Initializer: null })
         {
             return CastExpression(targetType, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)));
         }

--- a/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -65,3 +65,4 @@ CMPS0056 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Ser
 CMPS0057 | ComputeSharp.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0058 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0059 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPS0060 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -64,3 +64,4 @@ CMPS0055 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Ser
 CMPS0056 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0057 | ComputeSharp.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0058 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPS0059 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -843,4 +843,17 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "An initializer expression cannot be used in a compute shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a collection expression.
+    /// </summary>
+    public static readonly DiagnosticDescriptor CollectionExpression = new(
+        id: "CMPS0060",
+        title: "Collection expression",
+        messageFormat: "A collection expression cannot be used in a compute shader",
+        category: "ComputeSharp.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A collection expression cannot be used in a compute shader.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -830,4 +830,17 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "The [GloballyCoherent] attribute is only valid on ReadWriteBuffer<T> instance fields in compute shader types.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an initializer expression.
+    /// </summary>
+    public static readonly DiagnosticDescriptor InitializerExpression = new(
+        id: "CMPS0059",
+        title: "Initializer expression",
+        messageFormat: "An initializer expression cannot be used in a compute shader",
+        category: "ComputeSharp.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "An initializer expression cannot be used in a compute shader.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1344,6 +1344,79 @@ public class DiagnosticsTests
         VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0050");
     }
 
+    [TestMethod]
+    public void InitializerExpression_ObjectCreation()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            internal struct StructType
+            {
+                public float Field;
+            }
+            
+            [GeneratedComputeShaderDescriptor]
+            public partial struct MyShader : IComputeShader
+            {
+                public ReadWriteBuffer<StructType> buffer;
+
+                public void Execute()
+                {
+                    buffer[0] = new StructType { Age = 12 };
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0059");
+    }
+
+    [TestMethod]
+    public void InitializerExpression_ImplicitObjectCreation()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            internal struct StructType
+            {
+                public float Field;
+            }
+            
+            [GeneratedComputeShaderDescriptor]
+            public partial struct MyShader : IComputeShader
+            {
+                public ReadWriteBuffer<StructType> buffer;
+
+                public void Execute()
+                {
+                    buffer[0] = new() { Age = 12 };
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0059");
+    }
+
+    [TestMethod]
+    public void InitializerExpression_CollectionInitializer()
+    {
+        const string source = """
+            using ComputeSharp;
+            
+            [GeneratedComputeShaderDescriptor]
+            public partial struct MyShader : IComputeShader
+            {
+                public ReadWriteBuffer<int> buffer;
+
+                public void Execute()
+                {
+                    int[] numbers = { 1, 2, 3, 4 };
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0031", "CMPS0047", "CMPS0059");
+    }
+
     /// <summary>
     /// Verifies the output of a source generator.
     /// </summary>

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1344,6 +1344,7 @@ public class DiagnosticsTests
         VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0050");
     }
 
+    // See https://github.com/Sergio0694/ComputeSharp/issues/690
     [TestMethod]
     public void InvalidInitializerExpression_ObjectCreation()
     {

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1345,7 +1345,7 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
-    public void InitializerExpression_ObjectCreation()
+    public void InvalidInitializerExpression_ObjectCreation()
     {
         const string source = """
             using ComputeSharp;
@@ -1371,7 +1371,7 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
-    public void InitializerExpression_ImplicitObjectCreation()
+    public void InvalidInitializerExpression_ImplicitObjectCreation()
     {
         const string source = """
             using ComputeSharp;
@@ -1397,7 +1397,7 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
-    public void InitializerExpression_CollectionInitializer()
+    public void InvalidInitializerExpression_CollectionInitializer()
     {
         const string source = """
             using ComputeSharp;
@@ -1415,6 +1415,27 @@ public class DiagnosticsTests
             """;
 
         VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0031", "CMPS0047", "CMPS0059");
+    }
+
+    [TestMethod]
+    public void InvalidCollectionExpression()
+    {
+        const string source = """
+            using ComputeSharp;
+            
+            [GeneratedComputeShaderDescriptor]
+            public partial struct MyShader : IComputeShader
+            {
+                public ReadWriteBuffer<int> buffer;
+
+                public void Execute()
+                {
+                    int[] numbers = [1, 2, 3, 4];
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0031", "CMPS0047", "CMPS0060");
     }
 
     /// <summary>


### PR DESCRIPTION
### Closes #690

### Description

This PR includes a few changes:
- Fixes the HLSL rewriter crashing when handling object initializer expressions
- Fixes the HLSL rewriter crashing when inspecting array type syntax values
- Adds new diagnostics for both object initializer expressions and collection expressions
- Fixes some copy-paste errors in the D2D diagnostics using "compute" instead of "pixel" to refer to shaders