### PR TITLE
Remove 'CommunityToolkit.Diagnostics'

### DIFF
--- a/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
+++ b/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
@@ -19,7 +19,6 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
   </ItemGroup>
 

--- a/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
+++ b/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
@@ -10,7 +10,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
   </ItemGroup>
 

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.Implementation.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.Implementation.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using CommunityToolkit.Diagnostics;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing.Processors;
 using ImageSharpRgba32 = SixLabors.ImageSharp.PixelFormats.Rgba32;
@@ -260,7 +259,7 @@ public sealed partial class HlslBokehBlurProcessor
         {
             if (!source.DangerousTryGetSinglePixelMemory(out Memory<ImageSharpRgba32> pixelMemory))
             {
-                ThrowHelper.ThrowInvalidOperationException("Cannot process image frames wrapping discontiguous memory.");
+                throw new ArgumentException("Cannot process image frames wrapping discontiguous memory.");
             }
 
             Span<Rgba32> span = MemoryMarshal.Cast<ImageSharpRgba32, Rgba32>(pixelMemory.Span);

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslBokehBlurProcessor.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Runtime.CompilerServices;
-using CommunityToolkit.Diagnostics;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors;
@@ -76,7 +76,7 @@ public sealed partial class HlslBokehBlurProcessor : IImageProcessor
     {
         if (typeof(TPixel) != typeof(ImageSharpRgba32))
         {
-            ThrowHelper.ThrowInvalidOperationException("This processor only supports the RGBA32 pixel format.");
+            throw new NotSupportedException("This processor only supports the RGBA32 pixel format.");
         }
 
         Implementation processor = new(this, configuration, Unsafe.As<Image<ImageSharpRgba32>>(source), sourceRectangle);

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.Implementation.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.Implementation.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using CommunityToolkit.Diagnostics;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing.Processors;
 using ImageSharpRgba32 = SixLabors.ImageSharp.PixelFormats.Rgba32;
@@ -95,7 +94,7 @@ public sealed partial class HlslGaussianBlurProcessor
         {
             if (!source.DangerousTryGetSinglePixelMemory(out Memory<ImageSharpRgba32> pixelMemory))
             {
-                ThrowHelper.ThrowInvalidOperationException("Cannot process image frames wrapping discontiguous memory.");
+                throw new ArgumentException("Cannot process image frames wrapping discontiguous memory.");
             }
 
             Span<Rgba32> span = MemoryMarshal.Cast<ImageSharpRgba32, Rgba32>(pixelMemory.Span);

--- a/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.cs
+++ b/samples/ComputeSharp.ImageProcessing/Processors/HlslGaussianBlurProcessor.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Runtime.CompilerServices;
-using CommunityToolkit.Diagnostics;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing.Processors;
@@ -81,7 +81,7 @@ public sealed partial class HlslGaussianBlurProcessor : IImageProcessor
     {
         if (typeof(TPixel) != typeof(ImageSharpRgba32))
         {
-            ThrowHelper.ThrowInvalidOperationException("This processor only supports the RGBA32 pixel format.");
+            throw new NotSupportedException("This processor only supports the RGBA32 pixel format.");
         }
 
         Implementation processor = new(this, configuration, Unsafe.As<Image<ImageSharpRgba32>>(source), sourceRectangle);

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -30,7 +30,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Media" Version="7.1.2" />

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />

--- a/tests/ComputeSharp.Tests.DeviceLost/Extensions/DeviceExtensions.cs
+++ b/tests/ComputeSharp.Tests.DeviceLost/Extensions/DeviceExtensions.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Linq;
-using CommunityToolkit.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ComputeSharp.Tests.Extensions;
@@ -21,7 +21,7 @@ public static class DeviceExtensions
         {
             Device.Discrete => GraphicsDevice.QueryDevices(info => info.IsHardwareAccelerated).FirstOrDefault(),
             Device.Warp => GraphicsDevice.QueryDevices(info => !info.IsHardwareAccelerated).FirstOrDefault(),
-            _ => ThrowHelper.ThrowArgumentException<GraphicsDevice>("Invalid device.")
+            _ => throw new ArgumentException("Invalid device type.", nameof(type))
         };
 
         if (device is null)

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />

--- a/tests/ComputeSharp.Tests/Extensions/DeviceExtensions.cs
+++ b/tests/ComputeSharp.Tests/Extensions/DeviceExtensions.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Linq;
-using CommunityToolkit.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ComputeSharp.Tests.Extensions;
@@ -40,7 +40,7 @@ public static class DeviceExtensions
         {
             Device.Discrete => DiscreteDevice,
             Device.Warp => WarpDevice,
-            _ => ThrowHelper.ThrowArgumentException<GraphicsDevice>("Invalid device.")
+            _ => throw new ArgumentException("Invalid device type.", nameof(type))
         };
 
         if (device is null)

--- a/tests/ComputeSharp.Tests/Extensions/ImagingExtensions.cs
+++ b/tests/ComputeSharp.Tests/Extensions/ImagingExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using CommunityToolkit.Diagnostics;
 using ComputeSharp.Resources;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SixLabors.ImageSharp;
@@ -24,7 +23,7 @@ public static class ImagingExtensions
         where TFrom : unmanaged
         where TTo : unmanaged, IPixel<TTo>
     {
-        Guard.IsEqualTo(sizeof(TTo), sizeof(TFrom), nameof(TTo));
+        ArgumentOutOfRangeException.ThrowIfNotEqual(sizeof(TTo), sizeof(TFrom), nameof(TTo));
 
         Image<TTo> image = new(texture.Width, texture.Height);
 
@@ -49,7 +48,7 @@ public static class ImagingExtensions
         where TFrom : unmanaged
         where TTo : unmanaged, IPixel<TTo>
     {
-        Guard.IsEqualTo(sizeof(TTo), sizeof(TFrom), nameof(TTo));
+        ArgumentOutOfRangeException.ThrowIfNotEqual(sizeof(TTo), sizeof(TFrom), nameof(TTo));
 
         Image<TTo> image = new(texture.Width, texture.Height);
 


### PR DESCRIPTION
### Description

This PR includes some cleanup to reduce the number of dependencies. This one wasn't really needed.