### PR TITLE
Use 'ref readonly' where applicable

### DIFF
--- a/src/ComputeSharp.Pix/ComputeContextExtensions.cs
+++ b/src/ComputeSharp.Pix/ComputeContextExtensions.cs
@@ -18,7 +18,7 @@ public static class ComputeContextExtensions
     /// <param name="color">The color to use for the event (the alpha channel will be ignored).</param>
     /// <param name="message">The message to use for the event.</param>
     [Conditional("USE_PIX")]
-    public static unsafe void BeginEvent(this in ComputeContext context, Color color, string message)
+    public static unsafe void BeginEvent(this ref readonly ComputeContext context, Color color, string message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -35,7 +35,7 @@ public static class ComputeContextExtensions
     /// <param name="index">The index to identify the group this event belongs to (PIX will choose a color to represent all entries in the group).</param>
     /// <param name="message">The message to use for the event.</param>
     [Conditional("USE_PIX")]
-    public static unsafe void BeginEvent(this in ComputeContext context, byte index, string message)
+    public static unsafe void BeginEvent(this ref readonly ComputeContext context, byte index, string message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -50,7 +50,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to start the PIX event.</param>
     /// <param name="message">The message to use for the event.</param>
     [Conditional("USE_PIX")]
-    public static unsafe void BeginEvent(this in ComputeContext context, string message)
+    public static unsafe void BeginEvent(this ref readonly ComputeContext context, string message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -76,7 +76,7 @@ public static class ComputeContextExtensions
     /// </para>
     /// </remarks>
     [Conditional("USE_PIX")]
-    public static unsafe void BeginEventUnsafe(this in ComputeContext context, Color color, ReadOnlySpan<byte> message)
+    public static unsafe void BeginEventUnsafe(this ref readonly ComputeContext context, Color color, ReadOnlySpan<byte> message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -105,7 +105,7 @@ public static class ComputeContextExtensions
     /// </para>
     /// </remarks>
     [Conditional("USE_PIX")]
-    public static unsafe void BeginEventUnsafe(this in ComputeContext context, byte index, ReadOnlySpan<byte> message)
+    public static unsafe void BeginEventUnsafe(this ref readonly ComputeContext context, byte index, ReadOnlySpan<byte> message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -132,7 +132,7 @@ public static class ComputeContextExtensions
     /// </para>
     /// </remarks>
     [Conditional("USE_PIX")]
-    public static unsafe void BeginEventUnsafe(this in ComputeContext context, ReadOnlySpan<byte> message)
+    public static unsafe void BeginEventUnsafe(this ref readonly ComputeContext context, ReadOnlySpan<byte> message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -144,7 +144,7 @@ public static class ComputeContextExtensions
     /// </summary>
     /// <param name="context">The <see cref="ComputeContext"/> to use to end the PIX event.</param>
     [Conditional("USE_PIX")]
-    public static unsafe void EndEvent(this in ComputeContext context)
+    public static unsafe void EndEvent(this ref readonly ComputeContext context)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -158,7 +158,7 @@ public static class ComputeContextExtensions
     /// <param name="color">The color to use for the log (the alpha channel will be ignored).</param>
     /// <param name="message">The message to use for the marker.</param>
     [Conditional("USE_PIX")]
-    public static unsafe void Log(this in ComputeContext context, Color color, string message)
+    public static unsafe void Log(this ref readonly ComputeContext context, Color color, string message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -175,7 +175,7 @@ public static class ComputeContextExtensions
     /// <param name="index">The index to identify the group this log belongs to (PIX will choose a color to represent all entries in the group).</param>
     /// <param name="message">The message to use for the marker.</param>
     [Conditional("USE_PIX")]
-    public static unsafe void Log(this in ComputeContext context, byte index, string message)
+    public static unsafe void Log(this ref readonly ComputeContext context, byte index, string message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -190,7 +190,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the PIX marker.</param>
     /// <param name="message">The message to use for the marker.</param>
     [Conditional("USE_PIX")]
-    public static unsafe void Log(this in ComputeContext context, string message)
+    public static unsafe void Log(this ref readonly ComputeContext context, string message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -216,7 +216,7 @@ public static class ComputeContextExtensions
     /// </para>
     /// </remarks>
     [Conditional("USE_PIX")]
-    public static unsafe void LogUnsafe(this in ComputeContext context, Color color, ReadOnlySpan<byte> message)
+    public static unsafe void LogUnsafe(this ref readonly ComputeContext context, Color color, ReadOnlySpan<byte> message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -245,7 +245,7 @@ public static class ComputeContextExtensions
     /// </para>
     /// </remarks>
     [Conditional("USE_PIX")]
-    public static unsafe void LogUnsafe(this in ComputeContext context, byte index, ReadOnlySpan<byte> message)
+    public static unsafe void LogUnsafe(this ref readonly ComputeContext context, byte index, ReadOnlySpan<byte> message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 
@@ -272,7 +272,7 @@ public static class ComputeContextExtensions
     /// </para>
     /// </remarks>
     [Conditional("USE_PIX")]
-    public static unsafe void LogUnsafe(this in ComputeContext context, ReadOnlySpan<byte> message)
+    public static unsafe void LogUnsafe(this ref readonly ComputeContext context, ReadOnlySpan<byte> message)
     {
         ref CommandList commandList = ref context.GetCommandList(pipelineState: null);
 

--- a/src/ComputeSharp.SourceGeneration/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/ITypeSymbolExtensions.cs
@@ -62,9 +62,9 @@ internal static class ITypeSymbolExtensions
     /// </summary>
     /// <param name="symbol">The input <see cref="ITypeSymbol"/> instance.</param>
     /// <param name="builder">The target <see cref="ImmutableArrayBuilder{T}"/> instance.</param>
-    public static void AppendFullyQualifiedMetadataName(this ITypeSymbol symbol, in ImmutableArrayBuilder<char> builder)
+    public static void AppendFullyQualifiedMetadataName(this ITypeSymbol symbol, ref readonly ImmutableArrayBuilder<char> builder)
     {
-        static void BuildFrom(ISymbol? symbol, in ImmutableArrayBuilder<char> builder)
+        static void BuildFrom(ISymbol? symbol, ref readonly ImmutableArrayBuilder<char> builder)
         {
             switch (symbol)
             {

--- a/src/ComputeSharp/Attributes/Enums/DefaultThreadGroupSizes.cs
+++ b/src/ComputeSharp/Attributes/Enums/DefaultThreadGroupSizes.cs
@@ -12,7 +12,11 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch only along the X axis.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, in T)"/>.
+    /// This applies to using:
+    /// <list type="bullet">
+    ///   <item><see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, in T)"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, in T)"/>.</item>
+    /// </list>
     /// </remarks>
     X = 1 << 0,
 
@@ -20,8 +24,13 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch only along the Y axis.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>,
-    /// but only as long as the input dispatch size on both the X and Z axes is <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
+    /// This applies to using:
+    /// <list type="bullet">
+    ///   <item><see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>.</item>
+    /// </list>
+    /// But only as long as the input dispatch size on both the X and Z axes is <c>1</c>.
+    /// Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
     Y = 1 << 1,
 
@@ -29,8 +38,13 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch only along the Z axis.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>,
-    /// but only as long as the input dispatch size on both the X and Y axes is <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
+    /// This applies to using:
+    /// <list type="bullet">
+    ///   <item><see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>.</item>
+    /// </list>
+    /// But only as long as the input dispatch size on both the X and Y axes is <c>1</c>.
+    /// Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
     Z = 1 << 2,
 
@@ -38,9 +52,15 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch along the X and Y axes.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, in T)"/>, <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel})"/>,
-    /// <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>, <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, in T)"/>,
-    /// <see cref="ComputeContextExtensions.ForEach{T, TPixel}(ref readonly ComputeContext, IReadWriteNormalizedTexture2D{TPixel})"/> or <see cref="ComputeContextExtensions.ForEach{T, TPixel}(ref readonly ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>.
+    /// This applies to using:
+    /// <list type="bullet">
+    ///   <item><see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, in T)"/>.</item>
+    ///   <item><see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel})"/>.</item>
+    ///   <item><see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, in T)"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.ForEach{T, TPixel}(ref readonly ComputeContext, IReadWriteNormalizedTexture2D{TPixel})"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.ForEach{T, TPixel}(ref readonly ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>..</item>
+    /// </list>
     /// </remarks>
     XY = X | Y,
 
@@ -48,8 +68,13 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch along the X and Z axes.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>,
-    /// but only as long as the input dispatch size on the Y axis <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
+    /// This applies to using:
+    /// <list type="bullet">
+    ///   <item><see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>.</item>
+    /// </list>
+    /// But only as long as the input dispatch size on the Y axis <c>1</c>.
+    /// Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
     XZ = X | Z,
 
@@ -57,8 +82,13 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch along the Y and Z axes.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>,
-    /// but only as long as the input dispatch size on the X axis <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
+    /// This applies to using:
+    /// <list type="bullet">
+    ///   <item><see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>.</item>
+    /// </list>
+    /// But only as long as the input dispatch size on the X axis <c>1</c>.
+    /// Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
     YZ = Y | Z,
 
@@ -66,7 +96,11 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch along the X, Y and Z axes.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>.
+    /// This applies to using:
+    /// <list type="bullet">
+    ///   <item><see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/>.</item>
+    ///   <item><see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>.</item>
+    /// </list>
     /// </remarks>
     XYZ = X | Y | Z
 }

--- a/src/ComputeSharp/Attributes/Enums/DefaultThreadGroupSizes.cs
+++ b/src/ComputeSharp/Attributes/Enums/DefaultThreadGroupSizes.cs
@@ -12,7 +12,7 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch only along the X axis.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, in T)"/>.
+    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, in T)"/>.
     /// </remarks>
     X = 1 << 0,
 
@@ -20,7 +20,7 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch only along the Y axis.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>,
+    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>,
     /// but only as long as the input dispatch size on both the X and Z axes is <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
     Y = 1 << 1,
@@ -29,7 +29,7 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch only along the Z axis.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>,
+    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>,
     /// but only as long as the input dispatch size on both the X and Y axes is <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
     Z = 1 << 2,
@@ -39,8 +39,8 @@ public enum DefaultThreadGroupSizes
     /// </summary>
     /// <remarks>
     /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, in T)"/>, <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel})"/>,
-    /// <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>, <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, in T)"/>,
-    /// <see cref="ComputeContextExtensions.ForEach{T, TPixel}(in ComputeContext, IReadWriteNormalizedTexture2D{TPixel})"/> or <see cref="ComputeContextExtensions.ForEach{T, TPixel}(in ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>.
+    /// <see cref="GraphicsDeviceExtensions.ForEach{T, TPixel}(GraphicsDevice, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>, <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, in T)"/>,
+    /// <see cref="ComputeContextExtensions.ForEach{T, TPixel}(ref readonly ComputeContext, IReadWriteNormalizedTexture2D{TPixel})"/> or <see cref="ComputeContextExtensions.ForEach{T, TPixel}(ref readonly ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, in T)"/>.
     /// </remarks>
     XY = X | Y,
 
@@ -48,7 +48,7 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch along the X and Z axes.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>,
+    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>,
     /// but only as long as the input dispatch size on the Y axis <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
     XZ = X | Z,
@@ -57,7 +57,7 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch along the Y and Z axes.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>,
+    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>,
     /// but only as long as the input dispatch size on the X axis <c>1</c>. Using any other combination will not be able to leverage the precompiled shader bytecode.
     /// </remarks>
     YZ = Y | Z,
@@ -66,7 +66,7 @@ public enum DefaultThreadGroupSizes
     /// Indicates a shader dispatch along the X, Y and Z axes.
     /// </summary>
     /// <remarks>
-    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(in ComputeContext, int, int, int, in T)"/>.
+    /// This applies to using <see cref="GraphicsDeviceExtensions.For{T}(GraphicsDevice, int, int, int, in T)"/> or <see cref="ComputeContextExtensions.For{T}(ref readonly ComputeContext, int, int, int, in T)"/>.
     /// </remarks>
     XYZ = X | Y | Z
 }

--- a/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture1DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture1DExtensions.cs
@@ -16,7 +16,7 @@ public static class ReadWriteTexture1DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture1D{float}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture1D{float}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -42,7 +42,7 @@ public static class ReadWriteTexture1DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture1D{Float2}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture1D{Float2}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -68,7 +68,7 @@ public static class ReadWriteTexture1DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture1D{Float3}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture1D{Float3}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -94,7 +94,7 @@ public static class ReadWriteTexture1DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture1D{Float4}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture1D{Float4}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -122,7 +122,7 @@ public static class ReadWriteTexture1DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture1D{T, TPixel}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(ref readonly ComputeContext, ReadWriteTexture1D{T, TPixel}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.

--- a/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture2DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture2DExtensions.cs
@@ -16,7 +16,7 @@ public static class ReadWriteTexture2DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture2D{float}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture2D{float}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -42,7 +42,7 @@ public static class ReadWriteTexture2DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture2D{Float2}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture2D{Float2}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -68,7 +68,7 @@ public static class ReadWriteTexture2DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture2D{Float3}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture2D{Float3}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -94,7 +94,7 @@ public static class ReadWriteTexture2DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture2D{Float4}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture2D{Float4}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -122,7 +122,7 @@ public static class ReadWriteTexture2DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture2D{T, TPixel}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(ref readonly ComputeContext, ReadWriteTexture2D{T, TPixel}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.

--- a/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture3DExtensions.cs
+++ b/src/ComputeSharp/Graphics/Extensions/ReadWriteTexture3DExtensions.cs
@@ -16,7 +16,7 @@ public static class ReadWriteTexture3DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture3D{float}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture3D{float}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -42,7 +42,7 @@ public static class ReadWriteTexture3DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture3D{Float2}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture3D{Float2}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -68,7 +68,7 @@ public static class ReadWriteTexture3DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture3D{Float3}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture3D{Float3}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -94,7 +94,7 @@ public static class ReadWriteTexture3DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition(in ComputeContext, ReadWriteTexture3D{Float4}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition(ref readonly ComputeContext, ReadWriteTexture3D{Float4}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.
@@ -122,7 +122,7 @@ public static class ReadWriteTexture3DExtensions
     /// <para>The returned instance can be used in a shader to enable texture sampling.</para>
     /// <para>
     /// This is an advanced API that can only be used after the current instance has been transitioned to be in a readonly state. To do so,
-    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(in ComputeContext, ReadWriteTexture3D{T, TPixel}, ResourceState)"/>,
+    /// use <see cref="ComputeContextExtensions.Transition{T, TPixel}(ref readonly ComputeContext, ReadWriteTexture3D{T, TPixel}, ResourceState)"/>,
     /// and specify <see cref="ResourceState.ReadOnly"/>. After that, this method can be used to get a readonly wrapper for
     /// the current texture to use in a shader. This instance should not be cached or reused, but just passed directly to a shader
     /// being dispatched through that same <see cref="ComputeContext"/>, as it will not work if the texture changes state later on.

--- a/src/ComputeSharp/Imaging/Interfaces/IPixel{T,TPixel}.cs
+++ b/src/ComputeSharp/Imaging/Interfaces/IPixel{T,TPixel}.cs
@@ -16,8 +16,8 @@ public interface IPixel<T, TPixel>
     /// <returns>The <typeparamref name="TPixel"/> representation for the current value.</returns>
     /// <remarks>
     /// This method is primarily meant to be used to support
-    /// <see cref="ComputeContextExtensions.Fill{TPixel}(in ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, TPixel)"/>
-    /// and <see cref="ComputeContextExtensions.Fill{TPixel}(in ComputeContext, IReadWriteNormalizedTexture3D{TPixel}, TPixel)"/>.
+    /// <see cref="ComputeContextExtensions.Fill{TPixel}(ref readonly ComputeContext, IReadWriteNormalizedTexture2D{TPixel}, TPixel)"/>
+    /// and <see cref="ComputeContextExtensions.Fill{TPixel}(ref readonly ComputeContext, IReadWriteNormalizedTexture3D{TPixel}, TPixel)"/>.
     /// </remarks>
     TPixel ToPixel();
 }

--- a/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
+++ b/src/ComputeSharp/Shaders/Extensions/ComputeContextExtensions.cs
@@ -19,7 +19,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="T">The type of items stored on the buffer.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="buffer">The input <see cref="ReadWriteBuffer{T}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<T>(this in ComputeContext context, ReadWriteBuffer<T> buffer)
+    public static unsafe void Barrier<T>(this ref readonly ComputeContext context, ReadWriteBuffer<T> buffer)
         where T : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(buffer);
@@ -35,7 +35,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="T">The type of items stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<T>(this in ComputeContext context, ReadWriteTexture1D<T> texture)
+    public static unsafe void Barrier<T>(this ref readonly ComputeContext context, ReadWriteTexture1D<T> texture)
         where T : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -51,7 +51,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="T">The type of items stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<T>(this in ComputeContext context, ReadWriteTexture2D<T> texture)
+    public static unsafe void Barrier<T>(this ref readonly ComputeContext context, ReadWriteTexture2D<T> texture)
         where T : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -67,7 +67,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="T">The type of items stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="ReadWriteBuffer{T}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<T>(this in ComputeContext context, ReadWriteTexture3D<T> texture)
+    public static unsafe void Barrier<T>(this ref readonly ComputeContext context, ReadWriteTexture3D<T> texture)
         where T : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -84,7 +84,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T,TPixel}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<T, TPixel>(this in ComputeContext context, ReadWriteTexture1D<T, TPixel> texture)
+    public static unsafe void Barrier<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture1D<T, TPixel> texture)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -102,7 +102,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T,TPixel}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<T, TPixel>(this in ComputeContext context, ReadWriteTexture2D<T, TPixel> texture)
+    public static unsafe void Barrier<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture2D<T, TPixel> texture)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -120,7 +120,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture3D{T,TPixel}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<T, TPixel>(this in ComputeContext context, ReadWriteTexture3D<T, TPixel> texture)
+    public static unsafe void Barrier<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture3D<T, TPixel> texture)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -137,7 +137,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture1D{TPixel}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture1D<TPixel> texture)
+    public static unsafe void Barrier<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture1D<TPixel> texture)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -153,7 +153,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture2D{TPixel}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
+    public static unsafe void Barrier<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -169,7 +169,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to insert the resource barrier.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture3D{TPixel}"/> instance to insert the barrier for.</param>
-    public static unsafe void Barrier<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture)
+    public static unsafe void Barrier<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -185,7 +185,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="T">The type of items stored on the buffer.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="buffer">The input <see cref="ReadWriteBuffer{T}"/> instance to clear.</param>
-    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteBuffer<T> buffer)
+    public static unsafe void Clear<T>(this ref readonly ComputeContext context, ReadWriteBuffer<T> buffer)
         where T : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(buffer);
@@ -201,7 +201,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="T">The type of items stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T}"/> instance to clear.</param>
-    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture1D<T> texture)
+    public static unsafe void Clear<T>(this ref readonly ComputeContext context, ReadWriteTexture1D<T> texture)
         where T : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -217,7 +217,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="T">The type of items stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to clear.</param>
-    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture2D<T> texture)
+    public static unsafe void Clear<T>(this ref readonly ComputeContext context, ReadWriteTexture2D<T> texture)
         where T : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -233,7 +233,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="T">The type of items stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteBuffer{T}"/> instance to clear.</param>
-    public static unsafe void Clear<T>(this in ComputeContext context, ReadWriteTexture3D<T> texture)
+    public static unsafe void Clear<T>(this ref readonly ComputeContext context, ReadWriteTexture3D<T> texture)
         where T : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -250,7 +250,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T,TPixel}"/> instance to clear.</param>
-    public static unsafe void Clear<T, TPixel>(this in ComputeContext context, ReadWriteTexture1D<T, TPixel> texture)
+    public static unsafe void Clear<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture1D<T, TPixel> texture)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -268,7 +268,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T,TPixel}"/> instance to clear.</param>
-    public static unsafe void Clear<T, TPixel>(this in ComputeContext context, ReadWriteTexture2D<T, TPixel> texture)
+    public static unsafe void Clear<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture2D<T, TPixel> texture)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -286,7 +286,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels used on the GPU side.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture3D{T,TPixel}"/> instance to clear.</param>
-    public static unsafe void Clear<T, TPixel>(this in ComputeContext context, ReadWriteTexture3D<T, TPixel> texture)
+    public static unsafe void Clear<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture3D<T, TPixel> texture)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -303,7 +303,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture1D{TPixel}"/> instance to clear.</param>
-    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture1D<TPixel> texture)
+    public static unsafe void Clear<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture1D<TPixel> texture)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -321,7 +321,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture2D{TPixel}"/> instance to clear.</param>
-    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
+    public static unsafe void Clear<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -339,7 +339,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels stored on the texture.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to clear the resource.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture3D{TPixel}"/> instance to clear.</param>
-    public static unsafe void Clear<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture)
+    public static unsafe void Clear<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -359,7 +359,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to fill the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T,TPixel}"/> instance to fill.</param>
     /// <param name="value">The value to use to fill <paramref name="texture"/>.</param>
-    public static unsafe void Fill<T, TPixel>(this in ComputeContext context, ReadWriteTexture1D<T, TPixel> texture, T value)
+    public static unsafe void Fill<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture1D<T, TPixel> texture, T value)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -378,7 +378,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to fill the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T,TPixel}"/> instance to fill.</param>
     /// <param name="value">The value to use to fill <paramref name="texture"/>.</param>
-    public static unsafe void Fill<T, TPixel>(this in ComputeContext context, ReadWriteTexture2D<T, TPixel> texture, T value)
+    public static unsafe void Fill<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture2D<T, TPixel> texture, T value)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -397,7 +397,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to fill the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture3D{T,TPixel}"/> instance to fill.</param>
     /// <param name="value">The value to use to fill <paramref name="texture"/>.</param>
-    public static unsafe void Fill<T, TPixel>(this in ComputeContext context, ReadWriteTexture3D<T, TPixel> texture, T value)
+    public static unsafe void Fill<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture3D<T, TPixel> texture, T value)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -415,7 +415,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to fill the resource.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture1D{TPixel}"/> instance to fill.</param>
     /// <param name="value">The value to use to fill <paramref name="texture"/>.</param>
-    public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture1D<TPixel> texture, TPixel value)
+    public static unsafe void Fill<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture1D<TPixel> texture, TPixel value)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -438,7 +438,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to fill the resource.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture2D{TPixel}"/> instance to fill.</param>
     /// <param name="value">The value to use to fill <paramref name="texture"/>.</param>
-    public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture, TPixel value)
+    public static unsafe void Fill<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture, TPixel value)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -461,7 +461,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to fill the resource.</param>
     /// <param name="texture">The input <see cref="IReadWriteNormalizedTexture3D{TPixel}"/> instance to fill.</param>
     /// <param name="value">The value to use to fill <paramref name="texture"/>.</param>
-    public static unsafe void Fill<TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture, TPixel value)
+    public static unsafe void Fill<TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture3D<TPixel> texture, TPixel value)
         where TPixel : unmanaged
     {
         default(ArgumentNullException).ThrowIfNull(texture);
@@ -484,7 +484,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to run the shader.</param>
     /// <param name="x">The number of iterations to run on the X axis.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the compute shader to run.</param>
-    public static void For<T>(this in ComputeContext context, int x, in T shader)
+    public static void For<T>(this ref readonly ComputeContext context, int x, in T shader)
         where T : struct, IComputeShader, IComputeShaderDescriptor<T>
     {
         context.Run(x, in shader);
@@ -498,7 +498,7 @@ public static class ComputeContextExtensions
     /// <param name="x">The number of iterations to run on the X axis.</param>
     /// <param name="y">The number of iterations to run on the Y axis.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the compute shader to run.</param>
-    public static void For<T>(this in ComputeContext context, int x, int y, in T shader)
+    public static void For<T>(this ref readonly ComputeContext context, int x, int y, in T shader)
         where T : struct, IComputeShader, IComputeShaderDescriptor<T>
     {
         context.Run(x, y, in shader);
@@ -513,7 +513,7 @@ public static class ComputeContextExtensions
     /// <param name="y">The number of iterations to run on the Y axis.</param>
     /// <param name="z">The number of iterations to run on the Z axis.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the compute shader to run.</param>
-    public static void For<T>(this in ComputeContext context, int x, int y, int z, in T shader)
+    public static void For<T>(this ref readonly ComputeContext context, int x, int y, int z, in T shader)
         where T : struct, IComputeShader, IComputeShaderDescriptor<T>
     {
         context.Run(x, y, z, in shader);
@@ -526,7 +526,7 @@ public static class ComputeContextExtensions
     /// <typeparam name="TPixel">The type of pixels being processed by the shader.</typeparam>
     /// <param name="context">The <see cref="ComputeContext"/> to use to run the shader.</param>
     /// <param name="texture">The target texture to apply the pixel shader to.</param>
-    public static void ForEach<T, TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
+    public static void ForEach<T, TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture)
         where T : struct, IComputeShader<TPixel>, IComputeShaderDescriptor<T>
         where TPixel : unmanaged
     {
@@ -543,7 +543,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to run the shader.</param>
     /// <param name="texture">The target texture to apply the pixel shader to.</param>
     /// <param name="shader">The input <typeparamref name="T"/> instance representing the pixel shader to run.</param>
-    public static void ForEach<T, TPixel>(this in ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture, in T shader)
+    public static void ForEach<T, TPixel>(this ref readonly ComputeContext context, IReadWriteNormalizedTexture2D<TPixel> texture, in T shader)
         where T : struct, IComputeShader<TPixel>, IComputeShaderDescriptor<T>
         where TPixel : unmanaged
     {
@@ -558,7 +558,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture1D<float> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture1D<float> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -575,7 +575,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture1D<Float2> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture1D<Float2> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -592,7 +592,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture1D<Float3> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture1D<Float3> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -609,7 +609,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture1D<Float4> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture1D<Float4> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -628,7 +628,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture1D{T,TPixel}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition<T, TPixel>(this in ComputeContext context, ReadWriteTexture1D<T, TPixel> texture, ResourceState resourceState)
+    public static unsafe void Transition<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture1D<T, TPixel> texture, ResourceState resourceState)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -647,7 +647,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<float> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture2D<float> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -664,7 +664,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float2> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture2D<Float2> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -681,7 +681,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float3> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture2D<Float3> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -698,7 +698,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture2D<Float4> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture2D<Float4> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -717,7 +717,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture2D{T,TPixel}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition<T, TPixel>(this in ComputeContext context, ReadWriteTexture2D<T, TPixel> texture, ResourceState resourceState)
+    public static unsafe void Transition<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture2D<T, TPixel> texture, ResourceState resourceState)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {
@@ -736,7 +736,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<float> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture3D<float> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -753,7 +753,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float2> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture3D<Float2> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -770,7 +770,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float3> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture3D<Float3> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -787,7 +787,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture3D{T}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition(this in ComputeContext context, ReadWriteTexture3D<Float4> texture, ResourceState resourceState)
+    public static unsafe void Transition(this ref readonly ComputeContext context, ReadWriteTexture3D<Float4> texture, ResourceState resourceState)
     {
         default(ArgumentNullException).ThrowIfNull(texture);
 
@@ -806,7 +806,7 @@ public static class ComputeContextExtensions
     /// <param name="context">The <see cref="ComputeContext"/> to use to transition the resource.</param>
     /// <param name="texture">The input <see cref="ReadWriteTexture3D{T,TPixel}"/> instance to transition.</param>
     /// <param name="resourceState">The state to transition the input resource to.</param>
-    public static unsafe void Transition<T, TPixel>(this in ComputeContext context, ReadWriteTexture3D<T, TPixel> texture, ResourceState resourceState)
+    public static unsafe void Transition<T, TPixel>(this ref readonly ComputeContext context, ReadWriteTexture3D<T, TPixel> texture, ResourceState resourceState)
         where T : unmanaged, IPixel<T, TPixel>
         where TPixel : unmanaged
     {


### PR DESCRIPTION
### Description

This PR adopts the `ref readonly` feature, where applicable ([see docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-12.0/ref-readonly-parameters)).
It also tweaks some XML docs.