### PR TITLE
Skip generating unnecessary using for constant buffer

### DIFF
--- a/src/ComputeSharp.D2D1.WinUI/CanvasEffect.EffectGraph.cs
+++ b/src/ComputeSharp.D2D1.WinUI/CanvasEffect.EffectGraph.cs
@@ -13,7 +13,7 @@ partial class CanvasEffect
     protected readonly ref struct EffectGraph
     {
         /// <summary>
-        ///The owning <see cref="CanvasEffect"/> instance.
+        /// The owning <see cref="CanvasEffect"/> instance.
         /// </summary>
         private readonly CanvasEffect owner;
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/ConstantBufferSyntaxProcessor.Generation.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/ConstantBufferSyntaxProcessor.Generation.cs
@@ -51,8 +51,13 @@ partial class ConstantBufferSyntaxProcessor
         _ = usingDirectives.Add("global::System.CodeDom.Compiler");
         _ = usingDirectives.Add("global::System.Diagnostics");
         _ = usingDirectives.Add("global::System.Diagnostics.CodeAnalysis");
-        _ = usingDirectives.Add("global::System.Runtime.CompilerServices");
         _ = usingDirectives.Add("global::System.Runtime.InteropServices");
+
+        // Only add this directive if the marshaller is also present, as it's only needed there
+        if (!info.Fields.IsEmpty)
+        {
+            _ = usingDirectives.Add("global::System.Runtime.CompilerServices");
+        }
 
         // Declare the ConstantBuffer type
         static void ConstantBufferCallback(TInfo info, IndentedTextWriter writer)


### PR DESCRIPTION
### Description

Super minor PR just skipping generating a `CompilerServices` using if not needed for the constant buffer generator.