### PR TITLE
Addresses limitations of detecting ImageFormat / ContainerFormat from the file extension

### DIFF
--- a/src/ComputeSharp/Graphics/Helpers/WICFormatHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/WICFormatHelper.cs
@@ -111,7 +111,13 @@ internal static class WICFormatHelper
     /// <exception cref="ArgumentException">Thrown when the input filename doesn't have a valid file extension.</exception>
     public static Guid GetForFilename(ReadOnlySpan<char> filename)
     {
-        return Path.GetExtension(filename).ToString().ToLowerInvariant() switch
+        Span<char> extension = stackalloc char[4];
+
+        int length = Path.GetExtension(filename).ToLowerInvariant(extension);
+
+        default(ArgumentException).ThrowIf(length == -1, nameof(filename));
+
+        return extension[..length] switch
         {
             ".dib" or
             ".rle" or

--- a/src/ComputeSharp/Graphics/Helpers/WICFormatHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/WICFormatHelper.cs
@@ -111,16 +111,22 @@ internal static class WICFormatHelper
     /// <exception cref="ArgumentException">Thrown when the input filename doesn't have a valid file extension.</exception>
     public static Guid GetForFilename(ReadOnlySpan<char> filename)
     {
-        return Path.GetExtension(filename) switch
+        return Path.GetExtension(filename).ToString().ToLowerInvariant() switch
         {
+            ".dib" or
+            ".rle" or
             ".bmp" => GUID.GUID_ContainerFormatBmp,
             ".png" => GUID.GUID_ContainerFormatPng,
+            ".jpe" or
+            ".jfif" or
+            ".exif" or
             ".jpg" or
             ".jpeg" => GUID.GUID_ContainerFormatJpeg,
             ".jxr" or
             ".hdp" or
             ".wdp" or
             ".wmp" => GUID.GUID_ContainerFormatWmp,
+            ".tif" or
             ".tiff" => GUID.GUID_ContainerFormatTiff,
             ".dds" => GUID.GUID_ContainerFormatDds,
             _ => default(ArgumentException).Throw<Guid>(nameof(filename))

--- a/src/ComputeSharp/Graphics/Helpers/WICHelper.cs
+++ b/src/ComputeSharp/Graphics/Helpers/WICHelper.cs
@@ -358,6 +358,7 @@ internal sealed unsafe class WICHelper
         where T : unmanaged
     {
         using ComPtr<IWICBitmapEncoder> wicBitmapEncoder = default;
+
         Guid containerGuid = WICFormatHelper.GetForFilename(filename);
 
         // Create the image encoder
@@ -397,6 +398,7 @@ internal sealed unsafe class WICHelper
         where T : unmanaged
     {
         using ComPtr<IWICBitmapEncoder> wicBitmapEncoder = default;
+
         Guid containerGuid = WICFormatHelper.GetForFormat(format);
 
         // Create the image encoder
@@ -431,6 +433,7 @@ internal sealed unsafe class WICHelper
         where T : unmanaged
     {
         using ComPtr<IWICBitmapEncoder> wicBitmapEncoder = default;
+
         Guid containerGuid = WICFormatHelper.GetForFormat(format);
 
         // Create the image encoder


### PR DESCRIPTION
### Closes #799

### Description

Ensures case insensitive comparison of the file extension and manually maps all supported file extensions supported by the build in container formats (BMP, JPEG, PNG, TIFF, WMP, DDS).

### Additional context (optional)

Alternative approaches are possible, removing the need for hard coding any file extensions (see https://github.com/Sergio0694/ComputeSharp/issues/799#issuecomment-2142696288).  Such an approach is more involved and would be a better fit if it is planned to address #800.