### PR TITLE
Add new HLSL operators for 'int' and 'uint' operands

### DIFF
--- a/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
@@ -702,6 +702,24 @@ public unsafe partial struct Int2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator >>(Int2 xy, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator >>(Int2 xy, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2 operator >>(Int2 xy, Int2 amount) => default;
 
     /// <summary>
@@ -712,6 +730,24 @@ public unsafe partial struct Int2
     /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2 operator >>(Int2 xy, UInt2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator <<(Int2 xy, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator <<(Int2 xy, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int2"/> value.
@@ -735,6 +771,24 @@ public unsafe partial struct Int2
     /// Bitwise ands a <see cref="Int2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator &(Int2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator &(Int2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -753,6 +807,24 @@ public unsafe partial struct Int2
     /// Bitwise ors a <see cref="Int2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator |(Int2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator |(Int2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -766,6 +838,24 @@ public unsafe partial struct Int2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2 operator |(Int2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator ^(Int2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator ^(Int2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int2"/> value.

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
@@ -2042,6 +2042,24 @@ public unsafe partial struct Int3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator >>(Int3 xyz, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator >>(Int3 xyz, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3 operator >>(Int3 xyz, Int3 amount) => default;
 
     /// <summary>
@@ -2052,6 +2070,24 @@ public unsafe partial struct Int3
     /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3 operator >>(Int3 xyz, UInt3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator <<(Int3 xyz, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator <<(Int3 xyz, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int3"/> value.
@@ -2075,6 +2111,24 @@ public unsafe partial struct Int3
     /// Bitwise ands a <see cref="Int3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator &(Int3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator &(Int3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2093,6 +2147,24 @@ public unsafe partial struct Int3
     /// Bitwise ors a <see cref="Int3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator |(Int3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator |(Int3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2106,6 +2178,24 @@ public unsafe partial struct Int3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3 operator |(Int3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator ^(Int3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator ^(Int3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int3"/> value.

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
@@ -5379,6 +5379,24 @@ public unsafe partial struct Int4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator >>(Int4 xyzw, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator >>(Int4 xyzw, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4 operator >>(Int4 xyzw, Int4 amount) => default;
 
     /// <summary>
@@ -5389,6 +5407,24 @@ public unsafe partial struct Int4
     /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4 operator >>(Int4 xyzw, UInt4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator <<(Int4 xyzw, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator <<(Int4 xyzw, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int4"/> value.
@@ -5412,6 +5448,24 @@ public unsafe partial struct Int4
     /// Bitwise ands a <see cref="Int4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator &(Int4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator &(Int4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5430,6 +5484,24 @@ public unsafe partial struct Int4
     /// Bitwise ors a <see cref="Int4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator |(Int4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator |(Int4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5443,6 +5515,24 @@ public unsafe partial struct Int4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4 operator |(Int4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator ^(Int4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator ^(Int4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int4"/> value.

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -233,6 +233,24 @@ public unsafe partial struct Int1x1
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator >>(Int1x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator >>(Int1x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x1 operator >>(Int1x1 matrix, Int1x1 amount) => default;
 
     /// <summary>
@@ -243,6 +261,24 @@ public unsafe partial struct Int1x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x1 operator >>(Int1x1 matrix, UInt1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator <<(Int1x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator <<(Int1x1 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int1x1"/> value.
@@ -266,6 +302,24 @@ public unsafe partial struct Int1x1
     /// Bitwise ands a <see cref="Int1x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int1x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator &(Int1x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator &(Int1x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -284,6 +338,24 @@ public unsafe partial struct Int1x1
     /// Bitwise ors a <see cref="Int1x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int1x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator |(Int1x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator |(Int1x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -297,6 +369,24 @@ public unsafe partial struct Int1x1
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x1 operator |(Int1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator ^(Int1x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator ^(Int1x1 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int1x1"/> value.
@@ -658,6 +748,24 @@ public unsafe partial struct Int1x2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator >>(Int1x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator >>(Int1x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x2 operator >>(Int1x2 matrix, Int1x2 amount) => default;
 
     /// <summary>
@@ -668,6 +776,24 @@ public unsafe partial struct Int1x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x2 operator >>(Int1x2 matrix, UInt1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator <<(Int1x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator <<(Int1x2 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int1x2"/> value.
@@ -691,6 +817,24 @@ public unsafe partial struct Int1x2
     /// Bitwise ands a <see cref="Int1x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int1x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator &(Int1x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator &(Int1x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -709,6 +853,24 @@ public unsafe partial struct Int1x2
     /// Bitwise ors a <see cref="Int1x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int1x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator |(Int1x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator |(Int1x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -722,6 +884,24 @@ public unsafe partial struct Int1x2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x2 operator |(Int1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator ^(Int1x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator ^(Int1x2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int1x2"/> value.
@@ -1101,6 +1281,24 @@ public unsafe partial struct Int1x3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator >>(Int1x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator >>(Int1x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x3 operator >>(Int1x3 matrix, Int1x3 amount) => default;
 
     /// <summary>
@@ -1111,6 +1309,24 @@ public unsafe partial struct Int1x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x3 operator >>(Int1x3 matrix, UInt1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator <<(Int1x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator <<(Int1x3 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int1x3"/> value.
@@ -1134,6 +1350,24 @@ public unsafe partial struct Int1x3
     /// Bitwise ands a <see cref="Int1x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int1x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator &(Int1x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator &(Int1x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1152,6 +1386,24 @@ public unsafe partial struct Int1x3
     /// Bitwise ors a <see cref="Int1x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int1x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator |(Int1x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator |(Int1x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1165,6 +1417,24 @@ public unsafe partial struct Int1x3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x3 operator |(Int1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator ^(Int1x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator ^(Int1x3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int1x3"/> value.
@@ -1556,6 +1826,24 @@ public unsafe partial struct Int1x4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator >>(Int1x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator >>(Int1x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x4 operator >>(Int1x4 matrix, Int1x4 amount) => default;
 
     /// <summary>
@@ -1566,6 +1854,24 @@ public unsafe partial struct Int1x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x4 operator >>(Int1x4 matrix, UInt1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator <<(Int1x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator <<(Int1x4 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int1x4"/> value.
@@ -1589,6 +1895,24 @@ public unsafe partial struct Int1x4
     /// Bitwise ands a <see cref="Int1x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int1x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator &(Int1x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator &(Int1x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1607,6 +1931,24 @@ public unsafe partial struct Int1x4
     /// Bitwise ors a <see cref="Int1x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int1x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator |(Int1x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator |(Int1x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1620,6 +1962,24 @@ public unsafe partial struct Int1x4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x4 operator |(Int1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator ^(Int1x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int1x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator ^(Int1x4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int1x4"/> value.
@@ -1973,6 +2333,24 @@ public unsafe partial struct Int2x1
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator >>(Int2x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator >>(Int2x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x1 operator >>(Int2x1 matrix, Int2x1 amount) => default;
 
     /// <summary>
@@ -1983,6 +2361,24 @@ public unsafe partial struct Int2x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x1 operator >>(Int2x1 matrix, UInt2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator <<(Int2x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator <<(Int2x1 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int2x1"/> value.
@@ -2006,6 +2402,24 @@ public unsafe partial struct Int2x1
     /// Bitwise ands a <see cref="Int2x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator &(Int2x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator &(Int2x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2024,6 +2438,24 @@ public unsafe partial struct Int2x1
     /// Bitwise ors a <see cref="Int2x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator |(Int2x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator |(Int2x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2037,6 +2469,24 @@ public unsafe partial struct Int2x1
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x1 operator |(Int2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator ^(Int2x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator ^(Int2x1 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int2x1"/> value.
@@ -2357,6 +2807,24 @@ public unsafe partial struct Int2x2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator >>(Int2x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator >>(Int2x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x2 operator >>(Int2x2 matrix, Int2x2 amount) => default;
 
     /// <summary>
@@ -2367,6 +2835,24 @@ public unsafe partial struct Int2x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x2 operator >>(Int2x2 matrix, UInt2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator <<(Int2x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator <<(Int2x2 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int2x2"/> value.
@@ -2390,6 +2876,24 @@ public unsafe partial struct Int2x2
     /// Bitwise ands a <see cref="Int2x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator &(Int2x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator &(Int2x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2408,6 +2912,24 @@ public unsafe partial struct Int2x2
     /// Bitwise ors a <see cref="Int2x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator |(Int2x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator |(Int2x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2421,6 +2943,24 @@ public unsafe partial struct Int2x2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x2 operator |(Int2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator ^(Int2x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator ^(Int2x2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int2x2"/> value.
@@ -2845,6 +3385,24 @@ public unsafe partial struct Int2x3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator >>(Int2x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator >>(Int2x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x3 operator >>(Int2x3 matrix, Int2x3 amount) => default;
 
     /// <summary>
@@ -2855,6 +3413,24 @@ public unsafe partial struct Int2x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x3 operator >>(Int2x3 matrix, UInt2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator <<(Int2x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator <<(Int2x3 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int2x3"/> value.
@@ -2878,6 +3454,24 @@ public unsafe partial struct Int2x3
     /// Bitwise ands a <see cref="Int2x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator &(Int2x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator &(Int2x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2896,6 +3490,24 @@ public unsafe partial struct Int2x3
     /// Bitwise ors a <see cref="Int2x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator |(Int2x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator |(Int2x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2909,6 +3521,24 @@ public unsafe partial struct Int2x3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x3 operator |(Int2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator ^(Int2x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator ^(Int2x3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int2x3"/> value.
@@ -3359,6 +3989,24 @@ public unsafe partial struct Int2x4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator >>(Int2x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator >>(Int2x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x4 operator >>(Int2x4 matrix, Int2x4 amount) => default;
 
     /// <summary>
@@ -3369,6 +4017,24 @@ public unsafe partial struct Int2x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x4 operator >>(Int2x4 matrix, UInt2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator <<(Int2x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator <<(Int2x4 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int2x4"/> value.
@@ -3392,6 +4058,24 @@ public unsafe partial struct Int2x4
     /// Bitwise ands a <see cref="Int2x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator &(Int2x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator &(Int2x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3410,6 +4094,24 @@ public unsafe partial struct Int2x4
     /// Bitwise ors a <see cref="Int2x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int2x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator |(Int2x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator |(Int2x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3423,6 +4125,24 @@ public unsafe partial struct Int2x4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x4 operator |(Int2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator ^(Int2x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int2x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator ^(Int2x4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int2x4"/> value.
@@ -3782,6 +4502,24 @@ public unsafe partial struct Int3x1
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator >>(Int3x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator >>(Int3x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x1 operator >>(Int3x1 matrix, Int3x1 amount) => default;
 
     /// <summary>
@@ -3792,6 +4530,24 @@ public unsafe partial struct Int3x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x1 operator >>(Int3x1 matrix, UInt3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator <<(Int3x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator <<(Int3x1 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int3x1"/> value.
@@ -3815,6 +4571,24 @@ public unsafe partial struct Int3x1
     /// Bitwise ands a <see cref="Int3x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator &(Int3x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator &(Int3x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3833,6 +4607,24 @@ public unsafe partial struct Int3x1
     /// Bitwise ors a <see cref="Int3x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator |(Int3x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator |(Int3x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3846,6 +4638,24 @@ public unsafe partial struct Int3x1
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x1 operator |(Int3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator ^(Int3x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator ^(Int3x1 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int3x1"/> value.
@@ -4277,6 +5087,24 @@ public unsafe partial struct Int3x2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator >>(Int3x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator >>(Int3x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x2 operator >>(Int3x2 matrix, Int3x2 amount) => default;
 
     /// <summary>
@@ -4287,6 +5115,24 @@ public unsafe partial struct Int3x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x2 operator >>(Int3x2 matrix, UInt3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator <<(Int3x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator <<(Int3x2 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int3x2"/> value.
@@ -4310,6 +5156,24 @@ public unsafe partial struct Int3x2
     /// Bitwise ands a <see cref="Int3x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator &(Int3x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator &(Int3x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -4328,6 +5192,24 @@ public unsafe partial struct Int3x2
     /// Bitwise ors a <see cref="Int3x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator |(Int3x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator |(Int3x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -4341,6 +5223,24 @@ public unsafe partial struct Int3x2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x2 operator |(Int3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator ^(Int3x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator ^(Int3x2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int3x2"/> value.
@@ -4721,6 +5621,24 @@ public unsafe partial struct Int3x3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator >>(Int3x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator >>(Int3x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x3 operator >>(Int3x3 matrix, Int3x3 amount) => default;
 
     /// <summary>
@@ -4731,6 +5649,24 @@ public unsafe partial struct Int3x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x3 operator >>(Int3x3 matrix, UInt3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator <<(Int3x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator <<(Int3x3 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int3x3"/> value.
@@ -4754,6 +5690,24 @@ public unsafe partial struct Int3x3
     /// Bitwise ands a <see cref="Int3x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator &(Int3x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator &(Int3x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -4772,6 +5726,24 @@ public unsafe partial struct Int3x3
     /// Bitwise ors a <see cref="Int3x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator |(Int3x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator |(Int3x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -4785,6 +5757,24 @@ public unsafe partial struct Int3x3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x3 operator |(Int3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator ^(Int3x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator ^(Int3x3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int3x3"/> value.
@@ -5288,6 +6278,24 @@ public unsafe partial struct Int3x4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator >>(Int3x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator >>(Int3x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x4 operator >>(Int3x4 matrix, Int3x4 amount) => default;
 
     /// <summary>
@@ -5298,6 +6306,24 @@ public unsafe partial struct Int3x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x4 operator >>(Int3x4 matrix, UInt3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator <<(Int3x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator <<(Int3x4 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int3x4"/> value.
@@ -5321,6 +6347,24 @@ public unsafe partial struct Int3x4
     /// Bitwise ands a <see cref="Int3x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator &(Int3x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator &(Int3x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5339,6 +6383,24 @@ public unsafe partial struct Int3x4
     /// Bitwise ors a <see cref="Int3x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int3x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator |(Int3x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator |(Int3x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5352,6 +6414,24 @@ public unsafe partial struct Int3x4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x4 operator |(Int3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator ^(Int3x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int3x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator ^(Int3x4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int3x4"/> value.
@@ -5723,6 +6803,24 @@ public unsafe partial struct Int4x1
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator >>(Int4x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator >>(Int4x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x1 operator >>(Int4x1 matrix, Int4x1 amount) => default;
 
     /// <summary>
@@ -5733,6 +6831,24 @@ public unsafe partial struct Int4x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x1 operator >>(Int4x1 matrix, UInt4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator <<(Int4x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator <<(Int4x1 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int4x1"/> value.
@@ -5756,6 +6872,24 @@ public unsafe partial struct Int4x1
     /// Bitwise ands a <see cref="Int4x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator &(Int4x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator &(Int4x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5774,6 +6908,24 @@ public unsafe partial struct Int4x1
     /// Bitwise ors a <see cref="Int4x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator |(Int4x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator |(Int4x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5787,6 +6939,24 @@ public unsafe partial struct Int4x1
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x1 operator |(Int4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator ^(Int4x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator ^(Int4x1 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int4x1"/> value.
@@ -6245,6 +7415,24 @@ public unsafe partial struct Int4x2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator >>(Int4x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator >>(Int4x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x2 operator >>(Int4x2 matrix, Int4x2 amount) => default;
 
     /// <summary>
@@ -6255,6 +7443,24 @@ public unsafe partial struct Int4x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x2 operator >>(Int4x2 matrix, UInt4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator <<(Int4x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator <<(Int4x2 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int4x2"/> value.
@@ -6278,6 +7484,24 @@ public unsafe partial struct Int4x2
     /// Bitwise ands a <see cref="Int4x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator &(Int4x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator &(Int4x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -6296,6 +7520,24 @@ public unsafe partial struct Int4x2
     /// Bitwise ors a <see cref="Int4x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator |(Int4x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator |(Int4x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -6309,6 +7551,24 @@ public unsafe partial struct Int4x2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x2 operator |(Int4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator ^(Int4x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator ^(Int4x2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int4x2"/> value.
@@ -6813,6 +8073,24 @@ public unsafe partial struct Int4x3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator >>(Int4x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator >>(Int4x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x3 operator >>(Int4x3 matrix, Int4x3 amount) => default;
 
     /// <summary>
@@ -6823,6 +8101,24 @@ public unsafe partial struct Int4x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x3 operator >>(Int4x3 matrix, UInt4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator <<(Int4x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator <<(Int4x3 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int4x3"/> value.
@@ -6846,6 +8142,24 @@ public unsafe partial struct Int4x3
     /// Bitwise ands a <see cref="Int4x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator &(Int4x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator &(Int4x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -6864,6 +8178,24 @@ public unsafe partial struct Int4x3
     /// Bitwise ors a <see cref="Int4x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator |(Int4x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator |(Int4x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -6877,6 +8209,24 @@ public unsafe partial struct Int4x3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x3 operator |(Int4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator ^(Int4x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator ^(Int4x3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int4x3"/> value.
@@ -7349,6 +8699,24 @@ public unsafe partial struct Int4x4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator >>(Int4x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator >>(Int4x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x4 operator >>(Int4x4 matrix, Int4x4 amount) => default;
 
     /// <summary>
@@ -7359,6 +8727,24 @@ public unsafe partial struct Int4x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x4 operator >>(Int4x4 matrix, UInt4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator <<(Int4x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator <<(Int4x4 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int4x4"/> value.
@@ -7382,6 +8768,24 @@ public unsafe partial struct Int4x4
     /// Bitwise ands a <see cref="Int4x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator &(Int4x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator &(Int4x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -7400,6 +8804,24 @@ public unsafe partial struct Int4x4
     /// Bitwise ors a <see cref="Int4x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="Int4x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator |(Int4x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator |(Int4x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -7413,6 +8835,24 @@ public unsafe partial struct Int4x4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x4 operator |(Int4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator ^(Int4x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="Int4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="Int4x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator ^(Int4x4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="Int4x4"/> value.

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -456,6 +456,24 @@ public unsafe partial struct <#=fullTypeName#>
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator >>(<#=fullTypeName#> matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator >>(<#=fullTypeName#> matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=fullTypeName#> operator >>(<#=fullTypeName#> matrix, Int<#=rows#>x<#=columns#> amount) => default;
 
     /// <summary>
@@ -466,6 +484,24 @@ public unsafe partial struct <#=fullTypeName#>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=fullTypeName#> operator >>(<#=fullTypeName#> matrix, UInt<#=rows#>x<#=columns#> amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator <<(<#=fullTypeName#> matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator <<(<#=fullTypeName#> matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="<#=fullTypeName#>"/> value.
@@ -489,6 +525,24 @@ public unsafe partial struct <#=fullTypeName#>
     /// Bitwise ands a <see cref="<#=fullTypeName#>"/> value.
     /// </summary>
     /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator &(<#=fullTypeName#> left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator &(<#=fullTypeName#> left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int<#=rows#>x<#=columns#>"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -507,6 +561,24 @@ public unsafe partial struct <#=fullTypeName#>
     /// Bitwise ors a <see cref="<#=fullTypeName#>"/> value.
     /// </summary>
     /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator |(<#=fullTypeName#> left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator |(<#=fullTypeName#> left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int<#=rows#>x<#=columns#>"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -520,6 +592,24 @@ public unsafe partial struct <#=fullTypeName#>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=fullTypeName#> operator |(<#=fullTypeName#> left, UInt<#=rows#>x<#=columns#> right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator ^(<#=fullTypeName#> left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="<#=fullTypeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=fullTypeName#>"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator ^(<#=fullTypeName#> left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="<#=fullTypeName#>"/> value.

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
@@ -605,6 +605,24 @@ public unsafe partial struct UInt2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator >>(UInt2 xy, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator >>(UInt2 xy, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2 operator >>(UInt2 xy, Int2 amount) => default;
 
     /// <summary>
@@ -615,6 +633,24 @@ public unsafe partial struct UInt2
     /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2 operator >>(UInt2 xy, UInt2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator <<(UInt2 xy, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator <<(UInt2 xy, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt2"/> value.
@@ -638,6 +674,24 @@ public unsafe partial struct UInt2
     /// Bitwise ands a <see cref="UInt2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator &(UInt2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator &(UInt2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -656,6 +710,24 @@ public unsafe partial struct UInt2
     /// Bitwise ors a <see cref="UInt2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator |(UInt2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator |(UInt2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -669,6 +741,24 @@ public unsafe partial struct UInt2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2 operator |(UInt2 left, UInt2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator ^(UInt2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator ^(UInt2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt2"/> value.

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
@@ -1945,6 +1945,24 @@ public unsafe partial struct UInt3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator >>(UInt3 xyz, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator >>(UInt3 xyz, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3 operator >>(UInt3 xyz, Int3 amount) => default;
 
     /// <summary>
@@ -1955,6 +1973,24 @@ public unsafe partial struct UInt3
     /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3 operator >>(UInt3 xyz, UInt3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator <<(UInt3 xyz, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator <<(UInt3 xyz, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt3"/> value.
@@ -1978,6 +2014,24 @@ public unsafe partial struct UInt3
     /// Bitwise ands a <see cref="UInt3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator &(UInt3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator &(UInt3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1996,6 +2050,24 @@ public unsafe partial struct UInt3
     /// Bitwise ors a <see cref="UInt3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator |(UInt3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator |(UInt3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2009,6 +2081,24 @@ public unsafe partial struct UInt3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3 operator |(UInt3 left, UInt3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator ^(UInt3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator ^(UInt3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt3"/> value.

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
@@ -5282,6 +5282,24 @@ public unsafe partial struct UInt4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator >>(UInt4 xyzw, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator >>(UInt4 xyzw, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4 operator >>(UInt4 xyzw, Int4 amount) => default;
 
     /// <summary>
@@ -5292,6 +5310,24 @@ public unsafe partial struct UInt4
     /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4 operator >>(UInt4 xyzw, UInt4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator <<(UInt4 xyzw, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator <<(UInt4 xyzw, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4"/> value.
@@ -5315,6 +5351,24 @@ public unsafe partial struct UInt4
     /// Bitwise ands a <see cref="UInt4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator &(UInt4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator &(UInt4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5333,6 +5387,24 @@ public unsafe partial struct UInt4
     /// Bitwise ors a <see cref="UInt4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator |(UInt4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator |(UInt4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5346,6 +5418,24 @@ public unsafe partial struct UInt4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4 operator |(UInt4 left, UInt4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator ^(UInt4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator ^(UInt4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt4"/> value.

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -207,6 +207,24 @@ public unsafe partial struct UInt1x1
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator >>(UInt1x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator >>(UInt1x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x1 operator >>(UInt1x1 matrix, Int1x1 amount) => default;
 
     /// <summary>
@@ -217,6 +235,24 @@ public unsafe partial struct UInt1x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x1 operator >>(UInt1x1 matrix, UInt1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator <<(UInt1x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator <<(UInt1x1 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt1x1"/> value.
@@ -240,6 +276,24 @@ public unsafe partial struct UInt1x1
     /// Bitwise ands a <see cref="UInt1x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt1x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator &(UInt1x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator &(UInt1x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -258,6 +312,24 @@ public unsafe partial struct UInt1x1
     /// Bitwise ors a <see cref="UInt1x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt1x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator |(UInt1x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator |(UInt1x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int1x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -271,6 +343,24 @@ public unsafe partial struct UInt1x1
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x1 operator |(UInt1x1 left, UInt1x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator ^(UInt1x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator ^(UInt1x1 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt1x1"/> value.
@@ -523,6 +613,24 @@ public unsafe partial struct UInt1x2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator >>(UInt1x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator >>(UInt1x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x2 operator >>(UInt1x2 matrix, Int1x2 amount) => default;
 
     /// <summary>
@@ -533,6 +641,24 @@ public unsafe partial struct UInt1x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x2 operator >>(UInt1x2 matrix, UInt1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator <<(UInt1x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator <<(UInt1x2 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt1x2"/> value.
@@ -556,6 +682,24 @@ public unsafe partial struct UInt1x2
     /// Bitwise ands a <see cref="UInt1x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt1x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator &(UInt1x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator &(UInt1x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -574,6 +718,24 @@ public unsafe partial struct UInt1x2
     /// Bitwise ors a <see cref="UInt1x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt1x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator |(UInt1x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator |(UInt1x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int1x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -587,6 +749,24 @@ public unsafe partial struct UInt1x2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x2 operator |(UInt1x2 left, UInt1x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator ^(UInt1x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator ^(UInt1x2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt1x2"/> value.
@@ -857,6 +1037,24 @@ public unsafe partial struct UInt1x3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator >>(UInt1x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator >>(UInt1x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x3 operator >>(UInt1x3 matrix, Int1x3 amount) => default;
 
     /// <summary>
@@ -867,6 +1065,24 @@ public unsafe partial struct UInt1x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x3 operator >>(UInt1x3 matrix, UInt1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator <<(UInt1x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator <<(UInt1x3 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt1x3"/> value.
@@ -890,6 +1106,24 @@ public unsafe partial struct UInt1x3
     /// Bitwise ands a <see cref="UInt1x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt1x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator &(UInt1x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator &(UInt1x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -908,6 +1142,24 @@ public unsafe partial struct UInt1x3
     /// Bitwise ors a <see cref="UInt1x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt1x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator |(UInt1x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator |(UInt1x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int1x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -921,6 +1173,24 @@ public unsafe partial struct UInt1x3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x3 operator |(UInt1x3 left, UInt1x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator ^(UInt1x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator ^(UInt1x3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt1x3"/> value.
@@ -1203,6 +1473,24 @@ public unsafe partial struct UInt1x4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator >>(UInt1x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator >>(UInt1x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x4 operator >>(UInt1x4 matrix, Int1x4 amount) => default;
 
     /// <summary>
@@ -1213,6 +1501,24 @@ public unsafe partial struct UInt1x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x4 operator >>(UInt1x4 matrix, UInt1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator <<(UInt1x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator <<(UInt1x4 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt1x4"/> value.
@@ -1236,6 +1542,24 @@ public unsafe partial struct UInt1x4
     /// Bitwise ands a <see cref="UInt1x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt1x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator &(UInt1x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator &(UInt1x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1254,6 +1578,24 @@ public unsafe partial struct UInt1x4
     /// Bitwise ors a <see cref="UInt1x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt1x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator |(UInt1x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator |(UInt1x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int1x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1267,6 +1609,24 @@ public unsafe partial struct UInt1x4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x4 operator |(UInt1x4 left, UInt1x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator ^(UInt1x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt1x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt1x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator ^(UInt1x4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt1x4"/> value.
@@ -1525,6 +1885,24 @@ public unsafe partial struct UInt2x1
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator >>(UInt2x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator >>(UInt2x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x1 operator >>(UInt2x1 matrix, Int2x1 amount) => default;
 
     /// <summary>
@@ -1535,6 +1913,24 @@ public unsafe partial struct UInt2x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x1 operator >>(UInt2x1 matrix, UInt2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator <<(UInt2x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator <<(UInt2x1 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt2x1"/> value.
@@ -1558,6 +1954,24 @@ public unsafe partial struct UInt2x1
     /// Bitwise ands a <see cref="UInt2x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator &(UInt2x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator &(UInt2x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1576,6 +1990,24 @@ public unsafe partial struct UInt2x1
     /// Bitwise ors a <see cref="UInt2x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator |(UInt2x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator |(UInt2x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1589,6 +2021,24 @@ public unsafe partial struct UInt2x1
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x1 operator |(UInt2x1 left, UInt2x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator ^(UInt2x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator ^(UInt2x1 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt2x1"/> value.
@@ -1884,6 +2334,24 @@ public unsafe partial struct UInt2x2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator >>(UInt2x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator >>(UInt2x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x2 operator >>(UInt2x2 matrix, Int2x2 amount) => default;
 
     /// <summary>
@@ -1894,6 +2362,24 @@ public unsafe partial struct UInt2x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x2 operator >>(UInt2x2 matrix, UInt2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator <<(UInt2x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator <<(UInt2x2 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt2x2"/> value.
@@ -1917,6 +2403,24 @@ public unsafe partial struct UInt2x2
     /// Bitwise ands a <see cref="UInt2x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator &(UInt2x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator &(UInt2x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1935,6 +2439,24 @@ public unsafe partial struct UInt2x2
     /// Bitwise ors a <see cref="UInt2x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator |(UInt2x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator |(UInt2x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -1948,6 +2470,24 @@ public unsafe partial struct UInt2x2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x2 operator |(UInt2x2 left, UInt2x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator ^(UInt2x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator ^(UInt2x2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt2x2"/> value.
@@ -2263,6 +2803,24 @@ public unsafe partial struct UInt2x3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator >>(UInt2x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator >>(UInt2x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x3 operator >>(UInt2x3 matrix, Int2x3 amount) => default;
 
     /// <summary>
@@ -2273,6 +2831,24 @@ public unsafe partial struct UInt2x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x3 operator >>(UInt2x3 matrix, UInt2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator <<(UInt2x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator <<(UInt2x3 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt2x3"/> value.
@@ -2296,6 +2872,24 @@ public unsafe partial struct UInt2x3
     /// Bitwise ands a <see cref="UInt2x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator &(UInt2x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator &(UInt2x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2314,6 +2908,24 @@ public unsafe partial struct UInt2x3
     /// Bitwise ors a <see cref="UInt2x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator |(UInt2x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator |(UInt2x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2327,6 +2939,24 @@ public unsafe partial struct UInt2x3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x3 operator |(UInt2x3 left, UInt2x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator ^(UInt2x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator ^(UInt2x3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt2x3"/> value.
@@ -2668,6 +3298,24 @@ public unsafe partial struct UInt2x4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator >>(UInt2x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator >>(UInt2x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x4 operator >>(UInt2x4 matrix, Int2x4 amount) => default;
 
     /// <summary>
@@ -2678,6 +3326,24 @@ public unsafe partial struct UInt2x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x4 operator >>(UInt2x4 matrix, UInt2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator <<(UInt2x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator <<(UInt2x4 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt2x4"/> value.
@@ -2701,6 +3367,24 @@ public unsafe partial struct UInt2x4
     /// Bitwise ands a <see cref="UInt2x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator &(UInt2x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator &(UInt2x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2719,6 +3403,24 @@ public unsafe partial struct UInt2x4
     /// Bitwise ors a <see cref="UInt2x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt2x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator |(UInt2x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator |(UInt2x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int2x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -2732,6 +3434,24 @@ public unsafe partial struct UInt2x4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x4 operator |(UInt2x4 left, UInt2x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator ^(UInt2x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt2x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt2x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator ^(UInt2x4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt2x4"/> value.
@@ -2996,6 +3716,24 @@ public unsafe partial struct UInt3x1
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator >>(UInt3x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator >>(UInt3x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x1 operator >>(UInt3x1 matrix, Int3x1 amount) => default;
 
     /// <summary>
@@ -3006,6 +3744,24 @@ public unsafe partial struct UInt3x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x1 operator >>(UInt3x1 matrix, UInt3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator <<(UInt3x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator <<(UInt3x1 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt3x1"/> value.
@@ -3029,6 +3785,24 @@ public unsafe partial struct UInt3x1
     /// Bitwise ands a <see cref="UInt3x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator &(UInt3x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator &(UInt3x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3047,6 +3821,24 @@ public unsafe partial struct UInt3x1
     /// Bitwise ors a <see cref="UInt3x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator |(UInt3x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator |(UInt3x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3060,6 +3852,24 @@ public unsafe partial struct UInt3x1
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x1 operator |(UInt3x1 left, UInt3x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator ^(UInt3x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator ^(UInt3x1 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt3x1"/> value.
@@ -3382,6 +4192,24 @@ public unsafe partial struct UInt3x2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator >>(UInt3x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator >>(UInt3x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x2 operator >>(UInt3x2 matrix, Int3x2 amount) => default;
 
     /// <summary>
@@ -3392,6 +4220,24 @@ public unsafe partial struct UInt3x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x2 operator >>(UInt3x2 matrix, UInt3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator <<(UInt3x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator <<(UInt3x2 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt3x2"/> value.
@@ -3415,6 +4261,24 @@ public unsafe partial struct UInt3x2
     /// Bitwise ands a <see cref="UInt3x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator &(UInt3x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator &(UInt3x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3433,6 +4297,24 @@ public unsafe partial struct UInt3x2
     /// Bitwise ors a <see cref="UInt3x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator |(UInt3x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator |(UInt3x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3446,6 +4328,24 @@ public unsafe partial struct UInt3x2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x2 operator |(UInt3x2 left, UInt3x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator ^(UInt3x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator ^(UInt3x2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt3x2"/> value.
@@ -3801,6 +4701,24 @@ public unsafe partial struct UInt3x3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator >>(UInt3x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator >>(UInt3x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x3 operator >>(UInt3x3 matrix, Int3x3 amount) => default;
 
     /// <summary>
@@ -3811,6 +4729,24 @@ public unsafe partial struct UInt3x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x3 operator >>(UInt3x3 matrix, UInt3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator <<(UInt3x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator <<(UInt3x3 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt3x3"/> value.
@@ -3834,6 +4770,24 @@ public unsafe partial struct UInt3x3
     /// Bitwise ands a <see cref="UInt3x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator &(UInt3x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator &(UInt3x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3852,6 +4806,24 @@ public unsafe partial struct UInt3x3
     /// Bitwise ors a <see cref="UInt3x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator |(UInt3x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator |(UInt3x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -3865,6 +4837,24 @@ public unsafe partial struct UInt3x3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x3 operator |(UInt3x3 left, UInt3x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator ^(UInt3x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator ^(UInt3x3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt3x3"/> value.
@@ -4259,6 +5249,24 @@ public unsafe partial struct UInt3x4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator >>(UInt3x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator >>(UInt3x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x4 operator >>(UInt3x4 matrix, Int3x4 amount) => default;
 
     /// <summary>
@@ -4269,6 +5277,24 @@ public unsafe partial struct UInt3x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x4 operator >>(UInt3x4 matrix, UInt3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator <<(UInt3x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator <<(UInt3x4 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt3x4"/> value.
@@ -4292,6 +5318,24 @@ public unsafe partial struct UInt3x4
     /// Bitwise ands a <see cref="UInt3x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator &(UInt3x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator &(UInt3x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -4310,6 +5354,24 @@ public unsafe partial struct UInt3x4
     /// Bitwise ors a <see cref="UInt3x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt3x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator |(UInt3x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator |(UInt3x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int3x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -4323,6 +5385,24 @@ public unsafe partial struct UInt3x4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x4 operator |(UInt3x4 left, UInt3x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator ^(UInt3x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt3x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt3x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator ^(UInt3x4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt3x4"/> value.
@@ -4599,6 +5679,24 @@ public unsafe partial struct UInt4x1
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator >>(UInt4x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator >>(UInt4x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x1 operator >>(UInt4x1 matrix, Int4x1 amount) => default;
 
     /// <summary>
@@ -4609,6 +5707,24 @@ public unsafe partial struct UInt4x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x1 operator >>(UInt4x1 matrix, UInt4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator <<(UInt4x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator <<(UInt4x1 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4x1"/> value.
@@ -4632,6 +5748,24 @@ public unsafe partial struct UInt4x1
     /// Bitwise ands a <see cref="UInt4x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator &(UInt4x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator &(UInt4x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -4650,6 +5784,24 @@ public unsafe partial struct UInt4x1
     /// Bitwise ors a <see cref="UInt4x1"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator |(UInt4x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator |(UInt4x1 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4x1"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -4663,6 +5815,24 @@ public unsafe partial struct UInt4x1
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x1 operator |(UInt4x1 left, UInt4x1 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator ^(UInt4x1 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x1"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x1"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator ^(UInt4x1 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt4x1"/> value.
@@ -5012,6 +6182,24 @@ public unsafe partial struct UInt4x2
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator >>(UInt4x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator >>(UInt4x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x2 operator >>(UInt4x2 matrix, Int4x2 amount) => default;
 
     /// <summary>
@@ -5022,6 +6210,24 @@ public unsafe partial struct UInt4x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x2 operator >>(UInt4x2 matrix, UInt4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator <<(UInt4x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator <<(UInt4x2 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4x2"/> value.
@@ -5045,6 +6251,24 @@ public unsafe partial struct UInt4x2
     /// Bitwise ands a <see cref="UInt4x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator &(UInt4x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator &(UInt4x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5063,6 +6287,24 @@ public unsafe partial struct UInt4x2
     /// Bitwise ors a <see cref="UInt4x2"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator |(UInt4x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator |(UInt4x2 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4x2"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5076,6 +6318,24 @@ public unsafe partial struct UInt4x2
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x2 operator |(UInt4x2 left, UInt4x2 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator ^(UInt4x2 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x2"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x2"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator ^(UInt4x2 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt4x2"/> value.
@@ -5471,6 +6731,24 @@ public unsafe partial struct UInt4x3
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator >>(UInt4x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator >>(UInt4x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x3 operator >>(UInt4x3 matrix, Int4x3 amount) => default;
 
     /// <summary>
@@ -5481,6 +6759,24 @@ public unsafe partial struct UInt4x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x3 operator >>(UInt4x3 matrix, UInt4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator <<(UInt4x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator <<(UInt4x3 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4x3"/> value.
@@ -5504,6 +6800,24 @@ public unsafe partial struct UInt4x3
     /// Bitwise ands a <see cref="UInt4x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator &(UInt4x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator &(UInt4x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5522,6 +6836,24 @@ public unsafe partial struct UInt4x3
     /// Bitwise ors a <see cref="UInt4x3"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator |(UInt4x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator |(UInt4x3 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4x3"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -5535,6 +6867,24 @@ public unsafe partial struct UInt4x3
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x3 operator |(UInt4x3 left, UInt4x3 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator ^(UInt4x3 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x3"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x3"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator ^(UInt4x3 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt4x3"/> value.
@@ -5982,6 +7332,24 @@ public unsafe partial struct UInt4x4
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator >>(UInt4x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator >>(UInt4x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x4 operator >>(UInt4x4 matrix, Int4x4 amount) => default;
 
     /// <summary>
@@ -5992,6 +7360,24 @@ public unsafe partial struct UInt4x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x4 operator >>(UInt4x4 matrix, UInt4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator <<(UInt4x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator <<(UInt4x4 matrix, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4x4"/> value.
@@ -6015,6 +7401,24 @@ public unsafe partial struct UInt4x4
     /// Bitwise ands a <see cref="UInt4x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator &(UInt4x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator &(UInt4x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -6033,6 +7437,24 @@ public unsafe partial struct UInt4x4
     /// Bitwise ors a <see cref="UInt4x4"/> value.
     /// </summary>
     /// <param name="left">The <see cref="UInt4x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator |(UInt4x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator |(UInt4x4 left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int4x4"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -6046,6 +7468,24 @@ public unsafe partial struct UInt4x4
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x4 operator |(UInt4x4 left, UInt4x4 right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator ^(UInt4x4 left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="UInt4x4"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="UInt4x4"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator ^(UInt4x4 left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="UInt4x4"/> value.

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -487,6 +487,24 @@ public unsafe partial struct <#=typeName#>
     /// <param name="amount">The amount to shift each element right by.</param>
     /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator >>(<#=typeName#> <#=argumentName#>, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator >>(<#=typeName#> <#=argumentName#>, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=typeName#> operator >>(<#=typeName#> <#=argumentName#>, Int<#=i#> amount) => default;
 
     /// <summary>
@@ -497,6 +515,24 @@ public unsafe partial struct <#=typeName#>
     /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=typeName#> operator >>(<#=typeName#> <#=argumentName#>, UInt<#=i#> amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator <<(<#=typeName#> <#=argumentName#>, int amount) => default;
+
+    /// <summary>
+    /// Shifts left a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift left.</param>
+    /// <param name="amount">The amount to shift each element left by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> left by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator <<(<#=typeName#> <#=argumentName#>, uint amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="<#=typeName#>"/> value.
@@ -520,6 +556,24 @@ public unsafe partial struct <#=typeName#>
     /// Bitwise ands a <see cref="<#=typeName#>"/> value.
     /// </summary>
     /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator &(<#=typeName#> left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise and.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator &(<#=typeName#> left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ands a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise and.</param>
     /// <param name="right">The <see cref="Int<#=i#>"/> value to combine.</param>
     /// <returns>The result of performing the bitwise and between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -538,6 +592,24 @@ public unsafe partial struct <#=typeName#>
     /// Bitwise ors a <see cref="<#=typeName#>"/> value.
     /// </summary>
     /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator |(<#=typeName#> left, int right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise or.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator |(<#=typeName#> left, uint right) => default;
+
+    /// <summary>
+    /// Bitwise ors a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise or.</param>
     /// <param name="right">The <see cref="Int<#=i#>"/> value to combine.</param>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
@@ -551,6 +623,24 @@ public unsafe partial struct <#=typeName#>
     /// <returns>The result of performing the bitwise or between <paramref name="left"/> and <paramref name="right"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static <#=typeName#> operator |(<#=typeName#> left, UInt<#=i#> right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="int"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator ^(<#=typeName#> left, int right) => default;
+
+    /// <summary>
+    /// Bitwise xors a <see cref="<#=typeName#>"/> value.
+    /// </summary>
+    /// <param name="left">The <see cref="<#=typeName#>"/> value to bitwise xor.</param>
+    /// <param name="right">The <see cref="uint"/> value to combine.</param>
+    /// <returns>The result of performing the bitwise xor between <paramref name="left"/> and <paramref name="right"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator ^(<#=typeName#> left, uint right) => default;
 
     /// <summary>
     /// Bitwise xors a <see cref="<#=typeName#>"/> value.


### PR DESCRIPTION
### Closes #817

### Description

This PR adds new operators for all `int` and `uint` HLSL vector and matrix types, taking `int` and `uint` right operands. This makes it possible to use them with literal expressions in C# that could be ambiguous between `int` and `uint`.