### PR TITLE
Centralize source generator testing logic

### DIFF
--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
@@ -28,5 +28,6 @@
 
   <ItemGroup>
     <Compile Include="..\ComputeSharp.Tests.SourceGenerators\Helpers\CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs" Link="Helpers\CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs" />
+    <Compile Include="..\ComputeSharp.Tests.SourceGenerators\Helpers\CSharpGeneratorTest{TGenerator}.cs" Link="Helpers\CSharpGeneratorTest{TGenerator}.cs" />
   </ItemGroup>
 </Project>

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Diagnostics.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Diagnostics.cs
@@ -1,13 +1,5 @@
-extern alias Core;
-extern alias D2D1;
-
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Basic.Reference.Assemblies;
 using ComputeSharp.D2D1.SourceGenerators;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+using ComputeSharp.Tests.SourceGenerators.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ComputeSharp.D2D1.Tests.SourceGenerators;
@@ -39,7 +31,7 @@ public class Test_D2DPixelShaderSourceGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics(source, "CMPSD2D0080");
+        CSharpGeneratorTest<D2DPixelShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPSD2D0080");
     }
 
     [TestMethod]
@@ -67,55 +59,6 @@ public class Test_D2DPixelShaderSourceGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics(source, "CMPSD2D0081");
-    }
-
-    /// <summary>
-    /// Verifies the output of a source generator.
-    /// </summary>
-    /// <param name="source">The input source to process.</param>
-    /// <param name="diagnosticsIds">The expected diagnostics ids to be generated.</param>
-    /// <returns>The task for the operation.</returns>
-    private static void VerifyGeneratedDiagnostics(string source, params string[] diagnosticsIds)
-    {
-        // Get all assembly references for the .NET TFM and ComputeSharp
-        IEnumerable<MetadataReference> metadataReferences =
-        [
-            .. Net80.References.All,
-            MetadataReference.CreateFromFile(typeof(Core::ComputeSharp.Hlsl).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(D2D1::ComputeSharp.D2D1.ID2D1PixelShader).Assembly.Location)
-        ];
-
-        // Parse the source text (C# 12)
-        SyntaxTree sourceTree = CSharpSyntaxTree.ParseText(
-            source,
-            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12));
-
-        // Create the original compilation
-        CSharpCompilation compilation = CSharpCompilation.Create(
-            "original",
-            [sourceTree],
-            metadataReferences,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
-
-        // Create the generator driver with the D2D shader generator
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(new D2DPixelShaderDescriptorGenerator()).WithUpdatedParseOptions((CSharpParseOptions)sourceTree.Options);
-
-        // Run all source generators on the input source code
-        _ = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out ImmutableArray<Diagnostic> diagnostics);
-
-        Dictionary<string, Diagnostic> diagnosticMap = diagnostics.DistinctBy(diagnostic => diagnostic.Id).ToDictionary(diagnostic => diagnostic.Id);
-
-        // Check that the diagnostics match
-        Assert.IsTrue(diagnosticMap.Keys.ToHashSet().SetEquals(diagnosticsIds), $"Diagnostics didn't match. {string.Join(", ", diagnosticMap.Values)}");
-
-        // If the compilation was supposed to succeed, ensure that no further errors were generated
-        if (diagnosticsIds.Length == 0)
-        {
-            // Compute diagnostics for the final compiled output (just include errors)
-            List<Diagnostic> outputCompilationDiagnostics = outputCompilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToList();
-
-            Assert.IsTrue(outputCompilationDiagnostics.Count == 0, $"resultingIds: {string.Join(", ", outputCompilationDiagnostics)}");
-        }
+        CSharpGeneratorTest<D2DPixelShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPSD2D0081");
     }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Diagnostics.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Diagnostics.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests.SourceGenerators;
 
 [TestClass]
-public class Test_D2DPixelShaderSourceGenerator_DIagnostics
+public class Test_D2DPixelShaderSourceGenerator_Diagnostics
 {
     [TestMethod]
     public void MissingD2DRequiresDoublePrecisionSupportAttribute()

--- a/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpGeneratorTest{TGenerator}.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpGeneratorTest{TGenerator}.cs
@@ -6,8 +6,10 @@ extern alias D2D1;
 extern alias D3D12;
 #endif
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using Basic.Reference.Assemblies;
 using Microsoft.CodeAnalysis.CSharp;
@@ -30,6 +32,54 @@ internal static class CSharpGeneratorTest<TGenerator>
     /// <param name="diagnosticsIds">The expected diagnostics ids to be generated.</param>
     public static void VerifyDiagnostics(string source, params string[] diagnosticsIds)
     {
+        RunGenerator(source, out Compilation compilation, out ImmutableArray<Diagnostic> diagnostics);
+
+        Dictionary<string, Diagnostic> diagnosticMap = diagnostics.DistinctBy(diagnostic => diagnostic.Id).ToDictionary(diagnostic => diagnostic.Id);
+
+        // Check that the diagnostics match
+        Assert.IsTrue(diagnosticMap.Keys.ToHashSet().SetEquals(diagnosticsIds), $"Diagnostics didn't match. {string.Join(", ", diagnosticMap.Values)}");
+
+        // If the compilation was supposed to succeed, ensure that no further errors were generated
+        if (diagnosticsIds.Length == 0)
+        {
+            // Compute diagnostics for the final compiled output (just include errors)
+            List<Diagnostic> outputCompilationDiagnostics = compilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToList();
+
+            Assert.IsTrue(outputCompilationDiagnostics.Count == 0, $"resultingIds: {string.Join(", ", outputCompilationDiagnostics)}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies the resulting sources produced by a source generator.
+    /// </summary>
+    /// <param name="source">The input source to process.</param>
+    /// <param name="result">The expected source to be generated.</param>
+    public static void VerifySources(string source, (string Filename, string Source) result)
+    {
+        RunGenerator(source, out Compilation compilation, out ImmutableArray<Diagnostic> diagnostics);
+
+        // Ensure that no diagnostics were generated
+        CollectionAssert.AreEquivalent(Array.Empty<Diagnostic>(), diagnostics);
+
+        // Update the assembly version using the version from the assembly of the input generators.
+        // This allows the tests to not need updates whenever the version of the MVVM Toolkit changes.
+        string expectedText = result.Source.Replace("<ASSEMBLY_VERSION>", $"\"{typeof(TGenerator).Assembly.GetName().Version}\"");
+        string actualText = compilation.SyntaxTrees.Single(tree => Path.GetFileName(tree.FilePath) == result.Filename).ToString();
+
+        Assert.AreEqual(expectedText, actualText);
+    }
+
+    /// <summary>
+    /// Runs a generator and gathers the output results.
+    /// </summary>
+    /// <param name="source">The input source to process.</param>
+    /// <param name="compilation"><inheritdoc cref="GeneratorDriver.RunGeneratorsAndUpdateCompilation" path="/param[@name='outputCompilation']/node()"/></param>
+    /// <param name="diagnostics"><inheritdoc cref="GeneratorDriver.RunGeneratorsAndUpdateCompilation" path="/param[@name='diagnostics']/node()"/></param>
+    private static void RunGenerator(
+        string source,
+        out Compilation compilation,
+        out ImmutableArray<Diagnostic> diagnostics)
+    {
         // Get all assembly references for the .NET TFM and ComputeSharp
         IEnumerable<MetadataReference> metadataReferences =
         [
@@ -48,7 +98,7 @@ internal static class CSharpGeneratorTest<TGenerator>
             CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12));
 
         // Create the original compilation
-        CSharpCompilation compilation = CSharpCompilation.Create(
+        CSharpCompilation originalCompilation = CSharpCompilation.Create(
             "original",
             [sourceTree],
             metadataReferences,
@@ -58,20 +108,6 @@ internal static class CSharpGeneratorTest<TGenerator>
         GeneratorDriver driver = CSharpGeneratorDriver.Create(new TGenerator()).WithUpdatedParseOptions((CSharpParseOptions)sourceTree.Options);
 
         // Run all source generators on the input source code
-        _ = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out ImmutableArray<Diagnostic> diagnostics);
-
-        Dictionary<string, Diagnostic> diagnosticMap = diagnostics.DistinctBy(diagnostic => diagnostic.Id).ToDictionary(diagnostic => diagnostic.Id);
-
-        // Check that the diagnostics match
-        Assert.IsTrue(diagnosticMap.Keys.ToHashSet().SetEquals(diagnosticsIds), $"Diagnostics didn't match. {string.Join(", ", diagnosticMap.Values)}");
-
-        // If the compilation was supposed to succeed, ensure that no further errors were generated
-        if (diagnosticsIds.Length == 0)
-        {
-            // Compute diagnostics for the final compiled output (just include errors)
-            List<Diagnostic> outputCompilationDiagnostics = outputCompilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToList();
-
-            Assert.IsTrue(outputCompilationDiagnostics.Count == 0, $"resultingIds: {string.Join(", ", outputCompilationDiagnostics)}");
-        }
+        _ = driver.RunGeneratorsAndUpdateCompilation(originalCompilation, out compilation, out diagnostics);
     }
 }

--- a/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpGeneratorTest{TGenerator}.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpGeneratorTest{TGenerator}.cs
@@ -1,0 +1,77 @@
+extern alias Core;
+
+#if D2D1_TESTS
+extern alias D2D1;
+#else
+extern alias D3D12;
+#endif
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Basic.Reference.Assemblies;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.Tests.SourceGenerators.Helpers;
+
+/// <summary>
+/// A helper type to run source generator tests.
+/// </summary>
+/// <typeparam name="TGenerator">The type of generator to test.</typeparam>
+internal static class CSharpGeneratorTest<TGenerator>
+    where TGenerator : IIncrementalGenerator, new()
+{
+    /// <summary>
+    /// Verifies the resulting diagnostics from a source generator.
+    /// </summary>
+    /// <param name="source">The input source to process.</param>
+    /// <param name="diagnosticsIds">The expected diagnostics ids to be generated.</param>
+    public static void VerifyDiagnostics(string source, params string[] diagnosticsIds)
+    {
+        // Get all assembly references for the .NET TFM and ComputeSharp
+        IEnumerable<MetadataReference> metadataReferences =
+        [
+            .. Net80.References.All,
+            MetadataReference.CreateFromFile(typeof(Core::ComputeSharp.Hlsl).Assembly.Location),
+#if D2D1_TESTS
+            MetadataReference.CreateFromFile(typeof(D2D1::ComputeSharp.D2D1.ID2D1PixelShader).Assembly.Location)
+#else
+            MetadataReference.CreateFromFile(typeof(D3D12::ComputeSharp.IComputeShader).Assembly.Location)
+#endif
+        ];
+
+        // Parse the source text (C# 12)
+        SyntaxTree sourceTree = CSharpSyntaxTree.ParseText(
+            source,
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12));
+
+        // Create the original compilation
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "original",
+            [sourceTree],
+            metadataReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+
+        // Create the generator driver with the D2D shader generator
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new TGenerator()).WithUpdatedParseOptions((CSharpParseOptions)sourceTree.Options);
+
+        // Run all source generators on the input source code
+        _ = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out ImmutableArray<Diagnostic> diagnostics);
+
+        Dictionary<string, Diagnostic> diagnosticMap = diagnostics.DistinctBy(diagnostic => diagnostic.Id).ToDictionary(diagnostic => diagnostic.Id);
+
+        // Check that the diagnostics match
+        Assert.IsTrue(diagnosticMap.Keys.ToHashSet().SetEquals(diagnosticsIds), $"Diagnostics didn't match. {string.Join(", ", diagnosticMap.Values)}");
+
+        // If the compilation was supposed to succeed, ensure that no further errors were generated
+        if (diagnosticsIds.Length == 0)
+        {
+            // Compute diagnostics for the final compiled output (just include errors)
+            List<Diagnostic> outputCompilationDiagnostics = outputCompilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToList();
+
+            Assert.IsTrue(outputCompilationDiagnostics.Count == 0, $"resultingIds: {string.Join(", ", outputCompilationDiagnostics)}");
+        }
+    }
+}

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Diagnostics.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Diagnostics.cs
@@ -1,13 +1,5 @@
-extern alias Core;
-extern alias D3D12;
-
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using Basic.Reference.Assemblies;
 using ComputeSharp.SourceGenerators;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
+using ComputeSharp.Tests.SourceGenerators.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ComputeSharp.Tests.SourceGenerators;
@@ -33,7 +25,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0001", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0001", "CMPS0047");
     }
 
     [TestMethod]
@@ -54,7 +46,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0001", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0001", "CMPS0047");
     }
 
     [TestMethod]
@@ -72,7 +64,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0005", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0005", "CMPS0047");
     }
 
     [TestMethod]
@@ -102,7 +94,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, diagnosticsId, "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, diagnosticsId, "CMPS0047");
     }
 
     [TestMethod]
@@ -129,7 +121,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, diagnosticsId, "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, diagnosticsId, "CMPS0047");
     }
 
     [TestMethod]
@@ -154,7 +146,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0006", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0006", "CMPS0047");
     }
 
     [TestMethod]
@@ -177,7 +169,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0010", "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0010", "CMPS0031", "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -200,7 +192,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0010", "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0010", "CMPS0031", "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -223,7 +215,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0011", "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0011", "CMPS0031", "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -248,7 +240,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0012", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012", "CMPS0047");
     }
 
     [TestMethod]
@@ -270,7 +262,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0012", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012", "CMPS0047");
     }
 
     [TestMethod]
@@ -293,7 +285,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0012", "CMPS0013", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012", "CMPS0013", "CMPS0047");
     }
 
     [TestMethod]
@@ -318,7 +310,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0014", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0014", "CMPS0047");
     }
 
     [TestMethod]
@@ -346,7 +338,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0015", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0015", "CMPS0047");
     }
 
     [TestMethod]
@@ -371,7 +363,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0016", "CMPS0032", "CMPS0035", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0016", "CMPS0032", "CMPS0035", "CMPS0047");
     }
 
     [TestMethod]
@@ -396,7 +388,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0017", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0017", "CMPS0047");
     }
 
     [TestMethod]
@@ -421,7 +413,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0018", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0018", "CMPS0047");
     }
 
     [TestMethod]
@@ -444,7 +436,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0019", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0019", "CMPS0047");
     }
 
     [TestMethod]
@@ -467,7 +459,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0020", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0020", "CMPS0047");
     }
 
     [TestMethod]
@@ -492,7 +484,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0021", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0021", "CMPS0047");
     }
 
     [TestMethod]
@@ -515,7 +507,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0022", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0022", "CMPS0047");
     }
 
     [TestMethod]
@@ -540,7 +532,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0023", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0023", "CMPS0047");
     }
 
     [TestMethod]
@@ -563,7 +555,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0024", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0024", "CMPS0047");
     }
 
     [TestMethod]
@@ -586,7 +578,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0032", "CMPS0025", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0032", "CMPS0025", "CMPS0047");
     }
 
     [TestMethod]
@@ -609,7 +601,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0026", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0026", "CMPS0047");
     }
 
     [TestMethod]
@@ -637,7 +629,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0027", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0027", "CMPS0047");
     }
 
     [TestMethod]
@@ -660,7 +652,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0028", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0028", "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -683,7 +675,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0029", "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0029", "CMPS0031", "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -708,7 +700,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0029", "CMPS0031", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0029", "CMPS0031", "CMPS0047");
     }
 
     [TestMethod]
@@ -737,7 +729,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0030", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0030", "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -760,7 +752,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -783,7 +775,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0032", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0032", "CMPS0047");
     }
 
     [TestMethod]
@@ -806,7 +798,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0033", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0033", "CMPS0047");
     }
 
     [TestMethod]
@@ -831,7 +823,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0034", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0034", "CMPS0047");
     }
 
     [TestMethod]
@@ -856,7 +848,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0035", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0035", "CMPS0047");
     }
 
     [TestMethod]
@@ -881,7 +873,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0035", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0035", "CMPS0047");
     }
 
     [TestMethod]
@@ -904,7 +896,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0036", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0036", "CMPS0047");
     }
 
     [TestMethod]
@@ -932,7 +924,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0037", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0037", "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -956,7 +948,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0038", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0038", "CMPS0047");
     }
 
     [TestMethod]
@@ -980,7 +972,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
     }
 
     [TestMethod]
@@ -1009,7 +1001,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
     }
 
     [TestMethod]
@@ -1036,7 +1028,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
     }
 
     [TestMethod]
@@ -1060,7 +1052,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
     }
 
     [TestMethod]
@@ -1084,7 +1076,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
     }
 
     [TestMethod]
@@ -1112,7 +1104,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0041", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0041", "CMPS0047");
     }
 
     [TestMethod]
@@ -1142,7 +1134,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0044");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0044");
     }
 
     [TestMethod]
@@ -1166,7 +1158,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0048");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0048");
     }
 
     [TestMethod]
@@ -1190,7 +1182,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0048");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0048");
     }
 
     [TestMethod]
@@ -1214,7 +1206,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0048");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0048");
     }
 
     [TestMethod]
@@ -1238,7 +1230,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0049", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0049", "CMPS0047");
     }
 
     [TestMethod]
@@ -1262,7 +1254,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0063", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0063", "CMPS0047");
     }
 
     [TestMethod]
@@ -1286,7 +1278,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -1316,7 +1308,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0050");
     }
 
     [TestMethod]
@@ -1344,7 +1336,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0050");
     }
 
     // See https://github.com/Sergio0694/ComputeSharp/issues/690
@@ -1371,7 +1363,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0059");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0059");
     }
 
     [TestMethod]
@@ -1397,7 +1389,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0059");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0059");
     }
 
     [TestMethod]
@@ -1418,7 +1410,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0031", "CMPS0047", "CMPS0059");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0047", "CMPS0059");
     }
 
     [TestMethod]
@@ -1439,7 +1431,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0031", "CMPS0047", "CMPS0060");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0047", "CMPS0060");
     }
 
     [TestMethod]
@@ -1472,7 +1464,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0061");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0061");
     }
 
     [TestMethod]
@@ -1501,7 +1493,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0049");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0049");
     }
 
     [TestMethod]
@@ -1533,7 +1525,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0062");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0062");
     }
 
     [TestMethod]
@@ -1570,7 +1562,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0047", "CMPS0062");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0062");
     }
 
     [TestMethod]
@@ -1636,7 +1628,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
         // The HLSL compilation is expected to fail because recursion is not actually supported:
         //
         // "error: recursive functions not allowed"
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0046");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0046");
     }
 
     [TestMethod]
@@ -1661,7 +1653,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0064");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0064");
     }
 
     [TestMethod]
@@ -1687,56 +1679,6 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        VerifyGeneratedDiagnostics<ComputeShaderDescriptorGenerator>(source, "CMPS0065");
-    }
-
-    /// <summary>
-    /// Verifies the output of a source generator.
-    /// </summary>
-    /// <typeparam name="TGenerator">The generator type to use.</typeparam>
-    /// <param name="source">The input source to process.</param>
-    /// <param name="diagnosticsIds">The expected diagnostics ids to be generated.</param>
-    private static void VerifyGeneratedDiagnostics<TGenerator>(string source, params string[] diagnosticsIds)
-        where TGenerator : class, IIncrementalGenerator, new()
-    {
-        // Get all assembly references for the .NET TFM and ComputeSharp
-        IEnumerable<MetadataReference> metadataReferences =
-        [
-            .. Net80.References.All,
-            MetadataReference.CreateFromFile(typeof(Core::ComputeSharp.Hlsl).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(D3D12::ComputeSharp.IComputeShader).Assembly.Location)
-        ];
-
-        // Parse the source text (C# 12)
-        SyntaxTree sourceTree = CSharpSyntaxTree.ParseText(
-            source,
-            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.CSharp12));
-
-        // Create the original compilation
-        CSharpCompilation compilation = CSharpCompilation.Create(
-            "original",
-            [sourceTree],
-            metadataReferences,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
-
-        // Run the generator on the source compilation, get the diagnostics
-        _ = CSharpGeneratorDriver.Create(new TGenerator()).RunGeneratorsAndUpdateCompilation(
-            compilation,
-            out Compilation outputCompilation,
-            out ImmutableArray<Diagnostic> diagnostics);
-
-        Dictionary<string, Diagnostic> diagnosticMap = diagnostics.DistinctBy(diagnostic => diagnostic.Id).ToDictionary(diagnostic => diagnostic.Id);
-
-        // Check that the diagnostics match
-        Assert.IsTrue(diagnosticMap.Keys.ToHashSet().SetEquals(diagnosticsIds), $"Diagnostics didn't match. {string.Join(", ", diagnosticMap.Values)}");
-
-        // If the compilation was supposed to succeed, ensure that no further errors were generated
-        if (diagnosticsIds.Length == 0)
-        {
-            // Compute diagnostics for the final compiled output (just include errors)
-            List<Diagnostic> outputCompilationDiagnostics = outputCompilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToList();
-
-            Assert.IsTrue(outputCompilationDiagnostics.Count == 0, $"resultingIds: {string.Join(", ", outputCompilationDiagnostics)}");
-        }
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0065");
     }
 }

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Diagnostics.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Diagnostics.cs
@@ -13,7 +13,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.Tests.SourceGenerators;
 
 [TestClass]
-public class DiagnosticsTests
+public class Test_ComputeShaderDescriptorGenerator_Diagnostics
 {
     [TestMethod]
     public void InvalidShaderField()


### PR DESCRIPTION
### Description

This PR centralizes all logic to test source generators (both diagnostics and output sources).
It then uses this new centralized logic for all source generator tests for both DX12 and D2D.