### PR TITLE
Remove unnecessary 'IL2059' warning suppression

### DIFF
--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -22,20 +22,6 @@
     <MvvmToolkitEnableINotifyPropertyChangingSupport>false</MvvmToolkitEnableINotifyPropertyChangingSupport>
   </PropertyGroup>
 
-  <PropertyGroup>
-
-    <!--
-      Temporary workaround: don't fail builds for 'IL2059' errors, like this:
-      "XamlTypeInfo.g.cs(495): Trim analysis warning IL2059: ComputeSharp.SwapChain.WinUI.ComputeSharp_SwapChain_WinUI_XamlTypeInfo.XamlTypeInfoProvider.
-      StaticInitializer_38_Nullable(): Unrecognized value passed to the parameter 'type' of method 'System.Runtime. CompilerServices.RuntimeHelpers
-      .RunClassConstructor(RuntimeTypeHandle)'. It's not possible to guarantee the availability of the target static constructor."
-      This is due to a bug in the .NET trim analyzer and in ILC, see: https://github.com/dotnet/runtime/issues/106939.
-      The best fix would also be to update the XAML compiler in WinAppSDK to skip generating unnecessary static constructor stubs.
-    -->
-    <TrimmerSingleWarn>false</TrimmerSingleWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2059</WarningsNotAsErrors>
-  </PropertyGroup>
-
   <!-- Additional CsWinRT properties (temporary, until the .NET SDK is updated) -->
   <PropertyGroup>
     

--- a/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
+++ b/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
@@ -10,21 +10,11 @@
 
   <PropertyGroup>
 
-    <!--
-      Disable IIDOptimizer, as it's causing a build error when the debug mode is set to embedded.
-      This is only needed when generating projections anyway, and not in normal C# class libraries.
-      See: https://github.com/microsoft/CsWinRT/issues/1478.
-    -->
+    <!-- Also disabled in 'ComputeSharp.D2D1.WinUI', see notes there -->
     <CsWinRTIIDOptimizerOptOut>true</CsWinRTIIDOptimizerOptOut>
 
-    <!--
-      Ignore some warnings about ambiguous cref attribute references. These are because the assembly defines
-      blittable bindings for several ABI types from Win2D, in the same namespace as the ABI types from the
-      CsWinRT projections that are in Win2D. They are internal, but Roslyn will still complain about them.
-    -->
+    <!-- Same warnings as in 'ComputeSharp.D2D1.WinUI', see notes there -->
     <NoWarn>$(NoWarn);CS0419</NoWarn>
-
-    <!-- Ignore warnings for usings outside of a namespace (needed for some WinRT type aliases) -->
     <NoWarn>$(NoWarn);IDE0065</NoWarn>
 
     <!-- Temporary workaround: the Win2D .dll is not strong name signed, ignore the error for now -->


### PR DESCRIPTION
### Description

This PR removes some unnecessary suppressions, not needed anymore with WindowsAppSDK 1.6 stable.