### PR TITLE
Move D2D constant buffer size diagnostics to analyzer

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ConstantBuffer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ConstantBuffer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Immutable;
 using ComputeSharp.D2D1.SourceGenerators.Models;
 using ComputeSharp.SourceGeneration.Extensions;
@@ -6,7 +5,6 @@ using ComputeSharp.SourceGeneration.Helpers;
 using ComputeSharp.SourceGeneration.Models;
 using ComputeSharp.SourceGeneration.SyntaxProcessors;
 using Microsoft.CodeAnalysis;
-using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 
 namespace ComputeSharp.D2D1.SourceGenerators;
 
@@ -19,13 +17,11 @@ partial class D2DPixelShaderDescriptorGenerator
     private static class ConstantBuffer
     {
         /// <inheritdoc cref="ConstantBufferSyntaxProcessor.GetInfo"/>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="compilation"><inheritdoc cref="ConstantBufferSyntaxProcessor.GetInfo" path="/param[@name='compilation']/node()"/></param>
         /// <param name="structDeclarationSymbol"><inheritdoc cref="ConstantBufferSyntaxProcessor.GetInfo" path="/param[@name='structDeclarationSymbol']/node()"/></param>
         /// <param name="constantBufferSizeInBytes"><inheritdoc cref="ConstantBufferSyntaxProcessor.GetInfo" path="/param[@name='constantBufferSizeInBytes']/node()"/></param>
         /// <param name="fields"><inheritdoc cref="ConstantBufferSyntaxProcessor.GetInfo" path="/param[@name='fields']/node()"/></param>
         public static void GetInfo(
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
             Compilation compilation,
             ITypeSymbol structDeclarationSymbol,
             out int constantBufferSizeInBytes,
@@ -38,16 +34,6 @@ partial class D2DPixelShaderDescriptorGenerator
                 structDeclarationSymbol,
                 ref constantBufferSizeInBytes,
                 out fields);
-
-            // The maximum size for a constant buffer is 64KB
-            const int D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT = 4096;
-            const int MaximumConstantBufferSize = D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT * 4 * sizeof(float);
-
-            // Emit a diagnostic if the shader constant buffer is too large
-            if (constantBufferSizeInBytes > MaximumConstantBufferSize)
-            {
-                diagnostics.Add(ShaderDispatchDataSizeExceeded, structDeclarationSymbol, structDeclarationSymbol);
-            }
         }
 
         /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -88,7 +88,6 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
 
                     // Constant buffer info
                     ConstantBuffer.GetInfo(
-                        diagnostics,
                         context.SemanticModel.Compilation,
                         typeSymbol,
                         out int constantBufferSizeInBytes,

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/ExcedeedPixelShaderDispatchDataSizeAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/ExcedeedPixelShaderDispatchDataSizeAnalyzer.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.SyntaxProcessors;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates errors when a D2D pixel shader exceeds the maximum dispatch data size.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ExceededPixelShaderDispatchDataSizeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ExceededDispatchDataSize);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the ID2D1PixelShader symbol
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.ID2D1PixelShader") is not { } d2D1PixelShaderSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // We're validating all struct types (since they're the possible shader types)
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // Only validate fields for shader types (even without a generated descriptor)
+                if (!typeSymbol.HasInterfaceWithType(d2D1PixelShaderSymbol))
+                {
+                    return;
+                }
+
+                int constantBufferSizeInBytes = 0;
+
+                // Run the fast-path constant buffer processor logic.
+                // This only extracts the constant buffer size.
+                ConstantBufferSyntaxProcessor.GetInfo(
+                    context.Compilation,
+                    typeSymbol,
+                    ref constantBufferSizeInBytes);
+
+                // The maximum size for a constant buffer is 64KB
+                const int D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT = 4096;
+                const int MaximumConstantBufferSize = D3D11_REQ_CONSTANT_BUFFER_ELEMENT_COUNT * 4 * sizeof(float);
+
+                // Emit a diagnostic if the shader constant buffer is too large
+                if (constantBufferSizeInBytes > MaximumConstantBufferSize)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        ExceededDispatchDataSize,
+                        typeSymbol.Locations.First(),
+                        typeSymbol,
+                        constantBufferSizeInBytes));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -431,17 +431,17 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for a shader with a root signature that is too large.
     /// <para>
-    /// Format: <c>"The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values"</c>.
+    /// Format: <c>"The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values (the maximum size is 64KB, and the actual constant buffer size was {1} bytes)"</c>.
     /// </para>
     /// </summary>
-    public static readonly DiagnosticDescriptor ShaderDispatchDataSizeExceeded = new(
+    public static readonly DiagnosticDescriptor ExceededDispatchDataSize = new(
         id: "CMPSD2D0032",
         title: "Shader dispatch data size exceeded",
-        messageFormat: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values",
+        messageFormat: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values (the maximum size is 64KB, and the actual constant buffer size was {1} bytes)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values.",
+        description: "The D2D1 shader of type {0} has exceeded the maximum allowed size for captured values (the maximum size for constant buffers is 64KB).",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.ConstantBuffer.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.ConstantBuffer.cs
@@ -7,6 +7,8 @@ using ComputeSharp.SourceGeneration.SyntaxProcessors;
 using ComputeSharp.SourceGenerators.Models;
 using Microsoft.CodeAnalysis;
 
+#pragma warning disable CS0419
+
 namespace ComputeSharp.SourceGenerators;
 
 /// <inheritdoc/>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <Import Project="..\build\Directory.Build.props" />
 
-    <!-- Centralized packaging metadata for published projects -->
+  <!-- Centralized packaging metadata for published projects -->
   <PropertyGroup Condition="$(IsPackagedProject)">
 
     <!-- Package descriptions-->

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_Analyzers.cs
@@ -643,4 +643,96 @@ public class Test_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<InvalidShaderTypeCompileOptionsAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task ExceededDispatchDataSize_ConstantBufferTooLarge_Warns()
+    {
+        const string source = """
+            using ComputeSharp.D2D1;
+            using float1x3 = ComputeSharp.Float1x3;
+            using float2x2 = ComputeSharp.Float2x2;
+            using float3x2 = ComputeSharp.Float3x2;
+            using float4x3 = ComputeSharp.Float4x3;
+            using float4x4 = ComputeSharp.Float4x4;
+            using float2 = ComputeSharp.Float2;
+            using float3 = ComputeSharp.Float3;
+            using float4 = ComputeSharp.Float4;
+
+            public struct Data0
+            {
+                public float4x4 m0;
+                public float4 v0;
+                public float4 v1;
+                public float s0;
+                public float s1;
+                public float s2;
+                public float s3;
+            }
+
+            public struct Data1
+            {
+                public Data0 d0;
+                public Data0 d1;
+                public Data0 d2;
+                public Data0 d3;
+                public Data0 d4;
+                public float3x2 m0;
+                public float2x2 m1;
+                public float3 v0;
+                public float s0;
+                public float s1;
+            }
+
+            public struct Data2
+            {
+                public Data1 d0;
+                public Data1 d1;
+                public Data1 d2;
+                public Data1 d3;
+                public float2x2 m0;
+                public float1x3 m1;
+                public float3 v0;
+                public float4 v1;
+                public float2 v2;
+                public float s0;
+            }
+
+            public struct Data3
+            {
+                public Data1 d0;
+                public Data1 d1;
+                public Data1 d2;
+                public Data1 d3;
+                public Data2 d4;
+                public Data2 d5;
+                public Data2 d6;
+                public Data2 d7;
+                public Data2 d8;
+                public Data2 d9;
+                public float3 v0;
+            }
+
+            public struct Data4
+            {
+                public Data3 d0;
+                public Data3 d1;
+                public Data3 d2;
+                public Data3 d3;
+                public float4x3 m0;
+                public float s0;
+            }
+
+
+            [D2DInputCount(0)]
+            internal readonly partial struct {|CMPSD2D0032:MyType|}(Data4 data4) : ID2D1PixelShader
+            {
+                public float4 Execute()
+                {
+                    return data4.s0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<ExceededPixelShaderDispatchDataSizeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
@@ -1766,6 +1766,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
     {
         await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnAssemblyAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<D2DEnableRuntimeCompilationOnTypeAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<ExceededPixelShaderDispatchDataSizeAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidAssemblyLevelCompileOptionsAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2D1CompileOptionsEnableLinkingOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DGeneratedPixelShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);


### PR DESCRIPTION
### Description

This PR includes two improvements to the D2D generator:
- It moves the diagnostics for exceeding the constant buffer size on a shader type to an analyzer
- It adds new unit test for the diagnostic (there were none before)

The analyzer is not reusing the same exact method as the generator to allow for further optimizations. Specifically, it uses a minimal copy that avoids all the additional work to also compute the field info only required by the marshalling code.
