### PR TITLE
Check for cancellation while doing HLSL rewriting

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -119,11 +119,11 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
                     string hlslSource = HlslSource.GetHlslSource(
                         diagnostics,
                         context.SemanticModel.Compilation,
-                        (StructDeclarationSyntax)context.TargetNode,
                         typeSymbol,
                         inputCount,
                         inputSimpleIndices,
-                        inputComplexIndices);
+                        inputComplexIndices,
+                        token);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -60,7 +60,7 @@ partial class ComputeShaderDescriptorGenerator
             Dictionary<IFieldSymbol, string> constantDefinitions = new(SymbolEqualityComparer.Default);
 
             // Setup the semantic model and basic properties
-            INamedTypeSymbol? pixelShaderSymbol = structDeclarationSymbol.AllInterfaces.FirstOrDefault(static interfaceSymbol => interfaceSymbol is { IsGenericType: true, Name: nameof(IComputeShader<byte>) });
+            INamedTypeSymbol? pixelShaderSymbol = structDeclarationSymbol.AllInterfaces.FirstOrDefault(static interfaceSymbol => interfaceSymbol is { IsGenericType: true, Name: "IComputeShader" });
             bool isComputeShader = pixelShaderSymbol is null;
             string? implicitTextureType = isComputeShader ? null : HlslKnownTypes.GetMappedNameForPixelShaderType(pixelShaderSymbol!);
 
@@ -391,12 +391,12 @@ partial class ComputeShaderDescriptorGenerator
 
                 bool isShaderEntryPoint =
                     (isComputeShader &&
-                     methodSymbol.Name == nameof(IComputeShader.Execute) &&
+                     methodSymbol.Name == "Execute" &&
                      methodSymbol.ReturnsVoid &&
                      methodSymbol.TypeParameters.Length == 0 &&
                      methodSymbol.Parameters.Length == 0) ||
                     (!isComputeShader &&
-                     methodSymbol.Name == nameof(IComputeShader<byte>.Execute) &&
+                     methodSymbol.Name == "Execute" &&
                      methodSymbol.ReturnType is not null && // TODO: match for pixel type
                      methodSymbol.TypeParameters.Length == 0 &&
                      methodSymbol.Parameters.Length == 0);

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -85,11 +85,11 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                     HlslSource.GetInfo(
                         diagnostics,
                         context.SemanticModel.Compilation,
-                        (StructDeclarationSyntax)context.TargetNode,
                         typeSymbol,
                         threadsX,
                         threadsY,
                         threadsZ,
+                        token,
                         out bool isImplicitTextureUsed,
                         out bool isSamplerUsed,
                         out string hlslSource);

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -67,8 +67,6 @@
     <Compile Include="..\ComputeSharp\Dispatch\GroupSize.cs" Link="ComputeSharp\Dispatch\GroupSize.cs" />
     <Compile Include="..\ComputeSharp\Dispatch\ThreadIds.cs" Link="ComputeSharp\Dispatch\ThreadIds.cs" />
     <Compile Include="..\ComputeSharp\Dispatch\ThreadIds.Normalized.cs" Link="ComputeSharp\Dispatch\ThreadIds.Normalized.cs" />
-    <Compile Include="..\ComputeSharp\Interfaces\IComputeShader.cs" Link="ComputeSharp\Interfaces\IComputeShader.cs" />
-    <Compile Include="..\ComputeSharp\Interfaces\IComputeShader{TPixel}.cs" Link="ComputeSharp\Interfaces\IComputeShader{TPixel}.cs" />
     <Compile Include="..\ComputeSharp\Graphics\Helpers\AlignmentHelper.cs" Link="ComputeSharp\Graphics\Helpers\AlignmentHelper.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description

The HLSL rewriting can be potentially very expensive for large shaders. This PR checks for cancellation during the various steps of the HLSL rewriting, as well as between each entry point method being rewritten, for both the DX12 and D2D1 generators.