### PR TITLE
Remove header from generated HLSL sources

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslSource.cs
@@ -480,8 +480,6 @@ partial class D2DPixelShaderDescriptorGenerator
         {
             using IndentedTextWriter writer = new();
 
-            HlslSourceSyntaxProcessor.WriteHeader(writer);
-
             // Shader metadata
             writer.WriteLine($"#define D2D_INPUT_COUNT {inputCount}");
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslSourceSyntaxProcessor.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslSourceSyntaxProcessor.cs
@@ -9,23 +9,6 @@ namespace ComputeSharp.SourceGeneration.SyntaxProcessors;
 internal static class HlslSourceSyntaxProcessor
 {
     /// <summary>
-    /// Writes the header included at the top of each generated HLSL shader.
-    /// </summary>
-    /// <param name="writer">The <see cref="IndentedTextWriter"/> instance to write into.</param>
-    public static void WriteHeader(IndentedTextWriter writer)
-    {
-        writer.WriteLine("""
-            // ================================================
-            //                  AUTO GENERATED
-            // ================================================
-            // This shader was created by ComputeSharp.
-            // See: https://github.com/Sergio0694/ComputeSharp.
-            """, isMultiline: true);
-
-        writer.WriteLine();
-    }
-
-    /// <summary>
     /// Writes the top declarations in each generated HLSL shader:
     /// <list type="bullet">
     ///   <item>Defined constants.</item>

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -521,8 +521,6 @@ partial class ComputeShaderDescriptorGenerator
         {
             using IndentedTextWriter writer = new();
 
-            HlslSourceSyntaxProcessor.WriteHeader(writer);
-
             // Group size constants
             writer.WriteLine($"#define __GroupSize__get_X {threadsX}");
             writer.WriteLine($"#define __GroupSize__get_Y {threadsY}");

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator.cs
@@ -185,12 +185,6 @@ public class Test_D2DPixelShaderSourceGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define D2D_INPUT_COUNT 0
                         #define D2D_REQUIRES_SCENE_POSITION
 
@@ -487,12 +481,6 @@ public class Test_D2DPixelShaderSourceGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define D2D_INPUT_COUNT 0
                         #define D2D_REQUIRES_SCENE_POSITION
 
@@ -841,12 +829,6 @@ public class Test_D2DPixelShaderSourceGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define D2D_INPUT_COUNT 0
                         #define D2D_REQUIRES_SCENE_POSITION
 
@@ -1141,12 +1123,6 @@ public class Test_D2DPixelShaderSourceGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define D2D_INPUT_COUNT 0
                         #define D2D_REQUIRES_SCENE_POSITION
 
@@ -1438,12 +1414,6 @@ public class Test_D2DPixelShaderSourceGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define D2D_INPUT_COUNT 2
                         #define D2D_INPUT0_SIMPLE
                         #define D2D_INPUT1_COMPLEX
@@ -1727,12 +1697,6 @@ public class Test_D2DPixelShaderSourceGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define D2D_INPUT_COUNT 0
                         #define D2D_REQUIRES_SCENE_POSITION
 

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
@@ -19,12 +19,6 @@ public partial class D2D1ReflectionServicesTests
         Assert.IsNotNull(shaderInfo.CompilerVersion);
 
         Assert.AreEqual("""
-            // ================================================
-            //                  AUTO GENERATED
-            // ================================================
-            // This shader was created by ComputeSharp.
-            // See: https://github.com/Sergio0694/ComputeSharp.
-
             #define D2D_INPUT_COUNT 3
             #define D2D_INPUT0_SIMPLE
             #define D2D_INPUT1_COMPLEX
@@ -103,12 +97,6 @@ public partial class D2D1ReflectionServicesTests
         Assert.IsNotNull(shaderInfo.CompilerVersion);
 
         Assert.AreEqual("""
-            // ================================================
-            //                  AUTO GENERATED
-            // ================================================
-            // This shader was created by ComputeSharp.
-            // See: https://github.com/Sergio0694/ComputeSharp.
-
             #define D2D_INPUT_COUNT 1
 
             #include "d2d1effecthelpers.hlsli"

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ShaderCompilerTests.cs
@@ -236,12 +236,6 @@ public partial class D2D1ShaderCompilerTests
     public void CompileShaderWithWarning()
     {
         const string source = """
-            // ================================================
-            //                  AUTO GENERATED
-            // ================================================
-            // This shader was created by ComputeSharp.
-            // See: https://github.com/Sergio0694/ComputeSharp.
-
             #define D2D_INPUT_COUNT 0
 
             #include "d2d1effecthelpers.hlsli"
@@ -268,12 +262,6 @@ public partial class D2D1ShaderCompilerTests
     public void CompileShaderWithWarning_Suppressed()
     {
         const string source = """
-            // ================================================
-            //                  AUTO GENERATED
-            // ================================================
-            // This shader was created by ComputeSharp.
-            // See: https://github.com/Sergio0694/ComputeSharp.
-
             #define D2D_INPUT_COUNT 0
 
             #include "d2d1effecthelpers.hlsli"

--- a/tests/ComputeSharp.D2D1.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/ShaderRewriterTests.cs
@@ -15,12 +15,6 @@ public partial class ShaderRewriterTests
         D2D1ShaderInfo shaderInfo = D2D1ReflectionServices.GetShaderInfo<ClassWithShader.ShaderWithStructAndInstanceMethodUsingIt>();
 
         Assert.AreEqual("""
-            // ================================================
-            //                  AUTO GENERATED
-            // ================================================
-            // This shader was created by ComputeSharp.
-            // See: https://github.com/Sergio0694/ComputeSharp.
-
             #define D2D_INPUT_COUNT 0
 
             #include "d2d1effecthelpers.hlsli"

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
@@ -97,12 +97,6 @@ public class Test_ComputeShaderDescriptorGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.Descriptors.IComputeShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define __GroupSize__get_X 8
                         #define __GroupSize__get_Y 8
                         #define __GroupSize__get_Z 1
@@ -395,12 +389,6 @@ public class Test_ComputeShaderDescriptorGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.Descriptors.IComputeShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define __GroupSize__get_X 8
                         #define __GroupSize__get_Y 8
                         #define __GroupSize__get_Z 1
@@ -663,12 +651,6 @@ public class Test_ComputeShaderDescriptorGenerator
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string global::ComputeSharp.Descriptors.IComputeShaderDescriptor<MyShader>.HlslSource =>
                         """
-                        // ================================================
-                        //                  AUTO GENERATED
-                        // ================================================
-                        // This shader was created by ComputeSharp.
-                        // See: https://github.com/Sergio0694/ComputeSharp.
-
                         #define __GroupSize__get_X 8
                         #define __GroupSize__get_Y 8
                         #define __GroupSize__get_Z 1

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -615,12 +615,6 @@ namespace ComputeSharp.Tests
 
             Assert.AreEqual(
                 """
-                // ================================================
-                //                  AUTO GENERATED
-                // ================================================
-                // This shader was created by ComputeSharp.
-                // See: https://github.com/Sergio0694/ComputeSharp.
-
                 #define __GroupSize__get_X 64
                 #define __GroupSize__get_Y 1
                 #define __GroupSize__get_Z 1
@@ -713,12 +707,6 @@ namespace ComputeSharp.Tests
 
             Assert.AreEqual(
                 """
-                // ================================================
-                //                  AUTO GENERATED
-                // ================================================
-                // This shader was created by ComputeSharp.
-                // See: https://github.com/Sergio0694/ComputeSharp.
-
                 #define __GroupSize__get_X 64
                 #define __GroupSize__get_Y 1
                 #define __GroupSize__get_Z 1
@@ -795,12 +783,6 @@ namespace ComputeSharp.Tests
 
             Assert.AreEqual(
                 """
-                // ================================================
-                //                  AUTO GENERATED
-                // ================================================
-                // This shader was created by ComputeSharp.
-                // See: https://github.com/Sergio0694/ComputeSharp.
-
                 #define __GroupSize__get_X 64
                 #define __GroupSize__get_Y 1
                 #define __GroupSize__get_Z 1
@@ -880,12 +862,6 @@ namespace ComputeSharp.Tests
 
             Assert.AreEqual(
                 """
-                // ================================================
-                //                  AUTO GENERATED
-                // ================================================
-                // This shader was created by ComputeSharp.
-                // See: https://github.com/Sergio0694/ComputeSharp.
-
                 #define __GroupSize__get_X 64
                 #define __GroupSize__get_Y 1
                 #define __GroupSize__get_Z 1
@@ -977,12 +953,6 @@ namespace ComputeSharp.Tests
 
             Assert.AreEqual(
                 """
-                // ================================================
-                //                  AUTO GENERATED
-                // ================================================
-                // This shader was created by ComputeSharp.
-                // See: https://github.com/Sergio0694/ComputeSharp.
-
                 #define __GroupSize__get_X 64
                 #define __GroupSize__get_Y 1
                 #define __GroupSize__get_Z 1
@@ -1202,12 +1172,6 @@ namespace ComputeSharp.Tests
 
             Assert.AreEqual(
                 """
-                // ================================================
-                //                  AUTO GENERATED
-                // ================================================
-                // This shader was created by ComputeSharp.
-                // See: https://github.com/Sergio0694/ComputeSharp.
-
                 #define __GroupSize__get_X 64
                 #define __GroupSize__get_Y 1
                 #define __GroupSize__get_Z 1


### PR DESCRIPTION
### Description

This PR removes the generated headers in the HLSL sources. They weren't really that useful in the first place anyway.