### PR TITLE
Make 'AllowsUnsafeBlocks' analyzer only trigger on attribute uses

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
@@ -13,7 +13,7 @@ public sealed class MissingAllowUnsafeBlocksCompilationOptionAnalyzer : MissingA
     /// Creates a new <see cref="MissingAllowUnsafeBlocksCompilationOptionAnalyzer"/> instance.
     /// </summary>
     public MissingAllowUnsafeBlocksCompilationOptionAnalyzer()
-        : base(MissingAllowUnsafeBlocksOption)
+        : base(MissingAllowUnsafeBlocksOption, "ComputeSharp.D2D1.D2DGeneratedPixelShaderDescriptorAttribute")
     {
     }
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -944,19 +944,18 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>AllowUnsafeBlocks</c> option is not set.
     /// <para>
-    /// Format: <c>"Unsafe blocks must be enabled for the source generators to emit valid code (add &lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt; to your .csproj/.props file)"</c>.
+    /// Format: <c>"Using [D2DGeneratedPixelShaderDescriptor] requires unsafe blocks being enabled, as they needed by the source generators to emit valid code (add &lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt; to your .csproj/.props file)"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor MissingAllowUnsafeBlocksOption = new(
         id: "CMPSD2D0064",
         title: "Missing 'AllowUnsafeBlocks' compilation option",
-        messageFormat: "Unsafe blocks must be enabled for the source generators to emit valid code (add <AllowUnsafeBlocks>true</AllowUnsafeBlocks> to your .csproj/.props file)",
+        messageFormat: "Using [D2DGeneratedPixelShaderDescriptor] requires unsafe blocks being enabled, as they needed by the source generators to emit valid code (add <AllowUnsafeBlocks>true</AllowUnsafeBlocks> to your .csproj/.props file)",
         category: "ComputeSharp.D2D1.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Unsafe blocks must be enabled for the source generators to emit valid code (the <AllowUnsafeBlocks>true</AllowUnsafeBlocks> option must be set in the .csproj/.props file).",
-        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp",
-        customTags: WellKnownDiagnosticTags.CompilationEnd);
+        description: "Unsafe blocks must be enabled when using [D2DGeneratedPixelShaderDescriptor] for the source generators to emit valid code (the <AllowUnsafeBlocks>true</AllowUnsafeBlocks> option must be set in the .csproj/.props file).",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for when a pixel shader type doesn't have an associated descriptor.

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase.cs
@@ -9,7 +9,10 @@ namespace ComputeSharp.SourceGeneration.Diagnostics;
 /// A diagnostic analyzer that generates an error if the <c>AllowUnsafeBlocks</c> compilation option is not set.
 /// </summary>
 /// <param name="diagnosticDescriptor">The <see cref="DiagnosticDescriptor"/> instance to use.</param>
-public abstract class MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase(DiagnosticDescriptor diagnosticDescriptor) : DiagnosticAnalyzer
+/// <param name="generatedShaderDescriptorFullyQualifiedTypeName">The fully qualified type name of the target attribute.</param>
+public abstract class MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase(
+    DiagnosticDescriptor diagnosticDescriptor,
+    string generatedShaderDescriptorFullyQualifiedTypeName) : DiagnosticAnalyzer
 {
     /// <inheritdoc/>
     public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [diagnosticDescriptor];
@@ -20,13 +23,38 @@ public abstract class MissingAllowUnsafeBlocksCompilationOptionAnalyzerBase(Diag
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
         context.EnableConcurrentExecution();
 
-        context.RegisterCompilationAction(context =>
+        context.RegisterCompilationStartAction(context =>
         {
-            // Check whether unsafe blocks are available, and emit an error if they are not
-            if (!context.Compilation.IsAllowUnsafeBlocksEnabled())
+            // If unsafe blocks are allowed, we'll never need to emit a diagnostic
+            if (context.Compilation.IsAllowUnsafeBlocksEnabled())
             {
-                context.ReportDiagnostic(Diagnostic.Create(diagnosticDescriptor, location: null));
+                return;
             }
+
+            // Get the symbol for the target attribute type
+            if (context.Compilation.GetTypeByMetadataName(generatedShaderDescriptorFullyQualifiedTypeName) is not { } generatedShaderDescriptorAttributeSymbol)
+            {
+                return;
+            }
+
+            // Check if any types in the compilation are using the trigger attribute
+            context.RegisterSymbolAction(context =>
+            {
+                // Only struct types are possible targets
+                if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // If the target type is not using the attribute, there's nothing left to do
+                if (!typeSymbol.TryGetAttributeWithType(generatedShaderDescriptorAttributeSymbol, out AttributeData? attribute))
+                {
+                    return;
+                }
+
+                // Emit the error on the attribute use
+                context.ReportDiagnostic(Diagnostic.Create(diagnosticDescriptor, attribute.GetLocation()));
+            }, SymbolKind.NamedType);
         });
     }
 }

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/Analyzers/MissingAllowUnsafeBlocksCompilationOptionAnalyzer.cs
@@ -13,7 +13,7 @@ public sealed class MissingAllowUnsafeBlocksCompilationOptionAnalyzer : MissingA
     /// Creates a new <see cref="MissingAllowUnsafeBlocksCompilationOptionAnalyzer"/> instance.
     /// </summary>
     public MissingAllowUnsafeBlocksCompilationOptionAnalyzer()
-        : base(MissingAllowUnsafeBlocksOption)
+        : base(MissingAllowUnsafeBlocksOption, "ComputeSharp.GeneratedComputeShaderDescriptorAttribute")
     {
     }
 }

--- a/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -720,19 +720,18 @@ partial class DiagnosticDescriptors
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for when the <c>AllowUnsafeBlocks</c> option is not set.
     /// <para>
-    /// Format: <c>"Unsafe blocks must be enabled for the source generators to emit valid code (add &lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt; to your .csproj/.props file)"</c>.
+    /// Format: <c>"Using [GeneratedComputeShaderDescriptor] requires unsafe blocks being enabled, as they needed by the source generators to emit valid code (add &lt;AllowUnsafeBlocks&gt;true&lt;/AllowUnsafeBlocks&gt; to your .csproj/.props file)"</c>.
     /// </para>
     /// </summary>
     public static readonly DiagnosticDescriptor MissingAllowUnsafeBlocksOption = new(
         id: "CMPS0052",
         title: "Missing 'AllowUnsafeBlocks' compilation option",
-        messageFormat: "Unsafe blocks must be enabled for the source generators to emit valid code (add <AllowUnsafeBlocks>true</AllowUnsafeBlocks> to your .csproj/.props file)",
+        messageFormat: "Using [GeneratedComputeShaderDescriptor] requires unsafe blocks being enabled, as they needed by the source generators to emit valid code (add <AllowUnsafeBlocks>true</AllowUnsafeBlocks> to your .csproj/.props file)",
         category: "ComputeSharp.Shaders",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Unsafe blocks must be enabled for the source generators to emit valid code (the <AllowUnsafeBlocks>true</AllowUnsafeBlocks> option must be set in the .csproj/.props file).",
-        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp",
-        customTags: WellKnownDiagnosticTags.CompilationEnd);
+        description: "Unsafe blocks must be enabled when using [GeneratedComputeShaderDescriptor] for the source generators to emit valid code (the <AllowUnsafeBlocks>true</AllowUnsafeBlocks> option must be set in the .csproj/.props file).",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 
     /// <summary>
     /// Gets a <see cref="DiagnosticDescriptor"/> for when a compute shader type doesn't have an associated descriptor.

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
@@ -9,7 +9,27 @@ namespace ComputeSharp.D2D1.Tests.SourceGenerators;
 public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
 {
     [TestMethod]
-    public async Task MissingD2DPixelShaderDescriptor_ComputeShader()
+    public async Task AllowsUnsafeBlocksNotEnabled_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+            using ComputeSharp.D2D1;
+
+            [{|CMPSD2D0064:D2DGeneratedPixelShaderDescriptor|}]
+            internal partial struct MyShader : ID2D1PixelShader
+            {
+                public Float4 Execute()
+                {
+                    return 0;
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingAllowUnsafeBlocksCompilationOptionAnalyzer>.VerifyAnalyzerAsync(source, allowUnsafeBlocks: false);
+    }
+
+    [TestMethod]
+    public async Task MissingD2DPixelShaderDescriptor_Warns()
     {
         const string source = """
             using ComputeSharp;
@@ -28,7 +48,7 @@ public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
     }
 
     [TestMethod]
-    public async Task MissingComputeShaderDescriptor_ManuallyImplemented_DoesNotWarn()
+    public async Task MissingD2DPixelShaderDescriptor_ManuallyImplemented_DoesNotWarn()
     {
         const string source = """
             using System;

--- a/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Helpers/CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}.cs
@@ -24,6 +24,11 @@ internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpA
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
     /// <summary>
+    /// Whether to enable unsafe blocks.
+    /// </summary>
+    private readonly bool allowUnsafeBlocks;
+
+    /// <summary>
     /// The C# language version to use to parse code.
     /// </summary>
     private readonly LanguageVersion languageVersion;
@@ -31,10 +36,18 @@ internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpA
     /// <summary>
     /// Creates a new <see cref="CSharpAnalyzerWithLanguageVersionTest{TAnalyzer}"/> instance with the specified paramaters.
     /// </summary>
+    /// <param name="allowUnsafeBlocks">Whether to enable unsafe blocks.</param>
     /// <param name="languageVersion">The C# language version to use to parse code.</param>
-    private CSharpAnalyzerWithLanguageVersionTest(LanguageVersion languageVersion)
+    private CSharpAnalyzerWithLanguageVersionTest(bool allowUnsafeBlocks, LanguageVersion languageVersion)
     {
+        this.allowUnsafeBlocks = allowUnsafeBlocks;
         this.languageVersion = languageVersion;
+    }
+
+    /// <inheritdoc/>
+    protected override CompilationOptions CreateCompilationOptions()
+    {
+        return new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: this.allowUnsafeBlocks);
     }
 
     /// <inheritdoc/>
@@ -45,10 +58,14 @@ internal sealed class CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> : CSharpA
 
     /// <inheritdoc cref="AnalyzerVerifier{TAnalyzer, TTest, TVerifier}.VerifyAnalyzerAsync"/>
     /// <param name="source">The source code to analyze.</param>
+    /// <param name="allowUnsafeBlocks">Whether to enable unsafe blocks.</param>
     /// <param name="languageVersion">The language version to use to run the test.</param>
-    public static Task VerifyAnalyzerAsync(string source, LanguageVersion languageVersion = LanguageVersion.CSharp12)
+    public static Task VerifyAnalyzerAsync(
+        string source,
+        bool allowUnsafeBlocks = true,
+        LanguageVersion languageVersion = LanguageVersion.CSharp12)
     {
-        CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> test = new(languageVersion) { TestCode = source };
+        CSharpAnalyzerWithLanguageVersionTest<TAnalyzer> test = new(allowUnsafeBlocks, languageVersion) { TestCode = source };
 
         test.TestState.ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
         test.TestState.AdditionalReferences.Add(MetadataReference.CreateFromFile(typeof(Core::ComputeSharp.Hlsl).Assembly.Location));

--- a/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.Tests.SourceGenerators/Test_ComputeShaderDescriptorGenerator_Analyzers.cs
@@ -9,6 +9,27 @@ namespace ComputeSharp.Tests.SourceGenerators;
 public class Test_ComputeShaderDescriptorGenerator_Analyzers
 {
     [TestMethod]
+    public async Task AllowsUnsafeBlocksNotEnabled_Warns()
+    {
+        const string source = """
+            using ComputeSharp;
+
+            [ThreadGroupSize(DefaultThreadGroupSizes.X)]
+            [{|CMPS0052:GeneratedComputeShaderDescriptor|}]
+            internal readonly partial struct MyShader : IComputeShader
+            {
+                private readonly ReadWriteBuffer<float> buffer;
+
+                public void Execute()
+                {
+                }
+            }
+            """;
+
+        await CSharpAnalyzerWithLanguageVersionTest<MissingAllowUnsafeBlocksCompilationOptionAnalyzer>.VerifyAnalyzerAsync(source, allowUnsafeBlocks: false);
+    }
+
+    [TestMethod]
     public async Task MissingComputeShaderDescriptor_ComputeShader()
     {
         const string source = """


### PR DESCRIPTION
### Closes #815

### Description

This PR updates the analyzers for 'AllowsUnsafeBlocks' to only trigger on attribute uses, and not on all transitive projects.