### PR TITLE
Always use 'ExceptionHelpers.GetHRForException' for WinRT

### DIFF
--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasEffectFactoryNative.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasEffectFactoryNative.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Graphics.Canvas
                 {
                     ExceptionHelpers.SetErrorInfo(e);
 
-                    return Marshal.GetHRForException(e);
+                    return ExceptionHelpers.GetHRForException(e);
                 }
             }
         }

--- a/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasImageInterop.cs
+++ b/src/ComputeSharp.D2D1.UI/ABI.Microsoft.Graphics.Canvas/ICanvasImageInterop.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Graphics.Canvas
                 {
                     ExceptionHelpers.SetErrorInfo(e);
 
-                    return Marshal.GetHRForException(e);
+                    return ExceptionHelpers.GetHRForException(e);
                 }
             }
 
@@ -225,7 +225,7 @@ namespace Microsoft.Graphics.Canvas
                 {
                     ExceptionHelpers.SetErrorInfo(e);
 
-                    return Marshal.GetHRForException(e);
+                    return ExceptionHelpers.GetHRForException(e);
                 }
             }
         }


### PR DESCRIPTION
### Description

This PR uses `ExceptionHelpers.GetHRForException` for all exceptions marshalling in WinRT scenarios. This ensures that the returned HRESULT will match the one that CsWinRT will query for when reconstructing exception info, which should help debugging. If the HRESULT is different, all stacktrace info will be lost otherwise.