### PR TITLE
Update to .NET 9.0.200 SDK, fix build errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -95,6 +95,11 @@ dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
 
+# Disable 'Use collection expression for fluent (IDE0305)'. The rationale is that it's that collection
+# expressions can be hard to read when having sequences of multiple chained fluent invocations (eg. LINQ).
+# See: https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0305.
+dotnet_style_prefer_collection_expression = false
+
 # Field preferences
 dotnet_style_readonly_field = true:warning
 

--- a/.globalconfig
+++ b/.globalconfig
@@ -69,11 +69,9 @@ dotnet_diagnostic.CA2242.severity = warning
 
 dotnet_diagnostic.IDE0010.severity = none
 dotnet_diagnostic.IDE0130.severity = none
-dotnet_diagnostic.IDE0060.severity = none
 dotnet_diagnostic.IDE1006.severity = warning
 dotnet_diagnostic.IDE0023.severity = none
 dotnet_diagnostic.IDE0024.severity = none
-dotnet_diagnostic.IDE0060.severity = none
 dotnet_diagnostic.IDE0057.severity = none
 dotnet_diagnostic.IDE0046.severity = none
 dotnet_diagnostic.IDE0072.severity = none

--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -59,12 +59,6 @@
       since in order to use these APIs the caller already has to be in an unsafe context.
     -->
     <NoWarn>$(NoWarn);CS8500</NoWarn>
-
-    <!--
-      We are using the UWP support for .NET 9, which is currently in preview. The warning from the .NET 9 SDK
-      about this feature being in preview is unnecessary and it just produces a lot of noise, so we can disable it.
-    -->
-    <NoWarn>$(NoWarn);NETSDK1219</NoWarn>
   </PropertyGroup>
 
   <!-- Centralized location for all generated artifacts -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.200",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
+++ b/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
+++ b/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="9.0.100" />
+    <PackageReference Update="FSharp.Core" Version="9.0.201" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -60,7 +60,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
 
     <!--
       Reference CsWinRT locally for the source generators (see comments in ComputeSharp.D2D1.WinUI).

--- a/samples/ComputeSharp.SwapChain.D2D1.Uwp/ComputeSharp.SwapChain.D2D1.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Uwp/ComputeSharp.SwapChain.D2D1.Uwp.csproj
@@ -11,6 +11,9 @@
     <PublishProfile>win-$(Platform).pubxml</PublishProfile>
     <EnableMsixTooling>true</EnableMsixTooling>
     <EnableXamlCompilerTargetsForUwpApps>false</EnableXamlCompilerTargetsForUwpApps>
+
+    <!-- Temporary workaround until VS 17.14 GA -->
+    <MicrosoftWindowsSdkBuildToolsMSIXPackageVersion>1.3.20250314.1</MicrosoftWindowsSdkBuildToolsMSIXPackageVersion>
   </PropertyGroup>
 
   <!-- NativeAOT settings, and size saving options for unnecessary features (optimize for speed otherwise) -->

--- a/samples/ComputeSharp.SwapChain.Shaders.D2D1/ProteanClouds.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders.D2D1/ProteanClouds.cs
@@ -67,7 +67,7 @@ internal readonly partial struct ProteanClouds(float time, int2 dispatchSize) : 
         return new float2(d + (cl * 0.2f) + 0.25f, cl);
     }
 
-    private float4 Render(float3 ro, float3 rd, float time, float prm1, float2 bsMo)
+    private float4 Render(float3 ro, float3 rd, float prm1, float2 bsMo)
     {
         float4 rez = 0;
         float t = 1.5f;
@@ -162,7 +162,7 @@ internal readonly partial struct ProteanClouds(float time, int2 dispatchSize) : 
         rd.XY = Hlsl.Mul(rd.XY, Rotate((-Disp(scaledTime + 3.5f).X * 0.2f) + bsMo.X));
 
         float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(time * 0.3f));
-        float4 scn = Render(ro, rd, scaledTime, prm1, bsMo);
+        float4 scn = Render(ro, rd, prm1, bsMo);
         float3 col = scn.RGB;
 
         col = ILerp(col.BGR, col.RGB, Hlsl.Clamp(1.0f - prm1, 0.05f, 1.0f));

--- a/samples/ComputeSharp.SwapChain.Shaders/ProteanClouds.cs
+++ b/samples/ComputeSharp.SwapChain.Shaders/ProteanClouds.cs
@@ -62,7 +62,7 @@ internal readonly partial struct ProteanClouds(float time) : IComputeShader<floa
         return new float2(d + (cl * 0.2f) + 0.25f, cl);
     }
 
-    private float4 Render(float3 ro, float3 rd, float time, float prm1, float2 bsMo)
+    private float4 Render(float3 ro, float3 rd, float prm1, float2 bsMo)
     {
         float4 rez = 0;
         float t = 1.5f;
@@ -156,7 +156,7 @@ internal readonly partial struct ProteanClouds(float time) : IComputeShader<floa
         rd.XY = Hlsl.Mul(rd.XY, Rotate((-Disp(scaledTime + 3.5f).X * 0.2f) + bsMo.X));
 
         float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(time * 0.3f));
-        float4 scn = Render(ro, rd, scaledTime, prm1, bsMo);
+        float4 scn = Render(ro, rd, prm1, bsMo);
         float3 col = scn.RGB;
 
         col = ILerp(col.BGR, col.RGB, Hlsl.Clamp(1.0f - prm1, 0.05f, 1.0f));

--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -17,14 +17,6 @@
     <MvvmToolkitEnableINotifyPropertyChangingSupport>false</MvvmToolkitEnableINotifyPropertyChangingSupport>
   </PropertyGroup>
 
-  <!--
-    Use the Windows SDK from the NuGet-only release, to access early builds with the .NET 9 changes.
-    Can be removed when the new XAML compiler is ingested into Visual Studio and available in the CI.
-  -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.CPP" Version="10.0.26100.2161" IncludeAssets="build" PrivateAssets="all" IsImplicitlyDefined="true" />
-  </ItemGroup>
-
   <!-- Same CsWinRT options as the WinUI 3 sample app -->
   <PropertyGroup>
     <CsWinRTGenerateProjection>false</CsWinRTGenerateProjection>

--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
@@ -44,8 +44,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.241221-build.1360" />
-    <PackageReference Include="CommunityToolkit.Uwp.Media" Version="8.2.241221-build.1360" />
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250129-preview2" />
+    <PackageReference Include="CommunityToolkit.Uwp.Media" Version="8.2.250129-preview2" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
 
     <!-- Remove all WebView2 assets (transitive from WinUI 2), since we don't need it at all -->

--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -15,6 +15,9 @@
 
     <!-- Disable 'INotifyPropertyChanging' support, same as in the WinUI 3 sample app -->
     <MvvmToolkitEnableINotifyPropertyChangingSupport>false</MvvmToolkitEnableINotifyPropertyChangingSupport>
+
+    <!-- Temporary workaround until VS 17.14 GA -->
+    <MicrosoftWindowsSdkBuildToolsMSIXPackageVersion>1.3.20250314.1</MicrosoftWindowsSdkBuildToolsMSIXPackageVersion>
   </PropertyGroup>
 
   <!-- Same CsWinRT options as the WinUI 3 sample app -->

--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -54,7 +54,7 @@
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
 
     <!-- Remove all WebView2 assets (transitive from WinUI 2), since we don't need it at all -->
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2903.40" IncludeAssets="none" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3124.44" IncludeAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -51,8 +51,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.241112-preview1" />
-    <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.241112-preview1" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.2.250129-preview2" />
+    <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.2.250129-preview2" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
   </ItemGroup>
 

--- a/samples/ComputeSharp.SwapChain/ComputeSharp.SwapChain.csproj
+++ b/samples/ComputeSharp.SwapChain/ComputeSharp.SwapChain.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.Core/Intrinsics/Hlsl.cs
+++ b/src/ComputeSharp.Core/Intrinsics/Hlsl.cs
@@ -1,6 +1,6 @@
 using ComputeSharp.Core.Intrinsics;
 
-#pragma warning disable IDE0022
+#pragma warning disable IDE0022, IDE0060
 
 namespace ComputeSharp;
 

--- a/src/ComputeSharp.Core/Primitives/Bool/Bool.cs
+++ b/src/ComputeSharp.Core/Primitives/Bool/Bool.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+#pragma warning disable IDE0060
+
 namespace ComputeSharp;
 
 /// <summary>

--- a/src/ComputeSharp.D2D1.UI.SourceGenerators/CanvasEffectPropertyGenerator.Execute.cs
+++ b/src/ComputeSharp.D2D1.UI.SourceGenerators/CanvasEffectPropertyGenerator.Execute.cs
@@ -59,6 +59,8 @@ partial class CanvasEffectPropertyGenerator
                 return false;
             }
 
+            token.ThrowIfCancellationRequested();
+
             // The property must be in a type with a base type (as it must derive from CanvasEffect)
             return node.Parent?.IsTypeDeclarationWithOrPotentiallyWithBaseTypes<ClassDeclarationSyntax>() == true;
         }

--- a/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffect.cs
+++ b/src/ComputeSharp.D2D1.UI/PixelShaderEffect{T}.ICanvasEffect.cs
@@ -145,7 +145,7 @@ unsafe partial class PixelShaderEffect<T>
         Span<ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>> canvasEffects = sourceEffects.Length <= 16
             ? stackalloc ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>[16]
             : MemoryMarshal.Cast<IntPtr, ComPtr<ABI.Microsoft.Graphics.Canvas.Effects.ICanvasEffect>>(
-                canvasEffectsAbiArray = ArrayPool<IntPtr>.Shared.Rent(sourceEffects.Length));
+                (canvasEffectsAbiArray = ArrayPool<IntPtr>.Shared.Rent(sourceEffects.Length)).AsSpan());
 
         // Clear the span to ensure no false positives are accidentally disposed
         canvasEffects.Clear();

--- a/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
+++ b/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Win2D.uwp" Version="1.28.1" />
+    <PackageReference Include="Win2D.uwp" Version="1.28.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
+++ b/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.1" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.ID2D1EffectImplMethods.cs
@@ -6,6 +6,8 @@ using ComputeSharp.D2D1.Shaders.Interop.Effects.ResourceManagers;
 using ComputeSharp.D2D1.Shaders.Interop.Extensions;
 using ComputeSharp.Win32;
 
+#pragma warning disable IDE0060
+
 namespace ComputeSharp.D2D1.Interop.Effects;
 
 /// <summary>

--- a/src/ComputeSharp.SourceGeneration/Helpers/EquatableArray{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/EquatableArray{T}.cs
@@ -81,19 +81,19 @@ internal readonly struct EquatableArray<T>(ImmutableArray<T> array) : IEquatable
         get => AsImmutableArray().Length;
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public bool Equals(EquatableArray<T> array)
     {
         return AsSpan().SequenceEqual(array.AsSpan());
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public override bool Equals(object? obj)
     {
         return obj is EquatableArray<T> array && Equals(this, array);
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     public override unsafe int GetHashCode()
     {
         if (this.array is not T[] array)
@@ -174,13 +174,13 @@ internal readonly struct EquatableArray<T>(ImmutableArray<T> array) : IEquatable
         return AsImmutableArray().GetEnumerator();
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     IEnumerator<T> IEnumerable<T>.GetEnumerator()
     {
         return ((IEnumerable<T>)AsImmutableArray()).GetEnumerator();
     }
 
-    /// <sinheritdoc/>
+    /// <inheritdoc/>
     IEnumerator IEnumerable.GetEnumerator()
     {
         return ((IEnumerable)AsImmutableArray()).GetEnumerator();

--- a/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/ImmutableArrayBuilder{T}.cs
@@ -229,12 +229,6 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index += items.Length;
         }
 
-        /// <inheritdoc cref="ImmutableArrayBuilder{T}.Clear"/>
-        public void Clear(ReadOnlySpan<T> items)
-        {
-            this.index = 0;
-        }
-
         /// <inheritdoc cref="ImmutableArrayBuilder{T}.Insert"/>
         public void Insert(int index, T item)
         {
@@ -254,9 +248,7 @@ internal struct ImmutableArrayBuilder<T> : IDisposable
             this.index++;
         }
 
-        /// <summary>
-        /// Clears the items in the current writer.
-        /// </summary>
+        /// <inheritdoc cref="ImmutableArrayBuilder{T}.Clear"/>
         public void Clear()
         {
             if (typeof(T) != typeof(byte) &&

--- a/src/ComputeSharp.SourceGeneration/Helpers/IndentedTextWriter.cs
+++ b/src/ComputeSharp.SourceGeneration/Helpers/IndentedTextWriter.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-#pragma warning disable IDE0290
+#pragma warning disable IDE0060, IDE0290
 
 namespace ComputeSharp.SourceGeneration.Helpers;
 

--- a/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
+++ b/src/ComputeSharp.SourceGenerators/ComputeShaderDescriptorGenerator.HlslSource.cs
@@ -84,7 +84,6 @@ partial class ComputeShaderDescriptorGenerator
             token.ThrowIfCancellationRequested();
 
             ImmutableArray<HlslSharedBuffer> sharedBuffers = GetSharedBuffers(
-                diagnostics,
                 structDeclarationSymbol,
                 discoveredTypes);
 
@@ -323,12 +322,10 @@ partial class ComputeShaderDescriptorGenerator
         /// <summary>
         /// Gets a sequence of captured members and their mapped names.
         /// </summary>
-        /// <param name="diagnostics">The collection of produced <see cref="DiagnosticInfo"/> instances.</param>
         /// <param name="structDeclarationSymbol">The input <see cref="INamedTypeSymbol"/> instance to process.</param>
         /// <param name="types">The collection of currently discovered types.</param>
         /// <returns>A sequence of captured members in <paramref name="structDeclarationSymbol"/>.</returns>
         private static ImmutableArray<HlslSharedBuffer> GetSharedBuffers(
-            ImmutableArrayBuilder<DiagnosticInfo> diagnostics,
             INamedTypeSymbol structDeclarationSymbol,
             ICollection<INamedTypeSymbol> types)
         {

--- a/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
+++ b/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250228001" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="3.7.0" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
@@ -13,11 +13,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+
+    <!-- Top-level override to fix address security vulnerability warnings -->
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
@@ -1003,10 +1003,7 @@ public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
     }
 
     [TestMethod]
-    [DataRow(-1)]
-    [DataRow(6)]
-    [DataRow(int.MaxValue)]
-    public async Task OutOfRangeInputIndex_OutOfRange_BothInputTypes_WarnsOnce(int inputIndex)
+    public async Task OutOfRangeInputIndex_OutOfRange_BothInputTypes_WarnsOnce()
     {
         const string source = """
             using ComputeSharp.D2D1;

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators.csproj
@@ -12,11 +12,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
+
+    <!-- Top-level overrides to fix address security vulnerability warnings -->
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.3" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -58,9 +58,9 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" ExcludeAssets="build" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" ExcludeAssets="build" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="3.7.0" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
@@ -7,10 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.9" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
+
+    <!-- Top-level override to fix address security vulnerability warnings -->
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -11,9 +11,9 @@
   <ItemGroup>
     <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
     <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
-    <PackageReference Include="MSTest" Version="3.7.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.1" />
+    <PackageReference Include="MSTest" Version="3.8.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
+++ b/tests/ComputeSharp.Tests/ShaderCompilerTests.cs
@@ -5,7 +5,7 @@ using ComputeSharp.Interop;
 using ComputeSharp.Tests.Misc;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-#pragma warning disable IDE0008, IDE0022, IDE0009, IDE0290
+#pragma warning disable IDE0008, IDE0022, IDE0009, IDE0060, IDE0290
 
 namespace ComputeSharp.Tests
 {

--- a/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
+++ b/tests/ComputeSharp.Tests/Shaders/Compute/ProteanClouds.cs
@@ -74,7 +74,7 @@ internal readonly partial struct ProteanClouds : IComputeShader
         return new float2(d + cl * 0.2f + 0.25f, cl);
     }
 
-    private float4 Render(float3 ro, float3 rd, float time, float prm1, float2 bsMo)
+    private float4 Render(float3 ro, float3 rd, float prm1, float2 bsMo)
     {
         float4 rez = 0;
         float t = 1.5f;
@@ -165,7 +165,7 @@ internal readonly partial struct ProteanClouds : IComputeShader
         rd.XY = Hlsl.Mul(rd.XY, Rotate(-Disp(scaledTime + 3.5f).X * 0.2f + bsMo.X));
 
         float prm1 = Hlsl.SmoothStep(-0.4f, 0.4f, Hlsl.Sin(time * 0.3f));
-        float4 scn = Render(ro, rd, scaledTime, prm1, bsMo);
+        float4 scn = Render(ro, rd, prm1, bsMo);
         float3 col = scn.RGB;
 
         col = ILerp(col.BGR, col.RGB, Hlsl.Clamp(1.0f - prm1, 0.05f, 1.0f));


### PR DESCRIPTION
### Closes #901

### Description

This PR includes the following tweaks:
- Update the .NET SDK to 9.0.200
- Update all NuGet packages to latest stable, fix vulnerability warnings
- Fix the new build errors
- Re-enable and fix all IDE0060 warnings
- Tweak the suppressed analyzers
- Fix some typos
- Remove some unnecessary warning suppressions
- Remove the unnecessary Windows SDK lifted package