### PR TITLE
Move almost all [D2DPixelShaderSource] diagnostics to analyzers

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -63,10 +63,9 @@ partial class D2DPixelShaderSourceGenerator
         /// <summary>
         /// Extracts the shader profile for a target method, if present.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
         /// <returns>The shader profile to use to compile the shader, if present.</returns>
-        public static D2D1ShaderProfile GetShaderProfile(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, IMethodSymbol methodSymbol)
+        public static D2D1ShaderProfile? GetShaderProfile(IMethodSymbol methodSymbol)
         {
             if (methodSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DShaderProfileAttribute", out AttributeData? attributeData))
             {
@@ -78,13 +77,7 @@ partial class D2DPixelShaderSourceGenerator
                 return (D2D1ShaderProfile)attributeData.ConstructorArguments[0].Value!;
             }
 
-            diagnostics.Add(
-                MissingShaderProfileForD2DPixelShaderSource,
-                methodSymbol,
-                methodSymbol.Name,
-                methodSymbol.ContainingType);
-
-            return D2D1ShaderProfile.PixelShader50;
+            return null;
         }
 
         /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -83,10 +83,9 @@ partial class D2DPixelShaderSourceGenerator
         /// <summary>
         /// Extracts the compile options for the current shader.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
         /// <returns>The compile options to use to compile the shader, if present.</returns>
-        public static D2D1CompileOptions GetCompileOptions(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, IMethodSymbol methodSymbol)
+        public static D2D1CompileOptions GetCompileOptions(IMethodSymbol methodSymbol)
         {
             if (methodSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute", out AttributeData? attributeData))
             {
@@ -97,12 +96,6 @@ partial class D2DPixelShaderSourceGenerator
             {
                 return (D2D1CompileOptions)attributeData.ConstructorArguments[0].Value!;
             }
-
-            diagnostics.Add(
-                MissingCompileOptionsForD2DPixelShaderSource,
-                methodSymbol,
-                methodSymbol.Name,
-                methodSymbol.ContainingType);
 
             return D2D1CompileOptions.Default;
         }

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -1,4 +1,3 @@
-using System;
 using ComputeSharp.D2D1.SourceGenerators.Models;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
@@ -39,25 +38,19 @@ partial class D2DPixelShaderSourceGenerator
         }
 
         /// <summary>
-        /// Extracts the HLSL source from a method with the <see cref="D2DPixelShaderSourceAttribute"/> annotation.
+        /// Extracts the HLSL source from an annotated method.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
         /// <returns>The HLSL source to compile, if present.</returns>
-        public static string GetHlslSource(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, IMethodSymbol methodSymbol)
+        public static string? GetHlslSource(IMethodSymbol methodSymbol)
         {
-            _ = methodSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DPixelShaderSourceAttribute", out AttributeData? attributeData);
-
-            if (!attributeData!.TryGetConstructorArgument(0, out string? hlslSource))
+            if (methodSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.D2DPixelShaderSourceAttribute", out AttributeData? attributeData) &&
+                attributeData!.TryGetConstructorArgument(0, out string? hlslSource))
             {
-                diagnostics.Add(
-                    InvalidD2DPixelShaderSource,
-                    methodSymbol,
-                    methodSymbol.Name,
-                    methodSymbol.ContainingType);
+                return hlslSource;
             }
 
-            return hlslSource ?? "";
+            return null;
         }
 
         /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using ComputeSharp.D2D1.SourceGenerators.Models;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
@@ -98,38 +99,34 @@ partial class D2DPixelShaderSourceGenerator
         /// </summary>
         /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
         /// <param name="info">The source <see cref="HlslBytecodeInfo"/> instance.</param>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
-        public static void GetInfoDiagnostics(
-            IMethodSymbol methodSymbol,
-            HlslBytecodeInfo info,
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics)
+        /// <returns>The collection of produced <see cref="DiagnosticInfo"/> instances.</returns>
+        public static ImmutableArray<DiagnosticInfo> GetInfoDiagnostics(IMethodSymbol methodSymbol, HlslBytecodeInfo info)
         {
-            DiagnosticInfo? diagnostic = null;
-
             if (info is HlslBytecodeInfo.Win32Error win32Error)
             {
-                diagnostic = DiagnosticInfo.Create(
+                DiagnosticInfo diagnostic = DiagnosticInfo.Create(
                     D2DPixelShaderSourceCompilationFailedWithWin32Exception,
                     methodSymbol,
                     methodSymbol,
                     methodSymbol.ContainingType,
                     win32Error.HResult,
                     win32Error.Message);
+
+                return ImmutableArray.Create(diagnostic);
             }
             else if (info is HlslBytecodeInfo.CompilerError fxcError)
             {
-                diagnostic = DiagnosticInfo.Create(
+                DiagnosticInfo diagnostic = DiagnosticInfo.Create(
                     D2DPixelShaderSourceCompilationFailedWithFxcCompilationException,
                     methodSymbol,
                     methodSymbol,
                     methodSymbol.ContainingType,
                     fxcError.Message);
+
+                return ImmutableArray.Create(diagnostic);
             }
 
-            if (diagnostic is not null)
-            {
-                diagnostics.Add(diagnostic);
-            }
+            return ImmutableArray<DiagnosticInfo>.Empty;
         }
 
         /// <summary>

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.Execute.cs
@@ -20,10 +20,9 @@ partial class D2DPixelShaderSourceGenerator
         /// <summary>
         /// Validates that the return type of the annotated method is valid and returns the type name.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="methodSymbol">The input <see cref="IMethodSymbol"/> instance to process.</param>
-        /// <returns>The HLSL source to compile, if present.</returns>
-        public static string? GetInvalidReturnType(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, IMethodSymbol methodSymbol)
+        /// <returns>The fully qualified type name, if invalid.</returns>
+        public static string? GetInvalidReturnType(IMethodSymbol methodSymbol)
         {
             if (methodSymbol.ReturnType is not INamedTypeSymbol
                 {
@@ -33,13 +32,6 @@ partial class D2DPixelShaderSourceGenerator
                     TypeArguments: [{ SpecialType: SpecialType.System_Byte }]
                 })
             {
-                diagnostics.Add(
-                    InvalidD2DPixelShaderSourceMethodReturnType,
-                    methodSymbol,
-                    methodSymbol.Name,
-                    methodSymbol.ContainingType,
-                    methodSymbol.ReturnType);
-
                 return methodSymbol.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
             }
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -42,16 +42,19 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                     string methodName = methodSymbol.Name;
                     string? invalidReturnType = Execute.GetInvalidReturnType(methodSymbol);
                     string hlslSource = Execute.GetHlslSource(diagnostics, methodSymbol);
-                    D2D1ShaderProfile shaderProfile = Execute.GetShaderProfile(diagnostics, methodSymbol);
                     D2D1CompileOptions compileOptions = Execute.GetCompileOptions(diagnostics, methodSymbol);
-                    bool isCompilationEnabled = diagnostics.Count == 0;
+
+                    // For the shader profile, reuse the same logic as in D2D1PixelShaderDescriptorGenerator
+                    D2D1ShaderProfile? requestedShaderProfile = Execute.GetShaderProfile(methodSymbol);
+                    D2D1ShaderProfile effectiveShaderProfile = requestedShaderProfile ?? D2D1ShaderProfile.PixelShader50;
+                    bool isCompilationEnabled = requestedShaderProfile is not null;
 
                     token.ThrowIfCancellationRequested();
 
                     // Prepare the key to cache the bytecode (just like the main D2D1 generator)
                     HlslBytecodeInfoKey hlslInfoKey = new(
                         hlslSource,
-                        shaderProfile,
+                        effectiveShaderProfile,
                         compileOptions,
                         isCompilationEnabled);
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -42,7 +42,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                     string methodName = methodSymbol.Name;
                     string? invalidReturnType = Execute.GetInvalidReturnType(methodSymbol);
                     string hlslSource = Execute.GetHlslSource(diagnostics, methodSymbol);
-                    D2D1CompileOptions compileOptions = Execute.GetCompileOptions(diagnostics, methodSymbol);
+                    D2D1CompileOptions compileOptions = Execute.GetCompileOptions(methodSymbol);
 
                     // For the shader profile, reuse the same logic as in D2D1PixelShaderDescriptorGenerator
                     D2D1ShaderProfile? requestedShaderProfile = Execute.GetShaderProfile(methodSymbol);

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -35,8 +35,6 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                     MethodDeclarationSyntax methodDeclaration = (MethodDeclarationSyntax)context.TargetNode;
                     IMethodSymbol methodSymbol = (IMethodSymbol)context.TargetSymbol;
 
-                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = new();
-
                     // Get the remaining info for the current shader
                     ImmutableArray<ushort> modifiers = methodDeclaration.Modifiers.Select(token => (ushort)token.Kind()).ToImmutableArray();
                     string methodName = methodSymbol.Name;
@@ -65,8 +63,8 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
 
                     token.ThrowIfCancellationRequested();
 
-                    // Append any diagnostic for the shader compilation
-                    Execute.GetInfoDiagnostics(methodSymbol, hlslInfo, diagnostics);
+                    // Get any diagnostics for the shader compilation
+                    ImmutableArray<DiagnosticInfo> diagnostics = Execute.GetInfoDiagnostics(methodSymbol, hlslInfo);
 
                     token.ThrowIfCancellationRequested();
 
@@ -82,7 +80,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                         InvalidReturnType: invalidReturnType,
                         HlslInfoKey: hlslInfoKey,
                         HlslInfo: hlslInfo,
-                        Diagnostcs: diagnostics.ToImmutable());
+                        Diagnostcs: diagnostics);
                 })
             .WithTrackingName(WellKnownTrackingNames.Execute);
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderSourceGenerator.cs
@@ -40,7 +40,7 @@ public sealed partial class D2DPixelShaderSourceGenerator : IIncrementalGenerato
                     // Get the remaining info for the current shader
                     ImmutableArray<ushort> modifiers = methodDeclaration.Modifiers.Select(token => (ushort)token.Kind()).ToImmutableArray();
                     string methodName = methodSymbol.Name;
-                    string? invalidReturnType = Execute.GetInvalidReturnType(diagnostics, methodSymbol);
+                    string? invalidReturnType = Execute.GetInvalidReturnType(methodSymbol);
                     string hlslSource = Execute.GetHlslSource(diagnostics, methodSymbol);
                     D2D1ShaderProfile shaderProfile = Execute.GetShaderProfile(diagnostics, methodSymbol);
                     D2D1CompileOptions compileOptions = Execute.GetCompileOptions(diagnostics, methodSymbol);

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DPixelShaderSourceAttributeUseAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DPixelShaderSourceAttributeUseAnalyzer.cs
@@ -1,0 +1,59 @@
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates diagnostics when a method is using [D2DPixelShaderSource] with an invalid argument.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidD2DPixelShaderSourceAttributeUseAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidD2DPixelShaderSource);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the [D2DPixelShaderSource] symbol
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DPixelShaderSourceAttribute") is not { } d2DPixelShaderSourceAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only partial definition methods are possible targets
+                if (context.Symbol is not IMethodSymbol { IsPartialDefinition: true } methodSymbol)
+                {
+                    return;
+                }
+
+                // Ignore methods without [D2DPixelShaderSource]
+                if (!methodSymbol.TryGetAttributeWithType(d2DPixelShaderSourceAttributeSymbol, out AttributeData? attributeData))
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if there is no valid HLSL source argument
+                if (!attributeData.TryGetConstructorArgument(0, out string? hlslSource))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InvalidD2DPixelShaderSource,
+                        methodSymbol.Locations.First(),
+                        methodSymbol.Name,
+                        methodSymbol.ContainingType));
+                }
+            }, SymbolKind.Method);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
@@ -38,6 +39,12 @@ public sealed class InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer : Diagno
             {
                 // Only partial definition methods are possible targets
                 if (context.Symbol is not IMethodSymbol { IsPartialDefinition: true } methodSymbol)
+                {
+                    return;
+                }
+
+                // Ignore methods without [D2DPixelShaderSource]
+                if (!methodSymbol.HasAttributeWithType(d2DPixelShaderSourceAttributeSymbol))
                 {
                     return;
                 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer.cs
@@ -1,0 +1,58 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates diagnostics when [D2DPixelShaderSource] is used on a method with an incorrect return type.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(InvalidD2DPixelShaderSourceMethodReturnType);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the [D2DPixelShaderSource] symbol
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DPixelShaderSourceAttribute") is not { } d2DPixelShaderSourceAttributeSymbol)
+            {
+                return;
+            }
+
+            // Also get the constructed ReadOnlySpan<byte> type
+            INamedTypeSymbol readOnlySpanSymbol = context.Compilation.GetTypeByMetadataName("System.ReadOnlySpan`1")!;
+            INamedTypeSymbol byteSymbol = context.Compilation.GetSpecialType(SpecialType.System_Byte);
+            INamedTypeSymbol readOnlySpanOfByteSymbol = readOnlySpanSymbol.Construct(byteSymbol);
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only partial definition methods are possible targets
+                if (context.Symbol is not IMethodSymbol { IsPartialDefinition: true } methodSymbol)
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if the return type is not ReadOnlySpan<byte>
+                if (!SymbolEqualityComparer.Default.Equals(methodSymbol.ReturnType, readOnlySpanOfByteSymbol))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InvalidD2DPixelShaderSourceMethodReturnType,
+                        methodSymbol.Locations.First(),
+                        methodSymbol.Name,
+                        methodSymbol.ContainingType,
+                        methodSymbol.ReturnType));
+                }
+            }, SymbolKind.Method);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates diagnostics when a method with [D2DPixelShaderSource] isn't using [D2DCompileOptions].
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MissingCompileOptionsForD2DPixelShaderSource);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the [D2DPixelShaderSource] and [D2DShaderProfile] symbols
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DPixelShaderSourceAttribute") is not { } d2DPixelShaderSourceAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DCompileOptionsAttribute") is not { } d2DCompileOptionsAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only partial definition methods are possible targets
+                if (context.Symbol is not IMethodSymbol { IsPartialDefinition: true } methodSymbol)
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if there is no compile options available at any level
+                if (!methodSymbol.HasAttributeWithType(d2DCompileOptionsAttributeSymbol) &&
+                    !methodSymbol.ContainingAssembly.HasAttributeWithType(d2DCompileOptionsAttributeSymbol))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        MissingCompileOptionsForD2DPixelShaderSource,
+                        methodSymbol.Locations.First(),
+                        methodSymbol.Name,
+                        methodSymbol.ContainingType));
+                }
+            }, SymbolKind.Method);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer.cs
@@ -39,6 +39,12 @@ public sealed class MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer
                     return;
                 }
 
+                // Ignore methods without [D2DPixelShaderSource]
+                if (!methodSymbol.HasAttributeWithType(d2DPixelShaderSourceAttributeSymbol))
+                {
+                    return;
+                }
+
                 // Emit a diagnostic if there is no compile options available at any level
                 if (!methodSymbol.HasAttributeWithType(d2DCompileOptionsAttributeSymbol) &&
                     !methodSymbol.ContainingAssembly.HasAttributeWithType(d2DCompileOptionsAttributeSymbol))

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer.cs
@@ -1,0 +1,55 @@
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates diagnostics when a method with [D2DPixelShaderSource] isn't using [D2DShaderProfile].
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MissingShaderProfileForD2DPixelShaderSource);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the [D2DPixelShaderSource] and [D2DShaderProfile] symbols
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DPixelShaderSourceAttribute") is not { } d2DPixelShaderSourceAttributeSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DShaderProfileAttribute") is not { } d2DShaderProfileAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only partial definition methods are possible targets
+                if (context.Symbol is not IMethodSymbol { IsPartialDefinition: true } methodSymbol)
+                {
+                    return;
+                }
+
+                // Emit a diagnostic if there is no shader profile available at any level
+                if (!methodSymbol.HasAttributeWithType(d2DShaderProfileAttributeSymbol) &&
+                    !methodSymbol.ContainingAssembly.HasAttributeWithType(d2DShaderProfileAttributeSymbol))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        MissingShaderProfileForD2DPixelShaderSource,
+                        methodSymbol.Locations.First(),
+                        methodSymbol.Name,
+                        methodSymbol.ContainingType));
+                }
+            }, SymbolKind.Method);
+        });
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer.cs
@@ -39,6 +39,12 @@ public sealed class MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer 
                     return;
                 }
 
+                // Ignore methods without [D2DPixelShaderSource]
+                if (!methodSymbol.HasAttributeWithType(d2DPixelShaderSourceAttributeSymbol))
+                {
+                    return;
+                }
+
                 // Emit a diagnostic if there is no shader profile available at any level
                 if (!methodSymbol.HasAttributeWithType(d2DShaderProfileAttributeSymbol) &&
                     !methodSymbol.ContainingAssembly.HasAttributeWithType(d2DShaderProfileAttributeSymbol))

--- a/src/ComputeSharp.D2D1/Attributes/D2DPixelShaderSourceAttribute.cs
+++ b/src/ComputeSharp.D2D1/Attributes/D2DPixelShaderSourceAttribute.cs
@@ -21,7 +21,7 @@ namespace ComputeSharp.D2D1;
 ///         float3 rgb = saturate(1.0 - color.rgb);
 ///         return float4(rgb, 1);
 ///     }
-///     """")]
+///     """)]
 /// static partial ReadOnlySpan&lt;byte&gt; GetBytecode();
 /// </code>
 /// </para>

--- a/src/ComputeSharp.SourceGeneration/Extensions/AttributeDataExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/AttributeDataExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 
 namespace ComputeSharp.SourceGeneration.Extensions;
@@ -31,9 +32,9 @@ internal static class AttributeDataExtensions
     /// <param name="index">The index of the argument to try to retrieve.</param>
     /// <param name="result">The resulting argument, if it was found.</param>
     /// <returns>Whether or not an argument of type <typeparamref name="T"/> at position <paramref name="index"/> was found.</returns>
-    public static bool TryGetConstructorArgument<T>(this AttributeData attributeData, int index, out T? result)
+    public static bool TryGetConstructorArgument<T>(this AttributeData attributeData, int index, [NotNullWhen(true)] out T? result)
     {
-        if (attributeData.ConstructorArguments.Length >= index + 1 &&
+        if (attributeData.ConstructorArguments.Length > index &&
             attributeData.ConstructorArguments[index].Value is T argument)
         {
             result = argument;

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ComputeSharp.D2D1.Tests.SourceGenerators;
 
 [TestClass]
-public class Test_Analyzers
+public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
 {
     [TestMethod]
     public async Task MissingD2DPixelShaderDescriptor_ComputeShader()

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Analyzers.cs
@@ -71,4 +71,91 @@ public class Test_D2DPixelShaderSourceGenerator_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task MissingShaderProfileForD2DPixelShaderSource_ShaderProfileOnMethod_DoesNotWarn()
+    {
+        const string source = """"
+            using System;
+            using ComputeSharp.D2D1;
+
+            public partial class MyClass
+            {
+                [D2DPixelShaderSource("""
+                    #define D2D_INPUT_COUNT 0
+
+                    #include "d2d1effecthelpers.hlsli"
+
+                    D2D_PS_ENTRY(Execute)
+                    {
+                        return 0;
+                    }
+                    """)]
+                [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+                public static partial ReadOnlySpan<byte> InvertEffect();
+
+                public static partial ReadOnlySpan<byte> InvertEffect() => default;
+            }
+            """";
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task MissingShaderProfileForD2DPixelShaderSource_ShaderProfileOnAssembly_DoesNotWarn()
+    {
+        const string source = """"
+            using System;
+            using ComputeSharp.D2D1;
+
+            [assembly: D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+
+            public partial class MyClass
+            {
+                [D2DPixelShaderSource("""
+                    #define D2D_INPUT_COUNT 0
+
+                    #include "d2d1effecthelpers.hlsli"
+
+                    D2D_PS_ENTRY(Execute)
+                    {
+                        return 0;
+                    }
+                    """)]
+                public static partial ReadOnlySpan<byte> InvertEffect();
+
+                public static partial ReadOnlySpan<byte> InvertEffect() => default;
+            }
+            """";
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task MissingShaderProfileForD2DPixelShaderSource_MissingShaderProfile_Warns()
+    {
+        const string source = """"
+            using System;
+            using ComputeSharp.D2D1;
+
+            public partial class MyClass
+            {
+                [D2DPixelShaderSource("""
+                    #define D2D_INPUT_COUNT 0
+
+                    #include "d2d1effecthelpers.hlsli"
+
+                    D2D_PS_ENTRY(Execute)
+                    {
+                        return 0;
+                    }
+                    """)]
+                public static partial ReadOnlySpan<byte> {|CMPSD2D0055:InvertEffect|}();
+
+                public static partial ReadOnlySpan<byte> InvertEffect() => default;
+            }
+            """";
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Analyzers.cs
@@ -1,0 +1,74 @@
+using System.Threading.Tasks;
+using ComputeSharp.D2D1.SourceGenerators;
+using ComputeSharp.Tests.SourceGenerators.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ComputeSharp.D2D1.Tests.SourceGenerators;
+
+[TestClass]
+public class Test_D2DPixelShaderSourceGenerator_Analyzers
+{
+    [TestMethod]
+    public async Task InvalidD2DPixelShaderSourceMethodReturnType_ReadOnlySpanOfByte_DoesNotWarn()
+    {
+        const string source = """"
+            using System;
+            using ComputeSharp.D2D1;
+
+            public partial class MyClass
+            {
+                [D2DPixelShaderSource("""
+                    #define D2D_INPUT_COUNT 0
+
+                    #include "d2d1effecthelpers.hlsli"
+
+                    D2D_PS_ENTRY(Execute)
+                    {
+                        return 0;
+                    }
+                    """)]
+                public static partial ReadOnlySpan<byte> InvertEffect();
+
+                public static partial ReadOnlySpan<byte> InvertEffect() => default;
+            }
+            """";
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    [DataRow("TimeSpan")]
+    [DataRow("ReadOnlyMemory<byte>")]
+    [DataRow("ReadOnlySpan<int>")]
+    [DataRow("string")]
+    [DataRow("object")]
+    [DataRow("byte")]
+    [DataRow("dynamic")]
+    [DataRow("byte*")]
+    public async Task InvalidD2DPixelShaderSourceMethodReturnType_InvalidType_Warns(string returnType)
+    {
+        string source = $$""""
+            using System;
+            using ComputeSharp.D2D1;
+
+            public unsafe partial class MyClass
+            {
+                [D2DPixelShaderSource("""
+                    #define D2D_INPUT_COUNT 0
+
+                    #include "d2d1effecthelpers.hlsli"
+
+                    D2D_PS_ENTRY(Execute)
+                    {
+                        return 0;
+                    }
+                    """)]
+                public static partial {{returnType}} {|CMPSD2D0057:InvertEffect|}();
+
+                public static partial {{returnType}} InvertEffect() => default;
+            }
+            """";
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DPixelShaderSourceMethodReturnTypeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+}

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Analyzers.cs
@@ -158,4 +158,91 @@ public class Test_D2DPixelShaderSourceGenerator_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<MissingD2DShaderProfileOnD2DPixelShaderSourceMethodAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task MissingCompileOptionsForD2DPixelShaderSource_CompileOptionsOnMethod_DoesNotWarn()
+    {
+        const string source = """"
+            using System;
+            using ComputeSharp.D2D1;
+
+            public partial class MyClass
+            {
+                [D2DPixelShaderSource("""
+                    #define D2D_INPUT_COUNT 0
+
+                    #include "d2d1effecthelpers.hlsli"
+
+                    D2D_PS_ENTRY(Execute)
+                    {
+                        return 0;
+                    }
+                    """)]
+                [D2DCompileOptions(D2D1CompileOptions.OptimizationLevel0)]
+                public static partial ReadOnlySpan<byte> InvertEffect();
+
+                public static partial ReadOnlySpan<byte> InvertEffect() => default;
+            }
+            """";
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task MissingCompileOptionsForD2DPixelShaderSource_CompileOptionsOnAssembly_DoesNotWarn()
+    {
+        const string source = """"
+            using System;
+            using ComputeSharp.D2D1;
+
+            [assembly: D2DCompileOptions(D2D1CompileOptions.OptimizationLevel0)]
+
+            public partial class MyClass
+            {
+                [D2DPixelShaderSource("""
+                    #define D2D_INPUT_COUNT 0
+
+                    #include "d2d1effecthelpers.hlsli"
+
+                    D2D_PS_ENTRY(Execute)
+                    {
+                        return 0;
+                    }
+                    """)]
+                public static partial ReadOnlySpan<byte> InvertEffect();
+
+                public static partial ReadOnlySpan<byte> InvertEffect() => default;
+            }
+            """";
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task MissingCompileOptionsForD2DPixelShaderSource_MissingCompileOptions_Warns()
+    {
+        const string source = """"
+            using System;
+            using ComputeSharp.D2D1;
+
+            public partial class MyClass
+            {
+                [D2DPixelShaderSource("""
+                    #define D2D_INPUT_COUNT 0
+
+                    #include "d2d1effecthelpers.hlsli"
+
+                    D2D_PS_ENTRY(Execute)
+                    {
+                        return 0;
+                    }
+                    """)]
+                public static partial ReadOnlySpan<byte> {|CMPSD2D0056:InvertEffect|}();
+
+                public static partial ReadOnlySpan<byte> InvertEffect() => default;
+            }
+            """";
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderSourceGenerator_Analyzers.cs
@@ -245,4 +245,23 @@ public class Test_D2DPixelShaderSourceGenerator_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<MissingD2DCompileOptionsOnD2DPixelShaderSourceMethodAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task InvalidD2DPixelShaderSource_NullArgument_Warns()
+    {
+        const string source = """
+            using System;
+            using ComputeSharp.D2D1;
+
+            public partial class MyClass
+            {
+                [D2DPixelShaderSource(null)]
+                public static partial ReadOnlySpan<byte> {|CMPSD2D0052:InvertEffect|}();
+
+                public static partial ReadOnlySpan<byte> InvertEffect() => default;
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidD2DPixelShaderSourceAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }


### PR DESCRIPTION
### Description

This PR optimizes the diagnostics in the `[D2DPixelShaderSource]` generator. It moves these to analyzers:
- Invalid return type
- Missing D2D shader profile
- Missing D2D compile options
- Invalid HLSL source argument

It then further optimizes the diagnostics setup in the generator, by dropping the array builder entirely.