### PR TITLE
Update NuGet packages to latest stable

### DIFF
--- a/samples/ComputeSharp.NativeLibrary.WinRT/ComputeSharp.NativeLibrary.WinRT.csproj
+++ b/samples/ComputeSharp.NativeLibrary.WinRT/ComputeSharp.NativeLibrary.WinRT.csproj
@@ -43,7 +43,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.400" />
+    <PackageReference Update="FSharp.Core" Version="8.0.401" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -66,7 +66,7 @@
       Reference CsWinRT locally for the source generators (see comments in ComputeSharp.D2D1.WinUI).
       Note that this is an executable and not a library, so we must drop the 'PrivateAssets' here.
       -->
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
   </ItemGroup>
 
   <!-- Note: using SetPlatform="Platform=AnyCPU" for the analyzers to avoid issues (see https://github.com/dotnet/roslyn/issues/70148) -->

--- a/samples/ComputeSharp.SwapChain.D2D1.Uwp/ComputeSharp.SwapChain.D2D1.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Uwp/ComputeSharp.SwapChain.D2D1.Uwp.csproj
@@ -37,14 +37,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
 
     <!--
       This sample does not need WebView2, but WinAppSDK is pulling it in as a transitive NuGet
       dependency. We can manually exclude all of its assets to avoid them being in the output.
       This also prevents the old projections from being referenced and triggering the generator.
     -->
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2739.15" IncludeAssets="none" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" IncludeAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -15,6 +15,9 @@
       https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-MainLatest/nuget/v3/index.json;
     </RestoreSources>
 
+    <!-- Ignore warnings for the '[Experimental]' attribute ('CanvasAnimatedControl' temporarily has it) -->
+    <NoWarn>$(NoWarn);CS8305;WMC1501</NoWarn>
+
     <!--
       WinUI 3 doesn't need support for 'INotifyPropertyChanging', so we can disable it.
       This avoids all generated code for it and provides a small performance improvement.
@@ -61,9 +64,9 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.240824-build.1155" />
-    <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.240824-build.1155" />
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.241010-build.1216" />
+    <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.241010-build.1216" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" />
   </ItemGroup>
 
   <!-- 

--- a/src/ComputeSharp.CodeFixers/ComputeSharp.CodeFixers.csproj
+++ b/src/ComputeSharp.CodeFixers/ComputeSharp.CodeFixers.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.CodeFixers/ComputeSharp.D2D1.CodeFixers.csproj
+++ b/src/ComputeSharp.D2D1.CodeFixers/ComputeSharp.D2D1.CodeFixers.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
+++ b/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
@@ -28,7 +28,7 @@
       We need the CsWinRT reference for the generator to kick in and generate all necessary supporting code
       to make the exposed types AOT compatible. Since we only need the generator, we can mark this as private.
     -->
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
+++ b/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
@@ -31,13 +31,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.2.1-experimental2" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.0" />
 
     <!--
       We need the CsWinRT reference for the generator to kick in and generate all necessary supporting code
       to make the exposed types AOT compatible. Since we only need the generator, we can mark this as private.
     -->
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.Uwp/ComputeSharp.Uwp.csproj
+++ b/src/ComputeSharp.Uwp/ComputeSharp.Uwp.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
 
     <!-- Reference CsWinRT locally for the source generators (see comments in ComputeSharp.D2D1.WinUI) -->
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
+++ b/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
@@ -20,10 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
 
     <!-- Reference CsWinRT locally for the source generators (see comments in ComputeSharp.D2D1.WinUI) -->
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.6" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -5,8 +5,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.8" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -8,10 +8,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
+    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100" />
   </ItemGroup>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -57,10 +57,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
+    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" ExcludeAssets="build" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
+    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100" />
   </ItemGroup>
 

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
+    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
+    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
@@ -5,8 +5,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
@@ -4,12 +4,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.8" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.5.0" PrivateAssets="all" />
+    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100" />
   </ItemGroup>


### PR DESCRIPTION
### Description

This PR updates all NuGet packages to their latest stable versions (except the Roslyn packages).
It also does not update the UWP version of Win2D, as that needs the .NET 9 SDK in order to build.
