### PR TITLE
Fix 'x' offset in GPU powered BLAS method

### DIFF
--- a/samples/ComputeSharp.Benchmark/Blas/BlasHelpers.cs
+++ b/samples/ComputeSharp.Benchmark/Blas/BlasHelpers.cs
@@ -94,7 +94,7 @@ internal static partial class BlasHelpers
         /// <inheritdoc/>
         public void Execute()
         {
-            int x_offset = (ThreadIds.X * n * p) + (ThreadIds.Y * m);
+            int x_offset = (ThreadIds.X * n * m) + (ThreadIds.Y * m);
             float result = 0f;
 
             for (int k = 0; k < m; k++)


### PR DESCRIPTION
### Closes #820

### Description

Fixes the `x` offset in the GPU powered fully connected implementation.