### PR TITLE
Don't rewrite 'ConstantBuffer<T>.Length'

### DIFF
--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
@@ -451,6 +451,14 @@ internal sealed partial class ShaderSourceRewriter(
                 if (!this.staticMethods.TryGetValue(key, out MethodDeclarationSyntax? methodSyntax))
                 {
                     INamedTypeSymbol resourceType = (INamedTypeSymbol)SemanticModel.For(node).GetTypeInfo(node.Expression, CancellationToken).Type!;
+
+                    // Explicitly ignore 'ConstantBuffer<T>.Length', as that is not valid in HLSL.
+                    // The type should just be reworked entirely at some point, but not today.
+                    if (resourceType.Name == "ConstantBuffer")
+                    {
+                        return updatedNode;
+                    }
+
                     string resourceName = HlslKnownTypes.GetMappedName(resourceType);
 
                     // Create a static method to get a specified dimension for a target resource type.

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownProperties.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownProperties.cs
@@ -35,6 +35,10 @@ partial class HlslKnownProperties
     /// <inheritdoc/>
     private static partial Dictionary<string, (int Rank, int Axis)> BuildKnownSizeAccessors()
     {
+        // For 'Buffer`1', which is used by the '[RW]StructuredBuffer<T>' types in HLSL, the rank is
+        // 2 because 'GetDimensions' still has two parameters, even if the actual rank of the array
+        // is just 1. That is because the length is the first output, and the second is the stride.
+        // The latter will always be ignored by the generated code.
         return new()
         {
             ["ComputeSharp.Resources.Buffer`1.Length"] = (2, 0),


### PR DESCRIPTION
### Closes #794

### Description

This PR avoids rewriting `ConstantBuffer<T>.Length`, to produce a better error rather than completely invalid HLSL code.