### PR TITLE
Add incrementality unit tests for DX12 and D2D generators

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using ComputeSharp.D2D1.SourceGenerators.Models;
+using ComputeSharp.SourceGeneration.Constants;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
 using ComputeSharp.SourceGeneration.Models;
@@ -197,13 +198,21 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
                         HlslInfo: hlslInfo,
                         Diagnostcs: diagnostics.ToImmutable());
                 })
+            .WithTrackingName(WellKnownTrackingNames.Execute)
             .Where(static item => item is not null)!;
 
-        // We need to create two more incremental steps to ensure we correctly emit diagnostics and re-generate sources:
-        //   - One with just the diagnostics, which will trigger every time any of them changes
-        //   - One with just the shader info (and no diagnostics), so that changes there don't trigger generation unnecessarily
-        IncrementalValuesProvider<EquatableArray<DiagnosticInfo>> diagnosticInfo = shaderInfo.Select(static (item, _) => item.Diagnostcs);
-        IncrementalValuesProvider<D2D1ShaderInfo> outputInfo = shaderInfo.Select(static (item, _) => item with { Diagnostcs = default });
+        // We need to create two more incremental steps to ensure we correctly emit diagnostics and re-generate sources.
+        // First, select an incremental provider with just the diagnostics, which will trigger every time any of them changes.
+        IncrementalValuesProvider<EquatableArray<DiagnosticInfo>> diagnosticInfo =
+            shaderInfo
+            .Select(static (item, _) => item.Diagnostcs)
+            .WithTrackingName(WellKnownTrackingNames.Diagnostics);
+
+        // Next, select one with just the shader info (and no diagnostics), so that changes there don't trigger generation unnecessarily
+        IncrementalValuesProvider<D2D1ShaderInfo> outputInfo =
+            shaderInfo
+            .Select(static (item, _) => item with { Diagnostcs = default })
+            .WithTrackingName(WellKnownTrackingNames.Output);
 
         // Output the diagnostics, if any
         context.ReportDiagnostics(diagnosticInfo);

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -206,7 +206,8 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
         IncrementalValuesProvider<EquatableArray<DiagnosticInfo>> diagnosticInfo =
             shaderInfo
             .Select(static (item, _) => item.Diagnostcs)
-            .WithTrackingName(WellKnownTrackingNames.Diagnostics);
+            .WithTrackingName(WellKnownTrackingNames.Diagnostics)
+            .Where(static item => !item.IsEmpty);
 
         // Next, select one with just the shader info (and no diagnostics), so that changes there don't trigger generation unnecessarily
         IncrementalValuesProvider<D2D1ShaderInfo> outputInfo =

--- a/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>ComputeSharp.SourceGeneration.Hlsl</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Constants\WellKnownTrackingNames.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\NotAccessibleFieldTypeInGeneratedShaderDescriptorAttributeTargetAnalyzerBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\NotReadOnlyShaderTypeWithFieldsAnalyzerBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\Analyzers\NotAccessibleGeneratedShaderDescriptorAttributeTargetAnalyzerBase.cs" />

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Constants/WellKnownTrackingNames.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Constants/WellKnownTrackingNames.cs
@@ -1,0 +1,22 @@
+namespace ComputeSharp.SourceGeneration.Constants;
+
+/// <summary>
+/// The well known names for tracking steps, to test the incremental generators.
+/// </summary>
+internal static class WellKnownTrackingNames
+{
+    /// <summary>
+    /// The initial <see cref="Microsoft.CodeAnalysis.SyntaxValueProvider.ForAttributeWithMetadataName"/> transform node.
+    /// </summary>
+    public const string Execute = nameof(Execute);
+
+    /// <summary>
+    /// The filtered transform with just output diagnostics.
+    /// </summary>
+    public const string Diagnostics = nameof(Diagnostics);
+
+    /// <summary>
+    /// The filtered transform with just output sources.
+    /// </summary>
+    public const string Output = nameof(Output);
+}

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -154,7 +154,8 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
         IncrementalValuesProvider<EquatableArray<DiagnosticInfo>> diagnosticInfo =
             shaderInfo
             .Select(static (item, _) => item.Diagnostcs)
-            .WithTrackingName(WellKnownTrackingNames.Diagnostics);
+            .WithTrackingName(WellKnownTrackingNames.Diagnostics)
+            .Where(static item => !item.IsEmpty);
 
         // Gather the models to produce sources for
         IncrementalValuesProvider<ShaderInfo> outputInfo =

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
+using ComputeSharp.SourceGeneration.Constants;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
 using ComputeSharp.SourceGeneration.Models;
@@ -146,11 +147,20 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                         HlslInfo: hlslInfo,
                         Diagnostcs: diagnostics.ToImmutable());
                 })
+            .WithTrackingName(WellKnownTrackingNames.Execute)
             .Where(static item => item is not null)!;
 
         // Split the diagnostics, and drop them from the output provider (see more notes in the D2D1 generator)
-        IncrementalValuesProvider<EquatableArray<DiagnosticInfo>> diagnosticInfo = shaderInfo.Select(static (item, _) => item.Diagnostcs);
-        IncrementalValuesProvider<ShaderInfo> outputInfo = shaderInfo.Select(static (item, _) => item with { Diagnostcs = default });
+        IncrementalValuesProvider<EquatableArray<DiagnosticInfo>> diagnosticInfo =
+            shaderInfo
+            .Select(static (item, _) => item.Diagnostcs)
+            .WithTrackingName(WellKnownTrackingNames.Diagnostics);
+
+        // Gather the models to produce sources for
+        IncrementalValuesProvider<ShaderInfo> outputInfo =
+            shaderInfo
+            .Select(static (item, _) => item with { Diagnostcs = default })
+            .WithTrackingName(WellKnownTrackingNames.Output);
 
         // Output the diagnostics, if any
         context.ReportDiagnostics(diagnosticInfo);

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests.SourceGenerators;
 
 [TestClass]
-public class Test_D2DPixelShaderSourceGenerator
+public class Test_D2DPixelShaderDescriptorGenerator
 {
     [TestMethod]
     public async Task SimpleShader()

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Diagnostics.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Diagnostics.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests.SourceGenerators;
 
 [TestClass]
-public class Test_D2DPixelShaderSourceGenerator_Diagnostics
+public class Test_D2DPixelShaderDescriptorGenerator_Diagnostics
 {
     [TestMethod]
     public void MissingD2DRequiresDoublePrecisionSupportAttribute()

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Incrementality.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Incrementality.cs
@@ -1,0 +1,150 @@
+using ComputeSharp.D2D1.SourceGenerators;
+using ComputeSharp.Tests.SourceGenerators.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.D2D1.Tests.SourceGenerators;
+
+[TestClass]
+public class Test_D2DPixelShaderDescriptorGenerator_Incrementality
+{
+    [TestMethod]
+    public void ModifiedStatement_ModifiesOutput()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+            using float4 = global::ComputeSharp.Float4;
+
+            [D2DInputCount(0)]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal readonly partial struct MyShader : ID2D1PixelShader
+            {
+                public float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        const string updatedSource = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+            using float4 = global::ComputeSharp.Float4;
+
+            [D2DInputCount(0)]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal readonly partial struct MyShader : ID2D1PixelShader
+            {
+                public float4 Execute()
+                {
+                    // Some dummy comment
+                    return 42;
+                }
+            }
+            """;
+
+        CSharpGeneratorTest<D2DPixelShaderDescriptorGenerator>.VerifyIncrementalSteps(
+            source,
+            updatedSource,
+            executeReason: IncrementalStepRunReason.Modified,
+            diagnosticsReason: null,
+            outputReason: IncrementalStepRunReason.Modified,
+            diagnosticsSourceReason: null,
+            sourceReason: IncrementalStepRunReason.Modified);
+    }
+
+    [TestMethod]
+    public void AddedComment_DoesNotModifyOutput()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+            using float4 = global::ComputeSharp.Float4;
+
+            [D2DInputCount(0)]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal readonly partial struct MyShader : ID2D1PixelShader
+            {
+                public float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        const string updatedSource = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+            using float4 = global::ComputeSharp.Float4;
+
+            [D2DInputCount(0)]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal readonly partial struct MyShader : ID2D1PixelShader
+            {
+                public float4 Execute()
+                {
+                    // Some dummy comment
+                    return 0;
+                }
+            }
+            """;
+
+        CSharpGeneratorTest<D2DPixelShaderDescriptorGenerator>.VerifyIncrementalSteps(
+            source,
+            updatedSource,
+            executeReason: IncrementalStepRunReason.Unchanged,
+            diagnosticsReason: null,
+            outputReason: IncrementalStepRunReason.Cached,
+            diagnosticsSourceReason: null,
+            sourceReason: IncrementalStepRunReason.Cached);
+    }
+
+    [TestMethod]
+    public void AddedRequiresDoublePrecisionSupport_DoesNotModifyOutput()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+            using float4 = global::ComputeSharp.Float4;
+
+            [D2DInputCount(1)]
+            [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal readonly partial struct MyShader(double factor) : ID2D1PixelShader
+            {
+                public float4 Execute()
+                {
+                    return (float4)((double4)D2D.GetInput(0) * factor);
+                }
+            }
+            """;
+
+        const string updatedSource = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+            using float4 = global::ComputeSharp.Float4;
+
+            [D2DInputCount(1)]
+            [D2DRequiresDoublePrecisionSupport]
+            [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+            [D2DGeneratedPixelShaderDescriptor]
+            internal readonly partial struct MyShader(double factor) : ID2D1PixelShader
+            {
+                public float4 Execute()
+                {
+                    return (float4)((double4)D2D.GetInput(0) * factor);
+                }
+            }
+            """;
+
+        CSharpGeneratorTest<D2DPixelShaderDescriptorGenerator>.VerifyIncrementalSteps(
+            source,
+            updatedSource,
+            executeReason: IncrementalStepRunReason.Modified,
+            diagnosticsReason: IncrementalStepRunReason.Modified,
+            outputReason: IncrementalStepRunReason.Unchanged,
+            diagnosticsSourceReason: IncrementalStepRunReason.Modified,
+            sourceReason: IncrementalStepRunReason.Cached);
+    }
+}

--- a/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpGeneratorTest{TGenerator}.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpGeneratorTest{TGenerator}.cs
@@ -77,13 +77,15 @@ internal static class CSharpGeneratorTest<TGenerator>
     /// <param name="executeReason">The reason for the first <c>"Execute"</c> step.</param>
     /// <param name="diagnosticsReason">The reason for the <c>"Diagnostics"</c> step.</param>
     /// <param name="outputReason">The reason for the <c>"Output"</c> step.</param>
+    /// <param name="diagnosticsSourceReason">The reason for the output step for the diagnostics.</param>
     /// <param name="sourceReason">The reason for the final output source.</param>
     public static void VerifyIncrementalSteps(
         string source,
         string updatedSource,
         IncrementalStepRunReason executeReason,
-        IncrementalStepRunReason diagnosticsReason,
+        IncrementalStepRunReason? diagnosticsReason,
         IncrementalStepRunReason outputReason,
+        IncrementalStepRunReason? diagnosticsSourceReason,
         IncrementalStepRunReason sourceReason)
     {
         Compilation compilation = CreateCompilation(source);
@@ -105,19 +107,61 @@ internal static class CSharpGeneratorTest<TGenerator>
 
         GeneratorRunResult result = driver.GetRunResult().Results.Single();
 
-        // Get the generated sources (only one output file should be produced)
-        (object Value, IncrementalStepRunReason Reason)[] sourceOuputs =
-            result.TrackedOutputSteps
-            .SelectMany(outputStep => outputStep.Value)
-            .SelectMany(output => output.Outputs)
-            .ToArray();
+        // Get the generated sources and validate them. We have two possible cases: if no diagnostics
+        // are produced, then just the output source node is triggered. Otherwise, we'll also have one
+        // output node which is used to emit the gathered diagnostics from the initial transform step.
+        if (diagnosticsSourceReason is not null)
+        {
+            Assert.AreEqual(
+                expected: 2,
+                actual:
+                    result.TrackedOutputSteps
+                    .SelectMany(outputStep => outputStep.Value)
+                    .SelectMany(output => output.Outputs)
+                    .Count());
 
-        Assert.AreEqual(1, sourceOuputs.Length);
-        Assert.AreEqual(sourceReason, sourceOuputs[0].Reason);
+            // The "Diagnostics" name has one more parent compared to "Output", because it also
+            // has one extra Where(...) call on the node (used to filter out empty diagnostics).
+            Assert.AreEqual(
+                expected: diagnosticsSourceReason,
+                actual:
+                    result.TrackedOutputSteps
+                    .Single().Value
+                    .Single(run => run.Inputs[0].Source.Inputs[0].Source.Name == "Diagnostics")
+                    .Outputs.Single().Reason);
+
+            Assert.AreEqual(
+                expected: sourceReason,
+                actual:
+                    result.TrackedOutputSteps
+                    .Single().Value
+                    .Single(run => run.Inputs[0].Source.Name == "Output")
+                    .Outputs.Single().Reason);
+        }
+        else
+        {
+            (object Value, IncrementalStepRunReason Reason)[] sourceOuputs =
+                result.TrackedOutputSteps
+                .SelectMany(outputStep => outputStep.Value)
+                .SelectMany(output => output.Outputs)
+                .ToArray();
+
+            Assert.AreEqual(1, sourceOuputs.Length);
+            Assert.AreEqual(sourceReason, sourceOuputs[0].Reason);
+        }
 
         Assert.AreEqual(executeReason, result.TrackedSteps["Execute"].Single().Outputs[0].Reason);
-        Assert.AreEqual(diagnosticsReason, result.TrackedSteps["Diagnostics"].Single().Outputs[0].Reason);
         Assert.AreEqual(outputReason, result.TrackedSteps["Output"].Single().Outputs[0].Reason);
+
+        // Check the diagnostics reason, which might not be present
+        if (diagnosticsReason is not null)
+        {
+            Assert.AreEqual(diagnosticsReason, result.TrackedSteps["Diagnostics"].Single().Outputs[0].Reason);
+        }
+        else
+        {
+            Assert.IsFalse(result.TrackedSteps.ContainsKey("Diagnostics"));
+        }
     }
 
     /// <summary>

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Incrementality.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Incrementality.cs
@@ -1,0 +1,98 @@
+using ComputeSharp.SourceGenerators;
+using ComputeSharp.Tests.SourceGenerators.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.Tests.SourceGenerators;
+
+[TestClass]
+public class Test_ComputeShaderDescriptorGenerator_Incrementality
+{
+    [TestMethod]
+    public void AddedStatement_ModifiesOutput()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+            [GeneratedComputeShaderDescriptor]
+            internal readonly partial struct MyShader : IComputeShader
+            {
+                private readonly ReadWriteBuffer<float> buffer;
+
+                public void Execute()
+                {
+                }
+            }
+            """;
+
+        const string updatedSource = """
+            using ComputeSharp;
+
+            [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+            [GeneratedComputeShaderDescriptor]
+            internal readonly partial struct MyShader : IComputeShader
+            {
+                private readonly ReadWriteBuffer<float> buffer;
+
+                public void Execute()
+                {
+                    buffer[ThreadIds.X] *= 2.0;
+                }
+            }
+            """;
+
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyIncrementalSteps(
+            source,
+            updatedSource,
+            executeReason: IncrementalStepRunReason.Modified,
+            diagnosticsReason: null,
+            outputReason: IncrementalStepRunReason.Modified,
+            diagnosticsSourceReason: null,
+            sourceReason: IncrementalStepRunReason.Modified);
+    }
+
+    [TestMethod]
+    public void AddedComment_DoesNotModifyOutput()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+            [GeneratedComputeShaderDescriptor]
+            internal readonly partial struct MyShader : IComputeShader
+            {
+                private readonly ReadWriteBuffer<float> buffer;
+
+                public void Execute()
+                {
+                }
+            }
+            """;
+
+        const string updatedSource = """
+            using ComputeSharp;
+
+            [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+            [GeneratedComputeShaderDescriptor]
+            internal readonly partial struct MyShader : IComputeShader
+            {
+                private readonly ReadWriteBuffer<float> buffer;
+
+                public void Execute()
+                {
+                    // Some dummy comment
+                }
+            }
+            """;
+
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyIncrementalSteps(
+            source,
+            updatedSource,
+            executeReason: IncrementalStepRunReason.Unchanged,
+            diagnosticsReason: null,
+            outputReason: IncrementalStepRunReason.Cached,
+            diagnosticsSourceReason: null,
+            sourceReason: IncrementalStepRunReason.Cached);
+    }
+}


### PR DESCRIPTION
### Closes #738

### Description

This PR adds unit tests for incrementality to both the DX12 and D2D source generators. While at it, it also adds two missing `Where(...)` calls on the diagnostic steps for both generators, which allows the generators to avoid triggering that output step that's used to emit diagnostics, in all cases where no diagnostic is actually available. It also makes unit testing simpler.