### PR TITLE
Use global aliases to simplify HLSL generation code

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
@@ -325,6 +325,9 @@ partial class D2DPixelShaderDescriptorGenerator
             using ImmutableArrayBuilder<HlslMethod> methods = new();
 
             string? entryPoint = null;
+
+            // By default, the scene position is not required. We will set this while
+            // rewriting HLSL, if any method we traverse ends up requiring the position.
             needsD2D1RequiresScenePosition = false;
 
             foreach (ISymbol memberSymbol in structDeclarationSymbol.GetMembers())

--- a/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\FieldInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\HlslBytecodeInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Interfaces\IConstantBufferInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\TypeAliases.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\ConstantBufferSyntaxProcessor.Generation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\HlslDefinitionsSyntaxProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\HlslSourceRewriter.Tracking.cs" />

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Models/TypeAliases.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Models/TypeAliases.cs
@@ -1,0 +1,13 @@
+#pragma warning disable IDE0005
+
+// Shared type aliases for transparent models for gathered HLSL info. These are used
+// when writing the transpiled HLSL. No need for concrete types for any of these, so
+// just using type aliases keeps things simpler while still making the code explicit.
+global using HlslConstant = (string Name, string Value);
+global using HlslUserType = (string Name, string Definition);
+global using HlslResourceField = (string MetadataName, string Name, string Type);
+global using HlslValueField = (string Name, string Type);
+global using HlslResourceTextureField = (string Name, string Type, int Index);
+global using HlslStaticField = (string Name, string TypeDeclaration, string? Assignment);
+global using HlslSharedBuffer = (string Name, string Type, int? Count);
+global using HlslMethod = (string Signature, string Declaration);

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslDefinitionsSyntaxProcessor.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslDefinitionsSyntaxProcessor.cs
@@ -26,9 +26,9 @@ internal static class HlslDefinitionsSyntaxProcessor
     /// </summary>
     /// <param name="constantDefinitions">The collection of discovered constant definitions.</param>
     /// <returns>A sequence of discovered constants to declare in the shader.</returns>
-    public static ImmutableArray<(string Name, string Value)> GetDefinedConstants(IReadOnlyDictionary<IFieldSymbol, string> constantDefinitions)
+    public static ImmutableArray<HlslConstant> GetDefinedConstants(IReadOnlyDictionary<IFieldSymbol, string> constantDefinitions)
     {
-        using ImmutableArrayBuilder<(string, string)> builder = new();
+        using ImmutableArrayBuilder<HlslConstant> builder = new();
 
         foreach (KeyValuePair<IFieldSymbol, string> constant in constantDefinitions)
         {
@@ -144,14 +144,14 @@ internal static class HlslDefinitionsSyntaxProcessor
     /// <param name="instanceMethods">The collection of discovered instance methods for custom struct types.</param>
     /// <param name="constructors">The collection of discovered constructors for custom struct types.</param>
     /// <returns>A sequence of custom type definitions to add to the shader source.</returns>
-    public static ImmutableArray<(string Name, string Definition)> GetDeclaredTypes(
+    public static ImmutableArray<HlslUserType> GetDeclaredTypes(
         ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
         INamedTypeSymbol structDeclarationSymbol,
         IEnumerable<INamedTypeSymbol> types,
         IReadOnlyDictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods,
         IReadOnlyDictionary<IMethodSymbol, (MethodDeclarationSyntax, MethodDeclarationSyntax)> constructors)
     {
-        using ImmutableArrayBuilder<(string, string)> builder = new();
+        using ImmutableArrayBuilder<HlslUserType> builder = new();
 
         IReadOnlyCollection<INamedTypeSymbol> invalidTypes;
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslDefinitionsSyntaxProcessor.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslDefinitionsSyntaxProcessor.cs
@@ -17,7 +17,7 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace ComputeSharp.SourceGeneration.SyntaxProcessors;
 
 /// <summary>
-/// A processor responsible for extracting definitions from shader types
+/// A processor responsible for extracting definitions from shader types.
 /// </summary>
 internal static class HlslDefinitionsSyntaxProcessor
 {

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
@@ -40,7 +40,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
         SemanticModelProvider semanticModel,
         ICollection<INamedTypeSymbol> discoveredTypes,
         IDictionary<IFieldSymbol, string> constantDefinitions,
-        IDictionary<IFieldSymbol, (string, string, string?)> staticFieldDefinitions,
+        IDictionary<IFieldSymbol, HlslStaticField> staticFieldDefinitions,
         ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
         CancellationToken token)
     {
@@ -70,7 +70,7 @@ internal abstract partial class HlslSourceRewriter : CSharpSyntaxRewriter
     /// <summary>
     /// Gets the collection of discovered static field definitions.
     /// </summary>
-    protected IDictionary<IFieldSymbol, (string, string, string?)> StaticFieldDefinitions { get; }
+    protected IDictionary<IFieldSymbol, HlslStaticField> StaticFieldDefinitions { get; }
 
     /// <summary>
     /// Gets the collection of produced <see cref="DiagnosticInfo"/> instances.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
@@ -40,7 +40,7 @@ internal sealed partial class ShaderSourceRewriter(
     IDictionary<IMethodSymbol, MethodDeclarationSyntax> instanceMethods,
     IDictionary<IMethodSymbol, (MethodDeclarationSyntax, MethodDeclarationSyntax)> constructors,
     IDictionary<IFieldSymbol, string> constantDefinitions,
-    IDictionary<IFieldSymbol, (string, string, string?)> staticFieldDefinitions,
+    IDictionary<IFieldSymbol, HlslStaticField> staticFieldDefinitions,
     ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
     CancellationToken token,
     bool isEntryPoint = false)

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/StaticFieldRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/StaticFieldRewriter.cs
@@ -30,7 +30,7 @@ internal sealed partial class StaticFieldRewriter(
     SemanticModelProvider semanticModel,
     ICollection<INamedTypeSymbol> discoveredTypes,
     IDictionary<IFieldSymbol, string> constantDefinitions,
-    IDictionary<IFieldSymbol, (string, string, string?)> staticFieldDefinitions,
+    IDictionary<IFieldSymbol, HlslStaticField> staticFieldDefinitions,
     ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
     CancellationToken token)
     : HlslSourceRewriter(semanticModel, discoveredTypes, constantDefinitions, staticFieldDefinitions, diagnostics, token)

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -535,7 +535,7 @@ partial class ComputeShaderDescriptorGenerator
                 writer.WriteLine($"#define {name} {value}");
             }
 
-            writer.WriteLine();
+            writer.WriteLine(skipIfPresent: true);
 
             // Static fields
             foreach ((string Name, string TypeDeclaration, string? Assignment) field in staticFields)
@@ -579,25 +579,20 @@ partial class ComputeShaderDescriptorGenerator
             int readWriteBuffersCount = 0;
 
             // Optional implicit texture field
-            if (!isComputeShader)
-            {
-                writer.WriteLine(skipIfPresent: true);
-                writer.WriteLine($"{implicitTextureType} __outputTexture : register(u{readWriteBuffersCount++});");
-            }
+            writer.WriteLine(skipIfPresent: true);
+            writer.WriteLineIf(!isComputeShader, $"{implicitTextureType} __outputTexture : register(u{readWriteBuffersCount++});");
 
             // Optional sampler field
-            if (isSamplerUsed)
-            {
-                writer.WriteLine(skipIfPresent: true);
-                writer.WriteLine("SamplerState __sampler : register(s);");
-            }
+            writer.WriteLine(skipIfPresent: true);
+            writer.WriteLineIf(isSamplerUsed, "SamplerState __sampler : register(s);");
 
             // Resources
             foreach ((string metadataName, string fieldName, string fieldType) in resourceFields)
             {
+                writer.WriteLine(skipIfPresent: true);
+
                 if (HlslKnownTypes.IsConstantBufferType(metadataName))
                 {
-                    writer.WriteLine(skipIfPresent: true);
                     writer.WriteLine($"cbuffer _{fieldName} : register(b{constantBuffersCount++})");
 
                     using (writer.WriteBlock())
@@ -607,12 +602,10 @@ partial class ComputeShaderDescriptorGenerator
                 }
                 else if (HlslKnownTypes.IsReadOnlyTypedResourceType(metadataName))
                 {
-                    writer.WriteLine(skipIfPresent: true);
                     writer.WriteLine($"{fieldType} {fieldName} : register(t{readOnlyBuffersCount++});");
                 }
                 else if (HlslKnownTypes.IsReadWriteTypedResourceType(metadataName))
                 {
-                    writer.WriteLine(skipIfPresent: true);
                     writer.WriteLine($"{fieldType} {fieldName} : register(u{readWriteBuffersCount++});");
                 }
             }


### PR DESCRIPTION
### Description

This PR simplifies the DX12/D2D generators by using type aliases for all tuples used when rewriting HLSL.