### PR TITLE
Tweak .targets for published projects

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -38,7 +38,8 @@
 
     <!-- Package tags -->
     <PackageTags Condition="$(MSBuildProjectName.Contains('.D2D1'))">$(PackageTags) d2d d2d1 direct2d pixel</PackageTags>
-    <PackageTags Condition="$(MSBuildProjectName.EndsWith('.WinUI'))">$(PackageTags) winui winui3 wasdk</PackageTags>
+    <PackageTags Condition="$(MSBuildProjectName.EndsWith('.Uwp'))">$(PackageTags) uwp xaml winui winui2</PackageTags>
+    <PackageTags Condition="$(MSBuildProjectName.EndsWith('.WinUI'))">$(PackageTags) xaml winui winui3 winappsdk</PackageTags>
   </PropertyGroup>
 
   <!-- Additional properties for all source projects-->

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -42,19 +42,19 @@
           Visible="false" />
   </ItemGroup>
 
-  <!--
-    Enable trimming support on .NET 8. This can't be in a target unlike the other
-    properties set below, because if that is the case the trimmable attribute
-    will be set but the analyzers will not run, so warnings will be skipped.
-  -->
+  <!-- Properties exclusive to .NET 8 projects -->
   <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <IsAotCompatible>true</IsAotCompatible>
-  </PropertyGroup>
 
-  <!-- Emit the [DisableRuntimeMarshalling] attribute for all .NET 8 projects -->
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute" />
-  </ItemGroup>
+    <!--
+      Enable trimming support. This can't be in a target unlike the other properties
+      set below, because if that is the case the trimmable attribute will be set but
+      the analyzers will not run, so warnings will be skipped.
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
+
+    <!-- Emit the [DisableRuntimeMarshalling] attribute (also enables the associated analyzer) -->
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+  </PropertyGroup>
 
   <!-- Emit the [SupportedOSVersion] attribute if needed -->
   <Target Name="EmitSupportedOSVersionAttributeForTargetOS"
@@ -66,7 +66,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Emit the [ComVisible(false)] attribute for WinUI targets -->
+  <!-- Emit the [ComVisible(false)] attribute for UWP and WinUI targets -->
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows'))">
     <AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">
       <_Parameter1>false</_Parameter1>


### PR DESCRIPTION
### Description

This PR includes two tweaks to the .targets for published projects:
- Use the `DisableRuntimeMarshalling` .NET 8 property
- Update the default package tags and include tags for UWP packages