### PR TITLE
Add 'faceforward' HLSL intrinsic

### DIFF
--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.g.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.g.cs
@@ -7759,6 +7759,286 @@ partial class Hlsl
     public static Float4x4 Exp2(Float4x4 x) => default;
 
     /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static float FaceForward(float n, float i, float ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float2 FaceForward(Float2 n, Float2 i, Float2 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float3 FaceForward(Float3 n, Float3 i, Float3 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float4 FaceForward(Float4 n, Float4 i, Float4 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float1x1 FaceForward(Float1x1 n, Float1x1 i, Float1x1 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float1x2 FaceForward(Float1x2 n, Float1x2 i, Float1x2 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float1x3 FaceForward(Float1x3 n, Float1x3 i, Float1x3 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float1x4 FaceForward(Float1x4 n, Float1x4 i, Float1x4 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float2x1 FaceForward(Float2x1 n, Float2x1 i, Float2x1 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float2x2 FaceForward(Float2x2 n, Float2x2 i, Float2x2 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float2x3 FaceForward(Float2x3 n, Float2x3 i, Float2x3 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float2x4 FaceForward(Float2x4 n, Float2x4 i, Float2x4 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float3x1 FaceForward(Float3x1 n, Float3x1 i, Float3x1 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float3x2 FaceForward(Float3x2 n, Float3x2 i, Float3x2 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float3x3 FaceForward(Float3x3 n, Float3x3 i, Float3x3 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float3x4 FaceForward(Float3x4 n, Float3x4 i, Float3x4 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float4x1 FaceForward(Float4x1 n, Float4x1 i, Float4x1 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float4x2 FaceForward(Float4x2 n, Float4x2 i, Float4x2 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float4x3 FaceForward(Float4x3 n, Float4x3 i, Float4x3 ng) => default;
+
+    /// <summary>
+    /// Flips the surface-normal (if needed) to face in a direction opposite to <paramref name="i"/>, returns the result in <paramref name="n"/>.
+    /// </summary>
+    /// <param name="n">The resulting floating-point surface-normal vector.</param>
+    /// <param name="i">A floating-point, incident vector that points from the view position to the shading position.</param>
+    /// <param name="ng">A floating-point surface-normal vector.</param>
+    /// <returns>A floating-point, surface normal vector that is facing the view direction.</returns>
+    /// <remarks>
+    /// For more info, see <see href="https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward"/>.
+    /// <para>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</para>
+    /// </remarks>
+    [HlslIntrinsicName("faceforward")]
+    public static Float4x4 FaceForward(Float4x4 n, Float4x4 i, Float4x4 ng) => default;
+
+    /// <summary>
     /// Gets the location of the first set bit starting from the highest order bit and working downward, per component.
     /// </summary>
     /// <param name="value">The input value.</param>

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.tt
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.tt
@@ -22,6 +22,8 @@ foreach (var intrinsic in Intrinsics)
 
         var summary = Regex.Replace(intrinsic.Summary, @"{keyword=(\w+)}", m => $"<see langword=\"{m.Groups[1].Value}\"/>");
 
+        summary = Regex.Replace(summary, @"{param=(\w+)}", m => $"<paramref name=\"{m.Groups[1].Value}\"/>");
+
         WriteLine("/// <summary>");
         WriteLine($"/// {summary}");
         WriteLine("/// </summary>");

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.ttinclude
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.ttinclude
@@ -1102,6 +1102,43 @@ var Intrinsics = new[]
     },
     new
     {
+        Name = "FaceForward",
+        HlslName = "faceforward",
+        Summary = "Flips the surface-normal (if needed) to face in a direction opposite to {param=i}, returns the result in {param=n}.",
+        Url = "https://docs.microsoft.com/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward",
+        Parameters = new[]
+        {
+            new { IsOut = false, Name = "n", Info = "The resulting floating-point surface-normal vector." },
+            new { IsOut = false, Name = "i", Info = "A floating-point, incident vector that points from the view position to the shading position." },
+            new { IsOut = false, Name = "ng", Info = "A floating-point surface-normal vector." }
+        },
+        Returns = "A floating-point, surface normal vector that is facing the view direction.",
+        Overloads = new[]
+        {
+            new { Return = "float", Params = new[] { "float", "float", "float" } },
+            new { Return = "Float2", Params = new[] { "Float2", "Float2", "Float2" } },
+            new { Return = "Float3", Params = new[] { "Float3", "Float3", "Float3" } },
+            new { Return = "Float4", Params = new[] { "Float4", "Float4", "Float4" } },
+            new { Return = "Float1x1", Params = new[] { "Float1x1", "Float1x1", "Float1x1" } },
+            new { Return = "Float1x2", Params = new[] { "Float1x2", "Float1x2", "Float1x2" } },
+            new { Return = "Float1x3", Params = new[] { "Float1x3", "Float1x3", "Float1x3" } },
+            new { Return = "Float1x4", Params = new[] { "Float1x4", "Float1x4", "Float1x4" } },
+            new { Return = "Float2x1", Params = new[] { "Float2x1", "Float2x1", "Float2x1" } },
+            new { Return = "Float2x2", Params = new[] { "Float2x2", "Float2x2", "Float2x2" } },
+            new { Return = "Float2x3", Params = new[] { "Float2x3", "Float2x3", "Float2x3" } },
+            new { Return = "Float2x4", Params = new[] { "Float2x4", "Float2x4", "Float2x4" } },
+            new { Return = "Float3x1", Params = new[] { "Float3x1", "Float3x1", "Float3x1" } },
+            new { Return = "Float3x2", Params = new[] { "Float3x2", "Float3x2", "Float3x2" } },
+            new { Return = "Float3x3", Params = new[] { "Float3x3", "Float3x3", "Float3x3" } },
+            new { Return = "Float3x4", Params = new[] { "Float3x4", "Float3x4", "Float3x4" } },
+            new { Return = "Float4x1", Params = new[] { "Float4x1", "Float4x1", "Float4x1" } },
+            new { Return = "Float4x2", Params = new[] { "Float4x2", "Float4x2", "Float4x2" } },
+            new { Return = "Float4x3", Params = new[] { "Float4x3", "Float4x3", "Float4x3" } },
+            new { Return = "Float4x4", Params = new[] { "Float4x4", "Float4x4", "Float4x4" } }
+        }
+    },
+    new
+    {
         Name = "FirstBitHigh",
         HlslName = "firstbithigh",
         Summary = "Gets the location of the first set bit starting from the highest order bit and working downward, per component.",

--- a/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderRewriterTests.cs
@@ -892,7 +892,7 @@ public partial class ShaderRewriterTests
     [AllDevices]
     public void MiscHlslIntrinsics(Device device)
     {
-        float[] data1 = [1, 2, 0.4f, 3.14f, 2.4f, 0.8f, 0, 0];
+        float[] data1 = [1, 2, 0.4f, 3.14f, 2.4f, 0.8f, 1.5f, -0.8f, 2.4f, 0.5f, 0.6f, -0.9f, 0, 0, 0, 0];
         int[] data2 = [111, 222, 333, 2, 4, 8, 63, 42, 77, 0, 0, 0];
 
         using ReadWriteBuffer<float> buffer1 = device.Get().AllocateReadWriteBuffer(data1);
@@ -904,7 +904,7 @@ public partial class ShaderRewriterTests
         int[] results2 = buffer2.ToArray();
 
         CollectionAssert.AreEqual(
-            expected: new[] { 1, 2, 0.4f, 3.14f, 2.4f, 0.8f, 2.8f, 7.08f },
+            expected: new[] { 1, 2, 0.4f, 3.14f, 2.4f, 0.8f, 1.5f, -0.8f, 2.4f, 0.5f, 0.6f, -0.9f, 2.8f, 7.08f, -1.5f, 0.8f },
             actual: results1,
             comparer: Comparer<float>.Create(static (x, y) => Math.Abs(x - y) < 0.000001f ? 0 : x.CompareTo(y)));
 
@@ -929,15 +929,21 @@ public partial class ShaderRewriterTests
             int3 i1 = new(buffer2[0], buffer2[1], buffer2[2]);
             int3 i2 = new(buffer2[3], buffer2[4], buffer2[5]);
             int3 i3 = new(buffer2[6], buffer2[7], buffer2[8]);
+            float2 f4 = new(buffer1[6], buffer1[7]);
+            float2 f5 = new(buffer1[8], buffer1[9]);
+            float2 f6 = new(buffer1[10], buffer1[11]);
 
             float2 r1 = Hlsl.Mad(f1, f2, f3);
             int3 r2 = Hlsl.Mad(i1, i2, i3);
+            float2 r3 = Hlsl.FaceForward(f4, f5, f6);
 
-            buffer1[6] = r1.X;
-            buffer1[7] = r1.Y;
+            buffer1[12] = r1.X;
+            buffer1[13] = r1.Y;
             buffer2[9] = r2.X;
             buffer2[10] = r2.Y;
             buffer2[11] = r2.Z;
+            buffer1[14] = r3.X;
+            buffer1[15] = r3.Y;
         }
     }
 


### PR DESCRIPTION
### Closes #768

### Description

This PR adds the missing `faceforward` intrinsic ([see docs](https://learn.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-faceforward)).