### PR TITLE
Refactor and optimize D2D resource texture diagnostics

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.cs
@@ -39,6 +39,8 @@ partial class D2DPixelShaderDescriptorGenerator
             int rawInputCount = 0;
             bool isInputCountPresent = false;
 
+            // Note: this logic is shared with InvalidD2DResourceTextureIndexAttributeUseAnalyzer.
+            // If any changes are made here, they should be reflected in that analyzer as well.
             inputCount = 0;
 
             using ImmutableArrayBuilder<int> inputSimpleIndicesBuilder = new();

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -109,9 +109,7 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
 
                     // Get the resource texture info for ResourceTextureDescriptions
                     ResourceTextureDescriptions.GetInfo(
-                        diagnostics,
                         typeSymbol,
-                        inputCount,
                         out ImmutableArray<ResourceTextureDescription> resourceTextureDescriptions);
 
                     token.ThrowIfCancellationRequested();

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DResourceTextureIndexAttributeLocationAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DResourceTextureIndexAttributeLocationAnalyzer.cs
@@ -8,13 +8,13 @@ using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 namespace ComputeSharp.D2D1.SourceGenerators;
 
 /// <summary>
-/// A diagnostic analyzer that generates an error whenever [D2DResourceTextureIndex] is used incorrectly to annotate an invalid field.
+/// A diagnostic analyzer that generates an error whenever [D2DResourceTextureIndex] is used incorrectly to annotate a field.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class InvalidD2DResourceTextureIndexUseAnalyzer : DiagnosticAnalyzer
+public sealed class InvalidD2DResourceTextureIndexAttributeLocationAnalyzer : DiagnosticAnalyzer
 {
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidD2DResourceTextureIndexAttributeUse);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidD2DResourceTextureIndexAttributeLocation);
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -49,7 +49,7 @@ public sealed class InvalidD2DResourceTextureIndexUseAnalyzer : DiagnosticAnalyz
                           SymbolEqualityComparer.Default.Equals(typeSymbol.ConstructedFrom, d2D1ResourceTexture3DSymbol)))
                     {
                         Diagnostic diagnostic = Diagnostic.Create(
-                            InvalidD2DResourceTextureIndexAttributeUse,
+                            InvalidD2DResourceTextureIndexAttributeLocation,
                             fieldSymbol.Locations.First(),
                             fieldSymbol.Name,
                             fieldSymbol.ContainingType,

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DResourceTextureIndexAttributeUseAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DResourceTextureIndexAttributeUseAnalyzer.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates errors for all invalid uses of the [D2DResourceTextureIndex] attribute.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidD2DResourceTextureIndexAttributeUseAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        MissingD2DResourceTextureIndexAttribute,
+        ResourceTextureIndexOverlappingWithInputIndex,
+        OutOfRangeResourceTextureIndex,
+        RepeatedD2DResourceTextureIndices);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get all necessary symbols (we need a whole bunch of them here)
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DResourceTextureIndexAttribute") is not { } d2DResourceTextureIndexAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2D1ResourceTexture1D`1") is not { } d2D1ResourceTexture1DSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2D1ResourceTexture2D`1") is not { } d2D1ResourceTexture2DSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2D1ResourceTexture3D`1") is not { } d2D1ResourceTexture3DSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DInputCountAttribute") is not { } d2DInputCountAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.ID2D1PixelShader") is not { } d2D1PixelShaderSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // We're validating all struct types (since they're the possible shader types)
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // Only validate fields for shader types (even without a generated descriptor)
+                if (!typeSymbol.HasInterfaceWithType(d2D1PixelShaderSymbol))
+                {
+                    return;
+                }
+
+                using ImmutableArrayBuilder<(int? Index, int Rank)> resourceTextureInfos = new();
+
+                foreach (ISymbol memberSymbol in typeSymbol.GetMembers())
+                {
+                    // Only look for valid candidate fields (same logic as in D2DPixelShaderDescriptorGenerator.InputTypes)
+                    if (memberSymbol is not IFieldSymbol { IsStatic: false, Type: INamedTypeSymbol { IsUnmanagedType: true, IsGenericType: true } } fieldSymbol)
+                    {
+                        continue;
+                    }
+
+                    // Check that the field is a D2D resource texture and get the rank
+                    int rank = fieldSymbol.Type switch
+                    {
+                        _ when SymbolEqualityComparer.Default.Equals(d2D1ResourceTexture1DSymbol, fieldSymbol.Type) => 1,
+                        _ when SymbolEqualityComparer.Default.Equals(d2D1ResourceTexture2DSymbol, fieldSymbol.Type) => 2,
+                        _ when SymbolEqualityComparer.Default.Equals(d2D1ResourceTexture3DSymbol, fieldSymbol.Type) => 3,
+                        _ => 0
+                    };
+
+                    // The field is not a D2D resource texture, just skip it
+                    if (rank == 0)
+                    {
+                        continue;
+                    }
+
+                    int? index = null;
+
+                    // Try to get the annotated index for the D2D texture, and track it. This
+                    // logic is also in sync with D2DPixelShaderDescriptorGenerator.InputTypes.
+                    if (fieldSymbol.TryGetAttributeWithType(d2DResourceTextureIndexAttributeSymbol, out AttributeData? textureIndexData))
+                    {
+                        if (textureIndexData.TryGetConstructorArgument(0, out int resourceIndex))
+                        {
+                            index = resourceIndex;
+                        }
+                    }
+                    else
+                    {
+                        // If the attribute is missing, emit a diagnostic
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            MissingD2DResourceTextureIndexAttribute,
+                            fieldSymbol.Locations.First(),
+                            fieldSymbol.Name,
+                            typeSymbol));
+                    }
+
+                    resourceTextureInfos.Add((index, rank));
+                }
+
+                int inputCount = 0;
+
+                // Same logic as in D2DPixelShaderDescriptorGenerator.InputTypes (see there for reference).
+                // Keeping this in sync to ensure a consistent behavior (this should be updated if that changes).
+                if (typeSymbol.TryGetAttributeWithType(d2DInputCountAttributeSymbol, out AttributeData? inputCountData))
+                {
+                    inputCount = Math.Max((int)inputCountData.ConstructorArguments[0].Value!, 0);
+                }
+
+                // If the input count is invalid, do nothing and avoid emitting potentially incorrect diagnostics
+                // based on the resource texture indices with respect to the input count. The generator for the
+                // InputType property has already emitted diagnostic for this error, so this analyzer can just
+                // wait for users to go back and fix that issue before proceeding.
+                if (inputCount is not (>= 0 and <= 8))
+                {
+                    return;
+                }
+
+                // Validate that the resource texture indices don't overlap with the shader inputs
+                foreach ((int? index, _) in resourceTextureInfos.WrittenSpan)
+                {
+                    if (index < inputCount)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            ResourceTextureIndexOverlappingWithInputIndex,
+                            typeSymbol.Locations.First(),
+                            typeSymbol));
+
+                        return;
+                    }
+                }
+
+                // Validate that no resource texture has an index greater than or equal to 16
+                foreach ((int? index, _) in resourceTextureInfos.WrittenSpan)
+                {
+                    if (index >= 16)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            OutOfRangeResourceTextureIndex,
+                            typeSymbol.Locations.First(),
+                            typeSymbol));
+
+                        return;
+                    }
+                }
+
+                Span<bool> selectedResourceTextureIndices = stackalloc bool[16];
+
+                selectedResourceTextureIndices.Clear();
+
+                // All input description indices must be unique (also take this path for invalid indices)
+                foreach ((int? index, _) in resourceTextureInfos.WrittenSpan)
+                {
+                    ref bool isResourceTextureIndexUsed = ref selectedResourceTextureIndices[index ?? 0];
+
+                    if (isResourceTextureIndexUsed)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            RepeatedD2DResourceTextureIndices,
+                            typeSymbol.Locations.First(),
+                            typeSymbol));
+
+                        return;
+                    }
+
+                    isResourceTextureIndexUsed = true;
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DResourceTextureIndexUseAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DResourceTextureIndexUseAnalyzer.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
 using ComputeSharp.SourceGeneration.Extensions;
-using ComputeSharp.SourceGeneration.Mappings;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
@@ -23,26 +22,43 @@ public sealed class InvalidD2DResourceTextureIndexUseAnalyzer : DiagnosticAnalyz
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
         context.EnableConcurrentExecution();
 
-        context.RegisterSymbolAction(static context =>
+        context.RegisterCompilationStartAction(static context =>
         {
-            IFieldSymbol fieldSymbol = (IFieldSymbol)context.Symbol;
-
-            if (fieldSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DResourceTextureIndexAttribute", out _))
+            // Get the [D2DResourceTextureIndex] symbol, and the ones for the D2D resource texture types
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DResourceTextureIndexAttribute") is not { } d2DResourceTextureIndexAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2D1ResourceTexture1D`1") is not { } d2D1ResourceTexture1DSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2D1ResourceTexture2D`1") is not { } d2D1ResourceTexture2DSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2D1ResourceTexture3D`1") is not { } d2D1ResourceTexture3DSymbol)
             {
-                string metadataName = fieldSymbol.Type.GetFullyQualifiedMetadataName();
-
-                if (!HlslKnownTypes.IsResourceTextureType(metadataName))
-                {
-                    Diagnostic diagnostic = Diagnostic.Create(
-                        InvalidD2DResourceTextureIndexAttributeUse,
-                        fieldSymbol.Locations.First(),
-                        fieldSymbol.Name,
-                        fieldSymbol.ContainingType,
-                        fieldSymbol.Type);
-
-                    context.ReportDiagnostic(diagnostic);
-                }
+                return;
             }
-        }, SymbolKind.Field);
+
+            // Inspect all fields to make sure they're not using the attribute incorrectly
+            context.RegisterSymbolAction(context =>
+            {
+                IFieldSymbol fieldSymbol = (IFieldSymbol)context.Symbol;
+
+                if (fieldSymbol.HasAttributeWithType(d2DResourceTextureIndexAttributeSymbol))
+                {
+                    // If the field is using [D2DResourceTextureIndex], it must be a D2D resource texture. We can first
+                    // just check that the field type is a generic named type (since that's the case if it's indeed of
+                    // a D2D resource texture type). Past that, we just check that it's one of the three possible types.
+                    if (fieldSymbol.Type is not INamedTypeSymbol { IsGenericType: true } typeSymbol ||
+                        !(SymbolEqualityComparer.Default.Equals(typeSymbol.ConstructedFrom, d2D1ResourceTexture1DSymbol) ||
+                          SymbolEqualityComparer.Default.Equals(typeSymbol.ConstructedFrom, d2D1ResourceTexture2DSymbol) ||
+                          SymbolEqualityComparer.Default.Equals(typeSymbol.ConstructedFrom, d2D1ResourceTexture3DSymbol)))
+                    {
+                        Diagnostic diagnostic = Diagnostic.Create(
+                            InvalidD2DResourceTextureIndexAttributeUse,
+                            fieldSymbol.Locations.First(),
+                            fieldSymbol.Name,
+                            fieldSymbol.ContainingType,
+                            fieldSymbol.Type);
+
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }, SymbolKind.Field);
+        });
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -654,9 +654,9 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader with an out of range resource texture index (or more).
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a shader with an overlapping resource texture index (or more).
     /// <para>
-    /// Format: <c>"The D2D1 shader of type {0} is using some out of range resource texture indices"</c>.
+    /// Format: <c>"The D2D1 shader of type {0} is using some resource texture indices that overlap with the shader input indices"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor ResourceTextureIndexOverlappingWithInputIndex = new(

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -702,14 +702,14 @@ partial class DiagnosticDescriptors
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
-    /// Gets a <see cref="DiagnosticDescriptor"/> for an invalid use of <c>[D2DResourceTextureIndex]</c>.
+    /// Gets a <see cref="DiagnosticDescriptor"/> for an invalid location of <c>[D2DResourceTextureIndex]</c>.
     /// <para>
-    /// Format: <c>"The field "{0}" (in type {1}) is using [D2DResourceTextureIndex] incorrectly (the attribute can only be used on D2D1 resource texture types, but the field is of type {2})"</c>.
+    /// Format: <c>"The field "{0}" (in type {1}) is using [D2DResourceTextureIndex] on an invalid location (the attribute can only be used on D2D1 resource texture types, but the field is of type {2})"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor InvalidD2DResourceTextureIndexAttributeUse = new(
+    public static readonly DiagnosticDescriptor InvalidD2DResourceTextureIndexAttributeLocation = new(
         id: "CMPSD2D0049",
-        title: "Invalid [D2DResourceTextureIndex] use",
+        title: "Invalid [D2DResourceTextureIndex] location",
         messageFormat: """The field "{0}" (in type {1}) is using [D2DResourceTextureIndex] incorrectly (the attribute can only be used on D2D1 resource texture types, but the field is of type {2})""",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
@@ -22,6 +22,19 @@ partial class HlslKnownMethods
     }
 
     /// <inheritdoc/>
+    private static partial Dictionary<string, string?> BuildKnownResourceSamplers()
+    {
+        return new()
+        {
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture1D`1.Sample({typeof(float).FullName})"] = null,
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Sample({typeof(float).FullName}, {typeof(float).FullName})"] = "float2",
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Sample({typeof(Float2).FullName})"] = null,
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Sample({typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName})"] = "float3",
+            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Sample({typeof(Float3).FullName})"] = null
+        };
+    }
+
+    /// <inheritdoc/>
 
     static partial void AddKnownMethods(IDictionary<string, string> knownMethods)
     {
@@ -36,18 +49,5 @@ partial class HlslKnownMethods
 
             knownMethods.Add($"{typeof(D2D).FullName}{Type.Delimiter}{method.Name}", hlslName);
         }
-    }
-
-    /// <inheritdoc/>
-    private static partial IReadOnlyDictionary<string, string?> BuildKnownResourceSamplers()
-    {
-        return new Dictionary<string, string?>
-        {
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture1D`1.Sample({typeof(float).FullName})"] = null,
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Sample({typeof(float).FullName}, {typeof(float).FullName})"] = "float2",
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Sample({typeof(Float2).FullName})"] = null,
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Sample({typeof(float).FullName}, {typeof(float).FullName}, {typeof(float).FullName})"] = "float3",
-            [$"ComputeSharp.D2D1.D2D1ResourceTexture3D`1.Sample({typeof(Float3).FullName})"] = null
-        };
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownProperties.cs
@@ -6,9 +6,9 @@ namespace ComputeSharp.SourceGeneration.Mappings;
 partial class HlslKnownProperties
 {
     /// <inheritdoc/>
-    private static partial IReadOnlyDictionary<string, string> BuildKnownResourceIndexers()
+    private static partial Dictionary<string, string> BuildKnownResourceIndexers()
     {
-        return new Dictionary<string, string>
+        return new()
         {
             [$"ComputeSharp.D2D1.D2D1ResourceTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
             [$"ComputeSharp.D2D1.D2D1ResourceTexture3D`1.this[{typeof(int).FullName}, {typeof(int).FullName}, {typeof(int).FullName}]"] = "int3"
@@ -16,9 +16,9 @@ partial class HlslKnownProperties
     }
 
     /// <inheritdoc/>
-    private static partial IReadOnlyDictionary<string, (int Rank, int Axis)> BuildKnownSizeAccessors()
+    private static partial Dictionary<string, (int Rank, int Axis)> BuildKnownSizeAccessors()
     {
-        return new Dictionary<string, (int, int)>
+        return new()
         {
             ["ComputeSharp.D2D1.D2D1ResourceTexture1D`1.Width"] = (1, 0),
             ["ComputeSharp.D2D1.D2D1ResourceTexture2D`1.Width"] = (2, 0),

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownFields.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownFields.cs
@@ -10,7 +10,7 @@ internal static partial class HlslKnownFields
     /// <summary>
     /// The mapping of supported known fields to HLSL names.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> KnownFields = BuildKnownFieldsMap();
+    private static readonly Dictionary<string, string> KnownFields = BuildKnownFieldsMap();
 
     /// <summary>
     /// Builds the mapping of supported known fields to HLSL names.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
@@ -16,7 +16,7 @@ internal static partial class HlslKnownKeywords
     /// <summary>
     /// The mapping of known HLSL keywords.
     /// </summary>
-    private static readonly IReadOnlyCollection<string> KnownKeywords = BuildKnownKeywordsMap();
+    private static readonly HashSet<string> KnownKeywords = BuildKnownKeywordsMap();
 
     /// <summary>
     /// Builds the mapping of all known HLSL keywords.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownMethods.cs
@@ -14,12 +14,17 @@ internal static partial class HlslKnownMethods
     /// <summary>
     /// The mapping of supported known methods to HLSL names.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> KnownMethods = BuildKnownMethodsMap();
+    private static readonly Dictionary<string, string> KnownMethods = BuildKnownMethodsMap();
 
     /// <summary>
     /// The mapping of supported known methods that require parameters mapping to HLSL names.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> KnownMethodsParametersMapping = BuildKnownMethodsParametersMappingMap();
+    private static readonly Dictionary<string, string> KnownMethodsParametersMapping = BuildKnownMethodsParametersMappingMap();
+
+    /// <summary>
+    /// The mapping of supported known samplers to HLSL resource type names.
+    /// </summary>
+    private static readonly Dictionary<string, string?> KnownResourceSamplers = BuildKnownResourceSamplers();
 
     /// <summary>
     /// Builds the mapping of supported known methods to HLSL names.
@@ -95,21 +100,16 @@ internal static partial class HlslKnownMethods
     }
 
     /// <summary>
+    /// Builds the mapping of supported known samplers to HLSL resource type names.
+    /// </summary>
+    /// <returns>The mapping of supported known samplers to HLSL resource type names.</returns>
+    private static partial Dictionary<string, string?> BuildKnownResourceSamplers();
+
+    /// <summary>
     /// Adds more known methods to the mapping to use.
     /// </summary>
     /// <param name="knownMethods">The mapping of known methods being built.</param>
     static partial void AddKnownMethods(IDictionary<string, string> knownMethods);
-
-    /// <summary>
-    /// The mapping of supported known samplers to HLSL resource type names.
-    /// </summary>
-    private static readonly IReadOnlyDictionary<string, string?> KnownResourceSamplers = BuildKnownResourceSamplers();
-
-    /// <summary>
-    /// Builds the mapping of supported known samplers to HLSL resource type names.
-    /// </summary>
-    /// <returns>The mapping of supported known samplers to HLSL resource type names.</returns>
-    private static partial IReadOnlyDictionary<string, string?> BuildKnownResourceSamplers();
 
     /// <summary>
     /// Tries to get the mapped HLSL-compatible sampler resource type name for the input indexer name.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
@@ -14,7 +14,7 @@ internal static partial class HlslKnownOperators
     /// <summary>
     /// The mapping of supported known operators to HLSL names.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> KnownOperators = BuildKnownOperatorsMap();
+    private static readonly Dictionary<string, string> KnownOperators = BuildKnownOperatorsMap();
 
     /// <summary>
     /// Builds the mapping of supported known operators to HLSL names.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownSizes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownSizes.cs
@@ -14,7 +14,7 @@ internal static class HlslKnownSizes
     /// <summary>
     /// The mapping of supported known sizes to HLSL type names.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, (int, int)> KnownSizes = BuildKnownSizesMap();
+    private static readonly Dictionary<string, (int, int)> KnownSizes = BuildKnownSizesMap();
 
     /// <summary>
     /// Builds the mapping of known type sizes and alignments.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -57,22 +57,22 @@ internal static partial class HlslKnownTypes
     /// <summary>
     /// The mapping of supported known vector types to HLSL types.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> KnownVectorTypeMetadataNames = BuildKnownVectorTypeMetadataNames();
+    private static readonly Dictionary<string, string> KnownVectorTypeMetadataNames = BuildKnownVectorTypeMetadataNames();
 
     /// <summary>
     /// The mapping of supported known matrix types to HLSL types.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> KnownMatrixTypesMetadataNames = BuildKnownMatrixTypeMetadataNames();
+    private static readonly Dictionary<string, string> KnownMatrixTypesMetadataNames = BuildKnownMatrixTypeMetadataNames();
 
     /// <summary>
     /// The mapping of supported known types to HLSL types.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, string> KnownHlslTypeMetadataNames = BuildKnownHlslTypeMetadataNames();
+    private static readonly Dictionary<string, string> KnownHlslTypeMetadataNames = BuildKnownHlslTypeMetadataNames();
 
     /// <summary>
     /// The mapping of type info for all supported known matrix types to HLSL types.
     /// </summary>
-    private static readonly IReadOnlyDictionary<string, NonLinearMatrixTypeInfo> KnownNonLinearMatrixTypeInfo = BuildKnownNonLinearMatrixTypeInfo();
+    private static readonly Dictionary<string, NonLinearMatrixTypeInfo> KnownNonLinearMatrixTypeInfo = BuildKnownNonLinearMatrixTypeInfo();
 
     /// <summary>
     /// Builds the mapping of known HLSL vector types.

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownMethods.cs
@@ -6,9 +6,9 @@ namespace ComputeSharp.SourceGeneration.Mappings;
 partial class HlslKnownMethods
 {
     /// <inheritdoc/>
-    private static partial IReadOnlyDictionary<string, string?> BuildKnownResourceSamplers()
+    private static partial Dictionary<string, string?> BuildKnownResourceSamplers()
     {
-        return new Dictionary<string, string?>
+        return new()
         {
             [$"ComputeSharp.ReadOnlyTexture1D`2.Sample({typeof(float).FullName})"] = null,
             [$"ComputeSharp.IReadOnlyTexture1D`1.Sample({typeof(float).FullName})"] = null,

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownProperties.cs
@@ -9,9 +9,9 @@ namespace ComputeSharp.SourceGeneration.Mappings;
 partial class HlslKnownProperties
 {
     /// <inheritdoc/>
-    private static partial IReadOnlyDictionary<string, string> BuildKnownResourceIndexers()
+    private static partial Dictionary<string, string> BuildKnownResourceIndexers()
     {
-        return new Dictionary<string, string>
+        return new()
         {
             [$"ComputeSharp.ReadOnlyTexture2D`1.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
             [$"ComputeSharp.ReadOnlyTexture2D`2.this[{typeof(int).FullName}, {typeof(int).FullName}]"] = "int2",
@@ -33,9 +33,9 @@ partial class HlslKnownProperties
     }
 
     /// <inheritdoc/>
-    private static partial IReadOnlyDictionary<string, (int Rank, int Axis)> BuildKnownSizeAccessors()
+    private static partial Dictionary<string, (int Rank, int Axis)> BuildKnownSizeAccessors()
     {
-        return new Dictionary<string, (int, int)>
+        return new()
         {
             ["ComputeSharp.Resources.Buffer`1.Length"] = (2, 0),
             ["ComputeSharp.Resources.Texture1D`1.Width"] = (1, 0),

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -457,10 +457,10 @@ public class Test_Analyzers
             using ComputeSharp.D2D1;
 
             [D2DInputCount(2)]
-            internal partial struct MyType : ID2D1PixelShader
+            internal partial struct {|CMPSD2D0046:MyType|} : ID2D1PixelShader
             {
                 [D2DResourceTextureIndex(1)]
-                public D2D1ResourceTexture1D<float> {|CMPSD2D0046:texture|};
+                public D2D1ResourceTexture1D<float> texture;
 
                 public Float4 Execute()
                 {
@@ -480,10 +480,10 @@ public class Test_Analyzers
             using ComputeSharp.D2D1;
 
             [D2DInputCount(2)]
-            internal partial struct MyType : ID2D1PixelShader
+            internal partial struct {|CMPSD2D0046:MyType|} : ID2D1PixelShader
             {
                 [D2DResourceTextureIndex(0)]
-                public D2D1ResourceTexture1D<float> {|CMPSD2D0046:texture1D|};
+                public D2D1ResourceTexture1D<float> texture1D;
 
                 [D2DResourceTextureIndex(1)]
                 public D2D1ResourceTexture2D<float> texture2D;
@@ -506,10 +506,10 @@ public class Test_Analyzers
             using ComputeSharp.D2D1;
 
             [D2DInputCount(0)]
-            internal partial struct MyType : ID2D1PixelShader
+            internal partial struct {|CMPSD2D0047:MyType|} : ID2D1PixelShader
             {
                 [D2DResourceTextureIndex(16)]
-                public D2D1ResourceTexture1D<float> {|CMPSD2D0047:texture|};
+                public D2D1ResourceTexture1D<float> texture;
 
                 public Float4 Execute()
                 {
@@ -529,10 +529,10 @@ public class Test_Analyzers
             using ComputeSharp.D2D1;
 
             [D2DInputCount(0)]
-            internal partial struct MyType : ID2D1PixelShader
+            internal partial struct {|CMPSD2D0047:MyType|} : ID2D1PixelShader
             {
                 [D2DResourceTextureIndex(16)]
-                public D2D1ResourceTexture1D<float> {|CMPSD2D0047:texture1D|};
+                public D2D1ResourceTexture1D<float> texture1D;
 
                 [D2DResourceTextureIndex(17)]
                 public D2D1ResourceTexture2D<float> texture2D;
@@ -555,13 +555,51 @@ public class Test_Analyzers
             using ComputeSharp.D2D1;
 
             [D2DInputCount(0)]
-            internal partial struct MyType : ID2D1PixelShader
+            internal partial struct {|CMPSD2D0048:MyType|} : ID2D1PixelShader
             {
                 [D2DResourceTextureIndex(0)]
-                public D2D1ResourceTexture1D<float> {|CMPSD2D0048:texture1|};
+                public D2D1ResourceTexture1D<float> texture1;
 
                 [D2DResourceTextureIndex(0)]
                 public D2D1ResourceTexture1D<float> texture2;
+
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task InvalidD2DResourceTextureIndices_MultipleErrors_WarnsOncePerDiagnosticId()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(3)]
+            internal partial struct {|CMPSD2D0046:{|CMPSD2D0047:{|CMPSD2D0048:MyType|}|}|} : ID2D1PixelShader
+            {
+                [D2DResourceTextureIndex(0)]
+                public D2D1ResourceTexture1D<float> texture1;
+
+                [D2DResourceTextureIndex(1)]
+                public D2D1ResourceTexture1D<float> texture2;
+
+                [D2DResourceTextureIndex(16)]
+                public D2D1ResourceTexture1D<float> texture3;
+
+                [D2DResourceTextureIndex(17)]
+                public D2D1ResourceTexture2D<float> texture4;
+
+                [D2DResourceTextureIndex(2)]
+                public D2D1ResourceTexture1D<float> texture5;
+
+                [D2DResourceTextureIndex(2)]
+                public D2D1ResourceTexture1D<float> texture6;
 
                 public Float4 Execute()
                 {

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -415,4 +415,161 @@ public class Test_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DRequiresDoublePrecisionSupportAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task MissingD2DResourceTextureIndexAttribute_WarnsOnlyIfMissing()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(0)]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                public D2D1ResourceTexture1D<float> {|CMPSD2D0050:texture1D|};
+                public D2D1ResourceTexture2D<float> {|CMPSD2D0050:texture2D|};
+                public D2D1ResourceTexture3D<float> {|CMPSD2D0050:texture3D|};
+
+                [D2DResourceTextureIndex(0)]
+                public D2D1ResourceTexture1D<float> texture1D_2;
+
+                [D2DResourceTextureIndex(1)]
+                public D2D1ResourceTexture2D<float> texture2D_2;
+
+                [D2DResourceTextureIndex(2)]
+                public D2D1ResourceTexture3D<float> texture3D_2;
+
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ResourceTextureIndexOverlappingWithInputIndex_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(2)]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                [D2DResourceTextureIndex(1)]
+                public D2D1ResourceTexture1D<float> {|CMPSD2D0046:texture|};
+
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ResourceTextureIndexOverlappingWithInputIndex_WarnsOnlyOnce()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(2)]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                [D2DResourceTextureIndex(0)]
+                public D2D1ResourceTexture1D<float> {|CMPSD2D0046:texture1D|};
+
+                [D2DResourceTextureIndex(1)]
+                public D2D1ResourceTexture2D<float> texture2D;
+
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task OutOfRangeResourceTextureIndex_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(0)]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                [D2DResourceTextureIndex(16)]
+                public D2D1ResourceTexture1D<float> {|CMPSD2D0047:texture|};
+
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task OutOfRangeResourceTextureIndex_WarnsOnlyOnce()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(0)]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                [D2DResourceTextureIndex(16)]
+                public D2D1ResourceTexture1D<float> {|CMPSD2D0047:texture1D|};
+
+                [D2DResourceTextureIndex(17)]
+                public D2D1ResourceTexture2D<float> texture2D;
+
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task RepeatedD2DResourceTextureIndices_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(0)]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                [D2DResourceTextureIndex(0)]
+                public D2D1ResourceTexture1D<float> {|CMPSD2D0048:texture1|};
+
+                [D2DResourceTextureIndex(0)]
+                public D2D1ResourceTexture1D<float> texture2;
+
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
@@ -1770,7 +1770,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DRequiresDoublePrecisionSupportAnalyzer>.VerifyAnalyzerAsync(source);
-        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexUseAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeLocationAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidEffectIdValueAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidEffectMetadataValueAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MissingAllowUnsafeBlocksCompilationOptionAnalyzer>.VerifyAnalyzerAsync(source);

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
@@ -1771,6 +1771,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DRequiresDoublePrecisionSupportAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeLocationAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidEffectIdValueAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidEffectMetadataValueAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MissingAllowUnsafeBlocksCompilationOptionAnalyzer>.VerifyAnalyzerAsync(source);


### PR DESCRIPTION
### Description

This PR includes several generator/analyzer immprovements for the D2D backend:
- Move all diagnostics logic for D2D resource textures to a new analyzer
- Minor performance improvements to the D2D generator (and DX12 too)
- New unit tests for all the diagnostics previously emitted by the generator