### PR TITLE
Centralize and cleanup NoWarn properties

### DIFF
--- a/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
+++ b/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
+++ b/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.Sample.FSharp.Shaders/ComputeSharp.Sample.FSharp.Shaders.csproj
+++ b/samples/ComputeSharp.Sample.FSharp.Shaders/ComputeSharp.Sample.FSharp.Shaders.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.Sample/ComputeSharp.Sample.csproj
+++ b/samples/ComputeSharp.Sample/ComputeSharp.Sample.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
@@ -10,7 +10,6 @@
     <OutputType Condition="'$(CI_RUNNER_SAMPLES_INTEGRATION_TESTS)' != 'true'">WinExe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
-    <NoWarn>$(NoWarn);CA1416</NoWarn>
     <AssemblyName>computesharp.cli</AssemblyName>
 
     <!-- When explicitly optimizing for size, strip the icon (which adds about 100 KB of binary size) -->

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -6,15 +6,20 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platforms>x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
-    <NoWarn>$(NoWarn);IDE0065</NoWarn>
     <AssemblyName>computesharp.d2d1.cli</AssemblyName>
     <ApplicationIcon>..\..\assets\icon.ico</ApplicationIcon>
   </PropertyGroup>
 
   <PropertyGroup>
 
+    <!-- Suppress warnings for using directives inside namespaces (needed to avoid some WinRT conflicts) -->
+    <NoWarn>$(NoWarn);IDE0065</NoWarn>
+
     <!-- Workaround for WinRT.TypeExtensions.GetAuthoringMetadataType(Type) trim warning (see https://github.com/microsoft/CsWinRT/issues/1319) -->
     <NoWarn>$(NoWarn);IL2104;IL2026</NoWarn>
+
+    <!-- Workaround for WinRT.Runtime and System.Linq.Expressions producing trim warnings -->
+    <NoWarn>$(NoWarn);IL3053</NoWarn>
   </PropertyGroup>
 
   <!-- Options for R2R publishing -->
@@ -32,9 +37,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
     <StackTraceSupport>false</StackTraceSupport>
     <OptimizationPreference>Speed</OptimizationPreference>
-
-    <!-- Workaround for WinRT.Runtime and System.Linq.Expressions producing trim warnings -->
-    <NoWarn>$(NoWarn);IL3053</NoWarn>
   </PropertyGroup>
 
   <!-- Also include the .rd.xml file to fix some NativeAOT issues with CsWinRT -->

--- a/samples/ComputeSharp.SwapChain/ComputeSharp.SwapChain.csproj
+++ b/samples/ComputeSharp.SwapChain/ComputeSharp.SwapChain.csproj
@@ -3,7 +3,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <Platforms>x64;ARM64</Platforms>
-    <NoWarn>$(NoWarn);CA1416;IDE0210</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -6,8 +6,8 @@
     <!-- Samples don't need public XML docs for all APIs -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
-    <!-- Ignore obsolete warnings (due to APIs pending removal for 3.0) -->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <!-- Ignore platform compatibility warnings -->
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
   <!-- Reference PolySharp for all sample projects -->

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,9 +6,6 @@
     <!-- Test projects never need to be packaged -->
     <IsPackable>false</IsPackable>
 
-    <!-- Ignore warnings for ambiguous XML docs (to remove after renaming ComputeSharp Win32 bindings) -->
-    <NoWarn>$(NoWarn);CS0419</NoWarn>
-
     <!-- Unit tests don't need public XML docs -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
@@ -17,9 +14,6 @@
 
     <!-- Missing readonly modifier for readonly struct members (not needed in tests) -->
     <NoWarn>$(NoWarn);IDE0251</NoWarn>
-
-    <!-- Ignore obsolete warnings (due to APIs pending removal for 3.0) -->
-    <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
 
   <!-- Reference PolySharp for all test projects -->


### PR DESCRIPTION
### Description

This PR removes some unnecessary `NoWarn` properties, and centralizes others across all applicable projects.