### PR TITLE
Update copyright year to 2024

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Sergio Pedri
+Copyright (c) 2024 Sergio Pedri
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -116,7 +116,7 @@
     <Authors>Sergio Pedri</Authors>
     <Owners>Sergio Pedri</Owners>
     <Company>Sergio Pedri</Company>
-    <Copyright>Copyright (c) 2023 Sergio Pedri</Copyright>
+    <Copyright>Copyright (c) 2024 Sergio Pedri</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageProjectUrl>https://github.com/Sergio0694/ComputeSharp/</PackageProjectUrl>

--- a/src/ComputeSharp.Pix/LICENSE.txt
+++ b/src/ComputeSharp.Pix/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Sergio Pedri
+Copyright (c) 2024 Sergio Pedri
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Description

This PR simply bumps the year of the copyright notice to 2024 in all applicable files.