### PR TITLE
Use IsTargetFrameworkCompatible instead of StartsWith

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -43,17 +43,16 @@
   </ItemGroup>
 
   <!--
-    Enable trimming support on .NET 8 (we need to use StartsWith since it
-    could be a Windows TFM too). This can't be in a target unlike the other
+    Enable trimming support on .NET 8. This can't be in a target unlike the other
     properties set below, because if that is the case the trimmable attribute
     will be set but the analyzers will not run, so warnings will be skipped.
   -->
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- Emit the [DisableRuntimeMarshalling] attribute for all .NET 8 projects -->
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0'))">
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute" />
   </ItemGroup>
 
@@ -68,7 +67,7 @@
   </Target>
 
   <!-- Emit the [ComVisible(false)] attribute for WinUI targets -->
-  <ItemGroup Condition="$(TargetFramework.StartsWith('net8.0-windows'))">
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows'))">
     <AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">
       <_Parameter1>false</_Parameter1>
     </AssemblyAttribute>


### PR DESCRIPTION
### Description

This PR updates `Directory.Build.targets` to use `[MSBuild]::IsTargetFrameworkCompatible` to check for TFM compatibility, rather than using `StartsWith`. This also makes this more resilient to cases where mixed TFMs might be used (eg. when .NET 9 lands).