### PR TITLE
Flow cancellation token to SyntaxReference.GetSyntax() calls

### DIFF
--- a/src/ComputeSharp.SourceGeneration/Extensions/ISymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/ISymbolExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 
 namespace ComputeSharp.SourceGeneration.Extensions;
@@ -116,5 +117,32 @@ internal static class ISymbolExtensions
         attributeData = null;
 
         return false;
+    }
+
+    /// <summary>
+    /// Tries to get a syntax node with a given type from an input symbol.
+    /// </summary>
+    /// <typeparam name="T">The type of syntax node to look for.</typeparam>
+    /// <param name="symbol">The input <see cref="ISymbol"/> instance to get the syntax node for.</param>
+    /// <param name="token">The <see cref="CancellationToken"/> used to cancel the operation, if needed.</param>
+    /// <param name="syntaxNode">The resulting <typeparamref name="T"/> syntax node, if found.</param>
+    /// <returns>Whether or not a syntax node of type <typeparamref name="T"/> was retrieved successfully.</returns>
+    public static bool TryGetSyntaxNode<T>(this ISymbol symbol, CancellationToken token, [NotNullWhen(true)] out T? syntaxNode)
+        where T : SyntaxNode
+    {
+        // If there are no syntax references, there is nothing to do
+        if (symbol.DeclaringSyntaxReferences is not [SyntaxReference syntaxReference, ..])
+        {
+            syntaxNode = null;
+
+            return false;
+        }
+
+        // Get the target node, and check that it's of the desired type
+        T? candidateNode = syntaxReference.GetSyntax(token) as T;
+
+        syntaxNode = candidateNode;
+
+        return candidateNode is not null;
     }
 }

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -102,7 +102,8 @@ partial class ComputeShaderDescriptorGenerator
                 semanticModelProvider,
                 structDeclarationSymbol,
                 discoveredTypes,
-                constantDefinitions);
+                constantDefinitions,
+                token);
 
             token.ThrowIfCancellationRequested();
 
@@ -247,25 +248,27 @@ partial class ComputeShaderDescriptorGenerator
         /// <param name="structDeclarationSymbol">The type symbol for the shader type.</param>
         /// <param name="discoveredTypes">The collection of currently discovered types.</param>
         /// <param name="constantDefinitions">The collection of discovered constant definitions.</param>
+        /// <param name="token">The <see cref="CancellationToken"/> used to cancel the operation, if needed.</param>
         /// <returns>A sequence of static constant fields in <paramref name="structDeclarationSymbol"/>.</returns>
         private static ImmutableArray<(string Name, string TypeDeclaration, string? Assignment)> GetStaticFields(
             ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
             SemanticModelProvider semanticModel,
             INamedTypeSymbol structDeclarationSymbol,
             ICollection<INamedTypeSymbol> discoveredTypes,
-            IDictionary<IFieldSymbol, string> constantDefinitions)
+            IDictionary<IFieldSymbol, string> constantDefinitions,
+            CancellationToken token)
         {
             using ImmutableArrayBuilder<(string, string, string?)> builder = new();
 
             foreach (ISymbol memberSymbol in structDeclarationSymbol.GetMembers())
             {
                 // Find all declared static fields in the type
-                if (memberSymbol is not IFieldSymbol { IsImplicitlyDeclared: false, IsStatic: true, IsConst: false, DeclaringSyntaxReferences: [SyntaxReference fieldReference, ..] } fieldSymbol)
+                if (memberSymbol is not IFieldSymbol { IsImplicitlyDeclared: false, IsStatic: true, IsConst: false, } fieldSymbol)
                 {
                     continue;
                 }
 
-                if (fieldReference.GetSyntax() is not VariableDeclaratorSyntax variableDeclarator)
+                if (!fieldSymbol.TryGetSyntaxNode(token, out VariableDeclaratorSyntax? variableDeclarator))
                 {
                     continue;
                 }
@@ -379,12 +382,12 @@ partial class ComputeShaderDescriptorGenerator
             foreach (ISymbol memberSymbol in structDeclarationSymbol.GetMembers())
             {
                 // Find all declared methods in the type
-                if (memberSymbol is not IMethodSymbol { IsImplicitlyDeclared: false, DeclaringSyntaxReferences: [SyntaxReference methodReference, ..] } methodSymbol)
+                if (memberSymbol is not IMethodSymbol { IsImplicitlyDeclared: false, } methodSymbol)
                 {
                     continue;
                 }
 
-                if (methodReference.GetSyntax() is not MethodDeclarationSyntax methodDeclaration)
+                if (!methodSymbol.TryGetSyntaxNode(token, out MethodDeclarationSyntax? methodDeclaration))
                 {
                     continue;
                 }


### PR DESCRIPTION
### Follow up to #693

### Description

This PR fixes the calls to `SyntaxReference.GetSyntax` to also receive a cancellation token parameter, and moves the logic to check for declaring syntax references and extracting target syntax nodes from symbols to a shared extension method.