### PR TITLE
Update all analyzer .targets files for 4.9

### DIFF
--- a/src/ComputeSharp.Core/ComputeSharp.Core.targets
+++ b/src/ComputeSharp.Core/ComputeSharp.Core.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.5 (ComputeSharp.Core's generators require Roslyn 4.5) -->
+  <!-- Remove the analyzer if using Roslyn < 4.9 (ComputeSharp.Core's generators require Roslyn 4.9) -->
   <Target Name="_ComputeSharpCoreRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -29,10 +29,10 @@
       <ComputeSharpCoreCurrentCompilerVersion>@(ComputeSharpCoreCurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpCoreCurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCoreCurrentCompilerVersion), 4.5))">true</ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCoreCurrentCompilerVersion), 4.9))">true</ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.5, disable the source generators -->
+    <!-- If the Roslyn version is < 4.9, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpCoreCurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpCoreAnalyzer)"/>
     </ItemGroup>

--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.8 (ComputeSharp.D2D1's generators require Roslyn 4.8) -->
+  <!-- Remove the analyzer if using Roslyn < 4.9 (ComputeSharp.D2D1's generators require Roslyn 4.9) -->
   <Target Name="_ComputeSharpD2D1RemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -29,10 +29,10 @@
       <ComputeSharpD2D1CurrentCompilerVersion>@(ComputeSharpD2D1CurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpD2D1CurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpD2D1CurrentCompilerVersion), 4.8))">true</ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpD2D1CurrentCompilerVersion), 4.9))">true</ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.8, disable the source generators -->
+    <!-- If the Roslyn version is < 4.9, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpD2D1Analyzer)"/>
     </ItemGroup>
@@ -42,7 +42,7 @@
       emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
       disabled, and that ComputeSharp will not work at all unless a more up to date IDE or compiler version are used.
     -->
-    <Error Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp.D2D1 source generators have been disabled on the current configuration, as they need Roslyn 4.8 in order to work. ComputeSharp.D2D1 requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.8 or greater) or .NET SDK version (.NET 8 SDK or greater)."/>  
+    <Error Condition ="'$(ComputeSharpD2D1CurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp.D2D1 source generators have been disabled on the current configuration, as they need Roslyn 4.9 in order to work. ComputeSharp.D2D1 requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.8 or greater) or .NET SDK version (.NET 8 SDK or greater)."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->

--- a/src/ComputeSharp/ComputeSharp.targets
+++ b/src/ComputeSharp/ComputeSharp.targets
@@ -7,7 +7,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Remove the analyzer if using Roslyn < 4.8 (ComputeSharp's generators require Roslyn 4.8) -->
+  <!-- Remove the analyzer if using Roslyn < 4.9 (ComputeSharp's generators require Roslyn 4.9) -->
   <Target Name="_ComputeSharpRemoveAnalyzersForRoslyn3"
           Condition="'$(CSharpCoreTargetsPath)' != ''"
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
@@ -29,10 +29,10 @@
       <ComputeSharpCurrentCompilerVersion>@(ComputeSharpCurrentCompilerAssemblyIdentity->'%(Version)')</ComputeSharpCurrentCompilerVersion>
 
       <!-- The CurrentCompilerVersionIsNotNewEnough property can now be defined based on the Roslyn assembly version -->
-      <ComputeSharpCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCurrentCompilerVersion), 4.8))">true</ComputeSharpCurrentCompilerVersionIsNotNewEnough>
+      <ComputeSharpCurrentCompilerVersionIsNotNewEnough Condition="$([MSBuild]::VersionLessThan($(ComputeSharpCurrentCompilerVersion), 4.9))">true</ComputeSharpCurrentCompilerVersionIsNotNewEnough>
     </PropertyGroup>
 
-    <!-- If the Roslyn version is < 4.8, disable the source generators -->
+    <!-- If the Roslyn version is < 4.9, disable the source generators -->
     <ItemGroup Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'">
       <Analyzer Remove="@(_ComputeSharpAnalyzer)"/>
     </ItemGroup>
@@ -42,7 +42,7 @@
       emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
       disabled, and that ComputeSharp will not work at all unless a more up to date IDE or compiler version are used.
     -->
-    <Error Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp source generators have been disabled on the current configuration, as they need Roslyn 4.8 in order to work. ComputeSharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.8 or greater) or .NET SDK version (.NET 8 SDK or greater)."/>  
+    <Error Condition ="'$(ComputeSharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The ComputeSharp source generators have been disabled on the current configuration, as they need Roslyn 4.9 in order to work. ComputeSharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.8 or greater) or .NET SDK version (.NET 8 SDK or greater)."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->


### PR DESCRIPTION
### Description

This PR updates all .targets files in the source generators, to ensure they match the Roslyn versions they use (4.9).