### PR TITLE
Remove VectorN/Math/MatF HLSL projections

### DIFF
--- a/samples/ComputeSharp.ImageProcessing/Primitives/ComplexVector4.cs
+++ b/samples/ComputeSharp.ImageProcessing/Primitives/ComplexVector4.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Six Labors.
 // Licensed under the Apache License, Version 2.0.
 
-using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace SixLabors.ImageSharp;
@@ -14,21 +13,21 @@ internal struct ComplexVector4
     /// <summary>
     /// The real part of the complex vector
     /// </summary>
-    public Vector4 Real;
+    public float4 Real;
 
     /// <summary>
     /// The imaginary part of the complex number
     /// </summary>
-    public Vector4 Imaginary;
+    public float4 Imaginary;
 
     /// <summary>
     /// Performs a weighted sum on the current instance according to the given parameters
     /// </summary>
     /// <param name="a">The 'a' parameter, for the real component</param>
     /// <param name="b">The 'b' parameter, for the imaginary component</param>
-    /// <returns>The resulting <see cref="Vector4"/> value</returns>
+    /// <returns>The resulting <see cref="float4"/> value</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly Vector4 WeightedSum(float a, float b)
+    public readonly float4 WeightedSum(float a, float b)
     {
         return (this.Real * a) + (this.Imaginary * b);
     }

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.Implementation.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.Implementation.cs
@@ -371,11 +371,11 @@ public sealed partial class HlslBokehBlurProcessor
                     float4 sourceImaginary = imaginaries[offsetX, offsetY];
                     Complex64 factors = kernel[i];
 
-                    result.Real += (Vector4)((factors.Real * sourceReal) - (factors.Imaginary * sourceImaginary));
-                    result.Imaginary += (Vector4)((factors.Real * sourceImaginary) + (factors.Imaginary * sourceReal));
+                    result.Real += (factors.Real * sourceReal) - (factors.Imaginary * sourceImaginary);
+                    result.Imaginary += (factors.Real * sourceImaginary) + (factors.Imaginary * sourceReal);
                 }
 
-                target[ThreadIds.XY] += (float4)result.WeightedSum(z, w);
+                target[ThreadIds.XY] += result.WeightedSum(z, w);
             }
         }
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -81,3 +81,4 @@ CMPSD2D0071 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0072 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0073 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0074 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0075 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1109,4 +1109,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A pixel shader cannot use a 'this' expression outside of member accesses (such as 'this.field').",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an invocation of a <c>Math</c> or <c>MathF</c> API.
+    /// <para>
+    /// Format: <c>"The method {0} cannot be used in a shader, use equivalent APIs from the Hlsl type instead"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidMathOrMathFCall = new(
+        id: "CMPSD2D0075",
+        title: "Invalid Math or MathF invocation from a shader",
+        messageFormat: "The method {0} cannot be used in a shader, use equivalent APIs from the Hlsl type instead",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Methods from the Math and MathF types cannot be used in a shader, and equivalent APIs from the Hlsl type should be used instead.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -581,11 +581,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor InvalidDiscoveredType = new(
         id: "CMPSD2D0041",
         title: "Invalid discovered type",
-        messageFormat: "The D2D1 shader of type {0} uses the invalid type {1} (only some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons)",
+        messageFormat: "The D2D1 shader of type {0} uses the invalid type {1} (only some .NET primitive types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "D2D1 shaders can only use supported types (some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons).",
+        description: "D2D1 shaders can only use supported types (some .NET primitive types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons).",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownMethods.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using System.Reflection;
 using ComputeSharp.Core.Intrinsics.Attributes;
 
@@ -27,103 +26,7 @@ internal static partial class HlslKnownMethods
     /// </summary>
     private static Dictionary<string, string> BuildKnownMethodsMap()
     {
-        Dictionary<string, string> knownMethods = new()
-        {
-            [$"{typeof(Math).FullName}.{nameof(Math.Abs)}"] = "abs",
-            [$"{typeof(Math).FullName}.{nameof(Math.Max)}"] = "max",
-            [$"{typeof(Math).FullName}.{nameof(Math.Min)}"] = "min",
-            [$"{typeof(Math).FullName}.{nameof(Math.Pow)}"] = "pow",
-            [$"{typeof(Math).FullName}.{nameof(Math.Sin)}"] = "sin",
-            [$"{typeof(Math).FullName}.{nameof(Math.Sinh)}"] = "sinh",
-            [$"{typeof(Math).FullName}.{nameof(Math.Asin)}"] = "asin",
-            [$"{typeof(Math).FullName}.{nameof(Math.Cos)}"] = "cos",
-            [$"{typeof(Math).FullName}.{nameof(Math.Cosh)}"] = "cosh",
-            [$"{typeof(Math).FullName}.{nameof(Math.Acos)}"] = "acos",
-            [$"{typeof(Math).FullName}.{nameof(Math.Tan)}"] = "tan",
-            [$"{typeof(Math).FullName}.{nameof(Math.Tanh)}"] = "tanh",
-            [$"{typeof(Math).FullName}.{nameof(Math.Atan)}"] = "atan",
-            [$"{typeof(Math).FullName}.{nameof(Math.Atan2)}"] = "atan2",
-            [$"{typeof(Math).FullName}.{nameof(Math.Ceiling)}"] = "ceil",
-            [$"{typeof(Math).FullName}.{nameof(Math.Floor)}"] = "floor",
-            [$"{typeof(Math).FullName}.Clamp"] = "clamp",
-            [$"{typeof(Math).FullName}.{nameof(Math.Exp)}"] = "exp",
-            [$"{typeof(Math).FullName}.{nameof(Math.Log)}"] = "log",
-            [$"{typeof(Math).FullName}.{nameof(Math.Log10)}"] = "log10",
-            [$"{typeof(Math).FullName}.{nameof(Math.Max)}"] = "max",
-            [$"{typeof(Math).FullName}.{nameof(Math.Min)}"] = "min",
-            [$"{typeof(Math).FullName}.{nameof(Math.Round)}"] = "round",
-            [$"{typeof(Math).FullName}.{nameof(Math.Sqrt)}"] = "sqrt",
-            [$"{typeof(Math).FullName}.{nameof(Math.Sign)}"] = "sign",
-            [$"{typeof(Math).FullName}.{nameof(Math.Truncate)}"] = "trunc",
-
-            ["System.MathF.Abs"] = "abs",
-            ["System.MathF.Max"] = "max",
-            ["System.MathF.Min"] = "min",
-            ["System.MathF.Pow"] = "pow",
-            ["System.MathF.Sin"] = "sin",
-            ["System.MathF.Sinh"] = "sinh",
-            ["System.MathF.Asin"] = "asin",
-            ["System.MathF.Cos"] = "cos",
-            ["System.MathF.Cosh"] = "cosh",
-            ["System.MathF.Acos"] = "acos",
-            ["System.MathF.Tan"] = "tan",
-            ["System.MathF.Tanh"] = "tanh",
-            ["System.MathF.Atan"] = "atan",
-            ["System.MathF.Atan2"] = "atan2",
-            ["System.MathF.Ceiling"] = "ceil",
-            ["System.MathF.Floor"] = "floor",
-            ["System.MathF.Clamp"] = "clamp",
-            ["System.MathF.Exp"] = "exp",
-            ["System.MathF.Log"] = "log",
-            ["System.MathF.Log10"] = "log10",
-            ["System.MathF.Round"] = "round",
-            ["System.MathF.Sqrt"] = "sqrt",
-            ["System.MathF.Sign"] = "sign",
-            ["System.MathF.Truncate"] = "trunc",
-
-            [$"{typeof(float).FullName}.IsFinite"] = "isfinite",
-            [$"{typeof(float).FullName}.{nameof(float.IsInfinity)}"] = "isinf",
-            [$"{typeof(float).FullName}.{nameof(float.IsNaN)}"] = "isnan",
-
-            [$"{typeof(double).FullName}.IsFinite"] = "isfinite",
-            [$"{typeof(double).FullName}.{nameof(double.IsInfinity)}"] = "isinf",
-            [$"{typeof(double).FullName}.{nameof(double.IsNaN)}"] = "isnan",
-
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Abs)}"] = "abs",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Clamp)}"] = "clamp",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Distance)}"] = "distance",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Dot)}"] = "dot",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Lerp)}"] = "lerp",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Max)}"] = "max",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Min)}"] = "min",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Reflect)}"] = "reflect",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Transform)}"] = "mul",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.TransformNormal)}"] = "mul",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Normalize)}"] = "normalize",
-
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Abs)}"] = "abs",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Clamp)}"] = "clamp",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Cross)}"] = "cross",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Distance)}"] = "distance",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Dot)}"] = "dot",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Lerp)}"] = "lerp",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Max)}"] = "max",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Min)}"] = "min",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Reflect)}"] = "reflect",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Transform)}"] = "mul",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.TransformNormal)}"] = "mul",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Normalize)}"] = "normalize",
-
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Abs)}"] = "abs",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Clamp)}"] = "clamp",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Distance)}"] = "distance",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Dot)}"] = "dot",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Lerp)}"] = "lerp",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Max)}"] = "max",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Min)}"] = "min",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Transform)}"] = "mul",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Normalize)}"] = "normalize"
-        };
+        Dictionary<string, string> knownMethods = [];
 
         // Programmatically load mappings from the Hlsl class as well (the ones with no parameter matching)
         foreach (MethodInfo? method in

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownProperties.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Numerics;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
@@ -25,29 +24,6 @@ internal static partial class HlslKnownProperties
     {
         Dictionary<string, string> knownProperties = new()
         {
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.X)}"] = "x",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Y)}"] = "y",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.Zero)}"] = "(float2)0",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.One)}"] = "float2(1.0f, 1.0f)",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.UnitX)}"] = "float2(1.0f, 0.0f)",
-            [$"{typeof(Vector2).FullName}.{nameof(Vector2.UnitY)}"] = "float2(0.0f, 1.0f)",
-
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.X)}"] = "x",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Y)}"] = "y",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Z)}"] = "z",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.Zero)}"] = "(float3)0",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.One)}"] = "float3(1.0f, 1.0f, 1.0f)",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.UnitX)}"] = "float3(1.0f, 0.0f, 0.0f)",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.UnitY)}"] = "float3(0.0f, 1.0f, 0.0f)",
-            [$"{typeof(Vector3).FullName}.{nameof(Vector3.UnitZ)}"] = "float3(0.0f, 0.0f, 1.0f)",
-
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.X)}"] = "x",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Y)}"] = "y",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Z)}"] = "z",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.W)}"] = "w",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.Zero)}"] = "(float4)0",
-            [$"{typeof(Vector4).FullName}.{nameof(Vector4.One)}"] = "float4(1.0f, 1.0f, 1.0f, 1.0f)",
-
             [$"{typeof(Bool2).FullName}.{nameof(Bool2.False)}"] = "(bool2)0",
             [$"{typeof(Bool2).FullName}.{nameof(Bool2.True)}"] = "bool2(true, true)",
             [$"{typeof(Bool2).FullName}.{nameof(Bool2.TrueX)}"] = "bool2(true, false)",

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownSizes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownSizes.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Numerics;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
@@ -28,11 +27,7 @@ internal static class HlslKnownSizes
             [typeof(int).FullName] = (4, 4),
             [typeof(uint).FullName] = (4, 4),
             [typeof(float).FullName] = (4, 4),
-            [typeof(double).FullName] = (8, 8),
-
-            [typeof(Vector2).FullName] = (8, 4),
-            [typeof(Vector3).FullName] = (12, 4),
-            [typeof(Vector4).FullName] = (16, 4)
+            [typeof(double).FullName] = (8, 8)
         };
 
         foreach (

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Numerics;
 using ComputeSharp.SourceGeneration.Extensions;
 using Microsoft.CodeAnalysis;
 
@@ -110,9 +109,6 @@ internal static partial class HlslKnownTypes
             [typeof(int).FullName] = "int",
             [typeof(uint).FullName] = "uint",
             [typeof(float).FullName] = "float",
-            [typeof(Vector2).FullName] = "float2",
-            [typeof(Vector3).FullName] = "float3",
-            [typeof(Vector4).FullName] = "float4",
             [typeof(double).FullName] = "double"
         };
 

--- a/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -68,3 +68,4 @@ CMPS0059 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Ser
 CMPS0060 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0061 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0062 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPS0063 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -885,4 +885,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "A compute shader cannot use a 'this' expression outside of member accesses (such as 'this.field').",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an invocation of a <c>Math</c> or <c>MathF</c> API.
+    /// <para>
+    /// Format: <c>"The method {0} cannot be used in a shader, use equivalent APIs from the Hlsl type instead"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidMathOrMathFCall = new(
+        id: "CMPS0063",
+        title: "Invalid Math or MathF invocation from a shader",
+        messageFormat: "The method {0} cannot be used in a shader, use equivalent APIs from the Hlsl type instead",
+        category: "ComputeSharp.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Methods from the Math and MathF types cannot be used in a shader, and equivalent APIs from the Hlsl type should be used instead.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -694,11 +694,11 @@ partial class DiagnosticDescriptors
     public static readonly DiagnosticDescriptor InvalidDiscoveredType = new(
         id: "CMPS0050",
         title: "Invalid discovered type",
-        messageFormat: "The compute shader or method {0} uses the invalid type {1} (only some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons)",
+        messageFormat: "The compute shader or method {0} uses the invalid type {1} (only some .NET primitive types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons)",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Shaders and shader methods can only use supported types (some .NET primitives and vector types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons).",
+        description: "Shaders and shader methods can only use supported types (some .NET primitive types, HLSL primitive, vector and matrix types, and custom types containing these types can be used, and bool fields in custom struct types have to be replaced with the ComputeSharp.Bool type for alignment reasons).",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/BokehBlurEffect.cs
@@ -569,8 +569,8 @@ public sealed partial class BokehBlurEffect
                     float realFactor = this.kernelReals[i];
                     float imaginaryFactor = this.kernelImaginaries[i];
 
-                    result.Real += (Vector4)((realFactor * sourceReal) - (imaginaryFactor * sourceImaginary));
-                    result.Imaginary += (Vector4)((realFactor * sourceImaginary) + (imaginaryFactor * sourceReal));
+                    result.Real += (realFactor * sourceReal) - (imaginaryFactor * sourceImaginary);
+                    result.Imaginary += (realFactor * sourceImaginary) + (imaginaryFactor * sourceReal);
                 }
 
                 return result.WeightedSum(z, w);

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1242,6 +1242,30 @@ public class DiagnosticsTests
     }
 
     [TestMethod]
+    public void InvalidMethodCall_SystemMath()
+    {
+        const string source = """
+            using System;
+            using ComputeSharp;
+
+            namespace MyFancyApp.Sample;
+            
+            [GeneratedComputeShaderDescriptor]
+            public partial struct MyShader : IComputeShader
+            {
+                public readonly ReadWriteBuffer<float> buffer;
+
+                public void Execute()
+                {
+                    buffer[0] = Math.Abs(42);
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0063", "CMPS0047");
+    }
+
+    [TestMethod]
     public void InvalidDiscoveredType_Primitive()
     {
         const string source = """


### PR DESCRIPTION
### Description

This PR removes support for using `Vector2`, `Vector3`, `Vector4`, `Math` and `MathF` APIs in shaders. This was error prone and not really well supported anyway (lots of methods were still not usable from shaders). So with this, using HLSL primitives and APIs is actually required, which makes the shader code much more explicit and easier to understand, and with better separation.