### PR TITLE
Optimize HLSL type lookups in generators, refactor code

### DIFF
--- a/samples/ComputeSharp.SwapChain.WinUI/ViewModels/MainViewModel.cs
+++ b/samples/ComputeSharp.SwapChain.WinUI/ViewModels/MainViewModel.cs
@@ -79,7 +79,7 @@ public sealed partial class MainViewModel : ObservableObject
     /// <summary>
     /// Gets the available resolution scaling options (as percentage values).
     /// </summary>
-    public IList<int> ResolutionScaleOptions { get; } = new[] { 25, 50, 75, 100 };
+    public IList<int> ResolutionScaleOptions { get; } = [25, 50, 75, 100];
 
     /// <summary>
     /// Gets the collection of available compute shader.

--- a/samples/ComputeSharp.SwapChain/Program.cs
+++ b/samples/ComputeSharp.SwapChain/Program.cs
@@ -16,8 +16,8 @@ class Program
     static void Main()
     {
         // Prepare the mapping of available samples to choose from
-        (string ShaderName, Win32Application Application)[] samples = new[]
-        {
+        (string ShaderName, Win32Application Application)[] samples =
+        [
             (nameof(HelloWorld), Win32ApplicationFactory<HelloWorld>.Create(static time => new((float)time.TotalSeconds))),
             (nameof(FourColorGradient), Win32ApplicationFactory<FourColorGradient>.Create(static time => new((float)time.TotalSeconds))),
             (nameof(ColorfulInfinity), Win32ApplicationFactory<ColorfulInfinity>.Create(static time => new((float)time.TotalSeconds))),
@@ -31,7 +31,7 @@ class Program
             (nameof(TriangleGridContouring), Win32ApplicationFactory<TriangleGridContouring>.Create(static time => new((float)time.TotalSeconds))),
             (nameof(ContouredLayers), Win32ApplicationFactory<ContouredLayers>.Create(static time => new((float)time.TotalSeconds, RustyMetal.Value))),
             (nameof(TerracedHills), Win32ApplicationFactory<TerracedHills>.Create(static time => new((float)time.TotalSeconds))),
-        };
+        ];
 
         int index;
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -246,7 +246,7 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
             item.Hierarchy.WriteSyntax(
                 state: item,
                 writer: writer,
-                baseTypes: new[] { $"global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{item.Hierarchy.Hierarchy[0].QualifiedName}>" },
+                baseTypes: [$"global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{item.Hierarchy.Hierarchy[0].QualifiedName}>"],
                 memberCallbacks: declaredMembers.WrittenSpan);
 
             // If any generated types are needed, they go into a separate namespace

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -94,7 +94,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                 state: item,
                 writer: writer,
                 baseTypes: [],
-                memberCallbacks: new IndentedTextWriter.Callback<D2D1PixelShaderSourceInfo>[] { Execute.WriteSyntax });
+                memberCallbacks: [Execute.WriteSyntax]);
 
             context.AddSource($"{item.Hierarchy.FullyQualifiedMetadataName}.{item.MethodName}.g.cs", writer.ToString());
         });

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidEffectMetadataValueAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidEffectMetadataValueAnalyzer.cs
@@ -26,13 +26,13 @@ public sealed class InvalidEffectMetadataValueAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// The mapping of diagnostics to their attribute type names.
     /// </summary>
-    private static readonly ImmutableDictionary<string, DiagnosticDescriptor> AttributeTypeNameToDiagnosticMapping = ImmutableDictionary.CreateRange(new[]
-    {
+    private static readonly ImmutableDictionary<string, DiagnosticDescriptor> AttributeTypeNameToDiagnosticMapping = ImmutableDictionary.CreateRange(
+    [
         new KeyValuePair<string, DiagnosticDescriptor>("D2DEffectDisplayNameAttribute", InvalidD2DEffectDisplayNameAttributeValue),
         new KeyValuePair<string, DiagnosticDescriptor>("D2DEffectDescriptionAttribute", InvalidD2DEffectDescriptionAttributeValue),
         new KeyValuePair<string, DiagnosticDescriptor>("D2DEffectCategoryAttribute", InvalidD2DEffectCategoryAttributeValue),
         new KeyValuePair<string, DiagnosticDescriptor>("D2DEffectAuthorAttribute", InvalidD2DEffectAuthorAttributeValue)
-    });
+    ]);
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownTypes.cs
@@ -34,7 +34,7 @@ partial class HlslKnownTypes
             string genericArgumentName = ((INamedTypeSymbol)typeSymbol.TypeArguments[0]).GetFullyQualifiedMetadataName();
 
             // Get the HLSL name for the type argument (it can only be either float or float4)
-            _ = KnownHlslTypes.TryGetValue(genericArgumentName, out string? mappedElementType);
+            _ = KnownHlslTypeMetadataNames.TryGetValue(genericArgumentName, out string? mappedElementType);
 
             return typeName switch
             {
@@ -46,7 +46,7 @@ partial class HlslKnownTypes
         }
 
         // The captured field is of an HLSL primitive type
-        if (KnownHlslTypes.TryGetValue(typeName, out string? mappedType))
+        if (KnownHlslTypeMetadataNames.TryGetValue(typeName, out string? mappedType))
         {
             return mappedType;
         }

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownFields.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownFields.cs
@@ -15,9 +15,9 @@ internal static partial class HlslKnownFields
     /// <summary>
     /// Builds the mapping of supported known fields to HLSL names.
     /// </summary>
-    private static IReadOnlyDictionary<string, string> BuildKnownFieldsMap()
+    private static Dictionary<string, string> BuildKnownFieldsMap()
     {
-        Dictionary<string, string> knownMembers = new()
+        return new()
         {
             [$"float.{nameof(float.NaN)}"] = "asfloat(0xFFC00000)",
             [$"float.{nameof(float.PositiveInfinity)}"] = "asfloat(0x7F800000)",
@@ -27,8 +27,6 @@ internal static partial class HlslKnownFields
             [$"double.{nameof(double.PositiveInfinity)}"] = "asdouble(0x00000000, 0x7FF00000)",
             [$"double.{nameof(double.NegativeInfinity)}"] = "asdouble(0x00000000, 0xFFF00000)"
         };
-
-        return knownMembers;
     }
 
     /// <summary>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
@@ -21,7 +21,7 @@ internal static partial class HlslKnownKeywords
     /// <summary>
     /// Builds the mapping of all known HLSL keywords.
     /// </summary>
-    private static IReadOnlyCollection<string> BuildKnownKeywordsMap()
+    private static HashSet<string> BuildKnownKeywordsMap()
     {
         // HLSL keywords
         HashSet<string> knownKeywords = new(

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
@@ -47,7 +47,7 @@ internal static partial class HlslKnownKeywords
         ]);
 
         // HLSL primitive names
-        foreach (Type? type in HlslKnownTypes.KnownVectorTypes.Concat(HlslKnownTypes.KnownMatrixTypes))
+        foreach (Type? type in HlslKnownTypes.EnumerateKnownVectorTypes().Concat(HlslKnownTypes.EnumerateKnownMatrixTypes()))
         {
             _ = knownKeywords.Add(type.Name.ToLowerInvariant());
         }

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownMethods.cs
@@ -25,7 +25,7 @@ internal static partial class HlslKnownMethods
     /// <summary>
     /// Builds the mapping of supported known methods to HLSL names.
     /// </summary>
-    private static IReadOnlyDictionary<string, string> BuildKnownMethodsMap()
+    private static Dictionary<string, string> BuildKnownMethodsMap()
     {
         Dictionary<string, string> knownMethods = new()
         {
@@ -162,7 +162,7 @@ internal static partial class HlslKnownMethods
     /// <summary>
     /// Builds the mapping of supported known methods that require parameters mapping to HLSL names.
     /// </summary>
-    private static IReadOnlyDictionary<string, string> BuildKnownMethodsParametersMappingMap()
+    private static Dictionary<string, string> BuildKnownMethodsParametersMappingMap()
     {
         ILookup<string, MethodInfo> methodsLookup = typeof(Hlsl).GetMethods(BindingFlags.Public | BindingFlags.Static).ToLookup(static method => method.Name);
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
@@ -19,13 +19,14 @@ internal static partial class HlslKnownOperators
     /// <summary>
     /// Builds the mapping of supported known operators to HLSL names.
     /// </summary>
+    /// <returns>The mapping of supported known operators to HLSL names.</returns>
     private static IReadOnlyDictionary<string, string> BuildKnownOperatorsMap()
     {
         Dictionary<string, string> knownOperators = [];
 
         // Programmatically load mappings for the intrinsic operators on each HLSL primitive type
         foreach ((Type Type, MethodInfo Operator, string IntrinsicName, bool RequiresParametersMatching) item in
-            from type in HlslKnownTypes.KnownVectorTypes.Concat(HlslKnownTypes.KnownMatrixTypes)
+            from type in HlslKnownTypes.EnumerateKnownVectorTypes().Concat(HlslKnownTypes.EnumerateKnownMatrixTypes())
             from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
             where method.IsSpecialName && method.Name.StartsWith("op_", StringComparison.InvariantCulture)
             let attribute = method.GetCustomAttribute<HlslIntrinsicNameAttribute>()

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
@@ -20,7 +20,7 @@ internal static partial class HlslKnownOperators
     /// Builds the mapping of supported known operators to HLSL names.
     /// </summary>
     /// <returns>The mapping of supported known operators to HLSL names.</returns>
-    private static IReadOnlyDictionary<string, string> BuildKnownOperatorsMap()
+    private static Dictionary<string, string> BuildKnownOperatorsMap()
     {
         Dictionary<string, string> knownOperators = [];
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownProperties.cs
@@ -21,7 +21,7 @@ internal static partial class HlslKnownProperties
     /// <summary>
     /// Builds the mapping of supported known properties to HLSL names.
     /// </summary>
-    private static IReadOnlyDictionary<string, string> BuildKnownPropertiesMap()
+    private static Dictionary<string, string> BuildKnownPropertiesMap()
     {
         Dictionary<string, string> knownProperties = new()
         {

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownProperties.cs
@@ -141,7 +141,7 @@ internal static partial class HlslKnownProperties
 
         // Programmatically load mappings for the instance members of the HLSL vector types
         foreach ((Type Type, PropertyInfo Property) item in
-            from type in HlslKnownTypes.KnownVectorTypes
+            from type in HlslKnownTypes.EnumerateKnownVectorTypes()
             from property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
             select (Type: type, Property: property))
         {
@@ -150,7 +150,7 @@ internal static partial class HlslKnownProperties
 
         // Load mappings for the matrix properties as well
         foreach ((Type Type, PropertyInfo Property) item in
-            from type in HlslKnownTypes.KnownMatrixTypes
+            from type in HlslKnownTypes.EnumerateKnownMatrixTypes()
             from property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
             where Regex.IsMatch(property.Name, "^M[1-4]{2}$")
             select (Type: type, Property: property))

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownSizes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownSizes.cs
@@ -20,7 +20,7 @@ internal static class HlslKnownSizes
     /// <summary>
     /// Builds the mapping of known type sizes and alignments.
     /// </summary>
-    private static IReadOnlyDictionary<string, (int, int)> BuildKnownSizesMap()
+    private static Dictionary<string, (int, int)> BuildKnownSizesMap()
     {
         Dictionary<string, (int, int)> knownSizes = new()
         {

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -75,7 +75,7 @@ internal static partial class HlslKnownTypes
     /// Builds the mapping of known HLSL vector types.
     /// </summary>
     /// <returns>The mapping of known HLSL vector types.</returns>
-    private static IReadOnlyDictionary<string, string> BuildKnownVectorTypeMetadataNames()
+    private static Dictionary<string, string> BuildKnownVectorTypeMetadataNames()
     {
         return KnownVectorTypes.ToDictionary(
             keySelector: static type => type.FullName,
@@ -86,7 +86,7 @@ internal static partial class HlslKnownTypes
     /// Builds the mapping of known HLSL matrix types.
     /// </summary>
     /// <returns>The mapping of known HLSL matrix types.</returns>
-    private static IReadOnlyDictionary<string, string> BuildKnownMatrixTypeMetadataNames()
+    private static Dictionary<string, string> BuildKnownMatrixTypeMetadataNames()
     {
         return KnownMatrixTypes.ToDictionary(
             keySelector: static type => type.FullName,
@@ -97,7 +97,7 @@ internal static partial class HlslKnownTypes
     /// Builds the mapping of known primitive types.
     /// </summary>
     /// <returns>The mapping of known primitive types.</returns>
-    private static IReadOnlyDictionary<string, string> BuildKnownHlslTypeMetadataNames()
+    private static Dictionary<string, string> BuildKnownHlslTypeMetadataNames()
     {
         Dictionary<string, string> knownTypes = new()
         {

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -246,26 +246,6 @@ internal static partial class HlslKnownTypes
     }
 
     /// <summary>
-    /// Tracks an <see cref="ITypeSymbol"/> instance and returns an HLSL compatible type name.
-    /// </summary>
-    /// <param name="typeSymbol">The input <see cref="ITypeSymbol"/> instance to process.</param>
-    /// <param name="discoveredTypes">The collection of currently discovered types.</param>
-    /// <returns>A type name that represents a type compatible with HLSL.</returns>
-    public static string TrackType(ITypeSymbol typeSymbol, ICollection<INamedTypeSymbol> discoveredTypes)
-    {
-        string typeName = typeSymbol.GetFullyQualifiedName();
-
-        discoveredTypes.Add((INamedTypeSymbol)typeSymbol);
-
-        if (TryGetMappedName(typeName, out string? mappedName))
-        {
-            return mappedName!;
-        }
-
-        return typeName.ToHlslIdentifierName();
-    }
-
-    /// <summary>
     /// Gets the sequence of unique custom types from a collection of discovered types.
     /// </summary>
     /// <param name="discoveredTypes">The input collection of discovered types.</param>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Numerics;
@@ -240,7 +241,7 @@ internal static partial class HlslKnownTypes
     /// <param name="originalName">The input type name to map.</param>
     /// <param name="mappedName">The resulting mapped type name, if found.</param>
     /// <returns>Whether a mapped name was available.</returns>
-    public static bool TryGetMappedName(string originalName, out string? mappedName)
+    public static bool TryGetMappedName(string originalName, [NotNullWhen(true)] out string? mappedName)
     {
         return KnownHlslTypeMetadataNames.TryGetValue(originalName, out mappedName);
     }

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 using ComputeSharp.SourceGeneration.Extensions;
 using Microsoft.CodeAnalysis;
 
-#pragma warning disable RS1024
+#pragma warning disable IDE0055, RS1024
 
 namespace ComputeSharp.SourceGeneration.Mappings;
 
@@ -19,20 +19,20 @@ internal static partial class HlslKnownTypes
     /// <summary>
     /// Gets the set of HLSL vector types.
     /// </summary>
-    public static IReadOnlyCollection<Type> KnownVectorTypes { get; } = new[]
-    {
+    public static IReadOnlyCollection<Type> KnownVectorTypes { get; } =
+    [
         typeof(Bool2), typeof(Bool3), typeof(Bool4),
         typeof(Int2), typeof(Int3), typeof(Int4),
         typeof(UInt2), typeof(UInt3), typeof(UInt4),
         typeof(Float2), typeof(Float3), typeof(Float4),
         typeof(Double2), typeof(Double3), typeof(Double4)
-    };
+    ];
 
     /// <summary>
     /// Gets the set of HLSL matrix types.
     /// </summary>
-    public static IReadOnlyCollection<Type> KnownMatrixTypes { get; } = new[]
-    {
+    public static IReadOnlyCollection<Type> KnownMatrixTypes { get; } =
+    [
         typeof(Bool1x1), typeof(Bool1x2), typeof(Bool1x3), typeof(Bool1x4),
         typeof(Bool2x1), typeof(Bool2x2), typeof(Bool2x3), typeof(Bool2x4),
         typeof(Bool3x1), typeof(Bool3x2), typeof(Bool3x3), typeof(Bool3x4),
@@ -53,7 +53,7 @@ internal static partial class HlslKnownTypes
         typeof(Double2x1), typeof(Double2x2), typeof(Double2x3), typeof(Double2x4),
         typeof(Double3x1), typeof(Double3x2), typeof(Double3x3), typeof(Double3x4),
         typeof(Double4x1), typeof(Double4x2), typeof(Double4x3), typeof(Double4x4)
-    };
+    ];
 
     /// <summary>
     /// The mapping of supported known types to HLSL types.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslDefinitionsSyntaxProcessor.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslDefinitionsSyntaxProcessor.cs
@@ -192,7 +192,7 @@ internal static class HlslDefinitionsSyntaxProcessor
 
                 structDeclaration = structDeclaration.AddMembers(
                     FieldDeclaration(VariableDeclaration(
-                        IdentifierName(mappedType!)).AddVariables(
+                        IdentifierName(mappedType)).AddVariables(
                         VariableDeclarator(Identifier(mappedName!)))));
             }
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Tracking.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Tracking.cs
@@ -18,6 +18,17 @@ partial class HlslSourceRewriter
     protected TypeSyntax TrackType(SyntaxNode node, SemanticModel semanticModel)
     {
         ITypeSymbol typeSymbol = semanticModel.GetTypeInfo(node, CancellationToken).Type!;
+
+        return TrackType(typeSymbol);
+    }
+
+    /// <summary>
+    /// Tracks an <see cref="ITypeSymbol"/> instance and returns the HLSL compatible <see cref="TypeSyntax"/>.
+    /// </summary>
+    /// <param name="typeSymbol">The input <see cref="ITypeSymbol"/> instance to process.</param>
+    /// <returns>A <see cref="SyntaxNode"/> instance that represents a type compatible with HLSL.</returns>
+    protected TypeSyntax TrackType(ITypeSymbol typeSymbol)
+    {
         string typeName = typeSymbol.GetFullyQualifiedName();
 
         DiscoveredTypes.Add((INamedTypeSymbol)typeSymbol);

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Tracking.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.Tracking.cs
@@ -35,7 +35,7 @@ partial class HlslSourceRewriter
 
         if (HlslKnownTypes.TryGetMappedName(typeName, out string? mappedName))
         {
-            return ParseTypeName(mappedName!);
+            return ParseTypeName(mappedName);
         }
 
         return ParseTypeName(typeName.ToHlslIdentifierName());
@@ -94,7 +94,7 @@ partial class HlslSourceRewriter
 
         if (HlslKnownTypes.TryGetMappedName(typeName, out string? mappedName))
         {
-            TypeSyntax newType = ParseTypeName(mappedName!);
+            TypeSyntax newType = ParseTypeName(mappedName);
 
             return node.ReplaceNode(targetType, newType);
         }

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
@@ -627,7 +627,7 @@ internal sealed partial class ShaderSourceRewriter(
         // Track and rewrite the discarded declaration
         if (SemanticModel.For(node).GetOperation(node.Expression, CancellationToken) is IDiscardOperation operation)
         {
-            TypeSyntax typeSyntax = ParseTypeName(HlslKnownTypes.TrackType(operation.Type!, DiscoveredTypes));
+            TypeSyntax typeSyntax = TrackType(operation.Type!);
             string identifier = $"__implicit{this.implicitVariables.Count}";
 
             // Add the variable to the list of implicit declarations

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -183,7 +183,7 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
             item.Hierarchy.WriteSyntax(
                 state: item,
                 writer: writer,
-                baseTypes: new[] { $"global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{item.Hierarchy.Hierarchy[0].QualifiedName}>" },
+                baseTypes: [$"global::ComputeSharp.Descriptors.IComputeShaderDescriptor<{item.Hierarchy.Hierarchy[0].QualifiedName}>"],
                 memberCallbacks: declaredMembers.WrittenSpan);
 
             // Append any additional types as well

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
@@ -12,12 +12,12 @@ partial class HlslKnownTypes
     /// <summary>
     /// Gets the known HLSL dispatch types.
     /// </summary>
-    public static IReadOnlyCollection<Type> HlslDispatchTypes { get; } = new[]
-    {
+    public static IReadOnlyCollection<Type> HlslDispatchTypes { get; } =
+    [
         typeof(ThreadIds),
         typeof(GroupIds),
         typeof(GridIds)
-    };
+    ];
 
     /// <summary>
     /// Checks whether or not a given type name matches a constant buffer type.

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
@@ -159,7 +159,7 @@ partial class HlslKnownTypes
             string genericArgumentName = ((INamedTypeSymbol)typeSymbol.TypeArguments.Last()).GetFullyQualifiedMetadataName();
 
             // If the current type is a custom type, format it as needed
-            if (!KnownHlslTypes.TryGetValue(genericArgumentName, out string? mappedElementType))
+            if (!KnownHlslTypeMetadataNames.TryGetValue(genericArgumentName, out string? mappedElementType))
             {
                 mappedElementType = genericArgumentName.ToHlslIdentifierName();
             }
@@ -196,7 +196,7 @@ partial class HlslKnownTypes
         }
 
         // The captured field is of an HLSL primitive type
-        if (KnownHlslTypes.TryGetValue(typeName, out string? mappedType))
+        if (KnownHlslTypeMetadataNames.TryGetValue(typeName, out string? mappedType))
         {
             return mappedType;
         }
@@ -215,7 +215,7 @@ partial class HlslKnownTypes
         string genericArgumentName = ((INamedTypeSymbol)typeSymbol.TypeArguments.First()).GetFullyQualifiedMetadataName();
 
         // If the current type is a custom type, format it as needed
-        if (!KnownHlslTypes.TryGetValue(genericArgumentName, out string? mappedElementType))
+        if (!KnownHlslTypeMetadataNames.TryGetValue(genericArgumentName, out string? mappedElementType))
         {
             mappedElementType = genericArgumentName.ToHlslIdentifierName();
         }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
@@ -1830,7 +1830,7 @@ public class Test_D2DPixelShaderSourceGenerator
         // Create the original compilation
         CSharpCompilation compilation = CSharpCompilation.Create(
             "original",
-            new SyntaxTree[] { sourceTree },
+            [sourceTree],
             metadataReferences,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
 

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -101,14 +101,14 @@ namespace ComputeSharp.D2D1.Tests
         {
             CollectionAssert.AreEqual(new[]
             {
-            D2D1PixelShaderInputType.Simple,
-            D2D1PixelShaderInputType.Complex,
-            D2D1PixelShaderInputType.Simple,
-            D2D1PixelShaderInputType.Complex,
-            D2D1PixelShaderInputType.Complex,
-            D2D1PixelShaderInputType.Complex,
-            D2D1PixelShaderInputType.Simple
-        }, D2D1PixelShader.GetInputTypes<ShaderWithMultipleInputs>().ToArray());
+                D2D1PixelShaderInputType.Simple,
+                D2D1PixelShaderInputType.Complex,
+                D2D1PixelShaderInputType.Simple,
+                D2D1PixelShaderInputType.Complex,
+                D2D1PixelShaderInputType.Complex,
+                D2D1PixelShaderInputType.Complex,
+                D2D1PixelShaderInputType.Simple
+            }, D2D1PixelShader.GetInputTypes<ShaderWithMultipleInputs>().ToArray());
         }
 
         [TestMethod]

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1574,7 +1574,7 @@ public class DiagnosticsTests
         // Create the original compilation
         CSharpCompilation compilation = CSharpCompilation.Create(
             "original",
-            new SyntaxTree[] { sourceTree },
+            [sourceTree],
             metadataReferences,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
 

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
@@ -920,7 +920,7 @@ public class Test_ComputeShaderDescriptorGenerator
         // Create the original compilation
         CSharpCompilation compilation = CSharpCompilation.Create(
             "original",
-            new SyntaxTree[] { sourceTree },
+            [sourceTree],
             metadataReferences,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
 

--- a/tests/ComputeSharp.Tests/ShadersTests.cs
+++ b/tests/ComputeSharp.Tests/ShadersTests.cs
@@ -180,7 +180,7 @@ public class ShadersTests
 
                 Action<ReadWriteTexture2D<Rgba32, float4>> action = new(RunComputeShader<SwapChain.Shaders.Compute.ColorfulInfinity>);
 
-                _ = action.Method.GetGenericMethodDefinition().MakeGenericMethod(shaderType).Invoke(null, new[] { texture });
+                _ = action.Method.GetGenericMethodDefinition().MakeGenericMethod(shaderType).Invoke(null, [texture]);
             }
             else
             {
@@ -196,7 +196,7 @@ public class ShadersTests
 
                 Action<ReadWriteTexture2D<Rgba32, float4>> action = new(RunPixelShader<ColorfulInfinity>);
 
-                _ = action.Method.GetGenericMethodDefinition().MakeGenericMethod(shaderType).Invoke(null, new[] { texture });
+                _ = action.Method.GetGenericMethodDefinition().MakeGenericMethod(shaderType).Invoke(null, [texture]);
             }
 
             _ = image.DangerousTryGetSinglePixelMemory(out Memory<ImageSharpRgba32> memory);


### PR DESCRIPTION
### Description

This PR includes a few housecleaning changes:
- Optimize the lookups of all HLSL types by always using dictionaries and no linear iterations
- Optimize the lookups of non linear matrix types by adding a new dedicated lookup map
- Centralize a leftover `TrackType` extension that was in the wrong place
- Use collection expressions in more places