### PR TITLE
Move MultipleShaderTypesImplemented diagnostic to analyzer

### DIFF
--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -58,12 +58,6 @@ partial class ComputeShaderDescriptorGenerator
             Dictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods = new(SymbolEqualityComparer.Default);
             Dictionary<IFieldSymbol, string> constantDefinitions = new(SymbolEqualityComparer.Default);
 
-            // A given type can only represent a single shader type
-            if (structDeclarationSymbol.AllInterfaces.Count(static interfaceSymbol => interfaceSymbol is { Name: nameof(IComputeShader) } or { IsGenericType: true, Name: nameof(IComputeShader<byte>) }) > 1)
-            {
-                diagnostics.Add(MultipleShaderTypesImplemented, structDeclarationSymbol, structDeclarationSymbol);
-            }
-
             // Explore the syntax tree and extract the processed info
             SemanticModelProvider semanticModelProvider = new(compilation);
             INamedTypeSymbol? pixelShaderSymbol = structDeclarationSymbol.AllInterfaces.FirstOrDefault(static interfaceSymbol => interfaceSymbol is { IsGenericType: true, Name: nameof(IComputeShader<byte>) });

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/MultipleComputeShaderInterfacesOnShaderTypeAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/MultipleComputeShaderInterfacesOnShaderTypeAnalyzer.cs
@@ -1,0 +1,72 @@
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error when a shader type using [GeneratedComputeShaderDescriptor] is implementing multiple shader interfaces.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MultipleComputeShaderInterfacesOnShaderTypeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MultipleShaderTypesImplemented);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the IComputeShader, IComputeShader<TPixel>, [GeneratedComputeShaderDescriptor] symbols
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader") is not { } computeShaderSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader`1") is not { } pixelShaderSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.GeneratedComputeShaderDescriptorAttribute") is not { } generatedComputeShaderDescriptorAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only struct types are possible targets
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // We only want to check types using [GeneratedComputeShaderDescriptor]
+                if (!typeSymbol.HasAttributeWithType(generatedComputeShaderDescriptorAttributeSymbol))
+                {
+                    return;
+                }
+
+                int shaderInferfaceCount = 0;
+
+                // Count how many shader interfaces are implemented
+                foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.AllInterfaces)
+                {
+                    if (SymbolEqualityComparer.Default.Equals(interfaceSymbol, computeShaderSymbol) ||
+                        SymbolEqualityComparer.Default.Equals(interfaceSymbol.ConstructedFrom, pixelShaderSymbol))
+                    {
+                        shaderInferfaceCount++;
+                    }
+                }
+
+                // Emit a diagnostic if there's more than one
+                if (shaderInferfaceCount > 1)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        MultipleShaderTypesImplemented,
+                        typeSymbol.Locations.FirstOrDefault(),
+                        typeSymbol));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1117,26 +1117,6 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
-    public void MultipleShaderTypes()
-    {
-        const string source = """
-            using ComputeSharp;
-
-            namespace MyFancyApp.Sample;
-            
-            [GeneratedComputeShaderDescriptor]
-            public partial struct MyShader : IComputeShader, IComputeShader<float4>
-            {
-                public void Execute()
-                {
-                }
-            }
-            """;
-
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0042", "CMPS0047");
-    }
-
-    [TestMethod]
     [DataRow(-1, 1, 1)]
     [DataRow(1, -1, 1)]
     [DataRow(1, 1, -1)]

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_Analyzers.cs
@@ -391,4 +391,27 @@ public class Test_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task MultipleComputeShaderInterfacesOnShader_TwoInterfaces()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            [GeneratedComputeShaderDescriptor]
+            internal partial struct {|CMPS0042:MyType|} : IComputeShader, IComputeShader<Float4>
+            {
+                public void Execute()
+                {
+                }
+
+                Float4 IComputeShader<Float4>.Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<MultipleComputeShaderInterfacesOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
@@ -899,6 +899,7 @@ public class Test_D2DPixelShaderSourceGenerator
         await CSharpAnalyzerWithLanguageVersionTest<InvalidGroupSharedFieldDeclarationAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MissingAllowUnsafeBlocksCompilationOptionAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MissingComputeShaderDescriptorOnComputeShaderAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<MultipleComputeShaderInterfacesOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<NotAccessibleFieldTypeInGeneratedShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<NotAccessibleGeneratedComputeShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<NotReadOnlyComputeShaderTypeWithFieldsAnalyzer>.VerifyAnalyzerAsync(source);


### PR DESCRIPTION
### Description

This pull request introduces a new diagnostic analyzer that generates an error when a shader type using `[GeneratedComputeShaderDescriptor]` implements multiple shader interfaces, and moves emitting this diagnostic from the shader descriptor generator to the new analyzer (and updates the relevant unit tests).