### PR TITLE
Move D2D shader compile options diagnostics to analyzer

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.HlslBytecode.cs
@@ -1,9 +1,6 @@
 using System;
 using ComputeSharp.SourceGeneration.Extensions;
-using ComputeSharp.SourceGeneration.Helpers;
-using ComputeSharp.SourceGeneration.Models;
 using Microsoft.CodeAnalysis;
-using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 
 namespace ComputeSharp.D2D1.SourceGenerators;
 
@@ -38,24 +35,16 @@ partial class D2DPixelShaderDescriptorGenerator
         /// <summary>
         /// Extracts the requested compile options for the current shader.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
         /// <returns>The requested compile options to use to compile the shader, if present.</returns>
-        public static D2D1CompileOptions? GetRequestedCompileOptions(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, INamedTypeSymbol structDeclarationSymbol)
+        public static D2D1CompileOptions? GetRequestedCompileOptions(INamedTypeSymbol structDeclarationSymbol)
         {
             if (structDeclarationSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute", out AttributeData? attributeData))
             {
                 D2D1CompileOptions options = (D2D1CompileOptions)attributeData.ConstructorArguments[0].Value!;
 
-                if ((options & D2D1CompileOptions.PackMatrixColumnMajor) != 0)
-                {
-                    diagnostics.Add(
-                        InvalidPackMatrixColumnMajorOption,
-                        structDeclarationSymbol,
-                        structDeclarationSymbol);
-                }
-
-                // PackMatrixRowMajor is always automatically enabled
+                // PackMatrixRowMajor is always automatically enabled. If by any chance the attribute is requesting
+                // column major packing, the analyzer will emit a diagnostic (same as for the assembly-level case).
                 return options | D2D1CompileOptions.PackMatrixRowMajor;
             }
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputDescriptions.cs
@@ -34,7 +34,11 @@ partial class D2DPixelShaderDescriptorGenerator
 
             foreach (AttributeData attributeData in structDeclarationSymbol.GetAttributes())
             {
-                switch (attributeData.AttributeClass?.GetFullyQualifiedMetadataName())
+                using ImmutableArrayBuilder<char> builder = new();
+
+                attributeData.AttributeClass?.AppendFullyQualifiedMetadataName(in builder);
+
+                switch (builder.WrittenSpan)
                 {
                     case "ComputeSharp.D2D1.D2DInputCountAttribute":
                         inputCount = (int)attributeData.ConstructorArguments[0].Value!;

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.cs
@@ -48,7 +48,11 @@ partial class D2DPixelShaderDescriptorGenerator
 
             foreach (AttributeData attributeData in structDeclarationSymbol.GetAttributes())
             {
-                switch (attributeData.AttributeClass?.GetFullyQualifiedMetadataName())
+                using ImmutableArrayBuilder<char> builder = new();
+
+                attributeData.AttributeClass?.AppendFullyQualifiedMetadataName(in builder);
+
+                switch (builder.WrittenSpan)
                 {
                     case "ComputeSharp.D2D1.D2DInputCountAttribute":
                         rawInputCount = (int)attributeData.ConstructorArguments[0].Value!;

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -144,10 +144,10 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
 
                     token.ThrowIfCancellationRequested();
 
-                    // Get the shader profile and linking info for LoadBytecode()
+                    // Get the shader profile and linking info for the HLSL bytecode properties
                     bool isLinkingSupported = HlslBytecode.IsSimpleInputShader(context.SemanticModel.Compilation, typeSymbol, inputCount);
                     D2D1ShaderProfile? requestedShaderProfile = HlslBytecode.GetRequestedShaderProfile(typeSymbol);
-                    D2D1CompileOptions? requestedCompileOptions = HlslBytecode.GetRequestedCompileOptions(diagnostics, typeSymbol);
+                    D2D1CompileOptions? requestedCompileOptions = HlslBytecode.GetRequestedCompileOptions(typeSymbol);
                     D2D1ShaderProfile effectiveShaderProfile = HlslBytecode.GetEffectiveShaderProfile(requestedShaderProfile, out bool isCompilationEnabled);
                     D2D1CompileOptions effectiveCompileOptions = HlslBytecode.GetEffectiveCompileOptions(requestedCompileOptions, isLinkingSupported);
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidShaderTypeCompileOptionsAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidShaderTypeCompileOptionsAnalyzer.cs
@@ -1,0 +1,59 @@
+using System.Collections.Immutable;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error whenever invalid options are used in a [D2D1CompileOptions] attribute over a shader type.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidShaderTypeCompileOptionsAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidPackMatrixColumnMajorOption);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the [D2DCompileOptions] attribute type
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute") is not { } d2DCompileOptionsAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // We're validating all struct types (since they're the possible shader types)
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // Check that the type is using [D2DCompileOptions]
+                if (!typeSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute", out AttributeData? attributeData))
+                {
+                    return;
+                }
+
+                D2D1CompileOptions options = (D2D1CompileOptions)attributeData.ConstructorArguments[0].Value!;
+
+                // Same validation and diagnostic as in the assembly-level analyzer
+                if ((options & D2D1CompileOptions.PackMatrixColumnMajor) != 0)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InvalidPackMatrixColumnMajorOption,
+                        attributeData.ApplicationSyntaxReference?.GetSyntax(context.CancellationToken).GetLocation(),
+                        typeSymbol));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -610,4 +610,37 @@ public class Test_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task InvalidPackMatrixColumnMajorOption_AssemblyLevel_WithColumnMajor_Warns()
+    {
+        const string source = """
+            using ComputeSharp.D2D1;
+
+            [assembly: {|CMPSD2D0044:D2DCompileOptions(D2D1CompileOptions.PackMatrixColumnMajor)|}]
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidAssemblyLevelCompileOptionsAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task InvalidPackMatrixColumnMajorOption_ShaderType_WithColumnMajor_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [D2DInputCount(0)]
+            [{|CMPSD2D0044:D2DCompileOptions(D2D1CompileOptions.PackMatrixColumnMajor)|}]
+            internal partial struct MyType : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidShaderTypeCompileOptionsAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
@@ -1774,6 +1774,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DResourceTextureIndexAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidEffectIdValueAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidEffectMetadataValueAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidShaderTypeCompileOptionsAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MissingAllowUnsafeBlocksCompilationOptionAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MissingPixelShaderDescriptorOnPixelShaderAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<NotAccessibleD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);


### PR DESCRIPTION
### Description

This PR includes two improvements to the D2D generator:
- It moves the diagnostics for invalid D2D compile options on a shader type to an analyzer
- It removes a few small allocations in the D2D generator
