### PR TITLE
Tweak logic to generate supported OS attributes

### DIFF
--- a/src/ComputeSharp.D2D1/ComputeSharp.D2D1.csproj
+++ b/src/ComputeSharp.D2D1/ComputeSharp.D2D1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <SupportedOSVersion>windows6.1</SupportedOSVersion>
+    <SupportedOSPlatformVersion>6.1</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D3D12MemoryAllocator/ComputeSharp.D3D12MemoryAllocator.csproj
+++ b/src/ComputeSharp.D3D12MemoryAllocator/ComputeSharp.D3D12MemoryAllocator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <SupportedOSVersion>windows6.2</SupportedOSVersion>
+    <SupportedOSPlatformVersion>6.2</SupportedOSPlatformVersion>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/ComputeSharp.Dxc/ComputeSharp.Dxc.csproj
+++ b/src/ComputeSharp.Dxc/ComputeSharp.Dxc.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
-    <SupportedOSVersion>windows6.2</SupportedOSVersion>
+    <SupportedOSPlatformVersion>6.2</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.Pix/ComputeSharp.Pix.csproj
+++ b/src/ComputeSharp.Pix/ComputeSharp.Pix.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Platforms>AnyCPU;x64;ARM64</Platforms>
-    <SupportedOSVersion>windows6.2</SupportedOSVersion>
+    <SupportedOSPlatformVersion>6.2</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <!-- Reference to the main library-->

--- a/src/ComputeSharp/ComputeSharp.csproj
+++ b/src/ComputeSharp/ComputeSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <SupportedOSVersion>windows6.2</SupportedOSVersion>
+    <SupportedOSPlatformVersion>6.2</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -56,12 +56,18 @@
     <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
   </PropertyGroup>
 
-  <!-- Emit the [SupportedOSVersion] attribute if needed -->
+  <!--
+    Emit the [SupportedOSVersion] attribute if needed. Note that the .NET SDK already emits this attribute
+    automatically, but only when targeting the Windows TFM. We use this custom target to emit the same
+    attribute for projects only targeting plain .NET as well. This makes them easier to consume from
+    projects that are not using the Windows TFM as well. Doing so isn't strictly needed anyway unless
+    you're specifically consuming the Windows SDK projections, which those projects are not doing.
+  -->
   <Target Name="EmitSupportedOSVersionAttributeForTargetOS"
           BeforeTargets="PrepareForBuild">
-    <ItemGroup Condition="'$(SupportedOSVersion)' != ''">
+    <ItemGroup Condition="'$(SupportedOSPlatformVersion)' != '' AND !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows'))">
       <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute">
-        <_Parameter1>$(SupportedOSVersion)</_Parameter1>
+        <_Parameter1>Windows$(SupportedOSPlatformVersion)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
### Description

This PR tweaks the logic to emit `[SupportedOSPlatform]` attributes to be more consistent with the .NET SDK.