### PR TITLE
Fix new .NET analyzer warnings

### DIFF
--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/HlslSourceRewriter.cs
@@ -196,7 +196,7 @@ internal abstract partial class HlslSourceRewriter(
     }
 
     /// <inheritdoc/>
-    public sealed unsafe override SyntaxNode? VisitLiteralExpression(LiteralExpressionSyntax node)
+    public sealed override unsafe SyntaxNode? VisitLiteralExpression(LiteralExpressionSyntax node)
     {
         CancellationToken.ThrowIfCancellationRequested();
 

--- a/src/ComputeSharp.WinUI/Controls/AnimatedComputeShaderPanel.Properties.cs
+++ b/src/ComputeSharp.WinUI/Controls/AnimatedComputeShaderPanel.Properties.cs
@@ -188,7 +188,7 @@ partial class AnimatedComputeShaderPanel
         AnimatedComputeShaderPanel @this = (AnimatedComputeShaderPanel)d;
 
         if (@this.IsLoaded &&
-            (bool)e.NewValue is false &&
+            !(bool)e.NewValue &&
             @this.ShaderRunner is IShaderRunner shaderRunner)
         {
             @this.swapChainManager.StartRenderLoop(null, shaderRunner);


### PR DESCRIPTION
### Description

The latest .NET 8 SDK enables new analyzers by default, which are failing the build. This PR fixes those warnings.