### PR TITLE
Check for cancellation during HLSL rewriting

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
@@ -284,13 +284,20 @@ partial class D2DPixelShaderDescriptorGenerator
                     false => $"static {HlslKnownTypes.GetMappedName(typeSymbol)}"
                 };
 
+                token.ThrowIfCancellationRequested();
+
                 StaticFieldRewriter staticFieldRewriter = new(
                     semanticModel,
                     discoveredTypes,
                     constantDefinitions,
-                    diagnostics);
+                    diagnostics,
+                    token);
 
-                string? assignment = staticFieldRewriter.Visit(variableDeclarator)?.NormalizeWhitespace(eol: "\n").ToFullString();
+                ExpressionSyntax? processedDeclaration = staticFieldRewriter.Visit(variableDeclarator);
+
+                token.ThrowIfCancellationRequested();
+
+                string? assignment = processedDeclaration?.NormalizeWhitespace(eol: "\n").ToFullString();
 
                 needsD2D1RequiresScenePosition |= staticFieldRewriter.NeedsD2DRequiresScenePositionAttribute;
 
@@ -368,6 +375,7 @@ partial class D2DPixelShaderDescriptorGenerator
                     constructors,
                     constantDefinitions,
                     diagnostics,
+                    token,
                     isShaderEntryPoint);
 
                 // Rewrite the method syntax tree

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -298,13 +298,20 @@ partial class ComputeShaderDescriptorGenerator
                     false => $"static {HlslKnownTypes.GetMappedName(typeSymbol)}"
                 };
 
+                token.ThrowIfCancellationRequested();
+
                 StaticFieldRewriter staticFieldRewriter = new(
                     semanticModel,
                     discoveredTypes,
                     constantDefinitions,
-                    diagnostics);
+                    diagnostics,
+                    token);
 
-                string? assignment = staticFieldRewriter.Visit(variableDeclarator)?.NormalizeWhitespace(eol: "\n").ToFullString();
+                ExpressionSyntax? processedDeclaration = staticFieldRewriter.Visit(variableDeclarator);
+
+                token.ThrowIfCancellationRequested();
+
+                string? assignment = processedDeclaration?.NormalizeWhitespace(eol: "\n").ToFullString();
 
                 builder.Add((mapping ?? fieldSymbol.Name, typeDeclaration, assignment));
             }
@@ -427,6 +434,7 @@ partial class ComputeShaderDescriptorGenerator
                     constructors,
                     constantDefinitions,
                     diagnostics,
+                    token,
                     isShaderEntryPoint);
 
                 // Rewrite the method syntax tree

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/InvalidComputeContextCopyAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/InvalidComputeContextCopyAnalyzer.cs
@@ -239,7 +239,7 @@ public sealed class InvalidComputeContextCopyAnalyzer : DiagnosticAnalyzer
                         return;
                     }
 
-                    context.ReportDiagnostic(Diagnostic.Create(InvalidComputeContextCopy, symbol.DeclaringSyntaxReferences[0].GetSyntax().GetLocation()));
+                    context.ReportDiagnostic(Diagnostic.Create(InvalidComputeContextCopy, symbol.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken).GetLocation()));
                 }
             }, SymbolKind.Field);
         });


### PR DESCRIPTION
### Description

This pull request adds cancellation handling to the code execution in multiple files, allowing for better control and interruption of the generator execution, especially during quick edits. The `ShaderSourceRewriter` class now also has a `CancellationToken` parameter to the constructor, so it can flow to other internal logic. In particular, the most expensive visit methods now check for cancellation, and the token is also passed to all `GetSyntax()` calls in this type and derived ones (as well as analyzers).