### PR TITLE
Support 'this.' expressions within custom types

### DIFF
--- a/tests/ComputeSharp.D2D1.Tests/Effects/InvertWithUserTypeAndMutuallyInvokingMethods.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/InvertWithUserTypeAndMutuallyInvokingMethods.cs
@@ -6,9 +6,9 @@ public struct ColorWrapperUsingExternalType
 {
     private float4 value;
 
-    public ColorWrapperUsingExternalType(float4 color)
+    public ColorWrapperUsingExternalType(float4 value)
     {
-        this.value = color;
+        this.value = value;
     }
 
     public readonly float4 Invert()

--- a/tests/ComputeSharp.D2D1.Tests/Effects/InvertWithUserTypeWithConstructorEffect.cs
+++ b/tests/ComputeSharp.D2D1.Tests/Effects/InvertWithUserTypeWithConstructorEffect.cs
@@ -6,9 +6,9 @@ public struct ColorWrapper
 {
     private float4 value;
 
-    public ColorWrapper(float4 color)
+    public ColorWrapper(float4 value)
     {
-        this.value = color;
+        this.value = value;
     }
 
     public float4 Invert()


### PR DESCRIPTION
### Closes #726

### Description

This PR improves the handling of `this.` expressions, so that:
- They're elided when accessing instance members of the shader type (those fields are readonly anyway)
- They're preserved when accessing instance members of custom types (HLSL does support `this.` in this case)