### PR TITLE
Suppress 'WMC1006' warnings

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -8,5 +8,14 @@
 
     <!-- Ignore platform compatibility warnings -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
+
+    <!--
+      This ignores the following warning:
+      "WMC1006: Cannot resolve Assembly or Windows Metadata file '[...]\ComputeSharp.[...].dll'".
+      This happens because the XAML compiler tries to build the intermediate assembly before the
+      initial build of the referenced projects has completed, so those files are missing at that
+      time. This is fine, since normal builds will work just fine. Suppress it to remove noise.
+    -->
+    <NoWarn>$(NoWarn);WMC1006</NoWarn>
   </PropertyGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -14,5 +14,8 @@
 
     <!-- Missing readonly modifier for readonly struct members (not needed in tests) -->
     <NoWarn>$(NoWarn);IDE0251</NoWarn>
+
+    <!-- See notes in .props file in the sample projects directory -->
+    <NoWarn>$(NoWarn);WMC1006</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Description

This PR just suppresses some noisy XAML warnings, not actually needed.