### PR TITLE
Stop emitting unnecessary 'unsafe' modifiers

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ConstantBuffer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.ConstantBuffer.cs
@@ -48,7 +48,11 @@ partial class D2DPixelShaderDescriptorGenerator
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
             writer.WriteLine("[global::System.Runtime.CompilerServices.SkipLocalsInit]");
-            writer.WriteLine($"static unsafe void global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{typeName}>.LoadConstantBuffer<TLoader>(in {typeName} shader, ref TLoader loader)");
+
+            // Write the method declaration (we only need unsafe blocks if we have any values in the constant buffer)
+            writer.Write("static ");
+            writer.WriteIf(!info.Fields.IsEmpty, "unsafe ");
+            writer.WriteLine($"void global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{typeName}>.LoadConstantBuffer<TLoader>(in {typeName} shader, ref TLoader loader)");
 
             using (writer.WriteBlock())
             {
@@ -91,7 +95,7 @@ partial class D2DPixelShaderDescriptorGenerator
             writer.WriteLine("/// <inheritdoc/>");
             writer.WriteGeneratedAttributes(GeneratorName);
             writer.WriteLine("[global::System.Runtime.CompilerServices.SkipLocalsInit]");
-            writer.WriteLine($"static unsafe {typeName} global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{typeName}>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)");
+            writer.WriteLine($"static {typeName} global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{typeName}>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)");
 
             using (writer.WriteBlock())
             {

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
@@ -202,7 +202,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::System.Runtime.CompilerServices.SkipLocalsInit]
-                    static unsafe MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
+                    static MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
                     {
                         ref readonly global::ComputeSharp.D2D1.Generated.ConstantBuffer buffer = ref global::System.Runtime.InteropServices.MemoryMarshal.AsRef<global::ComputeSharp.D2D1.Generated.ConstantBuffer>(data);
 
@@ -502,7 +502,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::System.Runtime.CompilerServices.SkipLocalsInit]
-                    static unsafe MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
+                    static MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
                     {
                         ref readonly global::ComputeSharp.D2D1.Generated.ConstantBuffer buffer = ref global::System.Runtime.InteropServices.MemoryMarshal.AsRef<global::ComputeSharp.D2D1.Generated.ConstantBuffer>(data);
 
@@ -854,7 +854,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::System.Runtime.CompilerServices.SkipLocalsInit]
-                    static unsafe MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
+                    static MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
                     {
                         ref readonly global::ComputeSharp.D2D1.Generated.ConstantBuffer buffer = ref global::System.Runtime.InteropServices.MemoryMarshal.AsRef<global::ComputeSharp.D2D1.Generated.ConstantBuffer>(data);
 
@@ -1152,7 +1152,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::System.Runtime.CompilerServices.SkipLocalsInit]
-                    static unsafe MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
+                    static MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
                     {
                         ref readonly global::ComputeSharp.D2D1.Generated.ConstantBuffer buffer = ref global::System.Runtime.InteropServices.MemoryMarshal.AsRef<global::ComputeSharp.D2D1.Generated.ConstantBuffer>(data);
 
@@ -1442,7 +1442,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::System.Runtime.CompilerServices.SkipLocalsInit]
-                    static unsafe MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
+                    static MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
                     {
                         return default;
                     }
@@ -1452,7 +1452,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::System.Runtime.CompilerServices.SkipLocalsInit]
-                    static unsafe void global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.LoadConstantBuffer<TLoader>(in MyShader shader, ref TLoader loader)
+                    static void global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.LoadConstantBuffer<TLoader>(in MyShader shader, ref TLoader loader)
                     {
                         loader.LoadConstantBuffer(default);
                     }
@@ -1728,7 +1728,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::System.Runtime.CompilerServices.SkipLocalsInit]
-                    static unsafe MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
+                    static MyShader global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.CreateFromConstantBuffer(global::System.ReadOnlySpan<byte> data)
                     {
                         return default;
                     }
@@ -1738,7 +1738,7 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     [global::System.Runtime.CompilerServices.SkipLocalsInit]
-                    static unsafe void global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.LoadConstantBuffer<TLoader>(in MyShader shader, ref TLoader loader)
+                    static void global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.LoadConstantBuffer<TLoader>(in MyShader shader, ref TLoader loader)
                     {
                         loader.LoadConstantBuffer(default);
                     }


### PR DESCRIPTION
### Description

This PR removes some unnecessary `unsafe` modifiers that were being produced by the D2D source generator.