### PR TITLE
Flow cancellation token to all semantics operations

### DIFF
--- a/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
@@ -30,6 +30,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\Interfaces\IConstantBufferInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\ConstantBufferSyntaxProcessor.Generation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\HlslDefinitionsSyntaxProcessor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\HlslSourceRewriter.Tracking.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\HlslSourceRewriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\HlslSourceRewriter.Diagnostics.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\ShaderSourceRewriter.cs" />

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Tracking.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Tracking.cs
@@ -1,0 +1,93 @@
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Mappings;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace ComputeSharp.SourceGeneration.SyntaxRewriters;
+
+/// <inheritdoc cref="HlslSourceRewriter"/>
+partial class HlslSourceRewriter
+{
+    /// <summary>
+    /// Tracks the associated type for a <see cref="SyntaxNode"/> value and returns the HLSL compatible <see cref="TypeSyntax"/>.
+    /// </summary>
+    /// <param name="node">The input <see cref="SyntaxNode"/> to check.</param>
+    /// <param name="semanticModel">The <see cref="Microsoft.CodeAnalysis.SemanticModel"/> instance with info on the input tree.</param>
+    /// <returns>A <see cref="SyntaxNode"/> instance that represents a type compatible with HLSL.</returns>
+    protected TypeSyntax TrackType(SyntaxNode node, SemanticModel semanticModel)
+    {
+        ITypeSymbol typeSymbol = semanticModel.GetTypeInfo(node).Type!;
+        string typeName = typeSymbol.GetFullyQualifiedName();
+
+        DiscoveredTypes.Add((INamedTypeSymbol)typeSymbol);
+
+        if (HlslKnownTypes.TryGetMappedName(typeName, out string? mappedName))
+        {
+            return ParseTypeName(mappedName!);
+        }
+
+        return ParseTypeName(typeName.ToHlslIdentifierName());
+    }
+
+    /// <summary>
+    /// Checks a <see cref="SyntaxNode"/> value and replaces the value type to be HLSL compatible, if needed.
+    /// </summary>
+    /// <typeparam name="TRoot">The type of the input <see cref="TypeSyntax"/> instance.</typeparam>
+    /// <param name="node">The input <see cref="SyntaxNode"/> to check and modify if needed.</param>
+    /// <param name="sourceType">The source <see cref="SyntaxNode"/> to use to get type into from <paramref name="semanticModel"/>.</param>
+    /// <param name="semanticModel">The <see cref="Microsoft.CodeAnalysis.SemanticModel"/> instance with info on the input tree.</param>
+    /// <returns>A <see cref="SyntaxNode"/> instance that represents a type compatible with HLSL.</returns>
+    protected TRoot ReplaceAndTrackType<TRoot>(TRoot node, SyntaxNode sourceType, SemanticModel semanticModel)
+        where TRoot : TypeSyntax
+    {
+        return ReplaceAndTrackType(node, node, sourceType, semanticModel);
+    }
+
+    /// <summary>
+    /// Checks a <see cref="SyntaxNode"/> value and replaces the value type to be HLSL compatible, if needed.
+    /// </summary>
+    /// <typeparam name="TRoot">The type of the input <see cref="SyntaxNode"/> instance.</typeparam>
+    /// <param name="node">The input <see cref="SyntaxNode"/> to check and modify if needed.</param>
+    /// <param name="targetType">The target <see cref="TypeSyntax"/> node to replace.</param>
+    /// <param name="sourceType">The source <see cref="SyntaxNode"/> to use to get type into from <paramref name="semanticModel"/>.</param>
+    /// <param name="semanticModel">The <see cref="Microsoft.CodeAnalysis.SemanticModel"/> instance with info on the input tree.</param>
+    /// <returns>A <see cref="SyntaxNode"/> instance that represents a type compatible with HLSL.</returns>
+    protected TRoot ReplaceAndTrackType<TRoot>(TRoot node, TypeSyntax targetType, SyntaxNode sourceType, SemanticModel semanticModel)
+        where TRoot : SyntaxNode
+    {
+        // Skip immediately for function pointers
+        if (sourceType is FunctionPointerTypeSyntax)
+        {
+            return node.ReplaceNode(targetType, ParseTypeName("void*"));
+        }
+
+        // Handle the various possible type kinds
+        ITypeSymbol typeSymbol = sourceType switch
+        {
+            RefTypeSyntax refType => semanticModel.GetTypeInfo(refType.Type).Type!,
+            PointerTypeSyntax pointerType => semanticModel.GetTypeInfo(pointerType.ElementType).Type!,
+            ArrayTypeSyntax arrayType => semanticModel.GetTypeInfo(arrayType.ElementType).Type!,
+            _ => semanticModel.GetTypeInfo(sourceType).Type!
+        };
+
+        // Do nothing if the type is just void
+        if (typeSymbol.SpecialType == SpecialType.System_Void)
+        {
+            return node;
+        }
+
+        string typeName = typeSymbol.GetFullyQualifiedName();
+
+        DiscoveredTypes.Add((INamedTypeSymbol)typeSymbol);
+
+        if (HlslKnownTypes.TryGetMappedName(typeName, out string? mappedName))
+        {
+            TypeSyntax newType = ParseTypeName(mappedName!);
+
+            return node.ReplaceNode(targetType, newType);
+        }
+
+        return node.ReplaceNode(targetType, ParseTypeName(typeName.ToHlslIdentifierName()));
+    }
+}

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Tracking.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Tracking.cs
@@ -17,7 +17,7 @@ partial class HlslSourceRewriter
     /// <returns>A <see cref="SyntaxNode"/> instance that represents a type compatible with HLSL.</returns>
     protected TypeSyntax TrackType(SyntaxNode node, SemanticModel semanticModel)
     {
-        ITypeSymbol typeSymbol = semanticModel.GetTypeInfo(node).Type!;
+        ITypeSymbol typeSymbol = semanticModel.GetTypeInfo(node, CancellationToken).Type!;
         string typeName = typeSymbol.GetFullyQualifiedName();
 
         DiscoveredTypes.Add((INamedTypeSymbol)typeSymbol);
@@ -65,10 +65,10 @@ partial class HlslSourceRewriter
         // Handle the various possible type kinds
         ITypeSymbol typeSymbol = sourceType switch
         {
-            RefTypeSyntax refType => semanticModel.GetTypeInfo(refType.Type).Type!,
-            PointerTypeSyntax pointerType => semanticModel.GetTypeInfo(pointerType.ElementType).Type!,
-            ArrayTypeSyntax arrayType => semanticModel.GetTypeInfo(arrayType.ElementType).Type!,
-            _ => semanticModel.GetTypeInfo(sourceType).Type!
+            RefTypeSyntax refType => semanticModel.GetTypeInfo(refType.Type, CancellationToken).Type!,
+            PointerTypeSyntax pointerType => semanticModel.GetTypeInfo(pointerType.ElementType, CancellationToken).Type!,
+            ArrayTypeSyntax arrayType => semanticModel.GetTypeInfo(arrayType.ElementType, CancellationToken).Type!,
+            _ => semanticModel.GetTypeInfo(sourceType, CancellationToken).Type!
         };
 
         // Do nothing if the type is just void

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
@@ -95,7 +95,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
     {
         VariableDeclarationSyntax updatedNode = (VariableDeclarationSyntax)base.VisitVariableDeclaration(node)!;
 
-        if (SemanticModel.For(node).GetTypeInfo(node.Type).Type is ITypeSymbol { IsUnmanagedType: false } type)
+        if (SemanticModel.For(node).GetTypeInfo(node.Type, CancellationToken).Type is ITypeSymbol { IsUnmanagedType: false } type)
         {
             Diagnostics.Add(InvalidObjectDeclaration, node, type);
         }
@@ -137,7 +137,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
     {
         CancellationToken.ThrowIfCancellationRequested();
 
-        ITypeSymbol? typeSymbol = SemanticModel.For(node).GetTypeInfo(node).Type;
+        ITypeSymbol? typeSymbol = SemanticModel.For(node).GetTypeInfo(node, CancellationToken).Type;
 
         // Handle the edge case of the type being null (shouldn't really happen)
         if (typeSymbol is null)

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
@@ -87,7 +87,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
     {
         CastExpressionSyntax updatedNode = (CastExpressionSyntax)base.VisitCastExpression(node)!;
 
-        return updatedNode.ReplaceAndTrackType(updatedNode.Type, node.Type, SemanticModel.For(node), DiscoveredTypes);
+        return ReplaceAndTrackType(updatedNode, updatedNode.Type, node.Type, SemanticModel.For(node));
     }
 
     /// <inheritdoc/>
@@ -103,7 +103,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
         // If var is used, replace it with the explicit type
         if (updatedNode.Type is IdentifierNameSyntax { IsVar: true })
         {
-            updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.Type, node.Type, SemanticModel.For(node), DiscoveredTypes);
+            updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.Type, node.Type, SemanticModel.For(node));
         }
 
         return updatedNode;
@@ -114,7 +114,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
     {
         ObjectCreationExpressionSyntax updatedNode = (ObjectCreationExpressionSyntax)base.VisitObjectCreationExpression(node)!;
 
-        updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.Type, node, SemanticModel.For(node), DiscoveredTypes);
+        updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.Type, node, SemanticModel.For(node));
 
         return VisitObjectCreationExpression(node, updatedNode, updatedNode.Type);
     }
@@ -123,7 +123,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
     public sealed override SyntaxNode VisitImplicitObjectCreationExpression(ImplicitObjectCreationExpressionSyntax node)
     {
         ImplicitObjectCreationExpressionSyntax updatedNode = (ImplicitObjectCreationExpressionSyntax)base.VisitImplicitObjectCreationExpression(node)!;
-        TypeSyntax explicitType = IdentifierName("").ReplaceAndTrackType(node, SemanticModel.For(node), DiscoveredTypes);
+        TypeSyntax explicitType = ReplaceAndTrackType(IdentifierName(""), node, SemanticModel.For(node));
 
         return VisitObjectCreationExpression(node, updatedNode, explicitType);
     }
@@ -202,7 +202,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
     {
         DefaultExpressionSyntax updatedNode = (DefaultExpressionSyntax)base.VisitDefaultExpression(node)!;
 
-        updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.Type, node.Type, SemanticModel.For(node), DiscoveredTypes);
+        updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.Type, node.Type, SemanticModel.For(node));
 
         // A default expression becomes (T)0 in HLSL
         return CastExpression(updatedNode.Type, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)));
@@ -217,7 +217,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
 
         if (updatedNode.IsKind(SyntaxKind.DefaultLiteralExpression))
         {
-            TypeSyntax type = node.TrackType(SemanticModel.For(node), DiscoveredTypes);
+            TypeSyntax type = TrackType(node, SemanticModel.For(node));
 
             // Same HLSL-style expression in the form (T)0
             return CastExpression(type, LiteralExpression(SyntaxKind.NumericLiteralExpression, Literal(0)));

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
@@ -438,7 +438,7 @@ internal sealed partial class ShaderSourceRewriter(
 
                 if (!this.staticMethods.TryGetValue(key, out MethodDeclarationSyntax? methodSyntax))
                 {
-                    INamedTypeSymbol resourceType = (INamedTypeSymbol)SemanticModel.For(node).GetTypeInfo(node.Expression).Type!;
+                    INamedTypeSymbol resourceType = (INamedTypeSymbol)SemanticModel.For(node).GetTypeInfo(node.Expression, CancellationToken).Type!;
                     string resourceName = HlslKnownTypes.GetMappedName(resourceType);
 
                     // Create a static method to get a specified dimension for a target resource type.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
@@ -140,7 +140,7 @@ internal sealed partial class ShaderSourceRewriter(
 
         MethodDeclarationSyntax? updatedNode = (MethodDeclarationSyntax?)base.Visit(node)!;
 
-        updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.ReturnType, node!.ReturnType, SemanticModel.For(node), DiscoveredTypes);
+        updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.ReturnType, node!.ReturnType, SemanticModel.For(node));
 
         if (node!.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword)))
         {
@@ -175,7 +175,7 @@ internal sealed partial class ShaderSourceRewriter(
 
         LocalFunctionStatementSyntax? updatedNode = (LocalFunctionStatementSyntax?)base.Visit(node)!;
 
-        updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.ReturnType, node!.ReturnType, SemanticModel.For(node), DiscoveredTypes);
+        updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.ReturnType, node!.ReturnType, SemanticModel.For(node));
 
         if (node!.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword)))
         {
@@ -229,10 +229,10 @@ internal sealed partial class ShaderSourceRewriter(
 
         ExitLoop:
 
-        return updatedNode
-            .WithAttributeLists(default)
-            .ReplaceAndTrackType(updatedNode.Type!, node.Type!, SemanticModel.For(node), DiscoveredTypes)
-            .WithModifiers(TokenList(modifier));
+        updatedNode = updatedNode.WithAttributeLists(default);
+        updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.Type!, node.Type!, SemanticModel.For(node));
+
+        return updatedNode.WithModifiers(TokenList(modifier));
     }
 
     /// <inheritdoc/>
@@ -245,7 +245,7 @@ internal sealed partial class ShaderSourceRewriter(
             Diagnostics.Add(UsingStatementOrDeclaration, node);
         }
 
-        return updatedNode.ReplaceAndTrackType(updatedNode.Declaration.Type, node.Declaration.Type, SemanticModel.For(node), DiscoveredTypes);
+        return ReplaceAndTrackType(updatedNode, updatedNode.Declaration.Type, node.Declaration.Type, SemanticModel.For(node));
     }
 
     /// <inheritdoc/>
@@ -253,7 +253,7 @@ internal sealed partial class ShaderSourceRewriter(
     {
         DeclarationExpressionSyntax updatedNode = (DeclarationExpressionSyntax)base.VisitDeclarationExpression(node)!;
 
-        updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.Type, node.Type, SemanticModel.For(node), DiscoveredTypes);
+        updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.Type, node.Type, SemanticModel.For(node));
 
         // Add the variable to the list of implicit declarations
         this.implicitVariables.Add(VariableDeclaration(updatedNode.Type).AddVariables(VariableDeclarator(updatedNode.Designation.ToString())));
@@ -286,7 +286,7 @@ internal sealed partial class ShaderSourceRewriter(
                 .WithBlockBody()
                 .WithAttributeLists(List<AttributeListSyntax>());
 
-            updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.ReturnType, node!.ReturnType, SemanticModel.For(node), DiscoveredTypes);
+            updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.ReturnType, node!.ReturnType, SemanticModel.For(node));
 
             if (node.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword)))
             {
@@ -310,7 +310,7 @@ internal sealed partial class ShaderSourceRewriter(
                 .WithAttributeLists(List<AttributeListSyntax>())
                 .WithIdentifier(Identifier($"__{this.currentMethodIdentifier.Text}__{node.Identifier.Text}"));
 
-            updatedNode = updatedNode.ReplaceAndTrackType(updatedNode.ReturnType, node!.ReturnType, SemanticModel.For(node), DiscoveredTypes);
+            updatedNode = ReplaceAndTrackType(updatedNode, updatedNode.ReturnType, node!.ReturnType, SemanticModel.For(node));
 
             if (node.Modifiers.Any(m => m.IsKind(SyntaxKind.AsyncKeyword)))
             {

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/StaticFieldRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/StaticFieldRewriter.cs
@@ -54,7 +54,7 @@ internal sealed partial class StaticFieldRewriter(
         MemberAccessExpressionSyntax updatedNode = (MemberAccessExpressionSyntax)base.VisitMemberAccessExpression(node)!;
 
         if (node.IsKind(SyntaxKind.SimpleMemberAccessExpression) &&
-            SemanticModel.For(node).GetOperation(node) is IMemberReferenceOperation operation)
+            SemanticModel.For(node).GetOperation(node, CancellationToken) is IMemberReferenceOperation operation)
         {
             // Track and replace constants
             if (operation is IFieldReferenceOperation fieldOperation &&
@@ -96,7 +96,7 @@ internal sealed partial class StaticFieldRewriter(
     {
         InvocationExpressionSyntax updatedNode = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
 
-        if (SemanticModel.For(node).GetOperation(node) is IInvocationOperation operation &&
+        if (SemanticModel.For(node).GetOperation(node, CancellationToken) is IInvocationOperation operation &&
             operation.TargetMethod is IMethodSymbol method &&
             method.IsStatic)
         {


### PR DESCRIPTION
### Description

This PR flows cancellation tokens to all semantics operations (`GetTypeInfo` and `GetOperation`) while doing HLSL rewriting. It also moves the helpers to track and replace types to be under `HlslSourceRewriter`, as they're only used there anyway.