### PR TITLE
Fix support for ComputeSharp.Bool shader fields

### DIFF
--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -1232,5 +1232,34 @@ namespace ComputeSharp.D2D1.Tests
             // Just a sanity check that the generated code is present
             Assert.AreEqual(0, D2D1PixelShader.GetInputCount<ContainingClass.ContainingRecord.ContainingStruct.ContainingRecordStruct.IContainingInterface.DeeplyNestedShader>());
         }
+
+        // https://github.com/Sergio0694/ComputeSharp/issues/727
+        [TestMethod]
+        public unsafe void ShaderWithComputeSharpBoolInstanceField_IsMarshalledCorrectly()
+        {
+            Assert.AreEqual(4, D2D1PixelShader.GetConstantBufferSize<ShaderWithComputeSharpBoolInstanceField>());
+
+            ShaderWithComputeSharpBoolInstanceField shader = new(true);
+
+            ReadOnlyMemory<byte> memory = D2D1PixelShader.GetConstantBuffer(in shader);
+
+            ShaderWithComputeSharpBoolInstanceField roundTrip = D2D1PixelShader.CreateFromConstantBuffer<ShaderWithComputeSharpBoolInstanceField>(memory.Span);
+
+            Assert.IsTrue(shader.value);
+        }
+
+        [D2DInputCount(0)]
+        [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+        [D2DGeneratedPixelShaderDescriptor]
+        [AutoConstructor]
+        internal readonly partial struct ShaderWithComputeSharpBoolInstanceField : ID2D1PixelShader
+        {
+            public readonly Bool value;
+
+            public float4 Execute()
+            {
+                return Hlsl.BoolToFloat(this.value);
+            }
+        }
     }
 }

--- a/tests/ComputeSharp.Tests/ShaderMembersTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderMembersTests.cs
@@ -122,7 +122,7 @@ public partial class ShaderMembersTests
         public readonly bool g;
         public readonly bool2 h;
         public readonly int i;
-        public readonly bool j;
+        public readonly ComputeSharp.Bool j; // See https://github.com/Sergio0694/ComputeSharp/issues/727
 
         public void Execute()
         {


### PR DESCRIPTION
### Closes #727

### Description

This PR fixes the DX12/D2D generators not marshalling `ComputeSharp.Bool` fields correctly.