### PR TITLE
Add [D2DEnableRuntimeCompilation] and analyzers

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -83,3 +83,5 @@ CMPSD2D0073 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0074 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0075 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0076 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0077 | ComputeSharp.D2D1.Shaders | Info | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0078 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -82,3 +82,4 @@ CMPSD2D0072 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0073 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0074 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0075 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0076 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -85,3 +85,4 @@ CMPSD2D0075 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github
 CMPSD2D0076 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0077 | ComputeSharp.D2D1.Shaders | Info | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0078 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0079 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/D2DEnableRuntimeCompilationOnAssemblyAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/D2DEnableRuntimeCompilationOnAssemblyAnalyzer.cs
@@ -1,0 +1,39 @@
+using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates diagnostics for the [D2DEnableRuntimeCompilation] attribute, when used on an assembly.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class D2DEnableRuntimeCompilationOnAssemblyAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(D2DRuntimeCompilationOnAssemblyNotNecessary);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationAction(static context =>
+        {
+            IAssemblySymbol assemblySymbol = context.Compilation.Assembly;
+
+            // Emit a diagnostic if an assembly has both [D2DShaderProfile] and [D2DEnableRuntimeCompilation] (the latter is useless)
+            if (assemblySymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DShaderProfileAttribute", out _) &&
+                assemblySymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DEnableRuntimeCompilationAttribute", out AttributeData? attributeData))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    D2DRuntimeCompilationOnAssemblyNotNecessary,
+                    attributeData.GetLocation(),
+                    assemblySymbol));
+            }
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/D2DEnableRuntimeCompilationOnTypeAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/D2DEnableRuntimeCompilationOnTypeAnalyzer.cs
@@ -8,16 +8,16 @@ using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 namespace ComputeSharp.D2D1.SourceGenerators;
 
 /// <summary>
-/// A diagnostic analyzer that generates an error whenever a shader is not precompiled but runtime compilation is not enabled.
+/// A diagnostic analyzer that generates diagnostics for the [D2DEnableRuntimeCompilation] attribute, when used on a type.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class D2DRuntimeCompilationDisabledAnalyzer : DiagnosticAnalyzer
+public sealed class D2DEnableRuntimeCompilationOnTypeAnalyzer : DiagnosticAnalyzer
 {
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
         D2DRuntimeCompilationDisabled,
         D2DRuntimeCompilationAlreadyEnabled,
-        D2DRuntimeCompilationNotNecessary);
+        D2DRuntimeCompilationOnTypeNotNecessary);
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -78,7 +78,7 @@ public sealed class D2DRuntimeCompilationDisabledAnalyzer : DiagnosticAnalyzer
                     if (hasD2DEnableRuntimeCompilationAttributeOnType)
                     {
                         context.ReportDiagnostic(Diagnostic.Create(
-                            D2DRuntimeCompilationNotNecessary,
+                            D2DRuntimeCompilationOnTypeNotNecessary,
                             d2DEnableRuntimeCompilationAttributeData!.GetLocation(),
                             typeSymbol));
                     }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/D2DRuntimeCompilationDisabledAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/D2DRuntimeCompilationDisabledAnalyzer.cs
@@ -1,0 +1,68 @@
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error whenever a shader is not precompiled but runtime compilation is not enabled.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class D2DRuntimeCompilationDisabledAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(D2DRuntimeCompilationDisabled);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the [D2DShaderProfile], [D2DEnableRuntimeCompilation] and [D2DGeneratedPixelShaderDescriptor] symbols
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DShaderProfileAttribute") is not { } d2DShaderProfileAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DEnableRuntimeCompilationAttribute") is not { } d2DEnableRuntimeCompilationAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DGeneratedPixelShaderDescriptorAttribute") is not { } d2DGeneratedPixelShaderDescriptorAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only struct types are possible targets
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // Skip the type if it's not a generated shader descriptor target
+                if (!typeSymbol.HasAttributeWithType(d2DGeneratedPixelShaderDescriptorAttributeSymbol))
+                {
+                    return;
+                }
+
+                // If the shader is being precompiled, we don't have anything else to do
+                if (typeSymbol.HasAttributeWithType(d2DShaderProfileAttributeSymbol) ||
+                    typeSymbol.ContainingAssembly.HasAttributeWithType(d2DShaderProfileAttributeSymbol))
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if there is no [D2DEnableRuntimeCompilation] set anywhere
+                if (!typeSymbol.HasAttributeWithType(d2DEnableRuntimeCompilationAttributeSymbol) &&
+                    !typeSymbol.ContainingAssembly.HasAttributeWithType(d2DEnableRuntimeCompilationAttributeSymbol))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        D2DRuntimeCompilationDisabled,
+                        typeSymbol.Locations.FirstOrDefault(),
+                        typeSymbol));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1127,7 +1127,7 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an invocation of a <c>Math</c> or <c>MathF</c> API.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader not precompiled but with runtime compilation disabled.
     /// <para>
     /// Format: <c>"The shader {0} is not precompiled, but runtime compilation is not enabled (either precompile the shader by using [D2DShaderProfile], which is recommended, or enable runtime compilation using [D2DEnableRuntimeCompilation])"</c>.
     /// </para>
@@ -1140,5 +1140,37 @@ partial class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Shaders must either be precompiled using [D2DShaderProfile], which is recommended, or runtime compilation for shaders must be enabled using [D2DEnableRuntimeCompilation].",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an unnecessary [D2DEnableRuntimeCompilation] use.
+    /// <para>
+    /// Format: <c>"The shader {0} is annotated with [D2DEnableRuntimeCompilation], but its containing assembly is already annotated with this attribute (so using it again on the shader type is unnecessary)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor D2DRuntimeCompilationAlreadyEnabled = new(
+        id: "CMPSD2D0077",
+        title: "D2D runtime compilation already enabled",
+        messageFormat: "The shader {0} is annotated with [D2DEnableRuntimeCompilation], but its containing assembly is already annotated with this attribute (so using it again on the shader type is unnecessary)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "If an assembly is annotated with [D2DEnableRuntimeCompilation], that applies to all shader types within it. That means that using [D2DEnableRuntimeCompilation] on shader types too is unnecessary.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an unnecessary [D2DEnableRuntimeCompilation] use.
+    /// <para>
+    /// Format: <c>"The shader {0} is annotated with [D2DEnableRuntimeCompilation], but it is also being precompiled, as it has [D2DShaderProfile] on the type or containing assembly (so using [D2DEnableRuntimeCompilation] is unnecessary)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor D2DRuntimeCompilationNotNecessary = new(
+        id: "CMPSD2D0078",
+        title: "D2D runtime compilation is not necessary",
+        messageFormat: "The shader {0} is annotated with [D2DEnableRuntimeCompilation], but it is also being precompiled, as it has [D2DShaderProfile] on the type or containing assembly (so using [D2DEnableRuntimeCompilation] is unnecessary)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "If a shader is precompiled (ie. it has [D2DShaderProfile] on the type declaration or on its containing assembly), also using [D2DEnableRuntimeCompilation] is unnecessary.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1125,4 +1125,20 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Methods from the Math and MathF types cannot be used in a shader, and equivalent APIs from the Hlsl type should be used instead.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an invocation of a <c>Math</c> or <c>MathF</c> API.
+    /// <para>
+    /// Format: <c>"The shader {0} is not precompiled, but runtime compilation is not enabled (either precompile the shader by using [D2DShaderProfile], which is recommended, or enable runtime compilation using [D2DEnableRuntimeCompilation])"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor D2DRuntimeCompilationDisabled = new(
+        id: "CMPSD2D0076",
+        title: "D2D runtime compilation disabled",
+        messageFormat: "The shader {0} is not precompiled, but runtime compilation is not enabled (either precompile the shader by using [D2DShaderProfile], which is recommended, or enable runtime compilation using [D2DEnableRuntimeCompilation])",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Shaders must either be precompiled using [D2DShaderProfile], which is recommended, or runtime compilation for shaders must be enabled using [D2DEnableRuntimeCompilation].",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1159,18 +1159,35 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an unnecessary [D2DEnableRuntimeCompilation] use.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an unnecessary [D2DEnableRuntimeCompilation] use on .
     /// <para>
     /// Format: <c>"The shader {0} is annotated with [D2DEnableRuntimeCompilation], but it is also being precompiled, as it has [D2DShaderProfile] on the type or containing assembly (so using [D2DEnableRuntimeCompilation] is unnecessary)"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor D2DRuntimeCompilationNotNecessary = new(
+    public static readonly DiagnosticDescriptor D2DRuntimeCompilationOnTypeNotNecessary = new(
         id: "CMPSD2D0078",
-        title: "D2D runtime compilation is not necessary",
+        title: "D2D runtime compilation on type is not necessary",
         messageFormat: "The shader {0} is annotated with [D2DEnableRuntimeCompilation], but it is also being precompiled, as it has [D2DShaderProfile] on the type or containing assembly (so using [D2DEnableRuntimeCompilation] is unnecessary)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "If a shader is precompiled (ie. it has [D2DShaderProfile] on the type declaration or on its containing assembly), also using [D2DEnableRuntimeCompilation] is unnecessary.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an unnecessary [D2DEnableRuntimeCompilation] use on an assembly.
+    /// <para>
+    /// Format: <c>"The assembly {0} is annotated with [D2DEnableRuntimeCompilation], but it is also has an assembly-level [D2DShaderProfile] attribute, which will cause all shaders to be precompiled (so using [D2DEnableRuntimeCompilation] is unnecessary)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor D2DRuntimeCompilationOnAssemblyNotNecessary = new(
+        id: "CMPSD2D0079",
+        title: "D2D runtime compilation on assembly is not necessary",
+        messageFormat: "The assembly {0} is annotated with [D2DEnableRuntimeCompilation], but it is also has an assembly-level [D2DShaderProfile] attribute, which will cause all shaders to be precompiled (so using [D2DEnableRuntimeCompilation] is unnecessary)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "If an assembly is using [D2DShaderProfile] (meaning that all shaders declared within it will be precompiled), also using [D2DEnableRuntimeCompilation] is unnecessary.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp",
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
 }

--- a/src/ComputeSharp.D2D1.WinUI/CanvasEffect.EffectGraph.cs
+++ b/src/ComputeSharp.D2D1.WinUI/CanvasEffect.EffectGraph.cs
@@ -228,9 +228,7 @@ partial class CanvasEffect
     /// This interface only implemented by <see cref="EffectNode{T}"/> and it's not meant to be implemented by external types.
     /// </para>
     /// </remarks>
-    protected interface IEffectNode
-    {
-    }
+    protected interface IEffectNode;
 
     /// <summary>
     /// A marker interface for a generic effect node that was registered from an <see cref="EffectGraph"/> value.
@@ -246,16 +244,12 @@ partial class CanvasEffect
     /// </para>
     /// </remarks>
     protected interface IEffectNode<out T> : IEffectNode
-        where T : ICanvasImage
-    {
-    }
+        where T : ICanvasImage;
 
     /// <summary>
     /// A marker type for an effect node that can be registered and retrieved from an <see cref="EffectGraph"/> value.
     /// </summary>
     /// <typeparam name="T">The type of <see cref="ICanvasImage"/> associated with the current effect node.</typeparam>
     protected sealed class EffectNode<T> : IEffectNode<T>
-        where T : class, ICanvasImage
-    {
-    }
+        where T : class, ICanvasImage;
 }

--- a/src/ComputeSharp.D2D1/Attributes/D2DEnableRuntimeCompilation.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DEnableRuntimeCompilation.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace ComputeSharp.D2D1;
+
+/// <summary>
+/// An attribute that indicates that runtime compilation of D2D shaders is enabled.
+/// This attribute is required for all shaders that are not compiled at build time.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Precompiling shaders at build time is recommended, as it enables additional validation
+/// and diagnostics, and provides better performance at runtime when dispatching the shaders.
+/// </para>
+/// <para>
+/// This option can be used in advanced scenarios, for instance when trying to minimize
+/// binary size (which should only be done after carefully measuring the actual difference).
+/// </para>
+/// <para>
+/// Note that not using this attribute does not mean that trying to compile shaders at runtime will
+/// fail. The purpose of this attribute is to allow declaring shader types that are not precompiled.
+/// All other features, such as manually compiling a shader type with specific compile options or
+/// with a different shader profile, or manually compiling a shader from source at runtime, are
+/// always supported, regardless of whether nor not this attribute is used.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = false)]
+public sealed class D2DEnableRuntimeCompilationAttribute : Attribute;

--- a/src/ComputeSharp.D2D1/Attributes/D2DGeneratedPixelShaderDescriptorAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DGeneratedPixelShaderDescriptorAttribute.cs
@@ -19,6 +19,4 @@ namespace ComputeSharp.D2D1;
 /// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
-public sealed class D2DGeneratedPixelShaderDescriptorAttribute : Attribute
-{
-}
+public sealed class D2DGeneratedPixelShaderDescriptorAttribute : Attribute;

--- a/src/ComputeSharp.D2D1/Attributes/D2DRequiresScenePositionAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DRequiresScenePositionAttribute.cs
@@ -12,6 +12,4 @@ namespace ComputeSharp.D2D1;
 /// <para>For more info, see <see href="https://docs.microsoft.com/en-us/windows/win32/direct2d/hlsl-helpers"/>.</para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
-public sealed class D2DRequiresScenePositionAttribute : Attribute
-{
-}
+public sealed class D2DRequiresScenePositionAttribute : Attribute;

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/DiagnosticDescriptors.cs
@@ -5,6 +5,4 @@ namespace ComputeSharp.SourceGeneration.Diagnostics;
 /// <summary>
 /// A container for all <see cref="DiagnosticDescriptor"/> instances for errors reported by analyzers in this project.
 /// </summary>
-internal static partial class DiagnosticDescriptors
-{
-}
+internal static partial class DiagnosticDescriptors;

--- a/src/ComputeSharp/Attributes/GeneratedComputeShaderDescriptorAttribute.cs
+++ b/src/ComputeSharp/Attributes/GeneratedComputeShaderDescriptorAttribute.cs
@@ -22,6 +22,4 @@ namespace ComputeSharp;
 /// </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
-public sealed class GeneratedComputeShaderDescriptorAttribute : Attribute
-{
-}
+public sealed class GeneratedComputeShaderDescriptorAttribute : Attribute;

--- a/src/ComputeSharp/Attributes/GloballyCoherentAttribute.cs
+++ b/src/ComputeSharp/Attributes/GloballyCoherentAttribute.cs
@@ -21,6 +21,4 @@ namespace ComputeSharp;
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
-public sealed class GloballyCoherentAttribute : Attribute
-{
-}
+public sealed class GloballyCoherentAttribute : Attribute;

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -196,4 +196,70 @@ public class Test_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task ShaderWithNoPrecompiledBytecode_WithNoD2DEnableRuntimeCompilation_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(0)]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal partial struct {|CMPSD2D0076:MyType|} : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ShaderWithNoPrecompiledBytecode_WithD2DEnableRuntimeCompilation_OnType_DoesNotWarn()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(0)]
+            [D2DGeneratedPixelShaderDescriptor]
+            [D2DEnableRuntimeCompilation]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ShaderWithNoPrecompiledBytecode_WithD2DEnableRuntimeCompilation_OnAssembly_DoesNotWarn()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [assembly: D2DEnableRuntimeCompilation]
+
+            [D2DInputCount(0)]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -262,4 +262,75 @@ public class Test_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task ShaderWithNoPrecompiledBytecode_WithUnnecessaryD2DEnableRuntimeCompilation_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [assembly: D2DEnableRuntimeCompilation]
+
+            [D2DInputCount(0)]
+            [{|CMPSD2D0077:D2DEnableRuntimeCompilation|}]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ShaderWithPrecompiledBytecode_FromAssembly_WithUnnecessaryD2DEnableRuntimeCompilation_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [assembly: D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+
+            [D2DInputCount(0)]
+            [{|CMPSD2D0078:D2DEnableRuntimeCompilation|}]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ShaderWithPrecompiledBytecode_FromType_WithUnnecessaryD2DEnableRuntimeCompilation_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(0)]
+            [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+            [{|CMPSD2D0078:D2DEnableRuntimeCompilation|}]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -215,7 +215,7 @@ public class Test_Analyzers
             }
             """;
 
-        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnTypeAnalyzer>.VerifyAnalyzerAsync(source);
     }
 
     [TestMethod]
@@ -237,7 +237,7 @@ public class Test_Analyzers
             }
             """;
 
-        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnTypeAnalyzer>.VerifyAnalyzerAsync(source);
     }
 
     [TestMethod]
@@ -260,7 +260,7 @@ public class Test_Analyzers
             }
             """;
 
-        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnTypeAnalyzer>.VerifyAnalyzerAsync(source);
     }
 
     [TestMethod]
@@ -284,7 +284,7 @@ public class Test_Analyzers
             }
             """;
 
-        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnTypeAnalyzer>.VerifyAnalyzerAsync(source);
     }
 
     [TestMethod]
@@ -308,7 +308,7 @@ public class Test_Analyzers
             }
             """;
 
-        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnTypeAnalyzer>.VerifyAnalyzerAsync(source);
     }
 
     [TestMethod]
@@ -331,6 +331,19 @@ public class Test_Analyzers
             }
             """;
 
-        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task UnnecessaryD2DEnableRuntimeCompilation_OnAssembly_Warns()
+    {
+        const string source = """
+            using ComputeSharp.D2D1;
+
+            [assembly: D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+            [assembly: {|CMPSD2D0079:D2DEnableRuntimeCompilation|}]
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnAssemblyAnalyzer>.VerifyAnalyzerAsync(source);
     }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
@@ -30,6 +30,8 @@ public class Test_D2DPixelShaderSourceGenerator
             using float3 = global::ComputeSharp.Float3;
             using float4 = global::ComputeSharp.Float4;
 
+            [assembly: D2DEnableRuntimeCompilation]
+
             namespace MyNamespace;
 
             [D2DInputCount(0)]
@@ -679,6 +681,8 @@ public class Test_D2DPixelShaderSourceGenerator
             using float3 = global::ComputeSharp.Float3;
             using float4 = global::ComputeSharp.Float4;
 
+            [assembly: D2DEnableRuntimeCompilation]
+
             namespace MyNamespace;
 
             [D2DEffectId("B30E1384-DEE1-4200-9312-321521DF3B00")]
@@ -985,6 +989,8 @@ public class Test_D2DPixelShaderSourceGenerator
             using float3 = global::ComputeSharp.Float3;
             using float4 = global::ComputeSharp.Float4;
 
+            [assembly: D2DEnableRuntimeCompilation]
+
             namespace MyNamespace;
 
             [D2DInputCount(0)]
@@ -1280,6 +1286,8 @@ public class Test_D2DPixelShaderSourceGenerator
             using ComputeSharp.D2D1;
             using float4 = global::ComputeSharp.Float4;
 
+            [assembly: D2DEnableRuntimeCompilation]
+
             namespace MyNamespace;
 
             [D2DInputCount(2)]
@@ -1566,6 +1574,8 @@ public class Test_D2DPixelShaderSourceGenerator
             using int2 = global::ComputeSharp.Int2;
             using float4 = global::ComputeSharp.Float4;
 
+            [assembly: D2DEnableRuntimeCompilation]
+
             namespace MyNamespace;
 
             [D2DInputCount(0)]
@@ -1802,6 +1812,7 @@ public class Test_D2DPixelShaderSourceGenerator
     private static async Task VerifyGeneratedDiagnosticsAsync(string source, (string Filename, string Source) result)
     {
         // Also validate all analyzers
+        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidAssemblyLevelCompileOptionsAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
@@ -1812,7 +1812,8 @@ public class Test_D2DPixelShaderSourceGenerator
     private static async Task VerifyGeneratedDiagnosticsAsync(string source, (string Filename, string Source) result)
     {
         // Also validate all analyzers
-        await CSharpAnalyzerWithLanguageVersionTest<D2DRuntimeCompilationDisabledAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnAssemblyAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnTypeAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidAssemblyLevelCompileOptionsAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderEffectTests.cs
@@ -1,11 +1,14 @@
 using System;
 using System.ComponentModel;
+using ComputeSharp.D2D1;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.Tests.Effects;
 using ComputeSharp.D2D1.Tests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
+
+[assembly: D2DEnableRuntimeCompilation]
 
 #pragma warning disable IDE0022, IDE0044
 

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/PixelShaderEffectTests.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using ComputeSharp.D2D1;
 using ComputeSharp.D2D1.Interop;
 using ComputeSharp.D2D1.WinUI.Tests.Helpers;
 using Microsoft.Graphics.Canvas;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TerraFX.Interop.DirectX;
 using TerraFX.Interop.Windows;
+
+[assembly: D2DEnableRuntimeCompilation]
 
 namespace ComputeSharp.D2D1.WinUI.Tests;
 

--- a/tests/ComputeSharp.Tests/Attributes/AllDevicesAttribute.cs
+++ b/tests/ComputeSharp.Tests/Attributes/AllDevicesAttribute.cs
@@ -6,6 +6,4 @@ namespace ComputeSharp.Tests.Attributes;
 /// An attribute to use with <see cref="CombinatorialTestMethodAttribute"/> targeting all supported devices.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-public sealed class AllDevicesAttribute : Attribute
-{
-}
+public sealed class AllDevicesAttribute : Attribute;

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -838,9 +838,7 @@ namespace ComputeSharp.Tests
         [AutoConstructor]
         [ThreadGroupSize(DefaultThreadGroupSizes.X)]
         [GeneratedComputeShaderDescriptor]
-        internal readonly partial struct ShaderWithPartialDeclarations : IComputeShader
-        {
-        }
+        internal readonly partial struct ShaderWithPartialDeclarations : IComputeShader;
 
         partial struct ShaderWithPartialDeclarations
         {


### PR DESCRIPTION
### Contributes to #523

### Description

This PR adds a new `[D2DEnableRuntimeCompilation]` attribute, which makes runtime compilation of D2D shaders be opt-in. This helps developers (especially beginners) to avoid accidentally not precompiling shaders. That is now an explicit action for them.

There's also several new diagnostics to spot all possible mistakes when using the new attribute.