### PR TITLE
Refactor solution .targets files, enable detailed ILC warnings

### DIFF
--- a/ComputeSharp.sln
+++ b/ComputeSharp.sln
@@ -102,6 +102,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComputeSharp.Tests.GlobalSt
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B86A48A7-18BD-4946-B995-3CE26B092DDF}"
 	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.BeforeMicrosoftCommon.targets = src\Directory.Build.BeforeMicrosoftCommon.targets
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
 	EndProjectSection

--- a/ComputeSharp.sln
+++ b/ComputeSharp.sln
@@ -102,7 +102,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ComputeSharp.Tests.GlobalSt
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B86A48A7-18BD-4946-B995-3CE26B092DDF}"
 	ProjectSection(SolutionItems) = preProject
-		src\Directory.Build.BeforeMicrosoftCommon.targets = src\Directory.Build.BeforeMicrosoftCommon.targets
+		src\Directory.Build.BeforeMicrosoftNETSdkTargets.targets = src\Directory.Build.BeforeMicrosoftNETSdkTargets.targets
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
 	EndProjectSection

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -6,6 +6,12 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!--
+      Show full details for all trim/AOT warnings produced during builds.
+      Normally, the linker would only show a generic warning per assembly.
+    -->
+    <TrimmerSingleWarn>false</TrimmerSingleWarn>
+
+    <!--
       Enable the latest warning wave, which shows additional warnings for invalid language features that are disabled by default.
       For additional info, see https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves.
     -->

--- a/src/Directory.Build.BeforeMicrosoftCommon.targets
+++ b/src/Directory.Build.BeforeMicrosoftCommon.targets
@@ -1,5 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+
+  <!-- Properties exclusive to .NET 8 projects -->
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+
+    <!--
+      Enable trimming support. This can't be in a target unlike the other properties
+      set below, because if that is the case the trimmable attribute will be set but
+      the analyzers will not run, so warnings will be skipped.
+    -->
+    <IsAotCompatible>true</IsAotCompatible>
+
+    <!-- Emit the [DisableRuntimeMarshalling] attribute (also enables the associated analyzer) -->
+    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
+  </PropertyGroup>
+
+  <!--
+    Emit the [SupportedOSVersion] attribute if needed. Note that the .NET SDK already emits this attribute
+    automatically, but only when targeting the Windows TFM. We use this custom target to emit the same
+    attribute for projects only targeting plain .NET as well. This makes them easier to consume from
+    projects that are not using the Windows TFM as well. Doing so isn't strictly needed anyway unless
+    you're specifically consuming the Windows SDK projections, which those projects are not doing.
+  -->
+  <Target Name="EmitSupportedOSVersionAttributeForTargetOS"
+          BeforeTargets="PrepareForBuild">
+    <ItemGroup Condition="'$(SupportedOSPlatformVersion)' != '' AND !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows'))">
+      <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute">
+        <_Parameter1>Windows$(SupportedOSPlatformVersion)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
+
+  <!-- Emit the [ComVisible(false)] attribute for UWP and WinUI targets -->
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows'))">
+    <AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">
+      <_Parameter1>false</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
   
   <!-- Add a marker value to verify from a later .targets that this .targets has been correctly invoked -->
   <PropertyGroup>
@@ -9,11 +46,4 @@
   <!-- Import the original custom .targets, if it exists -->
   <Import Project="$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)"
           Condition="'$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)' != '' AND Exists('$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)')"/>
-
-  <!-- Emit an error if our custom 'BeforeCommon' .targets file has not been invoked -->
-  <Target Name="_ComputeSharpCheckForInvalidCustomBeforeMicrosoftCommonTargets"
-          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile">
-    <Error Condition ="'$(_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid)' != 'true'"
-           Text="The '_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid' marker property is not set."/>
-  </Target>
 </Project>

--- a/src/Directory.Build.BeforeMicrosoftCommon.targets
+++ b/src/Directory.Build.BeforeMicrosoftCommon.targets
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  
+  <!-- Add a marker value to verify from a later .targets that this .targets has been correctly invoked -->
+  <PropertyGroup>
+    <_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid>true</_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid>
+  </PropertyGroup>
+
+  <!-- Import the original custom .targets, if it exists -->
+  <Import Project="$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)"
+          Condition="'$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)' != '' AND Exists('$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)')"/>
+
+  <!-- Emit an error if our custom 'BeforeCommon' .targets file has not been invoked -->
+  <Target Name="_ComputeSharpCheckForInvalidCustomBeforeMicrosoftCommonTargets"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile">
+    <Error Condition ="'$(_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid)' != 'true'"
+           Text="The '_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid' marker property is not set."/>
+  </Target>
+</Project>

--- a/src/Directory.Build.BeforeMicrosoftNETSdkTargets.targets
+++ b/src/Directory.Build.BeforeMicrosoftNETSdkTargets.targets
@@ -40,10 +40,6 @@
   
   <!-- Add a marker value to verify from a later .targets that this .targets has been correctly invoked -->
   <PropertyGroup>
-    <_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid>true</_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid>
+    <_ComputeSharpBeforeMicrosoftNETSdkTargetsValid>true</_ComputeSharpBeforeMicrosoftNETSdkTargetsValid>
   </PropertyGroup>
-
-  <!-- Import the original custom .targets, if it exists -->
-  <Import Project="$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)"
-          Condition="'$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)' != '' AND Exists('$(_ComputeSharpCustomBeforeMicrosoftCommonTargets)')"/>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -85,13 +85,12 @@
   </ItemGroup>
 
   <!--
-    Setup the custom .targets to run as 'CustomBeforeMicrosoftCommonTargets'. We also make a copy of the original value so
-    that we can manually import it ourselves after ours. This is because we want to be able to read properties that are set
-    in .csproj files, and set properties depending on those before the .NET SDK .targets are imported. This is necessary
-    to ensure that the .NET tooling works correctly with some of them (eg. with 'IsAotCompatible').
+    Setup the custom .targets to run as 'BeforeMicrosoftNETSdkTargets'. This is because we want to be able to read properties
+    that are set in .csproj files, and set properties depending on those before the .NET SDK .targets are imported. This is
+    necessary to ensure that the .NET tooling works correctly with some of them (eg. with 'IsAotCompatible'). Note that the
+    .NET SDK doesn't use 'Exists' here, and '<Import>' supports multiple items, so we can just chain our .targets file directly.
   -->
   <PropertyGroup>
-    <_ComputeSharpCustomBeforeMicrosoftCommonTargets>$(CustomBeforeMicrosoftCommonTargets)</_ComputeSharpCustomBeforeMicrosoftCommonTargets>
-    <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Directory.Build.BeforeMicrosoftCommon.targets</CustomBeforeMicrosoftCommonTargets>
+    <BeforeMicrosoftNETSdkTargets>$(BeforeMicrosoftNETSdkTargets);$(MSBuildThisFileDirectory)Directory.Build.BeforeMicrosoftNETSdkTargets.targets</BeforeMicrosoftNETSdkTargets>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -83,4 +83,15 @@
     <!-- Pack the license file, if present -->
     <None Condition="$(IsLicenseFileAvailableForPacking)" Include="LICENSE.txt" Pack="true" PackagePath="\" Visible="False" />
   </ItemGroup>
+
+  <!--
+    Setup the custom .targets to run as 'CustomBeforeMicrosoftCommonTargets'. We also make a copy of the original value so
+    that we can manually import it ourselves after ours. This is because we want to be able to read properties that are set
+    in .csproj files, and set properties depending on those before the .NET SDK .targets are imported. This is necessary
+    to ensure that the .NET tooling works correctly with some of them (eg. with 'IsAotCompatible').
+  -->
+  <PropertyGroup>
+    <_ComputeSharpCustomBeforeMicrosoftCommonTargets>$(CustomBeforeMicrosoftCommonTargets)</_ComputeSharpCustomBeforeMicrosoftCommonTargets>
+    <CustomBeforeMicrosoftCommonTargets>$(MSBuildThisFileDirectory)Directory.Build.BeforeMicrosoftCommon.targets</CustomBeforeMicrosoftCommonTargets>
+  </PropertyGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -78,10 +78,10 @@
     </ItemGroup>
   </Target>
 
-  <!-- Emit an error if our custom 'BeforeCommon' .targets file has not been invoked -->
-  <Target Name="_ComputeSharpCheckForInvalidCustomBeforeMicrosoftCommonTargets"
+  <!-- Emit an error if our custom 'BeforeMicrosoftNETSdkTargets' .targets file has not been invoked -->
+  <Target Name="_ComputeSharpCheckForInvalidBeforeMicrosoftNETSdkTargets"
           BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile">
-    <Error Condition ="'$(_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid)' != 'true'"
-           Text="The '_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid' marker property is not set."/>
+    <Error Condition ="'$(_ComputeSharpBeforeMicrosoftNETSdkTargetsValid)' != 'true'"
+           Text="The '_ComputeSharpBeforeMicrosoftNETSdkTargetsValid' marker property is not set."/>
   </Target>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -42,43 +42,6 @@
           Visible="false" />
   </ItemGroup>
 
-  <!-- Properties exclusive to .NET 8 projects -->
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
-
-    <!--
-      Enable trimming support. This can't be in a target unlike the other properties
-      set below, because if that is the case the trimmable attribute will be set but
-      the analyzers will not run, so warnings will be skipped.
-    -->
-    <IsAotCompatible>true</IsAotCompatible>
-
-    <!-- Emit the [DisableRuntimeMarshalling] attribute (also enables the associated analyzer) -->
-    <DisableRuntimeMarshalling>true</DisableRuntimeMarshalling>
-  </PropertyGroup>
-
-  <!--
-    Emit the [SupportedOSVersion] attribute if needed. Note that the .NET SDK already emits this attribute
-    automatically, but only when targeting the Windows TFM. We use this custom target to emit the same
-    attribute for projects only targeting plain .NET as well. This makes them easier to consume from
-    projects that are not using the Windows TFM as well. Doing so isn't strictly needed anyway unless
-    you're specifically consuming the Windows SDK projections, which those projects are not doing.
-  -->
-  <Target Name="EmitSupportedOSVersionAttributeForTargetOS"
-          BeforeTargets="PrepareForBuild">
-    <ItemGroup Condition="'$(SupportedOSPlatformVersion)' != '' AND !$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows'))">
-      <AssemblyAttribute Include="System.Runtime.Versioning.SupportedOSPlatformAttribute">
-        <_Parameter1>Windows$(SupportedOSPlatformVersion)</_Parameter1>
-      </AssemblyAttribute>
-    </ItemGroup>
-  </Target>
-
-  <!-- Emit the [ComVisible(false)] attribute for UWP and WinUI targets -->
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0-windows'))">
-    <AssemblyAttribute Include="System.Runtime.InteropServices.ComVisibleAttribute">
-      <_Parameter1>false</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-
   <!--
     The following target has been ported from TerraFX.Interop.Windows.
     See: https://github.com/terrafx/terrafx.interop.windows.
@@ -99,7 +62,6 @@
 [module: System.Runtime.CompilerServices.SkipLocalsInitAttribute]]]>
     </GeneratedSkipLocalsInitFileLines>
   </PropertyGroup>
-
   <Target Name="GenerateSkipLocalsInit"
           BeforeTargets="BeforeCompile;CoreCompile"
           DependsOnTargets="PrepareForBuild"
@@ -114,5 +76,12 @@
     <ItemGroup>
       <Compile Include="$(GeneratedSkipLocalsInitFile)" />
     </ItemGroup>
+  </Target>
+
+  <!-- Emit an error if our custom 'BeforeCommon' .targets file has not been invoked -->
+  <Target Name="_ComputeSharpCheckForInvalidCustomBeforeMicrosoftCommonTargets"
+          BeforeTargets="_CheckForInvalidConfigurationAndPlatform;CoreCompile">
+    <Error Condition ="'$(_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid)' != 'true'"
+           Text="The '_ComputeSharpCustomBeforeMicrosoftCommonTargetsValid' marker property is not set."/>
   </Target>
 </Project>


### PR DESCRIPTION
### Description

This PR includes two changes:
- Moves the shared AOT props for the published projects to a "BeforeMicrosoftCommonTargets" file
  - This should ensure that things such as "IsAotCompatible" are set soon enough
- Disables "TrimmerSingleWarn" for the whole solution, to get detailed ILCXXXX warnings
