### PR TITLE
Add support for unsigned right shift operators on int/uint types

### DIFF
--- a/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
@@ -732,6 +732,42 @@ public unsafe partial struct Int2
     public static Int2 operator >>(Int2 xy, UInt2 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int2"/> value without considering sign.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator >>>(Int2 xy, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2"/> value without considering sign.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator >>>(Int2 xy, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2"/> value without considering sign.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator >>>(Int2 xy, Int2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2"/> value without considering sign.
+    /// </summary>
+    /// <param name="xy">The <see cref="Int2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2 operator >>>(Int2 xy, UInt2 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int2"/> value.
     /// </summary>
     /// <param name="xy">The <see cref="Int2"/> value to shift left.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
@@ -2072,6 +2072,42 @@ public unsafe partial struct Int3
     public static Int3 operator >>(Int3 xyz, UInt3 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int3"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator >>>(Int3 xyz, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator >>>(Int3 xyz, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator >>>(Int3 xyz, Int3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyz">The <see cref="Int3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3 operator >>>(Int3 xyz, UInt3 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int3"/> value.
     /// </summary>
     /// <param name="xyz">The <see cref="Int3"/> value to shift left.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
@@ -5409,6 +5409,42 @@ public unsafe partial struct Int4
     public static Int4 operator >>(Int4 xyzw, UInt4 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int4"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator >>>(Int4 xyzw, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator >>>(Int4 xyzw, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator >>>(Int4 xyzw, Int4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="Int4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4 operator >>>(Int4 xyzw, UInt4 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int4"/> value.
     /// </summary>
     /// <param name="xyzw">The <see cref="Int4"/> value to shift left.</param>

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -263,6 +263,42 @@ public unsafe partial struct Int1x1
     public static Int1x1 operator >>(Int1x1 matrix, UInt1x1 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int1x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator >>>(Int1x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator >>>(Int1x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator >>>(Int1x1 matrix, Int1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x1 operator >>>(Int1x1 matrix, UInt1x1 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int1x1"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int1x1"/> value to shift left.</param>
@@ -776,6 +812,42 @@ public unsafe partial struct Int1x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x2 operator >>(Int1x2 matrix, UInt1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator >>>(Int1x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator >>>(Int1x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator >>>(Int1x2 matrix, Int1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x2 operator >>>(Int1x2 matrix, UInt1x2 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int1x2"/> value.
@@ -1309,6 +1381,42 @@ public unsafe partial struct Int1x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int1x3 operator >>(Int1x3 matrix, UInt1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator >>>(Int1x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator >>>(Int1x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator >>>(Int1x3 matrix, Int1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x3 operator >>>(Int1x3 matrix, UInt1x3 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int1x3"/> value.
@@ -1856,6 +1964,42 @@ public unsafe partial struct Int1x4
     public static Int1x4 operator >>(Int1x4 matrix, UInt1x4 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int1x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator >>>(Int1x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator >>>(Int1x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator >>>(Int1x4 matrix, Int1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int1x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int1x4 operator >>>(Int1x4 matrix, UInt1x4 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int1x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int1x4"/> value to shift left.</param>
@@ -2363,6 +2507,42 @@ public unsafe partial struct Int2x1
     public static Int2x1 operator >>(Int2x1 matrix, UInt2x1 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int2x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator >>>(Int2x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator >>>(Int2x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator >>>(Int2x1 matrix, Int2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x1 operator >>>(Int2x1 matrix, UInt2x1 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int2x1"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int2x1"/> value to shift left.</param>
@@ -2835,6 +3015,42 @@ public unsafe partial struct Int2x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x2 operator >>(Int2x2 matrix, UInt2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator >>>(Int2x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator >>>(Int2x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator >>>(Int2x2 matrix, Int2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x2 operator >>>(Int2x2 matrix, UInt2x2 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int2x2"/> value.
@@ -3413,6 +3629,42 @@ public unsafe partial struct Int2x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int2x3 operator >>(Int2x3 matrix, UInt2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator >>>(Int2x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator >>>(Int2x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator >>>(Int2x3 matrix, Int2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x3 operator >>>(Int2x3 matrix, UInt2x3 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int2x3"/> value.
@@ -4019,6 +4271,42 @@ public unsafe partial struct Int2x4
     public static Int2x4 operator >>(Int2x4 matrix, UInt2x4 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int2x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator >>>(Int2x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator >>>(Int2x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator >>>(Int2x4 matrix, Int2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int2x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int2x4 operator >>>(Int2x4 matrix, UInt2x4 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int2x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int2x4"/> value to shift left.</param>
@@ -4530,6 +4818,42 @@ public unsafe partial struct Int3x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x1 operator >>(Int3x1 matrix, UInt3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator >>>(Int3x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator >>>(Int3x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator >>>(Int3x1 matrix, Int3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x1 operator >>>(Int3x1 matrix, UInt3x1 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int3x1"/> value.
@@ -5117,6 +5441,42 @@ public unsafe partial struct Int3x2
     public static Int3x2 operator >>(Int3x2 matrix, UInt3x2 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int3x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator >>>(Int3x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator >>>(Int3x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator >>>(Int3x2 matrix, Int3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x2 operator >>>(Int3x2 matrix, UInt3x2 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int3x2"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int3x2"/> value to shift left.</param>
@@ -5649,6 +6009,42 @@ public unsafe partial struct Int3x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int3x3 operator >>(Int3x3 matrix, UInt3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator >>>(Int3x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator >>>(Int3x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator >>>(Int3x3 matrix, Int3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x3 operator >>>(Int3x3 matrix, UInt3x3 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int3x3"/> value.
@@ -6308,6 +6704,42 @@ public unsafe partial struct Int3x4
     public static Int3x4 operator >>(Int3x4 matrix, UInt3x4 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int3x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator >>>(Int3x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator >>>(Int3x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator >>>(Int3x4 matrix, Int3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int3x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int3x4 operator >>>(Int3x4 matrix, UInt3x4 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int3x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int3x4"/> value to shift left.</param>
@@ -6831,6 +7263,42 @@ public unsafe partial struct Int4x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x1 operator >>(Int4x1 matrix, UInt4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator >>>(Int4x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator >>>(Int4x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator >>>(Int4x1 matrix, Int4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x1 operator >>>(Int4x1 matrix, UInt4x1 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int4x1"/> value.
@@ -7443,6 +7911,42 @@ public unsafe partial struct Int4x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x2 operator >>(Int4x2 matrix, UInt4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator >>>(Int4x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator >>>(Int4x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator >>>(Int4x2 matrix, Int4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x2 operator >>>(Int4x2 matrix, UInt4x2 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int4x2"/> value.
@@ -8103,6 +8607,42 @@ public unsafe partial struct Int4x3
     public static Int4x3 operator >>(Int4x3 matrix, UInt4x3 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="Int4x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator >>>(Int4x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator >>>(Int4x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator >>>(Int4x3 matrix, Int4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x3 operator >>>(Int4x3 matrix, UInt4x3 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="Int4x3"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="Int4x3"/> value to shift left.</param>
@@ -8727,6 +9267,42 @@ public unsafe partial struct Int4x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static Int4x4 operator >>(Int4x4 matrix, UInt4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator >>>(Int4x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator >>>(Int4x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator >>>(Int4x4 matrix, Int4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="Int4x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="Int4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static Int4x4 operator >>>(Int4x4 matrix, UInt4x4 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="Int4x4"/> value.

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -486,6 +486,42 @@ public unsafe partial struct <#=fullTypeName#>
     public static <#=fullTypeName#> operator >>(<#=fullTypeName#> matrix, UInt<#=rows#>x<#=columns#> amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="<#=fullTypeName#>"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator >>>(<#=fullTypeName#> matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=fullTypeName#>"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator >>>(<#=fullTypeName#> matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=fullTypeName#>"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator >>>(<#=fullTypeName#> matrix, Int<#=rows#>x<#=columns#> amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=fullTypeName#>"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=fullTypeName#> operator >>>(<#=fullTypeName#> matrix, UInt<#=rows#>x<#=columns#> amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="<#=fullTypeName#>"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="<#=fullTypeName#>"/> value to shift left.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt2.g.cs
@@ -635,6 +635,42 @@ public unsafe partial struct UInt2
     public static UInt2 operator >>(UInt2 xy, UInt2 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="UInt2"/> value without considering sign.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator >>>(UInt2 xy, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2"/> value without considering sign.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator >>>(UInt2 xy, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2"/> value without considering sign.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator >>>(UInt2 xy, Int2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2"/> value without considering sign.
+    /// </summary>
+    /// <param name="xy">The <see cref="UInt2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xy"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2 operator >>>(UInt2 xy, UInt2 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="UInt2"/> value.
     /// </summary>
     /// <param name="xy">The <see cref="UInt2"/> value to shift left.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt3.g.cs
@@ -1975,6 +1975,42 @@ public unsafe partial struct UInt3
     public static UInt3 operator >>(UInt3 xyz, UInt3 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="UInt3"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator >>>(UInt3 xyz, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator >>>(UInt3 xyz, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator >>>(UInt3 xyz, Int3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyz">The <see cref="UInt3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyz"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3 operator >>>(UInt3 xyz, UInt3 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="UInt3"/> value.
     /// </summary>
     /// <param name="xyz">The <see cref="UInt3"/> value to shift left.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UInt4.g.cs
@@ -5312,6 +5312,42 @@ public unsafe partial struct UInt4
     public static UInt4 operator >>(UInt4 xyzw, UInt4 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="UInt4"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator >>>(UInt4 xyzw, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator >>>(UInt4 xyzw, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator >>>(UInt4 xyzw, Int4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4"/> value without considering sign.
+    /// </summary>
+    /// <param name="xyzw">The <see cref="UInt4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="xyzw"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4 operator >>>(UInt4 xyzw, UInt4 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="UInt4"/> value.
     /// </summary>
     /// <param name="xyzw">The <see cref="UInt4"/> value to shift left.</param>

--- a/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/UInt/UIntMxN.g.cs
@@ -237,6 +237,42 @@ public unsafe partial struct UInt1x1
     public static UInt1x1 operator >>(UInt1x1 matrix, UInt1x1 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="UInt1x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator >>>(UInt1x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator >>>(UInt1x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator >>>(UInt1x1 matrix, Int1x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x1 operator >>>(UInt1x1 matrix, UInt1x1 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="UInt1x1"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="UInt1x1"/> value to shift left.</param>
@@ -641,6 +677,42 @@ public unsafe partial struct UInt1x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x2 operator >>(UInt1x2 matrix, UInt1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator >>>(UInt1x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator >>>(UInt1x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator >>>(UInt1x2 matrix, Int1x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x2 operator >>>(UInt1x2 matrix, UInt1x2 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt1x2"/> value.
@@ -1065,6 +1137,42 @@ public unsafe partial struct UInt1x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt1x3 operator >>(UInt1x3 matrix, UInt1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator >>>(UInt1x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator >>>(UInt1x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator >>>(UInt1x3 matrix, Int1x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x3 operator >>>(UInt1x3 matrix, UInt1x3 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt1x3"/> value.
@@ -1503,6 +1611,42 @@ public unsafe partial struct UInt1x4
     public static UInt1x4 operator >>(UInt1x4 matrix, UInt1x4 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="UInt1x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator >>>(UInt1x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator >>>(UInt1x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator >>>(UInt1x4 matrix, Int1x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt1x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt1x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt1x4 operator >>>(UInt1x4 matrix, UInt1x4 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="UInt1x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="UInt1x4"/> value to shift left.</param>
@@ -1913,6 +2057,42 @@ public unsafe partial struct UInt2x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x1 operator >>(UInt2x1 matrix, UInt2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator >>>(UInt2x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator >>>(UInt2x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator >>>(UInt2x1 matrix, Int2x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x1 operator >>>(UInt2x1 matrix, UInt2x1 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt2x1"/> value.
@@ -2362,6 +2542,42 @@ public unsafe partial struct UInt2x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x2 operator >>(UInt2x2 matrix, UInt2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator >>>(UInt2x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator >>>(UInt2x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator >>>(UInt2x2 matrix, Int2x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x2 operator >>>(UInt2x2 matrix, UInt2x2 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt2x2"/> value.
@@ -2831,6 +3047,42 @@ public unsafe partial struct UInt2x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt2x3 operator >>(UInt2x3 matrix, UInt2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator >>>(UInt2x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator >>>(UInt2x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator >>>(UInt2x3 matrix, Int2x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x3 operator >>>(UInt2x3 matrix, UInt2x3 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt2x3"/> value.
@@ -3328,6 +3580,42 @@ public unsafe partial struct UInt2x4
     public static UInt2x4 operator >>(UInt2x4 matrix, UInt2x4 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="UInt2x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator >>>(UInt2x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator >>>(UInt2x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator >>>(UInt2x4 matrix, Int2x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt2x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt2x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt2x4 operator >>>(UInt2x4 matrix, UInt2x4 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="UInt2x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="UInt2x4"/> value to shift left.</param>
@@ -3744,6 +4032,42 @@ public unsafe partial struct UInt3x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x1 operator >>(UInt3x1 matrix, UInt3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator >>>(UInt3x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator >>>(UInt3x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator >>>(UInt3x1 matrix, Int3x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x1 operator >>>(UInt3x1 matrix, UInt3x1 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt3x1"/> value.
@@ -4220,6 +4544,42 @@ public unsafe partial struct UInt3x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x2 operator >>(UInt3x2 matrix, UInt3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator >>>(UInt3x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator >>>(UInt3x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator >>>(UInt3x2 matrix, Int3x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x2 operator >>>(UInt3x2 matrix, UInt3x2 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt3x2"/> value.
@@ -4729,6 +5089,42 @@ public unsafe partial struct UInt3x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt3x3 operator >>(UInt3x3 matrix, UInt3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator >>>(UInt3x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator >>>(UInt3x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator >>>(UInt3x3 matrix, Int3x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x3 operator >>>(UInt3x3 matrix, UInt3x3 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt3x3"/> value.
@@ -5279,6 +5675,42 @@ public unsafe partial struct UInt3x4
     public static UInt3x4 operator >>(UInt3x4 matrix, UInt3x4 amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="UInt3x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator >>>(UInt3x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator >>>(UInt3x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator >>>(UInt3x4 matrix, Int3x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt3x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt3x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt3x4 operator >>>(UInt3x4 matrix, UInt3x4 amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="UInt3x4"/> value.
     /// </summary>
     /// <param name="matrix">The <see cref="UInt3x4"/> value to shift left.</param>
@@ -5707,6 +6139,42 @@ public unsafe partial struct UInt4x1
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x1 operator >>(UInt4x1 matrix, UInt4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator >>>(UInt4x1 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator >>>(UInt4x1 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator >>>(UInt4x1 matrix, Int4x1 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x1"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x1"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x1 operator >>>(UInt4x1 matrix, UInt4x1 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4x1"/> value.
@@ -6210,6 +6678,42 @@ public unsafe partial struct UInt4x2
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x2 operator >>(UInt4x2 matrix, UInt4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator >>>(UInt4x2 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator >>>(UInt4x2 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator >>>(UInt4x2 matrix, Int4x2 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x2"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x2"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x2 operator >>>(UInt4x2 matrix, UInt4x2 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4x2"/> value.
@@ -6759,6 +7263,42 @@ public unsafe partial struct UInt4x3
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x3 operator >>(UInt4x3 matrix, UInt4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator >>>(UInt4x3 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator >>>(UInt4x3 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator >>>(UInt4x3 matrix, Int4x3 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x3"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x3"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x3 operator >>>(UInt4x3 matrix, UInt4x3 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4x3"/> value.
@@ -7360,6 +7900,42 @@ public unsafe partial struct UInt4x4
     /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
     /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
     public static UInt4x4 operator >>(UInt4x4 matrix, UInt4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator >>>(UInt4x4 matrix, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator >>>(UInt4x4 matrix, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator >>>(UInt4x4 matrix, Int4x4 amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="UInt4x4"/> value without considering sign.
+    /// </summary>
+    /// <param name="matrix">The <see cref="UInt4x4"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="matrix"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static UInt4x4 operator >>>(UInt4x4 matrix, UInt4x4 amount) => default;
 
     /// <summary>
     /// Shifts left a <see cref="UInt4x4"/> value.

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -517,6 +517,42 @@ public unsafe partial struct <#=typeName#>
     public static <#=typeName#> operator >>(<#=typeName#> <#=argumentName#>, UInt<#=i#> amount) => default;
 
     /// <summary>
+    /// Shifts right a <see cref="<#=typeName#>"/> value without considering sign.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator >>>(<#=typeName#> <#=argumentName#>, int amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=typeName#>"/> value without considering sign.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator >>>(<#=typeName#> <#=argumentName#>, uint amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=typeName#>"/> value without considering sign.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator >>>(<#=typeName#> <#=argumentName#>, Int<#=i#> amount) => default;
+
+    /// <summary>
+    /// Shifts right a <see cref="<#=typeName#>"/> value without considering sign.
+    /// </summary>
+    /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift right.</param>
+    /// <param name="amount">The amount to shift each element right by.</param>
+    /// <returns>The result of shifting <paramref name="<#=argumentName#>"/> right by <paramref name="amount"/>.</returns>
+    /// <remarks>This method is an intrinsic and can only be used within a shader on the GPU. Using it on the CPU is undefined behavior.</remarks>
+    public static <#=typeName#> operator >>>(<#=typeName#> <#=argumentName#>, UInt<#=i#> amount) => default;
+
+    /// <summary>
     /// Shifts left a <see cref="<#=typeName#>"/> value.
     /// </summary>
     /// <param name="<#=argumentName#>">The <see cref="<#=typeName#>"/> value to shift left.</param>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/ComputeSharp.SourceGeneration.Hlsl.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\TypeAliases.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\HlslBytecodeSyntaxProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\ConstantBufferSyntaxProcessor.Generation.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\HlslOperatorsSyntaxProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\HlslSourceSyntaxProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxProcessors\HlslDefinitionsSyntaxProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntaxRewriters\HlslSourceRewriter.Tracking.cs" />

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using ComputeSharp.Core.Intrinsics.Attributes;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace ComputeSharp.SourceGeneration.Mappings;
 
@@ -45,6 +47,16 @@ internal static partial class HlslKnownOperators
         }
 
         return knownOperators;
+    }
+
+    /// <summary>
+    /// Checks whether a given operator kind represents a candidate special intrinsic that can handle.
+    /// </summary>
+    /// <param name="operatorKind">The input operator kind to check.</param>
+    /// <returns>Whether <paramref name="operatorKind"/> is a candidate operator for a special intrinsic to rewrite.</returns>
+    public static bool IsCandidateOperator(BinaryOperatorKind operatorKind)
+    {
+        return operatorKind is BinaryOperatorKind.Multiply or BinaryOperatorKind.UnsignedRightShift;
     }
 
     /// <summary>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownTypes.cs
@@ -238,6 +238,38 @@ internal static partial class HlslKnownTypes
     }
 
     /// <summary>
+    /// Checks whether a given type name represents a well known signed integer type.
+    /// </summary>
+    /// <param name="typeName">The type name to check.</param>
+    /// <returns>Whether <paramref name="typeName"/> represents a well known signed integer type.</returns>
+    public static bool IsKnownSignedIntegerType(string typeName)
+    {
+        return typeName is
+            "System.Int32" or
+            "ComputeSharp.Int2" or "ComputeSharp.Int3" or "ComputeSharp.Int4" or
+            "ComputeSharp.Int1x1" or "ComputeSharp.Int1x2" or "ComputeSharp.Int1x3" or "ComputeSharp.Int1x4" or
+            "ComputeSharp.Int2x1" or "ComputeSharp.Int2x2" or "ComputeSharp.Int2x3" or "ComputeSharp.Int2x4" or
+            "ComputeSharp.Int3x1" or "ComputeSharp.Int3x2" or "ComputeSharp.Int3x3" or "ComputeSharp.Int3x4" or
+            "ComputeSharp.Int4x1" or "ComputeSharp.Int4x2" or "ComputeSharp.Int4x3" or "ComputeSharp.Int4x4";
+    }
+
+    /// <summary>
+    /// Checks whether a given type name represents a well known unsigned integer type.
+    /// </summary>
+    /// <param name="typeName">The type name to check.</param>
+    /// <returns>Whether <paramref name="typeName"/> represents a well known known integer type.</returns>
+    public static bool IsKnownUnsignedIntegerType(string typeName)
+    {
+        return typeName is
+            "System.UInt32" or
+            "ComputeSharp.UInt2" or "ComputeSharp.UInt3" or "ComputeSharp.UInt4" or
+            "ComputeSharp.UInt1x1" or "ComputeSharp.UInt1x2" or "ComputeSharp.UInt1x3" or "ComputeSharp.UInt1x4" or
+            "ComputeSharp.UInt2x1" or "ComputeSharp.UInt2x2" or "ComputeSharp.UInt2x3" or "ComputeSharp.UInt2x4" or
+            "ComputeSharp.UInt3x1" or "ComputeSharp.UInt3x2" or "ComputeSharp.UInt3x3" or "ComputeSharp.UInt3x4" or
+            "ComputeSharp.UInt4x1" or "ComputeSharp.UInt4x2" or "ComputeSharp.UInt4x3" or "ComputeSharp.UInt4x4";
+    }
+
+    /// <summary>
     /// Gets the mapped HLSL-compatible type name for the input type symbol.
     /// </summary>
     /// <param name="typeSymbol">The input type to map.</param>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslOperatorsSyntaxProcessor.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxProcessors/HlslOperatorsSyntaxProcessor.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Mappings;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace ComputeSharp.SourceGeneration.SyntaxProcessors;
+
+/// <summary>
+/// A processor responsible for processing special HLSL operators.
+/// </summary>
+internal static class HlslOperatorsSyntaxProcessor
+{
+    /// <summary>
+    /// Tries to process a custom operator from an input expression node.
+    /// </summary>
+    /// <param name="originalNode">The original syntax node being processed.</param>
+    /// <param name="updatedNode">The updated node to propagate and potentially rewrite.</param>
+    /// <param name="semanticModel">The <see cref="SemanticModel"/> instance to use.</param>
+    /// <param name="token">The cancellation token for the operation.</param>
+    /// <param name="rewrittenNode">The rewritten node, if successfully produced.</param>
+    /// <returns>Whether a rewritten node was produced.</returns>
+    public static bool TryProcessCustomOperator(
+        ExpressionSyntax originalNode,
+        ExpressionSyntax updatedNode,
+        SemanticModel semanticModel,
+        CancellationToken token,
+        [NotNullWhen(true)] out ExpressionSyntax? rewrittenNode)
+    {
+        // Process binary operations to see if the target operator method is an intrinsic
+        if (semanticModel.GetOperation(originalNode, token) is not IBinaryOperation operation)
+        {
+            rewrittenNode = null;
+
+            return false;
+        }
+
+        // Pre-filter candidates based on the operation type, to minimize allocations
+        if (!HlslKnownOperators.IsCandidateOperator(operation.OperatorKind))
+        {
+            rewrittenNode = null;
+
+            return false;
+        }
+
+        // Get the binary nodes, in case we need them for rewriting
+        GetBinaryNodes(updatedNode, out ExpressionSyntax leftNode, out ExpressionSyntax rightNode);
+
+        // First, try to handle unsigned right shift operators, which are a special case.
+        // This is because they require explicit rewriting, and not just a change in method name.
+        // We need to do this after pre-filtering, as this is also supported on 'int' and 'uint'.
+        if (operation.OperatorKind == BinaryOperatorKind.UnsignedRightShift)
+        {
+            string typeName = operation.LeftOperand.Type!.GetFullyQualifiedMetadataName();
+
+            // If the left operand is already unsigned, there's no rewriting to do other
+            // than just replacing '>>>' with '>>', since the former doesn't exist in HLSL.
+            if (HlslKnownTypes.IsKnownUnsignedIntegerType(typeName))
+            {
+                rewrittenNode = BinaryExpression(SyntaxKind.RightShiftExpression, leftNode, rightNode);
+
+                return true;
+            }
+
+            // Rewrite the syntax tree as follows:
+            //
+            // x >>> y => (TYPE_X)((UNSIGNED_TYPE_X)x >> y)
+            if (HlslKnownTypes.IsKnownSignedIntegerType(typeName))
+            {
+                string typeNameOfLeftOperand = HlslKnownTypes.GetMappedName(typeName);
+                string unsignedTypeName = 'u' + typeNameOfLeftOperand;
+
+                rewrittenNode =
+                    CastExpression(
+                        IdentifierName(typeNameOfLeftOperand),
+                        ParenthesizedExpression(
+                            BinaryExpression(
+                                SyntaxKind.RightShiftExpression,
+                                CastExpression(IdentifierName(unsignedTypeName), leftNode),
+                                rightNode)));
+
+                return true;
+            }
+
+            // All other cases are unsupported, so just return the original tree
+            rewrittenNode = null;
+
+            return false;
+        }
+
+        // Also pre-filter just operators that are defined in ComputeSharp primitives
+        if (operation is not { OperatorMethod: { ContainingType.ContainingNamespace.Name: "ComputeSharp" } method })
+        {
+            rewrittenNode = null;
+
+            return false;
+        }
+
+        // If the operator is indeed an HLSL overload, replace the expression with an invocation.
+        // That is, do the following transformation:
+        //
+        // x * y => <INTRINSIC>(x, y)
+        if (HlslKnownOperators.TryGetMappedName(method.GetFullyQualifiedMetadataName(), method.Parameters.Select(static p => p.Type.Name), out string? mapped))
+        {
+            rewrittenNode =
+                InvocationExpression(IdentifierName(mapped!))
+                .AddArgumentListArguments(
+                    Argument(leftNode),
+                    Argument(rightNode));
+
+            return true;
+        }
+
+        rewrittenNode = null;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Extracts the binary children from an expression node.
+    /// </summary>
+    /// <param name="node">The input expression node.</param>
+    /// <param name="left">The resulting left child node.</param>
+    /// <param name="right">The resulting right child node.</param>
+    /// <exception cref="NotSupportedException">Thrown if <paramref name="node"/> is of an unsupported type.</exception>
+    private static void GetBinaryNodes(
+        ExpressionSyntax node,
+        out ExpressionSyntax left,
+        out ExpressionSyntax right)
+    {
+        switch (node)
+        {
+            case BinaryExpressionSyntax binaryExpression:
+                left = binaryExpression.Left;
+                right = binaryExpression.Right;
+                break;
+            case AssignmentExpressionSyntax assignmentExpression:
+                left = assignmentExpression.Left;
+                right = assignmentExpression.Right;
+                break;
+            default:
+                throw new NotSupportedException("Invalid input expression node.");
+        }
+    }
+}

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
@@ -377,20 +377,72 @@ internal abstract partial class HlslSourceRewriter(
         BinaryExpressionSyntax updatedNode = (BinaryExpressionSyntax)base.VisitBinaryExpression(node)!;
 
         // Process binary operations to see if the target operator method is an intrinsic
-        if (SemanticModel.For(node).GetOperation(node, CancellationToken) is IBinaryOperation { OperatorMethod: { ContainingType.ContainingNamespace.Name: "ComputeSharp" } method })
+        if (SemanticModel.For(node).GetOperation(node, CancellationToken) is not IBinaryOperation operation)
         {
-            // If the operator is indeed an HLSL overload, replace the expression with an invocation.
-            // That is, do the following transformation:
-            //
-            // x * y => <INTRINSIC>(x, y)
-            if (HlslKnownOperators.TryGetMappedName(method.GetFullyQualifiedMetadataName(), method.Parameters.Select(static p => p.Type.Name), out string? mapped))
+            return updatedNode;
+        }
+
+        // Pre-filter candidates based on the operation type, to minimize allocations
+        if (!HlslKnownOperators.IsCandidateOperator(operation.OperatorKind))
+        {
+            return updatedNode;
+        }
+
+        // First, try to handle unsigned right shift operators, which are a special case.
+        // This is because they require explicit rewriting, and not just a change in method name.
+        // We need to do this after pre-filtering, as this is also supported on 'int' and 'uint'.
+        if (operation.OperatorKind == BinaryOperatorKind.UnsignedRightShift)
+        {
+            string typeName = operation.LeftOperand.Type!.GetFullyQualifiedMetadataName();
+
+            // If the left operand is already unsigned, there's no rewriting to do other
+            // than just replacing '>>>' with '>>', since the former doesn't exist in HLSL.
+            if (HlslKnownTypes.IsKnownUnsignedIntegerType(typeName))
             {
-                return
-                    InvocationExpression(IdentifierName(mapped!))
-                    .AddArgumentListArguments(
-                        Argument(updatedNode.Left),
-                        Argument(updatedNode.Right));
+                return BinaryExpression(SyntaxKind.RightShiftExpression, updatedNode.Left, updatedNode.Right);
             }
+
+            // Rewrite the syntax tree as follows:
+            //
+            // x >>> y => (TYPE_X)((UNSIGNED_TYPE_X)x >> y)
+            if (HlslKnownTypes.IsKnownSignedIntegerType(typeName))
+            {
+                string typeNameOfLeftOperand = HlslKnownTypes.GetMappedName(typeName);
+                string unsignedTypeName = 'u' + typeNameOfLeftOperand;
+
+                return
+                    CastExpression(
+                        IdentifierName(typeNameOfLeftOperand),
+                        ParenthesizedExpression(
+                            BinaryExpression(
+                                SyntaxKind.RightShiftExpression,
+                                CastExpression(
+                                    IdentifierName(unsignedTypeName),
+                                    updatedNode.Left),
+                                updatedNode.Right)));
+            }
+
+            // All other cases are unsupported, so just return the original tree
+            return updatedNode;
+        }
+
+        // Also pre-filter just operators that are defined in ComputeSharp primitives
+        if (operation is not { OperatorMethod: { ContainingType.ContainingNamespace.Name: "ComputeSharp" } method })
+        {
+            return updatedNode;
+        }
+
+        // If the operator is indeed an HLSL overload, replace the expression with an invocation.
+        // That is, do the following transformation:
+        //
+        // x * y => <INTRINSIC>(x, y)
+        if (HlslKnownOperators.TryGetMappedName(method.GetFullyQualifiedMetadataName(), method.Parameters.Select(static p => p.Type.Name), out string? mapped))
+        {
+            return
+                InvocationExpression(IdentifierName(mapped!))
+                .AddArgumentListArguments(
+                    Argument(updatedNode.Left),
+                    Argument(updatedNode.Right));
         }
 
         return updatedNode;


### PR DESCRIPTION
### Description

This PR adds support for the [unsigned right shift operator](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/bitwise-and-shift-operators#unsigned-right-shift-operator-) on all `int`/`uint` scalar, vector and matrix types.