### PR TITLE
Add analyzer for input arguments for all 'D2D' intrinsics

### DIFF
--- a/src/ComputeSharp.Core/Intrinsics/Attributes/HlslIntrinsicNameAttribute.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Attributes/HlslIntrinsicNameAttribute.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 
-namespace ComputeSharp.Core.Intrinsics.Attributes;
+namespace ComputeSharp.Core.Intrinsics;
 
 /// <summary>
 /// An attribute indicating the native member name of a given HLSL intrinsic.

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.Casts.g.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.Casts.g.cs
@@ -1,4 +1,4 @@
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable IDE0022
 

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.Casts.tt
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.Casts.tt
@@ -2,7 +2,7 @@
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".g.cs"#>
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable IDE0022
 

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.Void.g.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.Void.g.cs
@@ -1,4 +1,4 @@
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable IDE0022
 

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.Void.tt
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.Void.tt
@@ -1,5 +1,5 @@
 <#@include file="Hlsl.Void.ttinclude" #>
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable IDE0022
 

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.cs
@@ -1,4 +1,4 @@
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable IDE0022
 

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.g.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.g.cs
@@ -1,4 +1,4 @@
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable IDE0022
 

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.tt
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.tt
@@ -1,5 +1,5 @@
 <#@include file="Hlsl.ttinclude" #>
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable IDE0022
 

--- a/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float2.g.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #nullable enable
 #pragma warning disable CS0660, CS0661

--- a/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float3.g.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #nullable enable
 #pragma warning disable CS0660, CS0661

--- a/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/Float4.g.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #nullable enable
 #pragma warning disable CS0660, CS0661

--- a/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Float/FloatMxN.g.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable CS0660, CS0661
 

--- a/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int2.g.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #nullable enable
 #pragma warning disable CS0660, CS0661

--- a/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int3.g.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #nullable enable
 #pragma warning disable CS0660, CS0661

--- a/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/Int4.g.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #nullable enable
 #pragma warning disable CS0660, CS0661

--- a/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
+++ b/src/ComputeSharp.Core/Primitives/Int/IntMxN.g.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable CS0660, CS0661
 

--- a/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/MatrixType.ttinclude
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 <#
     if (typeName == "Float" || typeName == "Int")
     {
-        WriteLine("using ComputeSharp.Core.Intrinsics.Attributes;");
+        WriteLine("using ComputeSharp.Core.Intrinsics;");
     }
 #>
 

--- a/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
+++ b/src/ComputeSharp.Core/Primitives/VectorType.ttinclude
@@ -73,7 +73,7 @@ void GenerateVectorProperties(string typeName, int elementSize)
 
     if (elementTypeName == "Float" || elementTypeName == "Int")
     {
-        WriteLine("using ComputeSharp.Core.Intrinsics.Attributes;");
+        WriteLine("using ComputeSharp.Core.Intrinsics;");
     }
 #>
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/ComputeSharp.D2D1.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -89,3 +89,5 @@ CMPSD2D0079 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://gith
 CMPSD2D0080 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0081 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
 CMPSD2D0082 | ComputeSharp.D2D1.Shaders | Warning | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0083 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)
+CMPSD2D0084 | ComputeSharp.D2D1.Shaders | Error | [Documentation](https://github.com/Sergio0694/ComputeSharp)

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -61,7 +61,9 @@
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1Filter.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOptions.cs" Link="ComputeSharp.D2D1\Attributes\Enums\D2D1PixelOptions.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Intrinsics\D2D.cs" Link="ComputeSharp.D2D1\Intrinsics\D2D.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Intrinsics\Attributes\HlslD2DIntrinsicInputTypeAttribute.cs" Link="ComputeSharp.D2D1\Intrinsics\Attributes\HlslD2DIntrinsicInputTypeAttribute.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" Link="ComputeSharp.D2D1\Shaders\Exceptions\FxcCompilationException.cs" />
+    <Compile Include="..\ComputeSharp.D2D1\Shaders\Interop\D2D1PixelShaderInputType.cs" Link="ComputeSharp.D2D1\Shaders\Interop\D2D1PixelShaderInputType.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Interop\Helpers\D2D1AssemblyAssociatedMemory.cs" Link="ComputeSharp.D2D1\Shaders\Interop\Helpers\D2D1AssemblyAssociatedMemory.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Translation\ASCII.cs" Link="ComputeSharp.D2D1\Shaders\Translation\ASCII.cs" />
     <Compile Include="..\ComputeSharp.D2D1\Shaders\Translation\D3DCompiler.cs" Link="ComputeSharp.D2D1\Shaders\Translation\D3DCompiler.cs" />

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.InputTypes.cs
@@ -13,7 +13,7 @@ partial class D2DPixelShaderDescriptorGenerator
     /// <summary>
     /// A helper with all logic to generate the <c>InputTypes</c> properties.
     /// </summary>
-    private static partial class InputTypes
+    internal static partial class InputTypes
     {
         /// <summary>
         /// Extracts the input info for the current shader.

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DInputArgumentAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DInputArgumentAnalyzer.cs
@@ -17,7 +17,11 @@ namespace ComputeSharp.D2D1.SourceGenerators;
 public sealed class InvalidD2DInputArgumentAnalyzer : DiagnosticAnalyzer
 {
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [InvalidD2DEffectIdAttributeValue];
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+    [
+        IndexOutOfRangeForD2DIntrinsic,
+        InvalidInputTypeForD2DIntrinsic
+    ];
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -88,13 +92,23 @@ public sealed class InvalidD2DInputArgumentAnalyzer : DiagnosticAnalyzer
                 // First validation: the index must be in range
                 if ((uint)index >= (uint)inputCount)
                 {
-                    // TODO: emit diagnostic
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        IndexOutOfRangeForD2DIntrinsic,
+                        operation.Syntax.GetLocation(),
+                        targetMethodSymbol.Name,
+                        index,
+                        typeSymbol,
+                        inputCount));
                 }
 
                 // Second validation: the input type must match
                 if ((D2D1PixelShaderInputType)inputTypes[index] != targetInputType)
                 {
-                    // TODO: emit diagnostic
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        InvalidInputTypeForD2DIntrinsic,
+                        operation.Syntax.GetLocation(),
+                        targetMethodSymbol.Name,
+                        index));
                 }
             }, OperationKind.Invocation);
         });

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DInputArgumentAnalyzer.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/Analyzers/InvalidD2DInputArgumentAnalyzer.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using ComputeSharp.D2D1.Interop;
+using ComputeSharp.SourceGeneration.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+using static ComputeSharp.SourceGeneration.Diagnostics.DiagnosticDescriptors;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <summary>
+/// A diagnostic analyzer that generates an error whenever an invocation to a D2D intrinsic references an out of range or invalid shader input.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class InvalidD2DInputArgumentAnalyzer : DiagnosticAnalyzer
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [InvalidD2DEffectIdAttributeValue];
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static context =>
+        {
+            // If we can't get the D2D methods map, we have to stop right away
+            if (!TryBuildMethodSymbolMap(context.Compilation, out ImmutableDictionary<IMethodSymbol, D2D1PixelShaderInputType>? methodSymbols))
+            {
+                return;
+            }
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            // Get the '[D2DInputCount]' symbol, which we need to validate the source input arguments
+            if (context.Compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2DInputCountAttribute") is not { } d2DInputCountAttributeSymbol)
+            {
+                return;
+            }
+
+            // We want to register a callback for each method invocation, as all 'D2D' intrinsics would map to one
+            context.RegisterOperationAction(context =>
+            {
+                IInvocationOperation operation = (IInvocationOperation)context.Operation;
+
+                // Cheap initial filter: we only care about static methods from the 'D2D' type
+                if (operation.TargetMethod is not { IsStatic: false, ContainingType.Name: "D2D" } targetMethodSymbol)
+                {
+                    return;
+                }
+
+                // Second cheap inital filter: we only care about invocations with a constant 'int' argument in first position.
+                // While we're validating this, let's also get the 'index' parameter, since we need to validate it anyway.
+                if (operation.Arguments is not [ILiteralOperation { Type.SpecialType: SpecialType.System_Int32, ConstantValue: { HasValue: true, Value: int index } }])
+                {
+                    return;
+                }
+
+                // Validate that the target method is one of the ones we care about, and get the target input type
+                if (!methodSymbols.TryGetValue(targetMethodSymbol, out D2D1PixelShaderInputType targetInputType))
+                {
+                    return;
+                }
+
+                // We have matched a target symbol, so let's try to get the parent shader
+                if (context.ContainingSymbol.FirstAncestorOrSelf<INamedTypeSymbol>() is not { TypeKind: TypeKind.Struct } typeSymbol)
+                {
+                    return;
+                }
+
+                // We found a containing type, make sure it has '[D2DInputCount]'
+                if (!typeSymbol.HasAttributeWithType(d2DInputCountAttributeSymbol))
+                {
+                    return;
+                }
+
+                // At this point we can assume the shader type is mostly valid: let's get the actual input counts and types
+                D2DPixelShaderDescriptorGenerator.InputTypes.GetInfo(
+                    typeSymbol,
+                    out int inputCount,
+                    out _,
+                    out _,
+                    out ImmutableArray<uint> inputTypes);
+
+                // First validation: the index must be in range
+                if ((uint)index >= (uint)inputCount)
+                {
+                    // TODO: emit diagnostic
+                }
+
+                // Second validation: the input type must match
+                if ((D2D1PixelShaderInputType)inputTypes[index] != targetInputType)
+                {
+                    // TODO: emit diagnostic
+                }
+            }, OperationKind.Invocation);
+        });
+    }
+
+    /// <summary>
+    /// Tries to build a map of <see cref="IMethodSymbol"/> instances for all D2D intrinsics and their associated D2D input type.
+    /// </summary>
+    /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>
+    /// <param name="methodSymbols">The resulting mapping of resolved <see cref="IMethodSymbol"/> instances.</param>
+    /// <returns>Whether all requested <see cref="IMethodSymbol"/> instances could be resolved.</returns>
+    private static bool TryBuildMethodSymbolMap(Compilation compilation, [NotNullWhen(true)] out ImmutableDictionary<IMethodSymbol, D2D1PixelShaderInputType>? methodSymbols)
+    {
+        // Get the 'D2D' symbol, to get methods from it
+        if (compilation.GetTypeByMetadataName("ComputeSharp.D2D1.D2D") is not { } d2DSymbol)
+        {
+            methodSymbols = null;
+
+            return false;
+        }
+
+        // Get the symbols for all relevant 'D2D' methods
+        List<IMethodSymbol?> d2DMethodSymbols =
+        [
+            d2DSymbol.GetMethod(nameof(D2D.GetInput)),
+            d2DSymbol.GetMethod(nameof(D2D.GetInputCoordinate)),
+            d2DSymbol.GetMethod(nameof(D2D.SampleInput)),
+            d2DSymbol.GetMethod(nameof(D2D.SampleInputAtOffset)),
+            d2DSymbol.GetMethod(nameof(D2D.GetInput))
+        ];
+
+        ImmutableDictionary<IMethodSymbol, D2D1PixelShaderInputType>.Builder inputTypeMethodMap = ImmutableDictionary.CreateBuilder<IMethodSymbol, D2D1PixelShaderInputType>(SymbolEqualityComparer.Default);
+
+        // Validate all methods and build the map
+        foreach (IMethodSymbol? d2DMethodSymbol in d2DMethodSymbols)
+        {
+            // We failed to find a symbol (shouldn't really ever happen), just stop here
+            if (d2DMethodSymbol is null)
+            {
+                methodSymbols = null;
+
+                return false;
+            }
+
+            // Lookup the attribute to get the D2D input type
+            if (!d2DMethodSymbol.TryGetAttributeWithFullyQualifiedMetadataName("ComputeSharp.D2D1.Intrinsics.HlslD2DIntrinsicInputTypeAttribute", out AttributeData? attributeData))
+            {
+                methodSymbols = null;
+
+                return false;
+            }
+
+            // Verify we can extract the D2D input type
+            if (attributeData.ConstructorArguments is not [{ Kind: TypedConstantKind.Primitive, Type.TypeKind: TypeKind.Enum, Value: int inputType }])
+            {
+                methodSymbols = null;
+
+                return false;
+            }
+
+            inputTypeMethodMap.Add(d2DMethodSymbol, (D2D1PixelShaderInputType)inputType);
+        }
+
+        methodSymbols = inputTypeMethodMap.ToImmutable();
+
+        return true;
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -1237,4 +1237,36 @@ partial class DiagnosticDescriptors
         isEnabledByDefault: true,
         description: "Shaders can only be annotated with [D2DRequiresDoublePrecisionSupport] to perform validation for use of double precision operations if they are precompiled.",
         helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a D2D intrinsic call with an out of range input.
+    /// <para>
+    /// Format: <c>"The D2D intrinsic '{0}' cannot be used for input {1}, as the containing shader {2} only declares {3} input(s) (use a valid argument for the D2D intrinsic, or adjust the number of inputs for the shader using [D2DInputCount])"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor IndexOutOfRangeForD2DIntrinsic = new(
+        id: "CMPSD2D0083",
+        title: "Index out of range for D2D intrinsic",
+        messageFormat: "The D2D intrinsic '{0}' cannot be used for input {1}, as the containing shader {2} only declares {3} input(s) (use a valid argument for the D2D intrinsic, or adjust the number of inputs for the shader using [D2DInputCount])",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "D2D intrinsics must be used with valid input indices (the number of inputs for a shader can be configured using [D2DInputCount]).",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> for a D2D intrinsic call with an invalid input type.
+    /// <para>
+    /// Format: <c>"The D2D intrinsic '{0}' cannot be used for input {1}, as it does not have the right input type (you can configure the input type of each input using [D2DInputSimple] and [D2DInputComplex] on the shader type)"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor InvalidInputTypeForD2DIntrinsic = new(
+        id: "CMPSD2D0084",
+        title: "Invalid input type for D2D intrinsic",
+        messageFormat: "The D2D intrinsic '{0}' cannot be used for input {1}, as it does not have the right input type (you can configure the input type of each input using [D2DInputSimple] and [D2DInputComplex] on the shader type)",
+        category: "ComputeSharp.D2D1.Shaders",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "D2D intrinsics must be used with compatible input types (the input type of each shader input can be configured using [D2DInputSimple] and [D2DInputComplex] on the shader type).",
+        helpLinkUri: "https://github.com/Sergio0694/ComputeSharp");
 }

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownKeywords.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownKeywords.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using System.Reflection;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 using ComputeSharp.D2D1;
 
 namespace ComputeSharp.SourceGeneration.Mappings;

--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 using ComputeSharp.D2D1;
 
 namespace ComputeSharp.SourceGeneration.Mappings;

--- a/src/ComputeSharp.D2D1/Intrinsics/Attributes/HlslD2DIntrinsicInputTypeAttribute.cs
+++ b/src/ComputeSharp.D2D1/Intrinsics/Attributes/HlslD2DIntrinsicInputTypeAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Diagnostics;
+using ComputeSharp.D2D1.Interop;
+
+namespace ComputeSharp.D2D1.Intrinsics;
+
+/// <summary>
+/// An attribute indicating the input type associated with a given D2D HLSL intrinsic.
+/// </summary>
+/// <param name="inputType">The input type for the current instance.</param>
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+[Conditional("SOURCE_GENERATOR")]
+internal sealed class HlslD2DIntrinsicInputTypeAttribute(D2D1PixelShaderInputType inputType) : Attribute
+{
+    /// <summary>
+    /// Gets the input type for the current instance.
+    /// </summary>
+    public D2D1PixelShaderInputType InputType { get; } = inputType;
+}

--- a/src/ComputeSharp.D2D1/Intrinsics/Attributes/HlslD2DIntrinsicInputTypeAttribute.cs
+++ b/src/ComputeSharp.D2D1/Intrinsics/Attributes/HlslD2DIntrinsicInputTypeAttribute.cs
@@ -8,6 +8,10 @@ namespace ComputeSharp.D2D1.Intrinsics;
 /// An attribute indicating the input type associated with a given D2D HLSL intrinsic.
 /// </summary>
 /// <param name="inputType">The input type for the current instance.</param>
+/// <remarks>
+/// <para>If this attribute is not present, methods will be considered as supporting all input types.</para>
+/// <para>This matches the behavior for <see cref="Core.Intrinsics.HlslIntrinsicNameAttribute"/>, when not present.</para>
+/// </remarks>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 [Conditional("SOURCE_GENERATOR")]
 internal sealed class HlslD2DIntrinsicInputTypeAttribute(D2D1PixelShaderInputType inputType) : Attribute

--- a/src/ComputeSharp.D2D1/Intrinsics/D2D.cs
+++ b/src/ComputeSharp.D2D1/Intrinsics/D2D.cs
@@ -1,4 +1,6 @@
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
+using ComputeSharp.D2D1.Interop;
+using ComputeSharp.D2D1.Intrinsics;
 
 #pragma warning disable IDE0022
 
@@ -17,6 +19,7 @@ public static class D2D
     /// <returns>The color from the target input at the current coordinate, in <c>INPUTN</c> format.</returns>
     /// <remarks>This method is only available for simple inputs.</remarks>
     [HlslIntrinsicName("D2DGetInput")]
+    [HlslD2DIntrinsicInputType(D2D1PixelShaderInputType.Simple)]
     public static Float4 GetInput(int index) => throw new InvalidExecutionContextException($"{typeof(D2D)}.{nameof(GetInput)}({typeof(int)})");
 
     /// <summary>
@@ -26,6 +29,7 @@ public static class D2D
     /// <returns>The input coordinate, in <c>TEXCOORDN</c> format.</returns>
     /// <remarks>This method is only available for complex inputs.</remarks>
     [HlslIntrinsicName("D2DGetInputCoordinate")]
+    [HlslD2DIntrinsicInputType(D2D1PixelShaderInputType.Complex)]
     public static Float4 GetInputCoordinate(int index) => throw new InvalidExecutionContextException($"{typeof(D2D)}.{nameof(GetInputCoordinate)}({typeof(int)})");
 
     /// <summary>
@@ -44,6 +48,7 @@ public static class D2D
     /// <returns>The sampled value from the texture, in <c>TEXCOORDN</c> format.</returns>
     /// <remarks>This method is only available for complex inputs.</remarks>
     [HlslIntrinsicName("D2DSampleInput")]
+    [HlslD2DIntrinsicInputType(D2D1PixelShaderInputType.Complex)]
     public static Float4 SampleInput(int index, Float2 uv) => throw new InvalidExecutionContextException($"{typeof(D2D)}.{nameof(SampleInput)}({typeof(int)}, {typeof(Float2)})");
 
     /// <summary>
@@ -54,6 +59,7 @@ public static class D2D
     /// <returns>The sampled value from the texture, in <c>TEXCOORDN</c> format.</returns>
     /// <remarks>This method is only available for complex inputs.</remarks>
     [HlslIntrinsicName("D2DSampleInputAtOffset")]
+    [HlslD2DIntrinsicInputType(D2D1PixelShaderInputType.Complex)]
     public static Float4 SampleInputAtOffset(int index, Float2 offset) => throw new InvalidExecutionContextException($"{typeof(D2D)}.{nameof(SampleInputAtOffset)}({typeof(int)}, {typeof(Float2)})");
 
     /// <summary>
@@ -64,5 +70,6 @@ public static class D2D
     /// <returns>The sampled value from the texture, in <c>TEXCOORDN</c> format.</returns>
     /// <remarks>This method is only available for complex inputs.</remarks>
     [HlslIntrinsicName("D2DSampleInputAtPosition")]
+    [HlslD2DIntrinsicInputType(D2D1PixelShaderInputType.Complex)]
     public static Float4 SampleInputAtPosition(int index, Float2 uv) => throw new InvalidExecutionContextException($"{typeof(D2D)}.{nameof(SampleInputAtPosition)}({typeof(int)}, {typeof(Float2)})");
 }

--- a/src/ComputeSharp.D2D1/Intrinsics/D2D.cs
+++ b/src/ComputeSharp.D2D1/Intrinsics/D2D.cs
@@ -17,9 +17,7 @@ public static class D2D
     /// </summary>
     /// <param name="index">The index of the input texture to get the input from.</param>
     /// <returns>The color from the target input at the current coordinate, in <c>INPUTN</c> format.</returns>
-    /// <remarks>This method is only available for simple inputs.</remarks>
     [HlslIntrinsicName("D2DGetInput")]
-    [HlslD2DIntrinsicInputType(D2D1PixelShaderInputType.Simple)]
     public static Float4 GetInput(int index) => throw new InvalidExecutionContextException($"{typeof(D2D)}.{nameof(GetInput)}({typeof(int)})");
 
     /// <summary>

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownKeywords.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 #pragma warning disable IDE0055
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownMethods.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 
 namespace ComputeSharp.SourceGeneration.Mappings;
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/Mappings/HlslKnownOperators.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using ComputeSharp.Core.Intrinsics.Attributes;
+using ComputeSharp.Core.Intrinsics;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 

--- a/src/ComputeSharp.SourceGeneration/Extensions/ISymbolExtensions.cs
+++ b/src/ComputeSharp.SourceGeneration/Extensions/ISymbolExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -154,5 +155,25 @@ internal static class ISymbolExtensions
         syntaxNode = candidateNode;
 
         return candidateNode is not null;
+    }
+
+    /// <summary>
+    /// Gets the first symbol of a specific type among the ancestors of a given symbol.
+    /// </summary>
+    /// <param name="symbol">The input symbol to start the search from.</param>
+    /// <param name="predicate">An optional predicate to filter symbols.</param>
+    /// <remarks>The resulting symbol, if a match was found.</remarks>
+    public static TSymbol? FirstAncestorOrSelf<TSymbol>(this ISymbol symbol, Func<TSymbol, bool>? predicate = null)
+        where TSymbol : class, ISymbol
+    {
+        for (ISymbol? parentSymbol = symbol; parentSymbol is not null; parentSymbol = parentSymbol.ContainingSymbol)
+        {
+            if (parentSymbol is TSymbol targetSymbol && (predicate?.Invoke(targetSymbol) is not false))
+            {
+                return targetSymbol;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
@@ -1354,6 +1354,7 @@ public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
                 public float4 Execute()
                 {
                     D2D.GetInput(0);
+                    D2D.GetInput(1);
                     D2D.GetInputCoordinate(1);
                     D2D.SampleInput(1, 0);
                     D2D.SampleInputAtOffset(1, 0);
@@ -1381,7 +1382,6 @@ public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
             {
                 public float4 Execute()
                 {
-                    {|CMPSD2D0084:D2D.GetInput(1)|};
                     {|CMPSD2D0084:D2D.GetInputCoordinate(0)|};
                     {|CMPSD2D0084:D2D.SampleInput(0, 0)|};
                     {|CMPSD2D0084:D2D.SampleInputAtOffset(0, 0)|};

--- a/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1PixelShaderTests.cs
@@ -558,12 +558,15 @@ namespace ComputeSharp.D2D1.Tests
         [D2DInputCount(1)]
         [D2DInputComplex(0)]
         [D2DShaderProfile(D2D1ShaderProfile.PixelShader40Level91)]
+        [D2DRequiresScenePosition]
         [D2DGeneratedPixelShaderDescriptor]
         internal readonly partial struct ComplexShaderWithExplicitShaderProfileAndNoCompileOptions : ID2D1PixelShader
         {
             public float4 Execute()
             {
-                return D2D.GetInput(0);
+                float2 uv = D2D.GetScenePosition().XY;
+
+                return D2D.SampleInput(0, uv);
             }
         }
 

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
@@ -21,7 +21,7 @@ public partial class D2D1ReflectionServicesTests
         Assert.AreEqual("""
             #define D2D_INPUT_COUNT 3
             #define D2D_INPUT0_SIMPLE
-            #define D2D_INPUT1_COMPLEX
+            #define D2D_INPUT1_SIMPLE
             #define D2D_INPUT2_COMPLEX
             #define D2D_REQUIRES_SCENE_POSITION
 
@@ -52,7 +52,7 @@ public partial class D2D1ReflectionServicesTests
 
     [D2DInputCount(3)]
     [D2DInputSimple(0)]
-    [D2DInputComplex(1)]
+    [D2DInputSimple(1)]
     [D2DInputComplex(2)]
     [D2DRequiresScenePosition]
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader41)]
@@ -98,6 +98,7 @@ public partial class D2D1ReflectionServicesTests
 
         Assert.AreEqual("""
             #define D2D_INPUT_COUNT 1
+            #define D2D_INPUT0_SIMPLE
 
             #include "d2d1effecthelpers.hlsli"
 
@@ -113,6 +114,7 @@ public partial class D2D1ReflectionServicesTests
     }
 
     [D2DInputCount(1)]
+    [D2DInputSimple(0)]
     [D2DRequiresDoublePrecisionSupport]
     [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
     [D2DGeneratedPixelShaderDescriptor]

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/PixelShaderEffectTests.cs
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/Tests/PixelShaderEffectTests.cs
@@ -473,6 +473,7 @@ public partial class PixelShaderEffectTests
     }
 
     [D2DInputCount(1)]
+    [D2DInputSimple(0)]
     [D2DGeneratedPixelShaderDescriptor]
     [AutoConstructor]
     internal readonly partial struct ShaderWithSomePropertiesAndInputs : ID2D1PixelShader


### PR DESCRIPTION
### Closes #769

### Description

This PR adds a new analyzer to emit errors if:
- A `D2D` API is used with an index out of range for the shader
- A `D2D` API is used with a shader input of an invalid type

### Example

![image](https://github.com/user-attachments/assets/3612da26-fd39-4031-8bee-c654ad81784f)