### PR TITLE
Move almost all [ComputeShaderDescriptor] diagnostics to analyzers

### DIFF
--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.Helpers.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.Helpers.cs
@@ -10,9 +10,9 @@ partial class ComputeShaderDescriptorGenerator
     /// </summary>
     /// <param name="typeSymbol">The input <see cref="INamedTypeSymbol"/> instance to check.</param>
     /// <param name="compilation">The <see cref="Compilation"/> instance currently in use.</param>
-    /// <param name="result">Whether <paramref name="typeSymbol"/> is a "pixel shader like" type.</param>
+    /// <param name="isPixelShaderLike">Whether <paramref name="typeSymbol"/> is a "pixel shader like" type.</param>
     /// <returns>Whether <paramref name="typeSymbol"/> is a compute shader type at all.</returns>
-    private static bool TryGetIsPixelShaderLike(INamedTypeSymbol typeSymbol, Compilation compilation, out bool result)
+    private static bool TryGetIsPixelShaderLike(INamedTypeSymbol typeSymbol, Compilation compilation, out bool isPixelShaderLike)
     {
         INamedTypeSymbol computeShaderSymbol = compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader")!;
         INamedTypeSymbol pixelShaderSymbol = compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader`1")!;
@@ -21,19 +21,19 @@ partial class ComputeShaderDescriptorGenerator
         {
             if (SymbolEqualityComparer.Default.Equals(interfaceSymbol, computeShaderSymbol))
             {
-                result = false;
+                isPixelShaderLike = false;
 
                 return true;
             }
             else if (SymbolEqualityComparer.Default.Equals(interfaceSymbol.ConstructedFrom, pixelShaderSymbol))
             {
-                result = true;
+                isPixelShaderLike = true;
 
                 return true;
             }
         }
 
-        result = false;
+        isPixelShaderLike = false;
 
         return false;
     }

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslBytecode.cs
@@ -1,6 +1,4 @@
 using ComputeSharp.SourceGeneration.Extensions;
-using ComputeSharp.SourceGeneration.Helpers;
-using ComputeSharp.SourceGeneration.Models;
 using Microsoft.CodeAnalysis;
 
 namespace ComputeSharp.SourceGenerators;
@@ -16,10 +14,9 @@ partial class ComputeShaderDescriptorGenerator
         /// <summary>
         /// Extracts the compile options for the current shader.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
         /// <returns>The requested compile options to use to compile the shader, if present.</returns>
-        public static CompileOptions GetCompileOptions(ImmutableArrayBuilder<DiagnosticInfo> diagnostics, INamedTypeSymbol structDeclarationSymbol)
+        public static CompileOptions GetCompileOptions(INamedTypeSymbol structDeclarationSymbol)
         {
             // If a [CompileOptions] annotation is present, return the explicit options
             if (structDeclarationSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.CompileOptionsAttribute", out AttributeData? attributeData) ||

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.Resources.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.Resources.cs
@@ -3,11 +3,9 @@ using System.Collections.Immutable;
 using ComputeSharp.SourceGeneration.Extensions;
 using ComputeSharp.SourceGeneration.Helpers;
 using ComputeSharp.SourceGeneration.Mappings;
-using ComputeSharp.SourceGeneration.Models;
 using ComputeSharp.SourceGeneration.SyntaxProcessors;
 using ComputeSharp.SourceGenerators.Models;
 using Microsoft.CodeAnalysis;
-using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
 
 namespace ComputeSharp.SourceGenerators;
 
@@ -22,19 +20,15 @@ partial class ComputeShaderDescriptorGenerator
         /// <summary>
         /// Gathers info on all resources captured by a given shader type.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="compilation">The input <see cref="Compilation"/> object currently in use.</param>
         /// <param name="structDeclarationSymbol">The current shader type being explored.</param>
         /// <param name="isImplicitTextureUsed">Indicates whether the current shader uses an implicit texture.</param>
-        /// <param name="constantBufferSizeInBytes">The size of the shader constant buffer.</param>
         /// <param name="resources">The sequence of <see cref="ResourceInfo"/> instances for all captured resources.</param>
         /// <param name="resourceDescriptors">The sequence of <see cref="ResourceDescriptor"/> instances for all captured resources.</param>
         public static void GetInfo(
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
             Compilation compilation,
             ITypeSymbol structDeclarationSymbol,
             bool isImplicitTextureUsed,
-            int constantBufferSizeInBytes,
             out ImmutableArray<ResourceInfo> resources,
             out ImmutableArray<ResourceDescriptor> resourceDescriptors)
         {
@@ -96,19 +90,6 @@ partial class ComputeShaderDescriptorGenerator
 
             resources = resourceBuilder.ToImmutable();
             resourceDescriptors = resourceDescriptorBuilder.ToImmutable();
-
-            // A shader root signature has a maximum size of 64 DWORDs, so 256 bytes.
-            // Loaded values in the root signature have the following costs:
-            //  - Root constants cost 1 DWORD each, since they are 32-bit values.
-            //  - Descriptor tables cost 1 DWORD each.
-            //  - Root descriptors (64-bit GPU virtual addresses) cost 2 DWORDs each.
-            // So here we check whether the current signature respects that constraint,
-            // and emit a build error otherwise. For more info on this, see the docs here:
-            // https://docs.microsoft.com/windows/win32/direct3d12/root-signature-limits.
-            if ((constantBufferSizeInBytes / sizeof(int)) + resourceBuilder.Count > 64)
-            {
-                diagnostics.Add(ShaderDispatchDataSizeExceeded, structDeclarationSymbol, structDeclarationSymbol);
-            }
         }
 
         /// <summary>

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -98,11 +98,9 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
 
                     // Get the resources info
                     Resources.GetInfo(
-                        diagnostics,
                         context.SemanticModel.Compilation,
                         typeSymbol,
                         isImplicitTextureUsed,
-                        constantBufferSizeInBytes,
                         out ImmutableArray<ResourceInfo> resourceInfo,
                         out ImmutableArray<ResourceDescriptor> resourceDescriptors);
 

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -59,8 +59,6 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                         return default;
                     }
 
-                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = new();
-
                     // Get the fields info
                     ConstantBuffer.GetInfo(
                         context.SemanticModel.Compilation,
@@ -81,6 +79,13 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
 
                     token.ThrowIfCancellationRequested();
 
+                    // Get the compile options as well
+                    CompileOptions compileOptions = HlslBytecode.GetCompileOptions(typeSymbol);
+
+                    token.ThrowIfCancellationRequested();
+
+                    using ImmutableArrayBuilder<DiagnosticInfo> diagnostics = new();
+
                     // Transpiled HLSL source info
                     HlslSource.GetInfo(
                         diagnostics,
@@ -96,18 +101,13 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
 
                     token.ThrowIfCancellationRequested();
 
-                    // Get the resources info
+                    // Get the resources info (we must do this after crawling the HLSL source)
                     Resources.GetInfo(
                         context.SemanticModel.Compilation,
                         typeSymbol,
                         isImplicitTextureUsed,
                         out ImmutableArray<ResourceInfo> resourceInfo,
                         out ImmutableArray<ResourceDescriptor> resourceDescriptors);
-
-                    token.ThrowIfCancellationRequested();
-
-                    // Get the compile options as well
-                    CompileOptions compileOptions = HlslBytecode.GetCompileOptions(typeSymbol);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -73,7 +73,6 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
 
                     // Thread group size info
                     NumThreads.GetInfo(
-                        diagnostics,
                         typeSymbol,
                         out int threadsX,
                         out int threadsY,

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -109,7 +109,7 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                     token.ThrowIfCancellationRequested();
 
                     // Get the compile options as well
-                    CompileOptions compileOptions = HlslBytecode.GetCompileOptions(diagnostics, typeSymbol);
+                    CompileOptions compileOptions = HlslBytecode.GetCompileOptions(typeSymbol);
 
                     token.ThrowIfCancellationRequested();
 

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/ExcedeedComputeShaderDispatchDataSizeAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/ExcedeedComputeShaderDispatchDataSizeAnalyzer.cs
@@ -1,0 +1,153 @@
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.Graphics.Helpers;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Mappings;
+using ComputeSharp.SourceGeneration.SyntaxProcessors;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates errors when a compute shader exceeds the maximum root descriptor size.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ExcedeedComputeShaderDispatchDataSizeAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ShaderDispatchDataSizeExceeded);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the IComputeShader and IComputeShader<TPixel> symbols
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader") is not { } computeShaderSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader`1") is not { } pixelShaderSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only struct types are possible targets
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // If the type is not a compute shader type, immediately bail out
+                if (!TryGetIsPixelShaderLike(typeSymbol, computeShaderSymbol, pixelShaderSymbol, out bool isPixelShaderLike))
+                {
+                    return;
+                }
+
+                // Setup the resource and byte offsets for tracking. This is the same logic as
+                // in ComputeShaderDescriptorGenerator.ConstantBuffer, see there for more info.
+                int constantBufferSizeInBytes = sizeof(int) * (isPixelShaderLike ? 2 : 3);
+
+                // Run the fast-path constant buffer processor logic (same as in the equivalent D2D analyzer)
+                ConstantBufferSyntaxProcessor.GetInfo(
+                    context.Compilation,
+                    typeSymbol,
+                    ref constantBufferSizeInBytes);
+
+                // Pad the size to get the number of root DWORD constants (see more notes in the same method)
+                constantBufferSizeInBytes = AlignmentHelper.Pad(constantBufferSizeInBytes, sizeof(int));
+
+                // Also get the number of captured resources
+                int resourceCount = GetNumberOfResources(typeSymbol);
+
+                // A shader root signature has a maximum size of 64 DWORDs, so 256 bytes.
+                // Loaded values in the root signature have the following costs:
+                //  - Root constants cost 1 DWORD each, since they are 32-bit values.
+                //  - Descriptor tables cost 1 DWORD each.
+                //  - Root descriptors (64-bit GPU virtual addresses) cost 2 DWORDs each.
+                // So here we check whether the current signature respects that constraint,
+                // and emit a build error otherwise. For more info on this, see the docs here:
+                // https://docs.microsoft.com/windows/win32/direct3d12/root-signature-limits.
+                int numberOfDwordConstants = (constantBufferSizeInBytes / sizeof(int)) + resourceCount;
+
+                // Emit an error in case we have in fact exceeded that limit
+                if (numberOfDwordConstants > 64)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        ShaderDispatchDataSizeExceeded,
+                        typeSymbol.Locations.First(),
+                        typeSymbol,
+                        numberOfDwordConstants));
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+
+    /// <summary>
+    /// Gets whether a given type is a compute shader type (ie. implements any of the interfaces).
+    /// </summary>
+    /// <param name="typeSymbol">The input <see cref="INamedTypeSymbol"/> instance to check.</param>
+    /// <param name="computeShaderSymbol">The <see cref="INamedTypeSymbol"/> for <c>"ComputeSharp.IComputeShader"</c>.</param>
+    /// <param name="pixelShaderSymbol">The <see cref="INamedTypeSymbol"/> for <c>"ComputeSharp.IComputeShader`1"</c>.</param>
+    /// <param name="isPixelShaderLike">Whether <paramref name="typeSymbol"/> is a "pixel shader like" type.</param>
+    /// <returns>Whether <paramref name="typeSymbol"/> is a compute shader type at all.</returns>
+    private static bool TryGetIsPixelShaderLike(
+        INamedTypeSymbol typeSymbol,
+        INamedTypeSymbol computeShaderSymbol,
+        INamedTypeSymbol pixelShaderSymbol,
+        out bool isPixelShaderLike)
+    {
+        foreach (INamedTypeSymbol interfaceSymbol in typeSymbol.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(interfaceSymbol, computeShaderSymbol))
+            {
+                isPixelShaderLike = false;
+
+                return true;
+            }
+            else if (SymbolEqualityComparer.Default.Equals(interfaceSymbol.ConstructedFrom, pixelShaderSymbol))
+            {
+                isPixelShaderLike = true;
+
+                return true;
+            }
+        }
+
+        isPixelShaderLike = false;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the number of captured resources in a given compute shader type.
+    /// </summary>
+    /// <param name="typeSymbol">The shader type to inspect.</param>
+    /// <returns>The number of captured resources in the given shader type.</returns>
+    private static int GetNumberOfResources(ITypeSymbol typeSymbol)
+    {
+        int resourceCount = 0;
+
+        foreach (ISymbol memberSymbol in typeSymbol.GetMembers())
+        {
+            // Only process instance fields
+            if (memberSymbol is not IFieldSymbol { Type: INamedTypeSymbol, IsConst: false, IsStatic: false, IsFixedSizeBuffer: false } fieldSymbol)
+            {
+                continue;
+            }
+
+            string typeName = fieldSymbol.Type.GetFullyQualifiedMetadataName();
+
+            // Check if the field is a resource
+            if (HlslKnownTypes.IsTypedResourceType(typeName))
+            {
+                resourceCount++;
+            }
+        }
+
+        return resourceCount;
+    }
+}

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/InvalidThreadGroupSizeAttributeUseAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/InvalidThreadGroupSizeAttributeUseAnalyzer.cs
@@ -1,0 +1,102 @@
+using System.Collections.Immutable;
+using System.Linq;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates diagnostics for invalid uses of [ThreadGroupSize].
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidThreadGroupSizeAttributeUseAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(
+        MissingThreadGroupSizeAttribute,
+        InvalidThreadGroupSizeAttributeDefaultThreadGroupSizes,
+        InvalidThreadGroupSizeAttributeValues);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // Get the IComputeShader, IComputeShader<TPixel> and [ThreadGroupSize] symbols
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader") is not { } computeShaderSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader`1") is not { } pixelShaderSymbol ||
+                context.Compilation.GetTypeByMetadataName("ComputeSharp.ThreadGroupSizeAttribute") is not { } threadGroupSizeAttributeSymbol)
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(context =>
+            {
+                // Only struct types are possible targets
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // If the type is not a compute shader type, immediately bail out
+                if (!MissingComputeShaderDescriptorOnComputeShaderAnalyzer.IsComputeShaderType(typeSymbol, computeShaderSymbol, pixelShaderSymbol))
+                {
+                    return;
+                }
+
+                // Warn if the shader type is not using [ThreadGroupSize]
+                if (!typeSymbol.TryGetAttributeWithType(threadGroupSizeAttributeSymbol, out AttributeData? attributeData))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        MissingThreadGroupSizeAttribute,
+                        typeSymbol.Locations.First(),
+                        typeSymbol));
+
+                    return;
+                }
+
+                // If there is a single argument, validate that it is valid
+                if (attributeData.ConstructorArguments is [{ Value: var defaultSize }])
+                {
+                    int? rawDefaultSize = defaultSize as int?;
+
+                    if ((DefaultThreadGroupSizes?)rawDefaultSize is not
+                        (DefaultThreadGroupSizes.X or
+                         DefaultThreadGroupSizes.Y or
+                         DefaultThreadGroupSizes.Z or
+                         DefaultThreadGroupSizes.XY or
+                         DefaultThreadGroupSizes.XZ or
+                         DefaultThreadGroupSizes.YZ or
+                         DefaultThreadGroupSizes.XYZ))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            InvalidThreadGroupSizeAttributeDefaultThreadGroupSizes,
+                            attributeData.GetLocation(),
+                            typeSymbol));
+                    }
+
+                    return;
+                }
+
+                // If there are three arguments, validate that they are also valid thread group sizes
+                if (attributeData.ConstructorArguments is not [{ Value: int threadsX }, { Value: int threadsY }, { Value: int threadsZ }] ||
+                    threadsX is < 1 or > 1024 ||
+                    threadsY is < 1 or > 1024 ||
+                    threadsZ is < 1 or > 64)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InvalidThreadGroupSizeAttributeValues,
+                        attributeData.GetLocation(),
+                        typeSymbol));
+
+                    return;
+                }
+            }, SymbolKind.NamedType);
+        });
+    }
+}

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -560,17 +560,17 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for a shader with a root signature that is too large.
     /// <para>
-    /// Format: <c>"The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources"</c>.
+    /// Format: <c>"The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources (the maximum size for the root signature is 64 DWORD constants, but the actual size was {1})"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor ShaderDispatchDataSizeExceeded = new(
         id: "CMPS0041",
         title: "Shader dispatch data size exceeded",
-        messageFormat: "The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources",
+        messageFormat: "The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources (the maximum size for the root signature is 64 DWORD constants, but the actual size was {1})",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources.",
+        description: "The compute shader of type {0} has exceeded the maximum allowed size for captured values and resources (the maximum size for the root signature is 64 DWORD constants).",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -592,13 +592,13 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for invalid thread group sizes.
     /// <para>
-    /// Format: <c>"The shader of type {0} is annotated with invalid [ThreadGroupSize] values"</c>.
+    /// Format: <c>"The [ThreadGroupSize] attribute on shader type {0} is using invalid thread group size values"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidThreadGroupSizeAttributeValues = new(
         id: "CMPS0044",
         title: "Invalid values for [ThreadGroupSize] attribute",
-        messageFormat: "The shader of type {0} is annotated with invalid [ThreadGroupSize] values",
+        messageFormat: "The [ThreadGroupSize] attribute on shader type {0} is using invalid thread group size values",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
@@ -656,13 +656,13 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for shaders shader with an invalid DefaultThreadGroupSizes value.
     /// <para>
-    /// Format: <c>"The shader of type {0} is using an invalid DefaultThreadGroupSizes value in its [ThreadGroupSize] attribute"</c>.
+    /// Format: <c>"The [ThreadGroupSize] attribute on shader type {0} is using an invalid DefaultThreadGroupSizes value"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor InvalidThreadGroupSizeAttributeDefaultThreadGroupSizes = new(
         id: "CMPS0048",
         title: "Invalid DefaultThreadGroupSizes value for [ThreadGroupSize] use",
-        messageFormat: "The shader of type {0} is using an invalid DefaultThreadGroupSizes value in its [ThreadGroupSize] attribute",
+        messageFormat: "The [ThreadGroupSize] attribute on shader type {0} is using an invalid DefaultThreadGroupSizes value",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
@@ -722,7 +722,6 @@ public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
                 public float s0;
             }
 
-
             [D2DInputCount(0)]
             internal readonly partial struct {|CMPSD2D0032:MyType|}(Data4 data4) : ID2D1PixelShader
             {

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
@@ -867,6 +867,7 @@ public class Test_ComputeShaderDescriptorGenerator
         await CSharpAnalyzerWithLanguageVersionTest<InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidGloballyCoherentFieldDeclarationAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidGroupSharedFieldDeclarationAnalyzer>.VerifyAnalyzerAsync(source);
+        await CSharpAnalyzerWithLanguageVersionTest<InvalidThreadGroupSizeAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MissingAllowUnsafeBlocksCompilationOptionAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MissingComputeShaderDescriptorOnComputeShaderAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<MultipleComputeShaderInterfacesOnShaderTypeAnalyzer>.VerifyAnalyzerAsync(source);

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
@@ -863,6 +863,7 @@ public class Test_ComputeShaderDescriptorGenerator
     /// <returns>The task for the operation.</returns>
     private static async Task VerifyGeneratedDiagnosticsAsync(string source, (string Filename, string Source) result)
     {
+        await CSharpAnalyzerWithLanguageVersionTest<ExcedeedComputeShaderDispatchDataSizeAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidComputeContextCopyAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidGeneratedComputeShaderDescriptorAttributeTargetAnalyzer>.VerifyAnalyzerAsync(source);
         await CSharpAnalyzerWithLanguageVersionTest<InvalidGloballyCoherentFieldDeclarationAnalyzer>.VerifyAnalyzerAsync(source);

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Analyzers.cs
@@ -545,4 +545,160 @@ public class Test_ComputeShaderDescriptorGenerator_Analyzers
 
         await CSharpAnalyzerWithLanguageVersionTest<InvalidThreadGroupSizeAttributeUseAnalyzer>.VerifyAnalyzerAsync(source);
     }
+
+    [TestMethod]
+    public async Task ExceededDispatchDataSize_ConstantBufferTooLarge_WithNestedTypes_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using float1x3 = ComputeSharp.Float1x3;
+            using float2x2 = ComputeSharp.Float2x2;
+            using float3x2 = ComputeSharp.Float3x2;
+            using float4x4 = ComputeSharp.Float4x4;
+            using float2 = ComputeSharp.Float2;
+            using float3 = ComputeSharp.Float3;
+            using float4 = ComputeSharp.Float4;
+
+            public struct Data0
+            {
+                public float4x4 m0;
+                public float4 v0;
+                public float4 v1;
+                public float s0;
+                public float s1;
+                public float s2;
+                public float s3;
+            }
+
+            public struct Data1
+            {
+                public Data0 d0;
+                public Data0 d1;
+                public Data0 d2;
+                public Data0 d3;
+                public Data0 d4;
+                public float3x2 m0;
+                public float2x2 m1;
+                public float3 v0;
+                public float s0;
+                public float s1;
+            }
+
+            public struct Data2
+            {
+                public Data1 d0;
+                public Data1 d1;
+                public Data1 d2;
+                public Data1 d3;
+                public float2x2 m0;
+                public float1x3 m1;
+                public float3 v0;
+                public float4 v1;
+                public float2 v2;
+                public float s0;
+            }
+
+            internal partial struct {|CMPS0041:MyType|}(Data2 data2) : IComputeShader
+            {
+                ReadWriteBuffer<float> result;
+
+                public void Execute()
+                {
+                    result[ThreadIds.X] = data2.s0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<ExcedeedComputeShaderDispatchDataSizeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ExceededDispatchDataSize_ConstantBufferTooLarge_WithDoubles_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using double4x4 = ComputeSharp.Double4x4;
+            using float4 = ComputeSharp.Float4;
+
+            internal partial struct {|CMPS0041:MyType|} : IComputeShader
+            {
+                public readonly ReadWriteBuffer<float> buffer;
+                public readonly double4x4 a;
+                public readonly double4x4 b;
+                public readonly int c;
+                public readonly float4 d;
+
+                public void Execute()
+                {
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<ExcedeedComputeShaderDispatchDataSizeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task ExceededDispatchDataSize_ConstantBufferTooLarge_WithManyResources_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using float4x4 = ComputeSharp.Float4x4;
+            using float4 = ComputeSharp.Float4;
+
+            public struct Data0
+            {
+                public float4x4 m0;
+                public float4 v0;
+                public float4 v1;
+                public float4 v2;
+                public float s0;
+                public float s1;
+                public float s2;
+                public float s3;
+            }
+
+            internal partial struct {|CMPS0041:MyType|}(Data0 data0) : IComputeShader
+            {
+                ReadWriteBuffer<float> result0;
+                ReadWriteBuffer<float> result1;
+                ReadWriteBuffer<float> result2;
+                ReadWriteBuffer<float> result3;
+                ReadWriteBuffer<float> result4;
+                ReadWriteBuffer<float> result5;
+                ReadWriteBuffer<float> result6;
+                ReadWriteBuffer<float> result7;
+                ReadWriteBuffer<float> result8;
+                ReadWriteBuffer<float> result9;
+                ReadWriteBuffer<float> result10;
+                ReadWriteBuffer<float> result11;
+                ReadWriteBuffer<float> result12;
+                ReadWriteBuffer<float> result13;
+                ReadWriteBuffer<float> result14;
+                ReadWriteBuffer<float> result15;
+                ReadWriteBuffer<float> result16;
+                ReadWriteBuffer<float> result17;
+                ReadWriteBuffer<float> result18;
+                ReadWriteBuffer<float> result19;
+                ReadWriteBuffer<float> result20;
+                ReadWriteBuffer<float> result21;
+                ReadWriteBuffer<float> result22;
+                ReadWriteBuffer<float> result23;
+                ReadWriteBuffer<float> result24;
+                ReadWriteBuffer<float> result25;
+                ReadWriteBuffer<float> result26;
+                ReadWriteBuffer<float> result27;
+                ReadWriteBuffer<float> result28;
+                ReadWriteBuffer<float> result29;
+                ReadWriteBuffer<float> result30;
+                ReadWriteBuffer<float> result31;
+
+                public void Execute()
+                {
+                    result0[ThreadIds.X] = data0.s0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<ExcedeedComputeShaderDispatchDataSizeAnalyzer>.VerifyAnalyzerAsync(source);
+    }
 }

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Diagnostics.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Diagnostics.cs
@@ -25,7 +25,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0001", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0001");
     }
 
     [TestMethod]
@@ -46,7 +46,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0001", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0001");
     }
 
     [TestMethod]
@@ -64,7 +64,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0005", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0005");
     }
 
     [TestMethod]
@@ -94,7 +94,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, diagnosticsId, "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, diagnosticsId);
     }
 
     [TestMethod]
@@ -121,7 +121,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, diagnosticsId, "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, diagnosticsId);
     }
 
     [TestMethod]
@@ -146,7 +146,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0006", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0006");
     }
 
     [TestMethod]
@@ -169,7 +169,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0010", "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0010", "CMPS0031", "CMPS0050");
     }
 
     [TestMethod]
@@ -192,7 +192,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0010", "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0010", "CMPS0031", "CMPS0050");
     }
 
     [TestMethod]
@@ -215,7 +215,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0011", "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0011", "CMPS0031", "CMPS0050");
     }
 
     [TestMethod]
@@ -240,7 +240,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012");
     }
 
     [TestMethod]
@@ -262,7 +262,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012");
     }
 
     [TestMethod]
@@ -285,7 +285,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012", "CMPS0013", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0012", "CMPS0013");
     }
 
     [TestMethod]
@@ -310,7 +310,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0014", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0014");
     }
 
     [TestMethod]
@@ -338,7 +338,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0015", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0015");
     }
 
     [TestMethod]
@@ -363,7 +363,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0016", "CMPS0032", "CMPS0035", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0016", "CMPS0032", "CMPS0035");
     }
 
     [TestMethod]
@@ -388,7 +388,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0017", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0017");
     }
 
     [TestMethod]
@@ -413,7 +413,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0018", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0018");
     }
 
     [TestMethod]
@@ -436,7 +436,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0019", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0019");
     }
 
     [TestMethod]
@@ -459,7 +459,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0020", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0020");
     }
 
     [TestMethod]
@@ -484,7 +484,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0021", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0021");
     }
 
     [TestMethod]
@@ -507,7 +507,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0022", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0022");
     }
 
     [TestMethod]
@@ -532,7 +532,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0023", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0023");
     }
 
     [TestMethod]
@@ -555,7 +555,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0024", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0024");
     }
 
     [TestMethod]
@@ -578,7 +578,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0032", "CMPS0025", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0032", "CMPS0025");
     }
 
     [TestMethod]
@@ -601,7 +601,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0026", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0026");
     }
 
     [TestMethod]
@@ -629,7 +629,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0027", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0027");
     }
 
     [TestMethod]
@@ -652,7 +652,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0028", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0028", "CMPS0050");
     }
 
     [TestMethod]
@@ -675,7 +675,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0029", "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0029", "CMPS0031", "CMPS0050");
     }
 
     [TestMethod]
@@ -700,7 +700,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0029", "CMPS0031", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0029", "CMPS0031");
     }
 
     [TestMethod]
@@ -729,7 +729,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0030", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0030", "CMPS0050");
     }
 
     [TestMethod]
@@ -752,7 +752,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0050");
     }
 
     [TestMethod]
@@ -775,7 +775,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0032", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0032");
     }
 
     [TestMethod]
@@ -798,7 +798,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0033", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0033");
     }
 
     [TestMethod]
@@ -823,7 +823,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0034", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0034");
     }
 
     [TestMethod]
@@ -848,7 +848,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0035", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0035");
     }
 
     [TestMethod]
@@ -873,7 +873,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0035", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0035");
     }
 
     [TestMethod]
@@ -896,7 +896,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0036", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0036");
     }
 
     [TestMethod]
@@ -924,7 +924,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0037", "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0037", "CMPS0050");
     }
 
     [TestMethod]
@@ -948,7 +948,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0038", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0038");
     }
 
     [TestMethod]
@@ -972,7 +972,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040");
     }
 
     [TestMethod]
@@ -1001,7 +1001,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040");
     }
 
     [TestMethod]
@@ -1028,7 +1028,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040");
     }
 
     [TestMethod]
@@ -1052,7 +1052,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040");
     }
 
     [TestMethod]
@@ -1076,7 +1076,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0040");
     }
 
     [TestMethod]
@@ -1104,109 +1104,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0041", "CMPS0047");
-    }
-
-    [TestMethod]
-    [DataRow(-1, 1, 1)]
-    [DataRow(1, -1, 1)]
-    [DataRow(1, 1, -1)]
-    [DataRow(1050, 1, 1)]
-    [DataRow(1, 1050, 1)]
-    [DataRow(1, 1, 70)]
-    public void InvalidThreadGroupSizeValues(int threadsX, int threadsY, int threadsZ)
-    {
-        string source = $$"""
-            using System;
-            using ComputeSharp;
-
-            namespace MyFancyApp.Sample;
-
-            [ThreadGroupSize({{threadsX}}, {{threadsY}}, {{threadsZ}})]
-            [GeneratedComputeShaderDescriptor]
-            public partial struct MyShader : IComputeShader
-            {
-                public ReadWriteBuffer<float> buffer;
-
-                public void Execute()
-                {
-                }
-            }
-            """;
-
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0044");
-    }
-
-    [TestMethod]
-    public void InvalidThreadGroupSizeDispatchSize_Flags()
-    {
-        const string source = """
-            using System;
-            using ComputeSharp;
-
-            namespace MyFancyApp.Sample;
-
-            [ThreadGroupSize(default)]
-            [GeneratedComputeShaderDescriptor]
-            public partial struct MyShader : IComputeShader
-            {
-                public ReadWriteBuffer<float> buffer;
-
-                public void Execute()
-                {
-                }
-            }
-            """;
-
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0048");
-    }
-
-    [TestMethod]
-    public void InvalidThreadGroupSizeDispatchSize_ExplicitValue()
-    {
-        const string source = """
-            using System;
-            using ComputeSharp;
-
-            namespace MyFancyApp.Sample;
-
-            [ThreadGroupSize((DefaultThreadGroupSizes)243712)]
-            [GeneratedComputeShaderDescriptor]
-            public partial struct MyShader : IComputeShader
-            {
-                public ReadWriteBuffer<float> buffer;
-
-                public void Execute()
-                {
-                }
-            }
-            """;
-
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0048");
-    }
-
-    [TestMethod]
-    public void InvalidThreadGroupSizeDispatchSize_ExplicitValue_Negative()
-    {
-        const string source = """
-            using System;
-            using ComputeSharp;
-
-            namespace MyFancyApp.Sample;
-
-            [ThreadGroupSize((DefaultThreadGroupSizes)(-289))]
-            [GeneratedComputeShaderDescriptor]
-            public partial struct MyShader : IComputeShader
-            {
-                public ReadWriteBuffer<float> buffer;
-
-                public void Execute()
-                {
-                }
-            }
-            """;
-
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0048");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0041");
     }
 
     [TestMethod]
@@ -1230,7 +1128,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0049", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0049");
     }
 
     [TestMethod]
@@ -1254,7 +1152,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0063", "CMPS0047");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0063");
     }
 
     [TestMethod]
@@ -1278,7 +1176,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0050");
     }
 
     [TestMethod]
@@ -1308,7 +1206,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0050");
     }
 
     [TestMethod]
@@ -1336,7 +1234,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0050");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0050");
     }
 
     // See https://github.com/Sergio0694/ComputeSharp/issues/690
@@ -1363,7 +1261,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0059");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0059");
     }
 
     [TestMethod]
@@ -1389,7 +1287,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0059");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0059");
     }
 
     [TestMethod]
@@ -1410,7 +1308,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0047", "CMPS0059");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0059");
     }
 
     [TestMethod]
@@ -1431,7 +1329,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0047", "CMPS0060");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0031", "CMPS0060");
     }
 
     [TestMethod]
@@ -1464,7 +1362,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0061");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0061");
     }
 
     [TestMethod]
@@ -1493,7 +1391,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0049");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0049");
     }
 
     [TestMethod]
@@ -1525,7 +1423,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0062");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0062");
     }
 
     [TestMethod]
@@ -1562,7 +1460,7 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
             }
             """;
 
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0047", "CMPS0062");
+        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0062");
     }
 
     [TestMethod]

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Diagnostics.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Diagnostics.cs
@@ -1080,34 +1080,6 @@ public class Test_ComputeShaderDescriptorGenerator_Diagnostics
     }
 
     [TestMethod]
-    public void ShaderDispatchDataSizeExceeded()
-    {
-        const string source = """
-            using ComputeSharp;
-            using double4x4 = ComputeSharp.Double4x4;
-            using float4 = ComputeSharp.Float4;
-
-            namespace MyFancyApp.Sample;
-            
-            [GeneratedComputeShaderDescriptor]
-            public partial struct MyShader : IComputeShader
-            {
-                public readonly ReadWriteBuffer<float> buffer;
-                public readonly double4x4 a;
-                public readonly double4x4 b;
-                public readonly int c;
-                public readonly float4 d;
-
-                public void Execute()
-                {
-                }
-            }
-            """;
-
-        CSharpGeneratorTest<ComputeShaderDescriptorGenerator>.VerifyDiagnostics(source, "CMPS0041");
-    }
-
-    [TestMethod]
     public void InvalidMethodCall()
     {
         const string source = """


### PR DESCRIPTION
### Description

This PR optimizes the diagnostics in the `[ComputeShaderDescriptor]` generator. It moves these to analyzers:
- Invalid thread group sizes
- Exceeded root signature size

It also includes a few tweaks to the DX12 generator, and improved tests (as well as new tests).