### PR TITLE
Add diagnostics for invalid 'this' expressions

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -80,3 +80,4 @@ CMPSD2D0070 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://gith
 CMPSD2D0071 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0072 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0073 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0074 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1096,4 +1096,17 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Only standalone constructors (with no base constructor declaration) can be used in a D2D1 shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a <see langword="this"/> expression.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ThisExpression = new(
+        id: "CMPSD2D0074",
+        title: "Invalid 'this' expression",
+        messageFormat: "A pixel shader cannot use a 'this' expression outside of member accesses (such as 'this.field')",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A pixel shader cannot use a 'this' expression outside of member accesses (such as 'this.field').",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Diagnostics.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Diagnostics.cs
@@ -215,4 +215,19 @@ partial class HlslSourceRewriter
 
         return base.VisitUnsafeStatement(node);
     }
+
+    /// <inheritdoc/>
+    public override SyntaxNode? VisitThisExpression(ThisExpressionSyntax node)
+    {
+        // Emit a diagnostic on 'this' expressions, but only if they're not part of a member access.
+        // That is, expressions such as 'this.field' are rewritten correctly to omit the 'this', so
+        // so they are still allowed. But actual 'this' expressions that copy or return the entire
+        // self instance are disallowed, as that use is not valid in HLSL syntax, unfortunately.
+        if (node.Parent is not MemberAccessExpressionSyntax)
+        {
+            Diagnostics.Add(ThisExpression, node);
+        }
+
+        return base.VisitThisExpression(node);
+    }
 }

--- a/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -67,3 +67,4 @@ CMPS0058 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Ser
 CMPS0059 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0060 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0061 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPS0062 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -872,4 +872,17 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Only standalone constructors (with no base constructor declaration) can be used in a shader.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a <see langword="this"/> expression.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ThisExpression = new(
+        id: "CMPS0062",
+        title: "Invalid 'this' expression",
+        messageFormat: "A compute shader cannot use a 'this' expression outside of member accesses (such as 'this.field')",
+        category: "ComputeSharp.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "A compute shader cannot use a 'this' expression outside of member accesses (such as 'this.field').",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1481,6 +1481,75 @@ public class DiagnosticsTests
         VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0049");
     }
 
+    [TestMethod]
+    public void InvalidThisExpression_Return()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            public struct MyStruct
+            {
+                public int X;
+
+                public MyStruct Copy()
+                {
+                    return this;
+                }
+            }
+            
+            [GeneratedComputeShaderDescriptor]
+            public partial struct MyShader : IComputeShader
+            {
+                public ReadWriteBuffer<int> buffer;
+
+                public void Execute()
+                {
+                    MyStruct x = (MyStruct)x;
+                    MyStruct y = x.Copy();
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0062");
+    }
+
+    [TestMethod]
+    public void InvalidThisExpression_Argument()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            public struct MyStruct
+            {
+                public int X;
+
+                public int Read()
+                {
+                    return Extract(this);
+                }
+
+                public static int Extract(MyStruct value)
+                {
+                    return value.X;
+                }
+            }
+            
+            [GeneratedComputeShaderDescriptor]
+            public partial struct MyShader : IComputeShader
+            {
+                public ReadWriteBuffer<int> buffer;
+
+                public void Execute()
+                {
+                    MyStruct x = (MyStruct)x;
+                    int y = x.Read();
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0062");
+    }
+
     /// <summary>
     /// Verifies the output of a source generator.
     /// </summary>


### PR DESCRIPTION
### Closes #480

### Description

This PR adds a new diagnostic error when using invalid `this` expressions in a shader (either DX12 or D2D). Using `this` is allowed for member accesses (eg. `this.field`), because the HLSL rewriter is rewriting those and omitting the `this` identifier in the final HLSL source, but the keyword itself is not actually valid in HLSL. So we now have a nice diagnostic rather than an obscure error.