### PR TITLE
Use '[ObservableProperty]' on partial properties

### DIFF
--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.UI/ViewModels/ShaderRunnerViewModel.cs
+++ b/samples/ComputeSharp.SwapChain.UI/ViewModels/ShaderRunnerViewModel.cs
@@ -38,5 +38,5 @@ public sealed partial class ShaderRunnerViewModel(
     /// Gets or sets whether the current shader is selected.
     /// </summary>
     [ObservableProperty]
-    private bool isSelected;
+    public partial bool IsSelected { get; set; }
 }

--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.241221-build.1360" />
     <PackageReference Include="CommunityToolkit.Uwp.Media" Version="8.2.241221-build.1360" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -50,7 +50,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.241112-preview1" />
     <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.241112-preview1" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.2" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageReference Include="MSTest" Version="3.7.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
     <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />


### PR DESCRIPTION
### Description

This PR updates the .NET Community Toolkit and switches to `[ObservableProperty]` on partial properties.