### PR TITLE
Tweak unit test files

### DIFF
--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/ConstantBufferSyntaxProcessor.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/ConstantBufferSyntaxProcessor.cs
@@ -36,7 +36,7 @@ internal static partial class ConstantBufferSyntaxProcessor
         ref int constantBufferSizeInBytes,
         out ImmutableArray<FieldInfo> fields)
     {
-        // Helper method that uses boxes instead of ref-s (illegal in enumerators)
+        // Helper method to traverse the type hierarchy and append all valid fields
         static void GetInfo(
             Compilation compilation,
             ITypeSymbol currentTypeSymbol,

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/D2D1PixelShaderTests.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests.AssemblyLevelAttributes;
 
 [TestClass]
-[TestCategory("D2D1PixelShader")]
 public partial class D2D1PixelShaderTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1EffectRegistrationDataTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1EffectRegistrationDataTests.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("D2D1EffectRegistrationData")]
 public partial class D2D1EffectRegistrationDataTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -12,7 +12,6 @@ using TerraFX.Interop.Windows;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("D2D1PixelShaderEffect")]
 public partial class D2D1PixelShaderEffectTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -76,7 +76,6 @@ internal readonly partial struct ShaderWithScalarVectorAndMatrixTypesInNestedStr
 namespace ComputeSharp.D2D1.Tests
 {
     [TestClass]
-    [TestCategory("D2D1PixelShader")]
     public partial class D2D1PixelShaderTests
     {
         [TestMethod]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("D2D1ReflectionServices")]
 public partial class D2D1ReflectionServicesTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ResourceTextureManagerTests.cs
@@ -19,7 +19,6 @@ using TerraFX.Interop.Windows;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("D2D1ResourceTextureManager")]
 public partial class D2D1ResourceTextureManagerTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("D2D1ShaderCompiler")]
 public partial class D2D1ShaderCompilerTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.Tests/D2D1TransformMapperTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1TransformMapperTests.cs
@@ -15,7 +15,6 @@ using Rectangle = System.Drawing.Rectangle;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("D2D1TransformMapper")]
 public partial class D2D1TransformMapperTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.Tests/D2DPixelShaderSourceTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2DPixelShaderSourceTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("D2DPixelShaderSource")]
 public partial class D2DPixelShaderSourceTests
 {
     [D2DPixelShaderSource("""

--- a/tests/ComputeSharp.D2D1.Tests/EffectsTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/EffectsTests.cs
@@ -12,7 +12,6 @@ using SixLabors.ImageSharp.Processing;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("Effects")]
 public class EffectsTests
 {
     [AssemblyInitialize]

--- a/tests/ComputeSharp.D2D1.Tests/ShadersTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/ShadersTests.cs
@@ -13,7 +13,6 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace ComputeSharp.D2D1.Tests;
 
 [TestClass]
-[TestCategory("Shaders")]
 public class ShadersTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/CanvasEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/CanvasEffectTests.cs
@@ -16,7 +16,6 @@ using Windows.UI;
 namespace ComputeSharp.D2D1.WinUI.Tests;
 
 [TestClass]
-[TestCategory("CanvasEffect")]
 public partial class CanvasEffectTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/PixelShaderEffectTests.cs
@@ -11,7 +11,6 @@ using TerraFX.Interop.Windows;
 namespace ComputeSharp.D2D1.WinUI.Tests;
 
 [TestClass]
-[TestCategory("PixelShaderEffect<T>")]
 public partial class PixelShaderEffectTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/ShadersTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/ShadersTests.cs
@@ -13,7 +13,6 @@ using Windows.UI;
 namespace ComputeSharp.D2D1.WinUI.Tests;
 
 [TestClass]
-[TestCategory("Shaders")]
 public class ShadersTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/DeviceDisposalTests.cs
@@ -13,7 +13,6 @@ using TerraFX.Interop.Windows;
 namespace ComputeSharp.Tests.DeviceLost;
 
 [TestClass]
-[TestCategory("DeviceDisposal")]
 public partial class DeviceDisposalTests
 {
     [AssemblyInitialize]

--- a/tests/ComputeSharp.Tests.DeviceLost/DeviceLostTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/DeviceLostTests.cs
@@ -11,7 +11,6 @@ using TerraFX.Interop.Windows;
 namespace ComputeSharp.Tests.DeviceLost;
 
 [TestClass]
-[TestCategory("DeviceLost")]
 public class DeviceLostTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests.DeviceLost/GetDefaultDeviceTests.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/GetDefaultDeviceTests.cs
@@ -8,7 +8,6 @@ using TerraFX.Interop.Windows;
 namespace ComputeSharp.Tests.DeviceLost;
 
 [TestClass]
-[TestCategory("GetDefaultDevice")]
 public class GetDefaultDeviceTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/DispatchTests.cs
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/DispatchTests.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.DisableDynamicCompilation;
 
 [TestClass]
-[TestCategory("Dispatch")]
 public partial class DispatchTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests.Internals/AlignmentHelperTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/AlignmentHelperTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.Internals;
 
 [TestClass]
-[TestCategory("AlignmentHelper")]
 public class AlignmentHelperTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests.Internals/DebugViewTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/DebugViewTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.Internals;
 
 [TestClass]
-[TestCategory("Buffer")]
 public partial class DebugViewTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests.Internals/NativeObjectTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/NativeObjectTests.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.Internals;
 
 [TestClass]
-[TestCategory("NativeObject")]
 public class NativeObjectTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
+++ b/tests/ComputeSharp.Tests.Internals/ShaderDataLoaderTests.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.Internals;
 
 [TestClass]
-[TestCategory("ShaderDataLoader")]
 public partial class ShaderDataLoaderTests
 {
     [AutoConstructor]

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -13,7 +13,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.SourceGenerators;
 
 [TestClass]
-[TestCategory("Diagnostics")]
 public class DiagnosticsTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_Analyzers.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.SourceGenerators;
 
 [TestClass]
-[TestCategory("Analyzers")]
 public class Test_Analyzers
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
@@ -17,7 +17,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.SourceGenerators;
 
 [TestClass]
-public class Test_D2DPixelShaderSourceGenerator
+public class Test_ComputeShaderDescriptorGenerator
 {
     [TestMethod]
     public async Task SimpleShader_ComputeShader()

--- a/tests/ComputeSharp.Tests/AllocationServicesTests.cs
+++ b/tests/ComputeSharp.Tests/AllocationServicesTests.cs
@@ -14,7 +14,6 @@ using TerraFX.Interop.Windows;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("AllocationServices")]
 public unsafe class AllocationServicesTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests/BufferTests.cs
+++ b/tests/ComputeSharp.Tests/BufferTests.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("Buffer")]
 public partial class BufferTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ComputeContextTests.cs
+++ b/tests/ComputeSharp.Tests/ComputeContextTests.cs
@@ -16,7 +16,6 @@ using ImageSharpRgba32 = SixLabors.ImageSharp.PixelFormats.Rgba32;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("ComputeContext")]
 public partial class ComputeContextTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/DispatchTests.cs
+++ b/tests/ComputeSharp.Tests/DispatchTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("Dispatch")]
 public partial class DispatchTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/GlobalUsingDirectivesTests.cs
+++ b/tests/ComputeSharp.Tests/GlobalUsingDirectivesTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("GlobalUsingDirectives")]
 public unsafe partial class GlobalUsingDirectivesTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests/IPixelShaderTests.cs
+++ b/tests/ComputeSharp.Tests/IPixelShaderTests.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("IPixelShader")]
 public partial class IPixelShaderTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ImageProcessingTests.cs
+++ b/tests/ComputeSharp.Tests/ImageProcessingTests.cs
@@ -12,7 +12,6 @@ using ImageSharpRgba32 = SixLabors.ImageSharp.PixelFormats.Rgba32;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("ImageProcessing")]
 public class ImageProcessingTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ImagingTests.cs
+++ b/tests/ComputeSharp.Tests/ImagingTests.cs
@@ -20,7 +20,6 @@ using ImageSharpL8 = SixLabors.ImageSharp.PixelFormats.L8;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("Imaging")]
 public class ImagingTests
 {
     [AssemblyInitialize]

--- a/tests/ComputeSharp.Tests/InitializationTests.cs
+++ b/tests/ComputeSharp.Tests/InitializationTests.cs
@@ -7,7 +7,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("Initialization")]
 public partial class InitializationTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests/InteropServicesTests.cs
+++ b/tests/ComputeSharp.Tests/InteropServicesTests.cs
@@ -10,7 +10,6 @@ using TerraFX.Interop.Windows;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("InteropServices")]
 public unsafe partial class InteropServicesTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.g.cs
@@ -5,7 +5,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("ResourceDimensions")]
 public partial class ResourceDimensionsTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
+++ b/tests/ComputeSharp.Tests/ResourceDimensionsTests.tt
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("ResourceDimensions")]
 public partial class ResourceDimensionsTests
 {
 <#

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests
 {
     [TestClass]
-    [TestCategory("ShaderCompiler")]
     public partial class ShaderCompilerTests
     {
         [TestMethod]
@@ -880,7 +879,6 @@ namespace ComputeSharp.Tests
 namespace ExternalNamespace
 {
     [TestClass]
-    [TestCategory("ShaderCompiler")]
     public partial class ShaderCompilerTestsInExternalNamespace
     {
         [AutoConstructor]

--- a/tests/ComputeSharp.Tests/ShaderMembersTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderMembersTests.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("ShaderMembers")]
 public partial class ShaderMembersTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("ShaderRewriter")]
 public partial class ShaderRewriterTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ShadersTests.cs
+++ b/tests/ComputeSharp.Tests/ShadersTests.cs
@@ -16,7 +16,6 @@ using ImageSharpRgba32 = SixLabors.ImageSharp.PixelFormats.Rgba32;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("Shaders")]
 public class ShadersTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/Texture1DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture1DTests.cs
@@ -8,7 +8,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("Texture1D")]
 public partial class Texture1DTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/Texture2DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture2DTests.cs
@@ -9,7 +9,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("Texture2D")]
 public partial class Texture2DTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/Texture3DTests.cs
+++ b/tests/ComputeSharp.Tests/Texture3DTests.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("Texture3D")]
 public partial class Texture3DTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/ThreadGroupSizeTests.cs
+++ b/tests/ComputeSharp.Tests/ThreadGroupSizeTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("ThreadGroupSize")]
 public partial class ThreadGroupSizeTests
 {
     [TestMethod]

--- a/tests/ComputeSharp.Tests/TransferBufferTests.cs
+++ b/tests/ComputeSharp.Tests/TransferBufferTests.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("TransferBuffer")]
 public partial class TransferBufferTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/TransferTexture1DTests.cs
+++ b/tests/ComputeSharp.Tests/TransferTexture1DTests.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("TransferTexture1D")]
 public partial class TransferTexture1DTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/TransferTexture2DTests.cs
+++ b/tests/ComputeSharp.Tests/TransferTexture2DTests.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("TransferTexture2D")]
 public partial class TransferTexture2DTests
 {
     [CombinatorialTestMethod]

--- a/tests/ComputeSharp.Tests/TransferTexture3DTests.cs
+++ b/tests/ComputeSharp.Tests/TransferTexture3DTests.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests;
 
 [TestClass]
-[TestCategory("TransferTexture3D")]
 public partial class TransferTexture3DTests
 {
     [CombinatorialTestMethod]


### PR DESCRIPTION
### Description

This PR includes a few minor tweaks:
- Remove the unnecessary `[TestCategory]` attributes from test classes
- Renames the file for the DX12 generator tests
- Updates an incorrect comment (leftover from before some changes)