### PR TITLE
Update .NET Community Toolkit packages to 8.3.0

### DIFF
--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -14,6 +14,12 @@
       https://api.nuget.org/v3/index.json;
       https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json;
     </RestoreSources>
+
+    <!--
+      WinUI 3 doesn't need support for 'INotifyPropertyChanging', so we can disable it.
+      This avoids all generated code for it and provides a small performance improvement.
+    -->
+    <MvvmToolkitEnableINotifyPropertyChangingSupport>false</MvvmToolkitEnableINotifyPropertyChangingSupport>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -68,7 +74,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0-build.5" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.240824-build.1155" />
     <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.240824-build.1155" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
-    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
     <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />


### PR DESCRIPTION
### Description

This PR updates all .NET Community Toolkit packages to 8.3.0, the latest stable release.