### PR TITLE
Rename 'CanvasEffect' API to 'SetPropertyAndInvalidateEffectGraph'

### DIFF
--- a/samples/ComputeSharp.NativeLibrary.WinRT/HelloWorldEffect.cs
+++ b/samples/ComputeSharp.NativeLibrary.WinRT/HelloWorldEffect.cs
@@ -26,7 +26,7 @@ public sealed partial class HelloWorldEffect : CanvasEffect
     public float Time
     {
         get => this.time;
-        set => SetAndInvalidateEffectGraph(ref this.time, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.time, value);
     }
 
     /// <summary>
@@ -35,7 +35,7 @@ public sealed partial class HelloWorldEffect : CanvasEffect
     public Rect DispatchArea
     {
         get => this.dispatchArea;
-        set => SetAndInvalidateEffectGraph(ref this.dispatchArea, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.dispatchArea, value);
     }
 
     /// <inheritdoc/>

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/Backend/PixelShaderEffect.cs
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/Backend/PixelShaderEffect.cs
@@ -31,7 +31,7 @@ internal abstract partial class PixelShaderEffect : CanvasEffect
     public TimeSpan ElapsedTime
     {
         get => this.elapsedTime;
-        set => SetAndInvalidateEffectGraph(ref this.elapsedTime, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.elapsedTime, value);
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ internal abstract partial class PixelShaderEffect : CanvasEffect
     public int ScreenWidth
     {
         get => this.screenWidth;
-        set => SetAndInvalidateEffectGraph(ref this.screenWidth, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.screenWidth, value);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ internal abstract partial class PixelShaderEffect : CanvasEffect
     public int ScreenHeight
     {
         get => this.screenHeight;
-        set => SetAndInvalidateEffectGraph(ref this.screenHeight, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.screenHeight, value);
     }
 
     /// <summary>

--- a/samples/ComputeSharp.SwapChain.D2D1.Uwp/Backend/PixelShaderEffect.cs
+++ b/samples/ComputeSharp.SwapChain.D2D1.Uwp/Backend/PixelShaderEffect.cs
@@ -31,7 +31,7 @@ internal abstract partial class PixelShaderEffect : CanvasEffect
     public TimeSpan ElapsedTime
     {
         get => this.elapsedTime;
-        set => SetAndInvalidateEffectGraph(ref this.elapsedTime, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.elapsedTime, value);
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ internal abstract partial class PixelShaderEffect : CanvasEffect
     public int ScreenWidth
     {
         get => this.screenWidth;
-        set => SetAndInvalidateEffectGraph(ref this.screenWidth, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.screenWidth, value);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ internal abstract partial class PixelShaderEffect : CanvasEffect
     public int ScreenHeight
     {
         get => this.screenHeight;
-        set => SetAndInvalidateEffectGraph(ref this.screenHeight, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.screenHeight, value);
     }
 
     /// <summary>

--- a/samples/ComputeSharp.SwapChain.WinUI/Shaders/PixelShaderEffect.cs
+++ b/samples/ComputeSharp.SwapChain.WinUI/Shaders/PixelShaderEffect.cs
@@ -31,7 +31,7 @@ public abstract partial class PixelShaderEffect : CanvasEffect
     public TimeSpan ElapsedTime
     {
         get => this.elapsedTime;
-        set => SetAndInvalidateEffectGraph(ref this.elapsedTime, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.elapsedTime, value);
     }
 
     /// <summary>
@@ -40,7 +40,7 @@ public abstract partial class PixelShaderEffect : CanvasEffect
     public int ScreenWidth
     {
         get => this.screenWidth;
-        set => SetAndInvalidateEffectGraph(ref this.screenWidth, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.screenWidth, value);
     }
 
     /// <summary>
@@ -49,7 +49,7 @@ public abstract partial class PixelShaderEffect : CanvasEffect
     public int ScreenHeight
     {
         get => this.screenHeight;
-        set => SetAndInvalidateEffectGraph(ref this.screenHeight, value);
+        set => SetPropertyAndInvalidateEffectGraph(ref this.screenHeight, value);
     }
 
     /// <summary>

--- a/src/ComputeSharp.D2D1.UI/CanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.UI/CanvasEffect.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Graphics.Canvas;
 
@@ -144,7 +145,7 @@ public abstract partial class CanvasEffect : ICanvasImage, ICanvasImageInterop
     /// <param name="storage">The storage for the effect property value.</param>
     /// <param name="value">The new effect property value to set.</param>
     /// <param name="invalidationType">The invalidation type to request.</param>
-    protected void SetAndInvalidateEffectGraph<T>([NotNullIfNotNull(nameof(value))] ref T storage, T value, CanvasEffectInvalidationType invalidationType = CanvasEffectInvalidationType.Update)
+    protected void SetPropertyAndInvalidateEffectGraph<T>([NotNullIfNotNull(nameof(value))] ref T storage, T value, CanvasEffectInvalidationType invalidationType = CanvasEffectInvalidationType.Update)
     {
         if (EqualityComparer<T>.Default.Equals(storage, value))
         {
@@ -154,6 +155,14 @@ public abstract partial class CanvasEffect : ICanvasImage, ICanvasImageInterop
         storage = value;
 
         InvalidateEffectGraph(invalidationType);
+    }
+
+    /// <inheritdoc cref="SetPropertyAndInvalidateEffectGraph"/>
+    [Obsolete("Use 'SetPropertyAndInvalidateEffectGraph' instead.")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    protected void SetAndInvalidateEffectGraph<T>([NotNullIfNotNull(nameof(value))] ref T storage, T value, CanvasEffectInvalidationType invalidationType = CanvasEffectInvalidationType.Update)
+    {
+        SetPropertyAndInvalidateEffectGraph(ref storage, value, invalidationType);
     }
 
     /// <summary>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/CanvasEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/CanvasEffectTests.cs
@@ -390,13 +390,13 @@ public partial class CanvasEffectTests
         public int Value
         {
             get => this.value;
-            set => SetAndInvalidateEffectGraph(ref this.value, value);
+            set => SetPropertyAndInvalidateEffectGraph(ref this.value, value);
         }
 
         public int ValueWithReload
         {
             get => this.value;
-            set => SetAndInvalidateEffectGraph(ref this.value, value, CanvasEffectInvalidationType.Creation);
+            set => SetPropertyAndInvalidateEffectGraph(ref this.value, value, CanvasEffectInvalidationType.Creation);
         }
 
         public int NumberOfBuildEffectGraphCalls { get; private set; }

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/ShadersTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/ShadersTests.cs
@@ -120,7 +120,7 @@ public class ShadersTests
         public T ConstantBuffer
         {
             get => this.constantBuffer;
-            set => SetAndInvalidateEffectGraph(ref this.constantBuffer, value);
+            set => SetPropertyAndInvalidateEffectGraph(ref this.constantBuffer, value);
         }
 
         protected override void BuildEffectGraph(CanvasEffectGraph effectGraph)


### PR DESCRIPTION
### Description

This PR renames `CanvasEffect.SetAndInvalidateEffectGraph` to `SetPropertyAndInvalidateEffectGraph`. This makes it more consistent with similar APIs in the ecosystem, such as [`ObservableObject.SetProperty`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.toolkit.mvvm.componentmodel.observableobject.setproperty) from the MVVM Toolkit.