### PR TITLE
Update to .NET 9.0.200 SDK, fix build errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -95,6 +95,11 @@ dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
 
+# Disable 'Use collection expression for fluent (IDE0305)'. The rationale is that it's that collection
+# expressions can be hard to read when having sequences of multiple chained fluent invocations (eg. LINQ).
+# See: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0305.
+dotnet_style_prefer_collection_expression = false
+
 # Field preferences
 dotnet_style_readonly_field = true:warning
 

--- a/.globalconfig
+++ b/.globalconfig
@@ -69,11 +69,9 @@ dotnet_diagnostic.CA2242.severity = warning
 
 dotnet_diagnostic.IDE0010.severity = none
 dotnet_diagnostic.IDE0130.severity = none
-dotnet_diagnostic.IDE0060.severity = none
 dotnet_diagnostic.IDE1006.severity = warning
 dotnet_diagnostic.IDE0023.severity = none
 dotnet_diagnostic.IDE0024.severity = none
-dotnet_diagnostic.IDE0060.severity = none
 dotnet_diagnostic.IDE0057.severity = none
 dotnet_diagnostic.IDE0046.severity = none
 dotnet_diagnostic.IDE0072.severity = none

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.200",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1/ProteanClouds.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1/ProteanClouds.cs
@@ -67,7 +67,7 @@ internal readonly partial struct ProteanClouds(float time, int2 dispatchSize) : 
         return new float2(d + (cl * 0.2f) + 0.25f, cl);
     }
 
-    private float4 Render(float3 ro, float3 rd, float time, float prm1, float2 bsMo)
+    private float4 Render(float3 ro, float3 rd, float prm1, float2 bsMo)
     {
         float4 rez = 0;
         float t = 1.5f;
@@ -162,7 +162,7 @@ internal readonly partial struct ProteanClouds(float time, int2 dispatchSize) : 
         rd.XY = Hlsl.Mul(rd.XY, Rotate((-Disp(scaledTime + 3.5f).X * 0.2f) + bsMo.X));
 
         float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(time * 0.3f));
-        float4 scn = Render(ro, rd, scaledTime, prm1, bsMo);
+        float4 scn = Render(ro, rd, prm1, bsMo);
         float3 col = scn.RGB;
 
         col = ILerp(col.BGR, col.RGB, Hlsl.Clamp(1.0f - prm1, 0.05f, 1.0f));

--- a/samples/ComputeSharp.SwapChain.Shaders/ProteanClouds.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders/ProteanClouds.cs
@@ -62,7 +62,7 @@ internal readonly partial struct ProteanClouds(float time) : IComputeShader<floa
         return new float2(d + (cl * 0.2f) + 0.25f, cl);
     }
 
-    private float4 Render(float3 ro, float3 rd, float time, float prm1, float2 bsMo)
+    private float4 Render(float3 ro, float3 rd, float prm1, float2 bsMo)
     {
         float4 rez = 0;
         float t = 1.5f;
@@ -156,7 +156,7 @@ internal readonly partial struct ProteanClouds(float time) : IComputeShader<floa
         rd.XY = Hlsl.Mul(rd.XY, Rotate((-Disp(scaledTime + 3.5f).X * 0.2f) + bsMo.X));
 
         float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(time * 0.3f));
-        float4 scn = Render(ro, rd, scaledTime, prm1, bsMo);
+        float4 scn = Render(ro, rd, prm1, bsMo);
         float3 col = scn.RGB;
 
         col = ILerp(col.BGR, col.RGB, Hlsl.Clamp(1.0f - prm1, 0.05f, 1.0f));

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.cs
@@ -1,6 +1,6 @@
 using ComputeSharp.Core.Intrinsics;
 
-#pragma warning disable IDE0022
+#pragma warning disable IDE0022, IDE0060
 
 namespace ComputeSharp;
 

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+#pragma warning disable IDE0060
+
 namespace ComputeSharp;
 
 /// <summary>

--- a/src/ComputeSharp.D2D1.UI.SourceGenerators/CanvasEffectPropertyGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.UI.SourceGenerators/CanvasEffectPropertyGenerator.Execute.cs
@@ -59,6 +59,8 @@ partial class CanvasEffectPropertyGenerator
                 return false;
             }
 
+            token.ThrowIfCancellationRequested();
+
             // The property must be in a type with a base type (as it must derive from CanvasEffect)
             return node.Parent?.IsTypeDeclarationWithOrPotentiallyWithBaseTypes<ClassDeclarationSyntax>() == true;
         }

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffect.cs
@@ -145,7 +145,7 @@ unsafe partial class PixelShaderEffect<T>
         Span<ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>> canvasEffects = sourceEffects.Length <= 16
             ? stackalloc ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>[16]
             : MemoryMarshal.Cast<IntPtr, ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>>(
-                canvasEffectsAbiArray = ArrayPool<IntPtr>.Shared.Rent(sourceEffects.Length));
+                (canvasEffectsAbiArray = ArrayPool<IntPtr>.Shared.Rent(sourceEffects.Length)).AsSpan());
 
         // Clear the span to ensure no false positives are accidentally disposed
         canvasEffects.Clear();

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
@@ -6,6 +6,8 @@ using ComputeSharp.D2D1.Shaders.Interop.Effects.ResourceManagers;
 using ComputeSharp.D2D1.Shaders.Interop.Extensions;
 using ComputeSharp.Win32;
 
+#pragma warning disable IDE0060
+
 namespace ComputeSharp.D2D1.Interop.Effects;
 
 /// <summary>

--- a/src/ComputeSharp.SourceGeneration/Helpers/EquatableArray{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/EquatableArray{T}.cs
@@ -81,19 +81,19 @@ internal readonly struct EquatableArray<T>(ImmutableArray<T> array) : IEquatable
         get => AsImmutableArray().Length;
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public bool Equals(EquatableArray<T> array)
     {
         return AsSpan().SequenceEqual(array.AsSpan());
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public override bool Equals(object? obj)
     {
         return obj is EquatableArray<T> array && Equals(this, array);
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public override unsafe int GetHashCode()
     {
         if (this.array is not T[] array)
@@ -174,13 +174,13 @@ internal readonly struct EquatableArray<T>(ImmutableArray<T> array) : IEquatable
         return AsImmutableArray().GetEnumerator();
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
         return ((IEnumerable<T>)AsImmutableArray()).GetEnumerator();
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator()
     {
         return ((IEnumerable)AsImmutableArray()).GetEnumerator();

--- a/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
@@ -229,12 +229,6 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index += items.Length;
         }
 
-        /// <inheritdoc cref="ImmutableArrayBuilder{T}.Clear"/>
-        public void Clear(ReadOnlySpan<T> items)
-        {
-            this.index = 0;
-        }
-
         /// <inheritdoc cref="ImmutableArrayBuilder{T}.Insert"/>
         public void Insert(int index, T item)
         {
@@ -254,9 +248,7 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index++;
         }
 
-        /// <summary>
-        /// Clears the items in the current writer.
-        /// </summary>
+        /// <inheritdoc cref="ImmutableArrayBuilder{T}.Clear"/>
         public void Clear()
         {
             if (typeof(T) != typeof(byte) &&

--- a/src/ComputeSharp.SourceGeneration/Helpers/IndentedTextWriter.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/IndentedTextWriter.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-#pragma warning disable IDE0290
+#pragma warning disable IDE0060, IDE0290
 
 namespace ComputeSharp.SourceGeneration.Helpers;
 

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -84,7 +84,6 @@ partial class ComputeShaderDescriptorGenerator
             token.ThrowIfCancellationRequested();
 
             ImmutableArray<HlslSharedBuffer> sharedBuffers = GetSharedBuffers(
-                diagnostics,
                 structDeclarationSymbol,
                 discoveredTypes);
 
@@ -323,12 +322,10 @@ partial class ComputeShaderDescriptorGenerator
         /// <summary>
         /// Gets a sequence of captured members and their mapped names.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
         /// <param name="types">The collection of currently discovered types.</param>
         /// <returns>A sequence of captured members in <paramref name="structDeclarationSymbol"/>.</returns>
         private static ImmutableArray<HlslSharedBuffer> GetSharedBuffers(
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
             INamedTypeSymbol structDeclarationSymbol,
             ICollection<INamedTypeSymbol> types)
         {

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
@@ -1003,10 +1003,7 @@ public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
     }
 
     [TestMethod]
-    [DataRow(-1)]
-    [DataRow(6)]
-    [DataRow(int.MaxValue)]
-    public async Task OutOfRangeInputIndex_OutOfRange_BothInputTypes_WarnsOnce(int inputIndex)
+    public async Task OutOfRangeInputIndex_OutOfRange_BothInputTypes_WarnsOnce()
     {
         const string source = """
             using ComputeSharp.D2D1;

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -5,7 +5,7 @@ using ComputeSharp.Interop;
 using ComputeSharp.Tests.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-#pragma warning disable IDE0008, IDE0022, IDE0009, IDE0290
+#pragma warning disable IDE0008, IDE0022, IDE0009, IDE0060, IDE0290
 
 namespace ComputeSharp.Tests
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
@@ -74,7 +74,7 @@ internal readonly partial struct ProteanClouds : IComputeShader
         return new float2(d + cl * 0.2f + 0.25f, cl);
     }
 
-    private float4 Render(float3 ro, float3 rd, float time, float prm1, float2 bsMo)
+    private float4 Render(float3 ro, float3 rd, float prm1, float2 bsMo)
     {
         float4 rez = 0;
         float t = 1.5f;
@@ -165,7 +165,7 @@ internal readonly partial struct ProteanClouds : IComputeShader
         rd.XY = Hlsl.Mul(rd.XY, Rotate(-Disp(scaledTime + 3.5f).X * 0.2f + bsMo.X));
 
         float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(time * 0.3f));
-        float4 scn = Render(ro, rd, scaledTime, prm1, bsMo);
+        float4 scn = Render(ro, rd, prm1, bsMo);
         float3 col = scn.RGB;
 
         col = ILerp(col.BGR, col.RGB, Hlsl.Clamp(1.0f - prm1, 0.05f, 1.0f));


### PR DESCRIPTION
### Closes #901

### Description

This PR includes the following tweaks:
- Update the .NET SDK to 9.0.200
- Fix the new build errors
- Re-enable and fix all IDE0060 warnings
- Tweak the suppressed analyzers
- Fix some typos