### PR TITLE
Add cast operators for all HLSL matrix types

### DIFF
--- a/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 #pragma warning disable CS0660, CS0661

--- a/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Double/DoubleMxN.g.cs
@@ -91,6 +91,27 @@ public unsafe partial struct Double1x1
     }
 
     /// <summary>
+    /// Casts a <see cref="Double1x1"/> value to a <see cref="Float1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float1x1(Double1x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double1x1"/> value to a <see cref="Int1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x1(Double1x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double1x1"/> value to a <see cref="UInt1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x1(Double1x1 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Double1x1"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Double1x1"/> value to negate.</param>
@@ -293,6 +314,27 @@ public unsafe partial struct Double1x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double1x2"/> value to a <see cref="Float1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float1x2(Double1x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double1x2"/> value to a <see cref="Int1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x2(Double1x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double1x2"/> value to a <see cref="UInt1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x2(Double1x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double1x2"/> value.
@@ -515,6 +557,27 @@ public unsafe partial struct Double1x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double1x3"/> value to a <see cref="Float1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float1x3(Double1x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double1x3"/> value to a <see cref="Int1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x3(Double1x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double1x3"/> value to a <see cref="UInt1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x3(Double1x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double1x3"/> value.
@@ -751,6 +814,27 @@ public unsafe partial struct Double1x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Double1x4"/> value to a <see cref="Float1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float1x4(Double1x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double1x4"/> value to a <see cref="Int1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x4(Double1x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double1x4"/> value to a <see cref="UInt1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x4(Double1x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Double1x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Double1x4"/> value to negate.</param>
@@ -959,6 +1043,27 @@ public unsafe partial struct Double2x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double2x1"/> value to a <see cref="Float2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float2x1(Double2x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double2x1"/> value to a <see cref="Int2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x1(Double2x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double2x1"/> value to a <see cref="UInt2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x1(Double2x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double2x1"/> value.
@@ -1206,6 +1311,27 @@ public unsafe partial struct Double2x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double2x2"/> value to a <see cref="Float2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float2x2(Double2x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double2x2"/> value to a <see cref="Int2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x2(Double2x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double2x2"/> value to a <see cref="UInt2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x2(Double2x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double2x2"/> value.
@@ -1473,6 +1599,27 @@ public unsafe partial struct Double2x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double2x3"/> value to a <see cref="Float2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float2x3(Double2x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double2x3"/> value to a <see cref="Int2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x3(Double2x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double2x3"/> value to a <see cref="UInt2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x3(Double2x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double2x3"/> value.
@@ -1768,6 +1915,27 @@ public unsafe partial struct Double2x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Double2x4"/> value to a <see cref="Float2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float2x4(Double2x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double2x4"/> value to a <see cref="Int2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x4(Double2x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double2x4"/> value to a <see cref="UInt2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x4(Double2x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Double2x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Double2x4"/> value to negate.</param>
@@ -1982,6 +2150,27 @@ public unsafe partial struct Double3x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double3x1"/> value to a <see cref="Float3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float3x1(Double3x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double3x1"/> value to a <see cref="Int3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x1(Double3x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double3x1"/> value to a <see cref="UInt3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x1(Double3x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double3x1"/> value.
@@ -2256,6 +2445,27 @@ public unsafe partial struct Double3x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double3x2"/> value to a <see cref="Float3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float3x2(Double3x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double3x2"/> value to a <see cref="Int3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x2(Double3x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double3x2"/> value to a <see cref="UInt3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x2(Double3x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double3x2"/> value.
@@ -2563,6 +2773,27 @@ public unsafe partial struct Double3x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double3x3"/> value to a <see cref="Float3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float3x3(Double3x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double3x3"/> value to a <see cref="Int3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x3(Double3x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double3x3"/> value to a <see cref="UInt3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x3(Double3x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double3x3"/> value.
@@ -2911,6 +3142,27 @@ public unsafe partial struct Double3x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Double3x4"/> value to a <see cref="Float3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float3x4(Double3x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double3x4"/> value to a <see cref="Int3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x4(Double3x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double3x4"/> value to a <see cref="UInt3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x4(Double3x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Double3x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Double3x4"/> value to negate.</param>
@@ -3137,6 +3389,27 @@ public unsafe partial struct Double4x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double4x1"/> value to a <see cref="Float4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float4x1(Double4x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double4x1"/> value to a <see cref="Int4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x1(Double4x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double4x1"/> value to a <see cref="UInt4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x1(Double4x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double4x1"/> value.
@@ -3438,6 +3711,27 @@ public unsafe partial struct Double4x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double4x2"/> value to a <see cref="Float4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float4x2(Double4x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double4x2"/> value to a <see cref="Int4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x2(Double4x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double4x2"/> value to a <see cref="UInt4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x2(Double4x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double4x2"/> value.
@@ -3785,6 +4079,27 @@ public unsafe partial struct Double4x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double4x3"/> value to a <see cref="Float4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float4x3(Double4x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double4x3"/> value to a <see cref="Int4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x3(Double4x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double4x3"/> value to a <see cref="UInt4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x3(Double4x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double4x3"/> value.
@@ -4184,6 +4499,27 @@ public unsafe partial struct Double4x4
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Double4x4"/> value to a <see cref="Float4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Float4x4(Double4x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double4x4"/> value to a <see cref="Int4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x4(Double4x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Double4x4"/> value to a <see cref="UInt4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Double4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x4(Double4x4 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Double4x4"/> value.

--- a/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
@@ -92,6 +92,27 @@ public unsafe partial struct Float1x1
     }
 
     /// <summary>
+    /// Casts a <see cref="Float1x1"/> value to a <see cref="Double1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x1(Float1x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float1x1"/> value to a <see cref="Int1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x1(Float1x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float1x1"/> value to a <see cref="UInt1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x1(Float1x1 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Float1x1"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Float1x1"/> value to negate.</param>
@@ -312,6 +333,27 @@ public unsafe partial struct Float1x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float1x2"/> value to a <see cref="Double1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x2(Float1x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float1x2"/> value to a <see cref="Int1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x2(Float1x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float1x2"/> value to a <see cref="UInt1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x2(Float1x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float1x2"/> value.
@@ -636,6 +678,27 @@ public unsafe partial struct Float1x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float1x3"/> value to a <see cref="Double1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x3(Float1x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float1x3"/> value to a <see cref="Int1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x3(Float1x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float1x3"/> value to a <see cref="UInt1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x3(Float1x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float1x3"/> value.
@@ -974,6 +1037,27 @@ public unsafe partial struct Float1x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Float1x4"/> value to a <see cref="Double1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x4(Float1x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float1x4"/> value to a <see cref="Int1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x4(Float1x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float1x4"/> value to a <see cref="UInt1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x4(Float1x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Float1x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Float1x4"/> value to negate.</param>
@@ -1284,6 +1368,27 @@ public unsafe partial struct Float2x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float2x1"/> value to a <see cref="Double2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x1(Float2x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float2x1"/> value to a <see cref="Int2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x1(Float2x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float2x1"/> value to a <see cref="UInt2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x1(Float2x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float2x1"/> value.
@@ -1621,6 +1726,27 @@ public unsafe partial struct Float2x2
     }
 
     /// <summary>
+    /// Casts a <see cref="Float2x2"/> value to a <see cref="Double2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x2(Float2x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float2x2"/> value to a <see cref="Int2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x2(Float2x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float2x2"/> value to a <see cref="UInt2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x2(Float2x2 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Float2x2"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Float2x2"/> value to negate.</param>
@@ -1904,6 +2030,27 @@ public unsafe partial struct Float2x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float2x3"/> value to a <see cref="Double2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x3(Float2x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float2x3"/> value to a <see cref="Int2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x3(Float2x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float2x3"/> value to a <see cref="UInt2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x3(Float2x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float2x3"/> value.
@@ -2301,6 +2448,27 @@ public unsafe partial struct Float2x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Float2x4"/> value to a <see cref="Double2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x4(Float2x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float2x4"/> value to a <see cref="Int2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x4(Float2x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float2x4"/> value to a <see cref="UInt2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x4(Float2x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Float2x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Float2x4"/> value to negate.</param>
@@ -2617,6 +2785,27 @@ public unsafe partial struct Float3x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float3x1"/> value to a <see cref="Double3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x1(Float3x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float3x1"/> value to a <see cref="Int3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x1(Float3x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float3x1"/> value to a <see cref="UInt3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x1(Float3x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float3x1"/> value.
@@ -2979,6 +3168,27 @@ public unsafe partial struct Float3x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float3x2"/> value to a <see cref="Double3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x2(Float3x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float3x2"/> value to a <see cref="Int3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x2(Float3x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float3x2"/> value to a <see cref="UInt3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x2(Float3x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float3x2"/> value.
@@ -3390,6 +3600,27 @@ public unsafe partial struct Float3x3
     }
 
     /// <summary>
+    /// Casts a <see cref="Float3x3"/> value to a <see cref="Double3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x3(Float3x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float3x3"/> value to a <see cref="Int3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x3(Float3x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float3x3"/> value to a <see cref="UInt3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x3(Float3x3 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Float3x3"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Float3x3"/> value to negate.</param>
@@ -3754,6 +3985,27 @@ public unsafe partial struct Float3x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Float3x4"/> value to a <see cref="Double3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x4(Float3x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float3x4"/> value to a <see cref="Int3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x4(Float3x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float3x4"/> value to a <see cref="UInt3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x4(Float3x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Float3x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Float3x4"/> value to negate.</param>
@@ -4082,6 +4334,27 @@ public unsafe partial struct Float4x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float4x1"/> value to a <see cref="Double4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x1(Float4x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float4x1"/> value to a <see cref="Int4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x1(Float4x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float4x1"/> value to a <see cref="UInt4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x1(Float4x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float4x1"/> value.
@@ -4471,6 +4744,27 @@ public unsafe partial struct Float4x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float4x2"/> value to a <see cref="Double4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x2(Float4x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float4x2"/> value to a <see cref="Int4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x2(Float4x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float4x2"/> value to a <see cref="UInt4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x2(Float4x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float4x2"/> value.
@@ -4920,6 +5214,27 @@ public unsafe partial struct Float4x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float4x3"/> value to a <see cref="Double4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x3(Float4x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float4x3"/> value to a <see cref="Int4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x3(Float4x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float4x3"/> value to a <see cref="UInt4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x3(Float4x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float4x3"/> value.
@@ -5421,6 +5736,27 @@ public unsafe partial struct Float4x4
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Float4x4"/> value to a <see cref="Double4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x4(Float4x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float4x4"/> value to a <see cref="Int4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x4(Float4x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Float4x4"/> value to a <see cref="UInt4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Float4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x4(Float4x4 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Float4x4"/> value.

--- a/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
 

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -92,6 +92,27 @@ public unsafe partial struct Int1x1
     }
 
     /// <summary>
+    /// Casts a <see cref="Int1x1"/> value to a <see cref="Float1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float1x1(Int1x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int1x1"/> value to a <see cref="Double1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x1(Int1x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int1x1"/> value to a <see cref="UInt1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x1(Int1x1 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Int1x1"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int1x1"/> value to negate.</param>
@@ -410,6 +431,27 @@ public unsafe partial struct Int1x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int1x2"/> value to a <see cref="Float1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float1x2(Int1x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int1x2"/> value to a <see cref="Double1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x2(Int1x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int1x2"/> value to a <see cref="UInt1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x2(Int1x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int1x2"/> value.
@@ -832,6 +874,27 @@ public unsafe partial struct Int1x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int1x3"/> value to a <see cref="Float1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float1x3(Int1x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int1x3"/> value to a <see cref="Double1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x3(Int1x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int1x3"/> value to a <see cref="UInt1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x3(Int1x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int1x3"/> value.
@@ -1268,6 +1331,27 @@ public unsafe partial struct Int1x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Int1x4"/> value to a <see cref="Float1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float1x4(Int1x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int1x4"/> value to a <see cref="Double1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x4(Int1x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int1x4"/> value to a <see cref="UInt1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt1x4(Int1x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Int1x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int1x4"/> value to negate.</param>
@@ -1676,6 +1760,27 @@ public unsafe partial struct Int2x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int2x1"/> value to a <see cref="Float2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float2x1(Int2x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int2x1"/> value to a <see cref="Double2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x1(Int2x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int2x1"/> value to a <see cref="UInt2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x1(Int2x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int2x1"/> value.
@@ -2111,6 +2216,27 @@ public unsafe partial struct Int2x2
     }
 
     /// <summary>
+    /// Casts a <see cref="Int2x2"/> value to a <see cref="Float2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float2x2(Int2x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int2x2"/> value to a <see cref="Double2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x2(Int2x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int2x2"/> value to a <see cref="UInt2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x2(Int2x2 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Int2x2"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int2x2"/> value to negate.</param>
@@ -2492,6 +2618,27 @@ public unsafe partial struct Int2x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int2x3"/> value to a <see cref="Float2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float2x3(Int2x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int2x3"/> value to a <see cref="Double2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x3(Int2x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int2x3"/> value to a <see cref="UInt2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x3(Int2x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int2x3"/> value.
@@ -2987,6 +3134,27 @@ public unsafe partial struct Int2x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Int2x4"/> value to a <see cref="Float2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float2x4(Int2x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int2x4"/> value to a <see cref="Double2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x4(Int2x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int2x4"/> value to a <see cref="UInt2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt2x4(Int2x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Int2x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int2x4"/> value to negate.</param>
@@ -3401,6 +3569,27 @@ public unsafe partial struct Int3x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int3x1"/> value to a <see cref="Float3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float3x1(Int3x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int3x1"/> value to a <see cref="Double3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x1(Int3x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int3x1"/> value to a <see cref="UInt3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x1(Int3x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int3x1"/> value.
@@ -3861,6 +4050,27 @@ public unsafe partial struct Int3x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int3x2"/> value to a <see cref="Float3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float3x2(Int3x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int3x2"/> value to a <see cref="Double3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x2(Int3x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int3x2"/> value to a <see cref="UInt3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x2(Int3x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int3x2"/> value.
@@ -4370,6 +4580,27 @@ public unsafe partial struct Int3x3
     }
 
     /// <summary>
+    /// Casts a <see cref="Int3x3"/> value to a <see cref="Float3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float3x3(Int3x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int3x3"/> value to a <see cref="Double3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x3(Int3x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int3x3"/> value to a <see cref="UInt3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x3(Int3x3 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Int3x3"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int3x3"/> value to negate.</param>
@@ -4832,6 +5063,27 @@ public unsafe partial struct Int3x4
     }
 
     /// <summary>
+    /// Casts a <see cref="Int3x4"/> value to a <see cref="Float3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float3x4(Int3x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int3x4"/> value to a <see cref="Double3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x4(Int3x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int3x4"/> value to a <see cref="UInt3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt3x4(Int3x4 matrix) => default;
+
+    /// <summary>
     /// Negates a <see cref="Int3x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int3x4"/> value to negate.</param>
@@ -5258,6 +5510,27 @@ public unsafe partial struct Int4x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int4x1"/> value to a <see cref="Float4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float4x1(Int4x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int4x1"/> value to a <see cref="Double4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x1(Int4x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int4x1"/> value to a <see cref="UInt4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x1(Int4x1 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int4x1"/> value.
@@ -5745,6 +6018,27 @@ public unsafe partial struct Int4x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int4x2"/> value to a <see cref="Float4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float4x2(Int4x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int4x2"/> value to a <see cref="Double4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x2(Int4x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int4x2"/> value to a <see cref="UInt4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x2(Int4x2 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int4x2"/> value.
@@ -6292,6 +6586,27 @@ public unsafe partial struct Int4x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int4x3"/> value to a <see cref="Float4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float4x3(Int4x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int4x3"/> value to a <see cref="Double4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x3(Int4x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int4x3"/> value to a <see cref="UInt4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x3(Int4x3 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int4x3"/> value.
@@ -6891,6 +7206,27 @@ public unsafe partial struct Int4x4
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="Int4x4"/> value to a <see cref="Float4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float4x4(Int4x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int4x4"/> value to a <see cref="Double4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x4(Int4x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="Int4x4"/> value to a <see cref="UInt4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="Int4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator UInt4x4(Int4x4 matrix) => default;
 
     /// <summary>
     /// Negates a <see cref="Int4x4"/> value.

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ComputeSharp.Core.Intrinsics.Attributes;
 

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -10,7 +10,12 @@ void GenerateAllMatrixProperties(string typeName, int elementSize)
 {
 #>
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
+<#
+    if (typeName == "Bool")
+    {
+        WriteLine("using System.Runtime.CompilerServices;");
+    }
+#>
 using System.Runtime.InteropServices;
 <#
     if (typeName == "Float" || typeName == "Int")

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -255,6 +255,30 @@ public unsafe partial struct <#=fullTypeName#>
     WriteLine("}");
     PopIndent();
 
+    // Generate the cast operators, when applicable
+    foreach (string targetType in new[] { "Float", "Double", "Int", "UInt" })
+    {
+        if (typeName != "Bool" && typeName != targetType)
+        {
+            WriteLine("");
+
+            bool isImplicit =
+                (typeName == "Float" && targetType == "Double") ||
+                (typeName == "Int" && targetType == "Float") ||
+                (typeName == "Int" && targetType == "Double") ||
+                (typeName == "UInt" && targetType == "Float") ||
+                (typeName == "UInt" && targetType == "Double");
+#>
+    /// <summary>
+    /// Casts a <see cref="<#=fullTypeName#>"/> value to a <see cref="<#=targetType#><#=rows#>x<#=columns#>"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="<#=fullTypeName#>"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=isImplicit ? "implicit" : "explicit"#> operator <#=targetType#><#=rows#>x<#=columns#>(<#=fullTypeName#> matrix) => default;
+<#
+        }
+    }
+
     // Generate the negation operator
     if (typeName != "UInt")
     {

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 #pragma warning disable CS0660, CS0661

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -91,6 +91,27 @@ public unsafe partial struct UInt1x1
     }
 
     /// <summary>
+    /// Casts a <see cref="UInt1x1"/> value to a <see cref="Float1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float1x1(UInt1x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x1"/> value to a <see cref="Double1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x1(UInt1x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x1"/> value to a <see cref="Int1x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x1(UInt1x1 matrix) => default;
+
+    /// <summary>
     /// Sums two <see cref="UInt1x1"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x1"/> value to sum.</param>
@@ -384,6 +405,27 @@ public unsafe partial struct UInt1x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x2"/> value to a <see cref="Float1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float1x2(UInt1x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x2"/> value to a <see cref="Double1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x2(UInt1x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x2"/> value to a <see cref="Int1x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x2(UInt1x2 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt1x2"/> values.
@@ -697,6 +739,27 @@ public unsafe partial struct UInt1x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x3"/> value to a <see cref="Float1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float1x3(UInt1x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x3"/> value to a <see cref="Double1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x3(UInt1x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x3"/> value to a <see cref="Int1x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x3(UInt1x3 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt1x3"/> values.
@@ -1024,6 +1087,27 @@ public unsafe partial struct UInt1x4
     }
 
     /// <summary>
+    /// Casts a <see cref="UInt1x4"/> value to a <see cref="Float1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float1x4(UInt1x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x4"/> value to a <see cref="Double1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double1x4(UInt1x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt1x4"/> value to a <see cref="Int1x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt1x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int1x4(UInt1x4 matrix) => default;
+
+    /// <summary>
     /// Sums two <see cref="UInt1x4"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="UInt1x4"/> value to sum.</param>
@@ -1323,6 +1407,27 @@ public unsafe partial struct UInt2x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x1"/> value to a <see cref="Float2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float2x1(UInt2x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x1"/> value to a <see cref="Double2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x1(UInt2x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x1"/> value to a <see cref="Int2x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x1(UInt2x1 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt2x1"/> values.
@@ -1661,6 +1766,27 @@ public unsafe partial struct UInt2x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x2"/> value to a <see cref="Float2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float2x2(UInt2x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x2"/> value to a <see cref="Double2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x2(UInt2x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x2"/> value to a <see cref="Int2x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x2(UInt2x2 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt2x2"/> values.
@@ -2019,6 +2145,27 @@ public unsafe partial struct UInt2x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x3"/> value to a <see cref="Float2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float2x3(UInt2x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x3"/> value to a <see cref="Double2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x3(UInt2x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x3"/> value to a <see cref="Int2x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x3(UInt2x3 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt2x3"/> values.
@@ -2405,6 +2552,27 @@ public unsafe partial struct UInt2x4
     }
 
     /// <summary>
+    /// Casts a <see cref="UInt2x4"/> value to a <see cref="Float2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float2x4(UInt2x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x4"/> value to a <see cref="Double2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double2x4(UInt2x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt2x4"/> value to a <see cref="Int2x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt2x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int2x4(UInt2x4 matrix) => default;
+
+    /// <summary>
     /// Sums two <see cref="UInt2x4"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="UInt2x4"/> value to sum.</param>
@@ -2710,6 +2878,27 @@ public unsafe partial struct UInt3x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x1"/> value to a <see cref="Float3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float3x1(UInt3x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x1"/> value to a <see cref="Double3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x1(UInt3x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x1"/> value to a <see cref="Int3x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x1(UInt3x1 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt3x1"/> values.
@@ -3075,6 +3264,27 @@ public unsafe partial struct UInt3x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x2"/> value to a <see cref="Float3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float3x2(UInt3x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x2"/> value to a <see cref="Double3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x2(UInt3x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x2"/> value to a <see cref="Int3x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x2(UInt3x2 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt3x2"/> values.
@@ -3473,6 +3683,27 @@ public unsafe partial struct UInt3x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x3"/> value to a <see cref="Float3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float3x3(UInt3x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x3"/> value to a <see cref="Double3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x3(UInt3x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x3"/> value to a <see cref="Int3x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x3(UInt3x3 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt3x3"/> values.
@@ -3912,6 +4143,27 @@ public unsafe partial struct UInt3x4
     }
 
     /// <summary>
+    /// Casts a <see cref="UInt3x4"/> value to a <see cref="Float3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float3x4(UInt3x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x4"/> value to a <see cref="Double3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double3x4(UInt3x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt3x4"/> value to a <see cref="Int3x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt3x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int3x4(UInt3x4 matrix) => default;
+
+    /// <summary>
     /// Sums two <see cref="UInt3x4"/> values.
     /// </summary>
     /// <param name="left">The first <see cref="UInt3x4"/> value to sum.</param>
@@ -4229,6 +4481,27 @@ public unsafe partial struct UInt4x1
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x1"/> value to a <see cref="Float4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float4x1(UInt4x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x1"/> value to a <see cref="Double4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x1(UInt4x1 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x1"/> value to a <see cref="Int4x1"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x1"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x1(UInt4x1 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt4x1"/> values.
@@ -4621,6 +4894,27 @@ public unsafe partial struct UInt4x2
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x2"/> value to a <see cref="Float4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float4x2(UInt4x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x2"/> value to a <see cref="Double4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x2(UInt4x2 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x2"/> value to a <see cref="Int4x2"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x2"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x2(UInt4x2 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt4x2"/> values.
@@ -5059,6 +5353,27 @@ public unsafe partial struct UInt4x3
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x3"/> value to a <see cref="Float4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float4x3(UInt4x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x3"/> value to a <see cref="Double4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x3(UInt4x3 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x3"/> value to a <see cref="Int4x3"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x3"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x3(UInt4x3 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt4x3"/> values.
@@ -5549,6 +5864,27 @@ public unsafe partial struct UInt4x4
 
         return matrix;
     }
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x4"/> value to a <see cref="Float4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Float4x4(UInt4x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x4"/> value to a <see cref="Double4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static implicit operator Double4x4(UInt4x4 matrix) => default;
+
+    /// <summary>
+    /// Casts a <see cref="UInt4x4"/> value to a <see cref="Int4x4"/> one.
+    /// </summary>
+    /// <param name="matrix">The input <see cref="UInt4x4"/> value to cast.</param>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static explicit operator Int4x4(UInt4x4 matrix) => default;
 
     /// <summary>
     /// Sums two <see cref="UInt4x4"/> values.

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -985,4 +985,74 @@ public partial class ShaderRewriterTests
             return this.Number;
         }
     }
+
+    [CombinatorialTestMethod]
+    [AllDevices]
+    public void HlslMatrixTypesCastOperators(Device device)
+    {
+        using ReadWriteBuffer<float> buffer1 = device.Get().AllocateReadWriteBuffer<float>(3);
+        using ReadWriteBuffer<int> buffer2 = device.Get().AllocateReadWriteBuffer<int>(8);
+        using ReadWriteBuffer<uint> buffer3 = device.Get().AllocateReadWriteBuffer<uint>(8);
+
+        device.Get().For(1, new HlslMatrixTypesCastOperatorsShader(buffer1, buffer2, buffer3));
+
+        float[] results1 = buffer1.ToArray();
+        int[] results2 = buffer2.ToArray();
+        uint[] results3 = buffer3.ToArray();
+
+        CollectionAssert.AreEqual(
+            expected: new float[] { 111, 222, 333 },
+            actual: results1,
+            comparer: Comparer<float>.Create(static (x, y) => Math.Abs(x - y) < 0.000001f ? 0 : x.CompareTo(y)));
+
+        CollectionAssert.AreEqual(
+            expected: new[] { 1, 3, 4, 5, 6, 1, 2, 3 },
+            actual: results2);
+
+        CollectionAssert.AreEqual(
+            expected: new uint[] { 1, 3, 4, 5, 6, 1, 2, 3 },
+            actual: results3);
+    }
+
+    [AutoConstructor]
+    [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+    [GeneratedComputeShaderDescriptor]
+    internal readonly partial struct HlslMatrixTypesCastOperatorsShader : IComputeShader
+    {
+        public readonly ReadWriteBuffer<float> buffer1;
+        public readonly ReadWriteBuffer<int> buffer2;
+        public readonly ReadWriteBuffer<uint> buffer3;
+
+        public void Execute()
+        {
+            int1x3 i1x3 = new(111, 222, 333);
+            float2x4 f2x4 = new(1, 3.14f, 4, 5, 6.28f, 1.11f, 2.22f, 3.33f);
+
+            float1x3 f1x3 = (float1x3)i1x3;
+            int2x4 i2x4 = (int2x4)f2x4;
+            uint2x4 ui2x4 = (uint2x4)f2x4;
+
+            buffer1[0] = f1x3.M11;
+            buffer1[1] = f1x3.M12;
+            buffer1[2] = f1x3.M13;
+
+            buffer2[0] = i2x4.M11;
+            buffer2[1] = i2x4.M12;
+            buffer2[2] = i2x4.M13;
+            buffer2[3] = i2x4.M14;
+            buffer2[4] = i2x4.M21;
+            buffer2[5] = i2x4.M22;
+            buffer2[6] = i2x4.M23;
+            buffer2[7] = i2x4.M24;
+
+            buffer3[0] = ui2x4.M11;
+            buffer3[1] = ui2x4.M12;
+            buffer3[2] = ui2x4.M13;
+            buffer3[3] = ui2x4.M14;
+            buffer3[4] = ui2x4.M21;
+            buffer3[5] = ui2x4.M22;
+            buffer3[6] = ui2x4.M23;
+            buffer3[7] = ui2x4.M24;
+        }
+    }
 }


### PR DESCRIPTION
### Description

This PR adds the missing cast operators for the various HLSL matrix types (all of them, except for `BoolMxN` types). This matches what the HLSL vector types have had for quite a while already, allowing for much simpler conversion between element types.