### PR TITLE
Support explicit interface implementations for shader entry points

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -53,8 +53,10 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
                         return default;
                     }
 
+                    INamedTypeSymbol shaderInterfaceType = context.SemanticModel.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.ID2D1PixelShader")!;
+
                     // Check that the shader implements the ID2D1PixelShader interface
-                    if (!typeSymbol.HasInterfaceWithType(context.SemanticModel.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.ID2D1PixelShader")!))
+                    if (!typeSymbol.HasInterfaceWithType(shaderInterfaceType))
                     {
                         return default;
                     }
@@ -142,6 +144,7 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
                         diagnostics,
                         context.SemanticModel.Compilation,
                         typeSymbol,
+                        shaderInterfaceType,
                         inputCount,
                         inputSimpleIndices,
                         inputComplexIndices,

--- a/src/ComputeSharp.SourceGeneration/Extensions/ITypeSymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/ITypeSymbolExtensions.cs
@@ -10,6 +10,26 @@ namespace ComputeSharp.SourceGeneration.Extensions;
 internal static class ITypeSymbolExtensions
 {
     /// <summary>
+    /// Gets the method of this symbol that have a particular name.
+    /// </summary>
+    /// <param name="symbol">The input <see cref="ITypeSymbol"/> instance to check.</param>
+    /// <param name="name">The name of the method to find.</param>
+    /// <returns>The target method, if present.</returns>
+    public static IMethodSymbol? GetMethod(this ITypeSymbol symbol, string name)
+    {
+        foreach (ISymbol memberSymbol in symbol.GetMembers(name))
+        {
+            if (memberSymbol is IMethodSymbol methodSymbol &&
+                memberSymbol.Name == name)
+            {
+                return methodSymbol;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
     /// Checks whether or not a given type symbol has a specified fully qualified metadata name.
     /// </summary>
     /// <param name="symbol">The input <see cref="ITypeSymbol"/> instance to check.</param>
@@ -28,7 +48,7 @@ internal static class ITypeSymbolExtensions
     /// Checks whether or not a given <see cref="ITypeSymbol"/> implements an interface of a specified type.
     /// </summary>
     /// <param name="typeSymbol">The target <see cref="ITypeSymbol"/> instance to check.</param>
-    /// <param name="interfaceSymbol">The <see cref="ITypeSymbol"/> instane to check for inheritance from.</param>
+    /// <param name="interfaceSymbol">The <see cref="ITypeSymbol"/> instance to check for inheritance from.</param>
     /// <returns>Whether or not <paramref name="typeSymbol"/> has an interface of type <paramref name="interfaceSymbol"/>.</returns>
     public static bool HasInterfaceWithType(this ITypeSymbol typeSymbol, ITypeSymbol interfaceSymbol)
     {

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.Helpers.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.Helpers.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 
 namespace ComputeSharp.SourceGenerators;
@@ -10,9 +11,14 @@ partial class ComputeShaderDescriptorGenerator
     /// </summary>
     /// <param name="typeSymbol">The input <see cref="INamedTypeSymbol"/> instance to check.</param>
     /// <param name="compilation">The <see cref="Compilation"/> instance currently in use.</param>
+    /// <param name="shaderInterfaceType">The (constructed) shader interface type implemented by the shader type.</param>
     /// <param name="isPixelShaderLike">Whether <paramref name="typeSymbol"/> is a "pixel shader like" type.</param>
     /// <returns>Whether <paramref name="typeSymbol"/> is a compute shader type at all.</returns>
-    private static bool TryGetIsPixelShaderLike(INamedTypeSymbol typeSymbol, Compilation compilation, out bool isPixelShaderLike)
+    private static bool TryGetIsPixelShaderLike(
+        INamedTypeSymbol typeSymbol,
+        Compilation compilation,
+        [NotNullWhen(true)] out INamedTypeSymbol? shaderInterfaceType,
+        out bool isPixelShaderLike)
     {
         INamedTypeSymbol computeShaderSymbol = compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader")!;
         INamedTypeSymbol pixelShaderSymbol = compilation.GetTypeByMetadataName("ComputeSharp.IComputeShader`1")!;
@@ -21,18 +27,21 @@ partial class ComputeShaderDescriptorGenerator
         {
             if (SymbolEqualityComparer.Default.Equals(interfaceSymbol, computeShaderSymbol))
             {
+                shaderInterfaceType = interfaceSymbol;
                 isPixelShaderLike = false;
 
                 return true;
             }
             else if (SymbolEqualityComparer.Default.Equals(interfaceSymbol.ConstructedFrom, pixelShaderSymbol))
             {
+                shaderInterfaceType = interfaceSymbol;
                 isPixelShaderLike = true;
 
                 return true;
             }
         }
 
+        shaderInterfaceType = null;
         isPixelShaderLike = false;
 
         return false;

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.cs
@@ -54,7 +54,11 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                     }
 
                     // Check whether type is a compute shader, and if so, if it's pixel shader like
-                    if (!TryGetIsPixelShaderLike(typeSymbol, context.SemanticModel.Compilation, out bool isPixelShaderLike))
+                    if (!TryGetIsPixelShaderLike(
+                        typeSymbol,
+                        context.SemanticModel.Compilation,
+                        out INamedTypeSymbol? shaderInterfaceType,
+                        out bool isPixelShaderLike))
                     {
                         return default;
                     }
@@ -91,6 +95,8 @@ public sealed partial class ComputeShaderDescriptorGenerator : IIncrementalGener
                         diagnostics,
                         context.SemanticModel.Compilation,
                         typeSymbol,
+                        shaderInterfaceType,
+                        isPixelShaderLike,
                         threadsX,
                         threadsY,
                         threadsZ,

--- a/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
+++ b/src/ComputeSharp.SourceGenerators/Mappings/HlslKnownTypes.cs
@@ -208,11 +208,18 @@ partial class HlslKnownTypes
     /// <summary>
     /// Gets the mapped HLSL-compatible type name for the output texture of a pixel shader.
     /// </summary>
-    /// <param name="typeSymbol">The pixel shader type to map.</param>
+    /// <param name="typeSymbol">The shader type to map.</param>
     /// <returns>The HLSL-compatible type name that can be used in an HLSL shader.</returns>
-    public static string GetMappedNameForPixelShaderType(INamedTypeSymbol typeSymbol)
+    public static string? GetMappedNameForPixelShaderType(INamedTypeSymbol typeSymbol)
     {
-        string genericArgumentName = ((INamedTypeSymbol)typeSymbol.TypeArguments.First()).GetFullyQualifiedMetadataName();
+        // If the shader type is not a pixel shader type (ie. it has a type argument), stop here.
+        // At this point the input is guaranteed to either be 'IComputeShader' or 'IComputeShader<TPixel>'.
+        if (typeSymbol.TypeArguments is not [INamedTypeSymbol pixelShaderType])
+        {
+            return null;
+        }
+
+        string genericArgumentName = pixelShaderType.GetFullyQualifiedMetadataName();
 
         // If the current type is a custom type, format it as needed
         if (!KnownHlslTypeMetadataNames.TryGetValue(genericArgumentName, out string? mappedElementType))

--- a/src/ComputeSharp.SourceGenerators/SyntaxRewriters/ExecuteMethodRewriter.cs
+++ b/src/ComputeSharp.SourceGenerators/SyntaxRewriters/ExecuteMethodRewriter.cs
@@ -25,6 +25,22 @@ internal abstract class ExecuteMethodRewriter(ShaderSourceRewriter shaderSourceR
     }
 
     /// <inheritdoc/>
+    public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        MethodDeclarationSyntax updatedNode = ((MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!).WithModifiers(TokenList());
+
+        // The entry point might be an explicit interface method implementation. In that case,
+        // the transpiled method will have the rewritten interface name as a prefix for the
+        // method name, which we don't want (it's invalid HLSL). So in that case, remove it.
+        if (updatedNode.ExplicitInterfaceSpecifier is not null)
+        {
+            updatedNode = updatedNode.WithExplicitInterfaceSpecifier(null);
+        }
+
+        return updatedNode;
+    }
+
+    /// <inheritdoc/>
     public override SyntaxNode? VisitParameterList(ParameterListSyntax node)
     {
         ParameterListSyntax updatedNode = (ParameterListSyntax)base.VisitParameterList(node)!;

--- a/src/ComputeSharp.SourceGenerators/SyntaxRewriters/ExecuteMethodRewriter.cs
+++ b/src/ComputeSharp.SourceGenerators/SyntaxRewriters/ExecuteMethodRewriter.cs
@@ -25,22 +25,6 @@ internal abstract class ExecuteMethodRewriter(ShaderSourceRewriter shaderSourceR
     }
 
     /// <inheritdoc/>
-    public override SyntaxNode? VisitMethodDeclaration(MethodDeclarationSyntax node)
-    {
-        MethodDeclarationSyntax updatedNode = ((MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!).WithModifiers(TokenList());
-
-        // The entry point might be an explicit interface method implementation. In that case,
-        // the transpiled method will have the rewritten interface name as a prefix for the
-        // method name, which we don't want (it's invalid HLSL). So in that case, remove it.
-        if (updatedNode.ExplicitInterfaceSpecifier is not null)
-        {
-            updatedNode = updatedNode.WithExplicitInterfaceSpecifier(null);
-        }
-
-        return updatedNode;
-    }
-
-    /// <inheritdoc/>
     public override SyntaxNode? VisitParameterList(ParameterListSyntax node)
     {
         ParameterListSyntax updatedNode = (ParameterListSyntax)base.VisitParameterList(node)!;

--- a/tests/ComputeSharp.D2D1.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/ShaderRewriterTests.cs
@@ -208,4 +208,33 @@ public partial class ShaderRewriterTests
             return new float4(0.0f, 1.0f, 0.0f, 1.0f);
         }
     }
+
+    // See https://github.com/Sergio0694/ComputeSharp/issues/855
+    [TestMethod]
+    public void ExplicitEntryPointMethodPixelShader_IsRewrittenCorrectly()
+    {
+        D2D1ShaderInfo shaderInfo = D2D1ReflectionServices.GetShaderInfo<ExplicitEntryPointMethodPixelShader>();
+
+        Assert.AreEqual("""
+            #define D2D_INPUT_COUNT 0
+            
+            #include "d2d1effecthelpers.hlsli"
+            
+            D2D_PS_ENTRY(Execute)
+            {
+                return (float4)0;
+            }
+            """, shaderInfo.HlslSource);
+    }
+
+    [D2DInputCount(0)]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+    [D2DGeneratedPixelShaderDescriptor]
+    internal readonly partial struct ExplicitEntryPointMethodPixelShader : ID2D1PixelShader
+    {
+        float4 ID2D1PixelShader.Execute()
+        {
+            return default;
+        }
+    }
 }

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -315,6 +315,31 @@ namespace ComputeSharp.Tests
 
             Assert.AreEqual(info.TextureStoreInstructionCount, 1u);
             Assert.AreEqual(info.BoundResourceCount, 2u);
+            Assert.AreEqual("""
+                #define __GroupSize__get_X 8
+                #define __GroupSize__get_Y 8
+                #define __GroupSize__get_Z 1
+                
+                cbuffer _ : register(b0)
+                {
+                    uint __x;
+                    uint __y;
+                }
+                
+                RWTexture2D<unorm float4> __outputTexture : register(u0);
+                
+                [NumThreads(__GroupSize__get_X, __GroupSize__get_Y, __GroupSize__get_Z)]
+                void Execute(uint3 ThreadIds : SV_DispatchThreadID)
+                {
+                    if (ThreadIds.x < __x && ThreadIds.y < __y)
+                    {
+                        {
+                            __outputTexture[ThreadIds.xy] = float4(1, 1, 1, 1);
+                            return;
+                        }
+                    }
+                }
+                """, info.HlslSource);
         }
 
         [ThreadGroupSize(DefaultThreadGroupSizes.XY)]


### PR DESCRIPTION
### Closes #855

### Description

This PR updates the DX12/D2D generators to correctly handle entry points using explicit interface implementations.
It also adds a small performance improvement when rewriting entry point methods with no implicit locals.
Lastly, it adds one more transpiled source unit test (as well as new tests for the new supported scenario).