### PR TITLE
Remove 'WebView2' package dependency

### DIFF
--- a/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
+++ b/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
@@ -5,9 +5,6 @@
     <WindowsSdkPackageVersion>10.0.22621.54</WindowsSdkPackageVersion>
     <Platforms>x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
-
-    <!-- Workaround for 'CoreWebView2' issue (see notes in ComputeSharp.WinUI) -->
-    <WebView2EnableCsWinRTProjectionExcludeCoreRef>true</WebView2EnableCsWinRTProjectionExcludeCoreRef>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -25,6 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
+
+    <!-- Workaround for 'CoreWebView2' issue (see notes in ComputeSharp.WinUI) -->
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3124.44" PrivateAssets="all" IncludeAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
+++ b/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
@@ -5,16 +5,18 @@
     <WindowsSdkPackageVersion>10.0.22621.54</WindowsSdkPackageVersion>
     <Platforms>x64;ARM64</Platforms>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
-
-    <!--
-      Workaround for the 'CoreWebView2' SDK package referencing the WinRT implementation binary (Microsoft.Web.WebView2.Core.dll)
-      when 'TargetPlatform=AnyCPU'. It's not needed for the CsWinRT projection, so set it to not be loaded at all to fix the build.
-    -->
-    <WebView2EnableCsWinRTProjectionExcludeCoreRef>true</WebView2EnableCsWinRTProjectionExcludeCoreRef>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250228001" />
+
+    <!--
+      The 'Microsoft.Web.WebView2' package that WindowsAppSDK has a transitive dependency on is an older version, which
+      has a bug causing 'WebView2Loader.dll' to be referenced in the .pri file produced for this library. This breaks
+      downstream consumers, as that .dll will not actually exist in the NuGet package (it's from the 'WebView2' package).
+      Because we don't even need anything from this package at all anyway, we can fix this by just excluding it entirely.
+    -->
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3124.44" PrivateAssets="all" IncludeAssets="none" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

This PR is a workaround for a bug in the PRI files for the *.WinUI packages, caused by the WebView2 package:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<PriInfo>
  <ResourceMap name="ComputeSharp.D2D1.WinUI" version="1.0" primary="true">
    <Qualifiers/>
    <ResourceMapSubtree name="Files">
      <ResourceMapSubtree name="ComputeSharp.D2D1.WinUI">
        <ResourceMapSubtree name="runtimes">
          <ResourceMapSubtree name="win-arm64">
            <ResourceMapSubtree name="native">
              <NamedResource name="WebView2Loader.dll" uri="ms-resource://ComputeSharp.D2D1.WinUI/Files/ComputeSharp.D2D1.WinUI/runtimes/win-arm64/native/WebView2Loader.dll">
                <Candidate type="Path">
                  <Value>ComputeSharp.D2D1.WinUI\runtimes\win-arm64\native\WebView2Loader.dll</Value>
                </Candidate>
              </NamedResource>
            </ResourceMapSubtree>
          </ResourceMapSubtree>
          <ResourceMapSubtree name="win-x64">
            <ResourceMapSubtree name="native">
              <NamedResource name="WebView2Loader.dll" uri="ms-resource://ComputeSharp.D2D1.WinUI/Files/ComputeSharp.D2D1.WinUI/runtimes/win-x64/native/WebView2Loader.dll">
                <Candidate type="Path">
                  <Value>ComputeSharp.D2D1.WinUI\runtimes\win-x64\native\WebView2Loader.dll</Value>
                </Candidate>
              </NamedResource>
            </ResourceMapSubtree>
          </ResourceMapSubtree>
          <ResourceMapSubtree name="win-x86">
            <ResourceMapSubtree name="native">
              <NamedResource name="WebView2Loader.dll" uri="ms-resource://ComputeSharp.D2D1.WinUI/Files/ComputeSharp.D2D1.WinUI/runtimes/win-x86/native/WebView2Loader.dll">
                <Candidate type="Path">
                  <Value>ComputeSharp.D2D1.WinUI\runtimes\win-x86\native\WebView2Loader.dll</Value>
                </Candidate>
              </NamedResource>
            </ResourceMapSubtree>
          </ResourceMapSubtree>
        </ResourceMapSubtree>
      </ResourceMapSubtree>
    </ResourceMapSubtree>
  </ResourceMap>
</PriInfo>
```

Those `WebView2Loader.dll` items should not be there, and will cause all consumer projects to fail to build.

This PR simply removes all the WebView2 package references entirely, so the issue can't happen at all.