### PR TITLE
Minor tweaks to generated code

### DIFF
--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/ConstantBufferSyntaxProcessor.Generation.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/ConstantBufferSyntaxProcessor.Generation.cs
@@ -199,7 +199,7 @@ partial class ConstantBufferSyntaxProcessor
                     writer.WriteLine($"""/// <returns>The marshalled <see cref="{fullyQualifiedTypeName}"/> instance.</returns>""");
                     writer.WriteLine($"""[MethodImpl(MethodImplOptions.AggressiveInlining)]""");
                     writer.WriteLine($"""[SkipLocalsInit]""");
-                    writer.WriteLine($"public static {fullyQualifiedTypeName} ToManaged(in ConstantBuffer buffer)");
+                    writer.WriteLine($"public static {fullyQualifiedTypeName} ToManaged(ref readonly ConstantBuffer buffer)");
 
                     using (writer.WriteBlock())
                     {

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.ConstantBuffer.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.ConstantBuffer.cs
@@ -82,7 +82,7 @@ partial class ComputeShaderDescriptorGenerator
                 writer.WriteLine("buffer.__x = x;");
                 writer.WriteLine("buffer.__y = y;");
                 writer.WriteLineIf(!info.IsPixelShaderLike, "buffer.__z = z;");
-                writer.WriteLineIf(!info.IsPixelShaderLike);
+                writer.WriteLine(skipIfPresent: true);
                 writer.WriteLine("loader.LoadConstantBuffer(new global::System.ReadOnlySpan<byte>(&buffer, sizeof(global::ComputeSharp.Generated.ConstantBuffer)));");
             }
         }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
@@ -281,7 +281,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     /// <returns>The marshalled <see cref="global::MyNamespace.MyShader"/> instance.</returns>
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     [SkipLocalsInit]
-                    public static global::MyNamespace.MyShader ToManaged(in ConstantBuffer buffer)
+                    public static global::MyNamespace.MyShader ToManaged(ref readonly ConstantBuffer buffer)
                     {
                         Unsafe.SkipInit(out global::MyNamespace.MyShader shader);
 
@@ -583,7 +583,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     /// <returns>The marshalled <see cref="global::MyNamespace.MyShader"/> instance.</returns>
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     [SkipLocalsInit]
-                    public static global::MyNamespace.MyShader ToManaged(in ConstantBuffer buffer)
+                    public static global::MyNamespace.MyShader ToManaged(ref readonly ConstantBuffer buffer)
                     {
                         Unsafe.SkipInit(out global::MyNamespace.MyShader shader);
 
@@ -933,7 +933,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     /// <returns>The marshalled <see cref="global::MyNamespace.MyShader"/> instance.</returns>
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     [SkipLocalsInit]
-                    public static global::MyNamespace.MyShader ToManaged(in ConstantBuffer buffer)
+                    public static global::MyNamespace.MyShader ToManaged(ref readonly ConstantBuffer buffer)
                     {
                         Unsafe.SkipInit(out global::MyNamespace.MyShader shader);
 
@@ -1231,7 +1231,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     /// <returns>The marshalled <see cref="global::MyNamespace.MyShader"/> instance.</returns>
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
                     [SkipLocalsInit]
-                    public static global::MyNamespace.MyShader ToManaged(in ConstantBuffer buffer)
+                    public static global::MyNamespace.MyShader ToManaged(ref readonly ConstantBuffer buffer)
                     {
                         Unsafe.SkipInit(out global::MyNamespace.MyShader shader);
 

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator.cs
@@ -423,6 +423,7 @@ public class Test_ComputeShaderDescriptorGenerator
 
                         buffer.__x = x;
                         buffer.__y = y;
+
                         loader.LoadConstantBuffer(new global::System.ReadOnlySpan<byte>(&buffer, sizeof(global::ComputeSharp.Generated.ConstantBuffer)));
                     }
 


### PR DESCRIPTION
### Description

This PR includes two tweaks to generated code:
- Changes the parameter of `ToManaged` to `ref readonly` (from `in`)
- Adds a missing blank line in some cases in the `LoadConstantBuffer` method for DX12