### PR TITLE
Update 'CanvasEffect' property generator

### DIFF
--- a/src/ComputeSharp.D2D1.UI.SourceGenerators/CanvasEffectPropertyGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.UI.SourceGenerators/CanvasEffectPropertyGenerator.Execute.cs
@@ -1,7 +1,9 @@
 using System.Threading;
 #if WINDOWS_UWP
+using ComputeSharp.D2D1.Uwp.SourceGenerators.Constants;
 using ComputeSharp.D2D1.Uwp.SourceGenerators.Models;
 #else
+using ComputeSharp.D2D1.WinUI.SourceGenerators.Constants;
 using ComputeSharp.D2D1.WinUI.SourceGenerators.Models;
 #endif
 using ComputeSharp.SourceGeneration.Extensions;
@@ -182,7 +184,7 @@ partial class CanvasEffectPropertyGenerator
                             On{{propertyInfo.PropertyName}}Changed(value);
                             On{{propertyInfo.PropertyName}}Changed(oldValue, value);
                     
-                            InvalidateEffectGraph(global::ComputeSharp.D2D1.WinUI.CanvasEffectInvalidationType.{{propertyInfo.InvalidationType}});
+                            InvalidateEffectGraph(global::{{WellKnownTypeNames.CanvasEffectInvalidationType}}.{{propertyInfo.InvalidationType}});
                         }
                     }
                     """, isMultiline: true);

--- a/src/ComputeSharp.D2D1.UI.SourceGenerators/Constants/WellKnownTypeNames.cs
+++ b/src/ComputeSharp.D2D1.UI.SourceGenerators/Constants/WellKnownTypeNames.cs
@@ -20,12 +20,22 @@ internal static class WellKnownTypeNames
 #endif
 
     /// <summary>
-    /// The fully qualified type name for the <c>[CanvasEffect]</c> type.
+    /// The fully qualified type name for the <c>CanvasEffect</c> type.
     /// </summary>
     public const string CanvasEffect =
 #if WINDOWS_UWP
         "ComputeSharp.D2D1.Uwp.CanvasEffect";
 #else
         "ComputeSharp.D2D1.WinUI.CanvasEffect";
+#endif
+
+    /// <summary>
+    /// The fully qualified type name for the <c>CanvasEffect</c> type.
+    /// </summary>
+    public const string CanvasEffectInvalidationType =
+#if WINDOWS_UWP
+        "ComputeSharp.D2D1.Uwp.CanvasEffectInvalidationType";
+#else
+        "ComputeSharp.D2D1.WinUI.CanvasEffectInvalidationType";
 #endif
 }

--- a/tests/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />


### PR DESCRIPTION
### Follow up for #813

### Description

This PR includes two tweaks for the `CanvasEffect` property generator:
- Fixes the codegen in UWP projects, which were using the wrong namespace
- Updates all NuGet packages to latest stable in the test project