### PR TITLE
Add [RequiresDoublePrecisionSupport] attribute

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>$(DefineConstants);D2D1_GENERATOR</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.cs
@@ -202,7 +202,7 @@ partial class D2DPixelShaderDescriptorGenerator
                     token.ThrowIfCancellationRequested();
 
                     // Compile the shader bytecode using the effective parameters
-                    using ComPtr<ID3DBlob> dxcBlobBytecode = D3DCompiler.Compile(
+                    using ComPtr<ID3DBlob> d3DBlob = D3DCompiler.Compile(
                         key.HlslSource.AsSpan(),
                         key.ShaderProfile,
                         key.CompileOptions);
@@ -210,12 +210,12 @@ partial class D2DPixelShaderDescriptorGenerator
                     token.ThrowIfCancellationRequested();
 
                     // Check whether double precision operations are required
-                    bool requiresDoublePrecisionSupport = D3DCompiler.IsDoublePrecisionSupportRequired(dxcBlobBytecode.Get());
+                    bool requiresDoublePrecisionSupport = D3DCompiler.IsDoublePrecisionSupportRequired(d3DBlob.Get());
 
                     token.ThrowIfCancellationRequested();
 
-                    byte* buffer = (byte*)dxcBlobBytecode.Get()->GetBufferPointer();
-                    int length = checked((int)dxcBlobBytecode.Get()->GetBufferSize());
+                    byte* buffer = (byte*)d3DBlob.Get()->GetBufferPointer();
+                    int length = checked((int)d3DBlob.Get()->GetBufferSize());
 
                     byte[] array = new ReadOnlySpan<byte>(buffer, length).ToArray();
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.cs
@@ -257,14 +257,17 @@ partial class D2DPixelShaderDescriptorGenerator
                 diagnostic = DiagnosticInfo.Create(
                     HlslBytecodeFailedWithWin32Exception,
                     structDeclarationSymbol,
-                    [structDeclarationSymbol, win32Error.HResult, win32Error.Message]);
+                    structDeclarationSymbol,
+                    win32Error.HResult,
+                    win32Error.Message);
             }
             else if (info is HlslBytecodeInfo.CompilerError fxcError)
             {
                 diagnostic = DiagnosticInfo.Create(
                     HlslBytecodeFailedWithFxcCompilationException,
                     structDeclarationSymbol,
-                    [structDeclarationSymbol, fxcError.Message]);
+                    structDeclarationSymbol,
+                    fxcError.Message);
             }
 
             if (diagnostic is not null)

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -140,14 +140,19 @@ partial class D2DPixelShaderSourceGenerator
                 diagnostic = DiagnosticInfo.Create(
                     D2DPixelShaderSourceCompilationFailedWithWin32Exception,
                     methodSymbol,
-                    [methodSymbol, methodSymbol.ContainingType, win32Error.HResult, win32Error.Message]);
+                    methodSymbol,
+                    methodSymbol.ContainingType,
+                    win32Error.HResult,
+                    win32Error.Message);
             }
             else if (info is HlslBytecodeInfo.CompilerError fxcError)
             {
                 diagnostic = DiagnosticInfo.Create(
                     D2DPixelShaderSourceCompilationFailedWithFxcCompilationException,
                     methodSymbol,
-                    [methodSymbol, methodSymbol.ContainingType, fxcError.Message]);
+                    methodSymbol,
+                    methodSymbol.ContainingType,
+                    fxcError.Message);
             }
 
             if (diagnostic is not null)

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1194,21 +1194,21 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for a shader missing [D2DRequiresDoublePrecisionSupport].
     /// <para>
-    /// Format: <c>"The shader {0} requires double precision support, but it does not have the [D2DRequiresDoublePrecisionSupport] attribute on it (adding the attribute is necessary to explicitly opt-in into that functionality)"</c>.
+    /// Format: <c>"The shader {0} requires double precision support, but it does not have the [D2DRequiresDoublePrecisionSupport] attribute on it (adding the attribute is necessary to explicitly opt-in to that functionality)"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor MissingD2DRequiresDoublePrecisionSupportAttribute = new(
         id: "CMPSD2D0080",
         title: "Missing [D2DRequiresDoublePrecisionSupport] attribute",
-        messageFormat: "The shader {0} requires double precision support, but it does not have the [D2DRequiresDoublePrecisionSupport] attribute on it (adding the attribute is necessary to explicitly opt-in into that functionality)",
+        messageFormat: "The shader {0} requires double precision support, but it does not have the [D2DRequiresDoublePrecisionSupport] attribute on it (adding the attribute is necessary to explicitly opt-in to that functionality)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Shaders performing double precision operations must be annotated with [D2DRequiresDoublePrecisionSupport] to explicitly opt-in into that functionality.",
+        description: "Shaders performing double precision operations must be annotated with [D2DRequiresDoublePrecisionSupport] to explicitly opt-in to that functionality.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader is unnecessarily using [UnnecessaryD2DRequiresDoublePrecisionSupportAttribute].
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader is unnecessarily using [D2DRequiresDoublePrecisionSupport].
     /// <para>
     /// Format: <c>"The shader {0} does not require double precision support, but it has the [D2DRequiresDoublePrecisionSupport] attribute on it (using the attribute is not needed if the shader is not performing any double precision operations)"</c>.
     /// </para>
@@ -1224,7 +1224,7 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader is using [UnnecessaryD2DRequiresDoublePrecisionSupportAttribute] incorrectly.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader is using [D2DRequiresDoublePrecisionSupport] incorrectly.
     /// <para>
     /// Format: <c>"The shader {0} has the [D2DRequiresDoublePrecisionSupport] attribute on it, but it is not precompiled, so validation for use of double precision operations cannot be performed"</c>.
     /// </para>

--- a/src/ComputeSharp.D2D1.SourceGenerators/Fxc/D3DCompiler.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Fxc/D3DCompiler.cs
@@ -26,7 +26,7 @@ partial class D3DCompiler
             pInterface: &iidOfID3D11ShaderReflection,
             ppReflector: (void**)d3D11ShaderReflection.GetAddressOf()).Assert();
 
-        ulong doublePrecisionFlags = DirectX.D3D_SHADER_REQUIRES_DOUBLES | DirectX.D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS;
+        const ulong doublePrecisionFlags = DirectX.D3D_SHADER_REQUIRES_DOUBLES | DirectX.D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS;
 
         return (d3D11ShaderReflection.Get()->GetRequiresFlags() & doublePrecisionFlags) != 0;
     }

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Models/HlslBytecodeInfo.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Models/HlslBytecodeInfo.cs
@@ -11,17 +11,8 @@ internal abstract record HlslBytecodeInfo
     /// A successfully compiled HLSL shader.
     /// </summary>
     /// <param name="Bytecode">The resulting HLSL bytecode.</param>
-    public sealed record Success(
-#if D3D12_GENERATOR
-        EquatableArray<byte> Bytecode)
-#else
-
-#pragma warning disable CS1573
-        EquatableArray<byte> Bytecode,
-        bool RequiresDoublePrecisionSupport) // Whether the shader requires support for double precision operations.
-#pragma warning restore CS1573
-#endif
-        : HlslBytecodeInfo;
+    /// <param name="RequiresDoublePrecisionSupport">Whether the shader requires support for double precision operations.</param>
+    public sealed record Success(EquatableArray<byte> Bytecode, bool RequiresDoublePrecisionSupport) : HlslBytecodeInfo;
 
     /// <summary>
     /// An HLSL shader that failed to compile due to a Win32 error.

--- a/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -69,3 +69,5 @@ CMPS0060 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Ser
 CMPS0061 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0062 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPS0063 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPS0064 | ComputeSharp.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPS0065 | ComputeSharp.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
@@ -62,6 +62,11 @@ partial class ComputeShaderDescriptorGenerator
 
                     token.ThrowIfCancellationRequested();
 
+                    // Check whether double precision operations are required
+                    bool requiresDoublePrecisionSupport = DxcShaderCompiler.Instance.IsDoublePrecisionSupportRequired(dxcBlob.Get());
+
+                    token.ThrowIfCancellationRequested();
+
                     byte* buffer = (byte*)dxcBlob.Get()->GetBufferPointer();
                     int length = checked((int)dxcBlob.Get()->GetBufferSize());
 
@@ -69,7 +74,7 @@ partial class ComputeShaderDescriptorGenerator
 
                     ImmutableArray<byte> bytecode = Unsafe.As<byte[], ImmutableArray<byte>>(ref array);
 
-                    return new HlslBytecodeInfo.Success(bytecode);
+                    return new HlslBytecodeInfo.Success(bytecode, requiresDoublePrecisionSupport);
                 }
                 catch (Win32Exception e)
                 {

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using System.Threading;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
@@ -78,11 +77,11 @@ partial class ComputeShaderDescriptorGenerator
                 }
                 catch (Win32Exception e)
                 {
-                    return new HlslBytecodeInfo.Win32Error(e.NativeErrorCode, FixupExceptionMessage(e.Message));
+                    return new HlslBytecodeInfo.Win32Error(e.NativeErrorCode, DxcShaderCompiler.FixupExceptionMessage(e.Message));
                 }
                 catch (DxcCompilationException e)
                 {
-                    return new HlslBytecodeInfo.CompilerError(FixupExceptionMessage(e.Message));
+                    return new HlslBytecodeInfo.CompilerError(DxcShaderCompiler.FixupExceptionMessage(e.Message));
                 }
             }
 
@@ -139,25 +138,6 @@ partial class ComputeShaderDescriptorGenerator
             {
                 diagnostics.Add(diagnostic);
             }
-        }
-
-        /// <summary>
-        /// Fixes up an exception message to improve the way it's displayed in VS.
-        /// </summary>
-        /// <param name="message">The input exception message.</param>
-        /// <returns>The updated exception message.</returns>
-        private static string FixupExceptionMessage(string message)
-        {
-            // Add square brackets around error headers
-            message = Regex.Replace(message, @"^(error|warning):", static m => $"[{m.Groups[1].Value}]:", RegexOptions.Multiline);
-
-            // Remove lines with notes
-            message = Regex.Replace(message, @"^note:.+", string.Empty, RegexOptions.Multiline);
-
-            // Remove syntax error indicators
-            message = Regex.Replace(message, @"^ +\^", string.Empty, RegexOptions.Multiline);
-
-            return message.NormalizeToSingleLine();
         }
     }
 }

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
@@ -124,14 +124,17 @@ partial class ComputeShaderDescriptorGenerator
                 diagnostic = DiagnosticInfo.Create(
                     HlslBytecodeFailedWithWin32Exception,
                     structDeclarationSymbol,
-                    [structDeclarationSymbol, win32Error.HResult, win32Error.Message]);
+                    structDeclarationSymbol,
+                    win32Error.HResult,
+                    win32Error.Message);
             }
             else if (info is HlslBytecodeInfo.CompilerError dxcError)
             {
                 diagnostic = DiagnosticInfo.Create(
                     HlslBytecodeFailedWithDxcCompilationException,
                     structDeclarationSymbol,
-                    [structDeclarationSymbol, dxcError.Message]);
+                    structDeclarationSymbol,
+                    dxcError.Message);
             }
 
             if (diagnostic is not null)

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -122,6 +122,7 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                     token.ThrowIfCancellationRequested();
 
                     HlslBytecode.GetInfoDiagnostics(typeSymbol, hlslInfo, diagnostics);
+                    HlslBytecode.GetDoublePrecisionSupportDiagnostics(typeSymbol, hlslInfo, diagnostics);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <DefineConstants>$(DefineConstants);D3D12_GENERATOR</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -901,4 +901,36 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Methods from the Math and MathF types cannot be used in a shader, and equivalent APIs from the Hlsl type should be used instead.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader missing [RequiresDoublePrecisionSupport].
+    /// <para>
+    /// Format: <c>"The shader {0} requires double precision support, but it does not have the [RequiresDoublePrecisionSupport] attribute on it (adding the attribute is necessary to explicitly opt-in to that functionality)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor MissingRequiresDoublePrecisionSupportAttribute = new(
+        id: "CMPS0064",
+        title: "Missing [RequiresDoublePrecisionSupport] attribute",
+        messageFormat: "The shader {0} requires double precision support, but it does not have the [RequiresDoublePrecisionSupport] attribute on it (adding the attribute is necessary to explicitly opt-in to that functionality)",
+        category: "ComputeSharp.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Shaders performing double precision operations must be annotated with [RequiresDoublePrecisionSupport] to explicitly opt-in to that functionality.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader is unnecessarily using [RequiresDoublePrecisionSupportAttribute].
+    /// <para>
+    /// Format: <c>"The shader {0} does not require double precision support, but it has the [RequiresDoublePrecisionSupport] attribute on it (using the attribute is not needed if the shader is not performing any double precision operations)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor UnnecessaryRequiresDoublePrecisionSupportAttribute = new(
+        id: "CMPS0065",
+        title: "Unnecessary [RequiresDoublePrecisionSupport] attribute",
+        messageFormat: "The shader {0} does not require double precision support, but it has the [RequiresDoublePrecisionSupport] attribute on it (using the attribute is not needed if the shader is not performing any double precision operations)",
+        category: "ComputeSharp.Shaders",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Shaders not performing any double precision operations should not be annotated with [RequiresDoublePrecisionSupport], as the attribute is not needed in that case.",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.SourceGenerators/Dxc/DxcShaderCompiler.cs
+++ b/src/ComputeSharp.SourceGenerators/Dxc/DxcShaderCompiler.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
+using ComputeSharp.SourceGeneration.Extensions;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.Graphics.Direct3D.Dxc;
@@ -272,6 +273,25 @@ internal sealed unsafe class DxcShaderCompiler
         const ulong doublePrecisionFlags = DirectX.D3D_SHADER_REQUIRES_DOUBLES | DirectX.D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS;
 
         return (d3D12ShaderReflection.Get()->GetRequiresFlags() & doublePrecisionFlags) != 0;
+    }
+
+    /// <summary>
+    /// Fixes up an exception message to improve the way it's displayed in VS.
+    /// </summary>
+    /// <param name="message">The input exception message.</param>
+    /// <returns>The updated exception message.</returns>
+    public static string FixupExceptionMessage(string message)
+    {
+        // Add square brackets around error headers
+        message = Regex.Replace(message, @"^(error|warning):", static m => $"[{m.Groups[1].Value}]:", RegexOptions.Multiline);
+
+        // Remove lines with notes
+        message = Regex.Replace(message, @"^note:.+", string.Empty, RegexOptions.Multiline);
+
+        // Remove syntax error indicators
+        message = Regex.Replace(message, @"^ +\^", string.Empty, RegexOptions.Multiline);
+
+        return message.NormalizeToSingleLine();
     }
 
     /// <summary>

--- a/src/ComputeSharp.SourceGenerators/NativeMethods.txt
+++ b/src/ComputeSharp.SourceGenerators/NativeMethods.txt
@@ -1,6 +1,9 @@
 CLSID_DxcCompiler
 CLSID_DxcLibrary
 DxcCreateInstance
+D3D_SHADER_REQUIRES_DOUBLES
+D3D_SHADER_REQUIRES_11_1_DOUBLE_EXTENSIONS
+ID3D12ShaderReflection
 IDxcCompiler3
 IDxcUtils
 IDxcResult

--- a/src/ComputeSharp/Attributes/RequiresDoublePrecisionSupportAttribute.cs
+++ b/src/ComputeSharp/Attributes/RequiresDoublePrecisionSupportAttribute.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace ComputeSharp;
+
+/// <summary>
+/// An attribute for a compute shader indicating that the shader requires support for double precision operations.
+/// </summary>
+/// <remarks>
+/// This attribute does not map to any HLSL feature or compile option directly, but it is needed to make using double
+/// precision operations opt-in. It is easy to accidentally introduce them in a shader when that is not intented, and
+/// doing so can make the shader run slower and not being compatible with some GPUs (eg. many arm64 GPUs lack support
+/// for double precision operations). To avoid this, support is disabled by default, and it is necessary to add this
+/// attribute over a shader type to explicitly allow using these operations.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Struct, AllowMultiple = false)]
+public sealed class RequiresDoublePrecisionSupportAttribute : Attribute;

--- a/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/DiagnosticsTests.cs
@@ -1639,6 +1639,57 @@ public class DiagnosticsTests
         VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0046");
     }
 
+    [TestMethod]
+    public void MissingRequiresDoublePrecisionSupportAttribute()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            namespace MyNamespace;
+
+            [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+            [GeneratedComputeShaderDescriptor]
+            internal readonly partial struct MyShader : IComputeShader
+            {
+                private readonly ReadWriteBuffer<float> results;
+                private readonly float time;
+
+                public void Execute()
+                {
+                    results[ThreadIds.X] = (float)(Hlsl.Abs(time * 2.0));
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0064");
+    }
+
+    [TestMethod]
+    public void UnnecessaryRequiresDoublePrecisionSupportAttribute()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            namespace MyNamespace;
+
+            [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+            [RequiresDoublePrecisionSupport]
+            [GeneratedComputeShaderDescriptor]
+            internal readonly partial struct MyShader : IComputeShader
+            {
+                private readonly ReadWriteBuffer<float> results;
+                private readonly float time;
+
+                public void Execute()
+                {
+                    results[ThreadIds.X] = (float)(time * 2.0f);
+                }
+            }
+            """;
+
+        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0065");
+    }
+
     /// <summary>
     /// Verifies the output of a source generator.
     /// </summary>

--- a/tests/ComputeSharp.Tests/BufferTests.cs
+++ b/tests/ComputeSharp.Tests/BufferTests.cs
@@ -375,6 +375,7 @@ public partial class BufferTests
 
     [AutoConstructor]
     [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+    [RequiresDoublePrecisionSupport]
     [GeneratedComputeShaderDescriptor]
     public readonly partial struct DoublePrecisionSupportShader : IComputeShader
     {

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -361,6 +361,7 @@ namespace ComputeSharp.Tests
 
         [AutoConstructor]
         [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+        [RequiresDoublePrecisionSupport]
         [GeneratedComputeShaderDescriptor]
         public readonly partial struct DoublePrecisionSupportShader : IComputeShader
         {

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -52,6 +52,7 @@ public partial class ShaderRewriterTests
 
     [AutoConstructor]
     [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+    [RequiresDoublePrecisionSupport]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct NanAndInfiniteShader : IComputeShader
     {
@@ -622,6 +623,7 @@ public partial class ShaderRewriterTests
 
     [AutoConstructor]
     [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+    [RequiresDoublePrecisionSupport]
     [GeneratedComputeShaderDescriptor]
     internal readonly partial struct DoubleConstantsInShaderConstantFieldsShader : IComputeShader
     {


### PR DESCRIPTION
### Related to #523, follow up to #721

### Description

This PR adds the new `[RequiresDoublePrecisionSupport]` attribute, which is now required to have a DX12 shader that uses double precision operations. If the attribute is used incorrectly (missing, unnecessary, or invalid), there's also new diagnostics being produced. This will make it easier for developers to spot shaders accidentally using double precision operations, which makes them both slower and also potentially not compatible at all with several GPUs (eg. many arm64 integrated GPUs).