### PR TITLE
Add `ID2D1PixelShaderDescriptor<T>.EffectFactory` and remove runtime delegate marshalling

### DIFF
--- a/build/Directory.Build.props
+++ b/build/Directory.Build.props
@@ -72,7 +72,7 @@
     As such, this needs to be changed before a new release as well.
   -->
   <PropertyGroup>
-    <ComputeSharpPackageVersion>3.1.0</ComputeSharpPackageVersion>
+    <ComputeSharpPackageVersion>3.2.0</ComputeSharpPackageVersion>
     <IsCommitOnReleaseBranch>false</IsCommitOnReleaseBranch>
   </PropertyGroup>
 

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectFactory.Syntax.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.EffectFactory.Syntax.cs
@@ -1,0 +1,46 @@
+using ComputeSharp.D2D1.SourceGenerators.Models;
+using ComputeSharp.SourceGeneration.Extensions;
+using ComputeSharp.SourceGeneration.Helpers;
+
+namespace ComputeSharp.D2D1.SourceGenerators;
+
+/// <inheritdoc/>
+partial class D2DPixelShaderDescriptorGenerator
+{
+    /// <summary>
+    /// A helper with all logic to generate the <c>EffectFactory</c> property.
+    /// </summary>
+    private static class EffectFactory
+    {
+        /// <summary>
+        /// Writes the <c>EffectFactory</c> property.
+        /// </summary>
+        /// <param name="info">The input <see cref="D2D1ShaderInfo"/> instance with gathered shader info.</param>
+        /// <param name="writer">The <see cref="IndentedTextWriter"/> instance to write into.</param>
+        public static void WriteSyntax(D2D1ShaderInfo info, IndentedTextWriter writer)
+        {
+            writer.WriteLine("/// <inheritdoc/>");
+            writer.WriteGeneratedAttributes(GeneratorName);
+            writer.WriteLine($"static unsafe nint global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<{info.Hierarchy.Hierarchy[0].QualifiedName}>.EffectFactory");
+
+            using (writer.WriteBlock())
+            {
+                writer.WriteLine("[global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
+                writer.WriteLine("get");
+
+                using (writer.WriteBlock())
+                {
+                    writer.WriteLine($$"""
+                        [global::System.Runtime.InteropServices.UnmanagedCallersOnly(CallConvs = [typeof(global::System.Runtime.CompilerServices.CallConvStdcall)])]
+                        static int EffectFactory(void** effectImpl)
+                        {
+                            return global::ComputeSharp.D2D1.Interop.D2D1PixelShaderEffect.CreateEffectUnsafe<{{info.Hierarchy.Hierarchy[0].QualifiedName}}>(effectImpl);
+                        }
+
+                        return (nint)(delegate* unmanaged[Stdcall]<void**, int>)&EffectFactory;
+                        """, isMultiline: true);
+                }
+            }
+        }
+    }
+}

--- a/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/D2DPixelShaderDescriptorGenerator.cs
@@ -225,6 +225,7 @@ public sealed partial class D2DPixelShaderDescriptorGenerator : IIncrementalGene
             declaredMembers.Add(EffectMetadata.WriteEffectDescriptionSyntax);
             declaredMembers.Add(EffectMetadata.WriteEffectCategorySyntax);
             declaredMembers.Add(EffectMetadata.WriteEffectAuthorSyntax);
+            declaredMembers.Add(EffectFactory.WriteSyntax);
             declaredMembers.Add(NumericProperties.WriteConstantBufferSizeSyntax);
             declaredMembers.Add(NumericProperties.WriteInputCountSyntax);
             declaredMembers.Add(NumericProperties.WriteResourceTextureCountSyntax);

--- a/src/ComputeSharp.D2D1/Interfaces/Descriptors/ID2D1PixelShaderDescriptor{T}.cs
+++ b/src/ComputeSharp.D2D1/Interfaces/Descriptors/ID2D1PixelShaderDescriptor{T}.cs
@@ -53,6 +53,19 @@ public interface ID2D1PixelShaderDescriptor<T>
     static abstract string? EffectAuthor { get; }
 
     /// <summary>
+    /// Gets a pointer to the effect factory for the current shader.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This only applies to effects created from <see cref="D2D1PixelShaderEffect"/>.
+    /// </para>
+    /// <para>
+    /// The returned function pointer should have a signature matching <a href="https://learn.microsoft.com/windows/win32/api/d2d1_1/nc-d2d1_1-pd2d1_effect_factory"><c>PD2D1_EFFECT_FACTORY</c></a>.
+    /// </para>
+    /// </remarks>
+    static abstract nint EffectFactory { get; }
+
+    /// <summary>
     /// Gets the size in bytes of the constant buffer for the current shader.
     /// </summary>
     static abstract int ConstantBufferSize { get; }

--- a/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
+++ b/src/ComputeSharp.D2D1/Shaders/Interop/Effects/PixelShaderEffect.cs
@@ -103,7 +103,7 @@ internal unsafe partial struct PixelShaderEffect
     /// <param name="globals">The <see cref="Globals"/> instance to use.</param>
     /// <param name="effectImpl">The resulting effect instance.</param>
     /// <returns>The <see cref="HRESULT"/> for the operation.</returns>
-    private static int Factory(Globals globals, IUnknown** effectImpl)
+    public static int Factory(Globals globals, IUnknown** effectImpl)
     {
         PixelShaderEffect* @this = null;
         GCHandle globalsHandle = default;

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator.cs
@@ -106,6 +106,25 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                    static unsafe nint global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectFactory
+                    {
+                        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                        get
+                        {
+                            [global::System.Runtime.InteropServices.UnmanagedCallersOnly(CallConvs = [typeof(global::System.Runtime.CompilerServices.CallConvStdcall)])]
+                            static int EffectFactory(void** effectImpl)
+                            {
+                                return global::ComputeSharp.D2D1.Interop.D2D1PixelShaderEffect.CreateEffectUnsafe<MyShader>(effectImpl);
+                            }
+
+                            return (nint)(delegate* unmanaged[Stdcall]<void**, int>)&EffectFactory;
+                        }
+                    }
+
+                    /// <inheritdoc/>
+                    [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
+                    [global::System.Diagnostics.DebuggerNonUserCode]
+                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.ConstantBufferSize => 12;
 
                     /// <inheritdoc/>
@@ -401,6 +420,25 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string? global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectAuthor => null;
+
+                    /// <inheritdoc/>
+                    [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
+                    [global::System.Diagnostics.DebuggerNonUserCode]
+                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                    static unsafe nint global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectFactory
+                    {
+                        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                        get
+                        {
+                            [global::System.Runtime.InteropServices.UnmanagedCallersOnly(CallConvs = [typeof(global::System.Runtime.CompilerServices.CallConvStdcall)])]
+                            static int EffectFactory(void** effectImpl)
+                            {
+                                return global::ComputeSharp.D2D1.Interop.D2D1PixelShaderEffect.CreateEffectUnsafe<MyShader>(effectImpl);
+                            }
+
+                            return (nint)(delegate* unmanaged[Stdcall]<void**, int>)&EffectFactory;
+                        }
+                    }
 
                     /// <inheritdoc/>
                     [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
@@ -758,6 +796,25 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                    static unsafe nint global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectFactory
+                    {
+                        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                        get
+                        {
+                            [global::System.Runtime.InteropServices.UnmanagedCallersOnly(CallConvs = [typeof(global::System.Runtime.CompilerServices.CallConvStdcall)])]
+                            static int EffectFactory(void** effectImpl)
+                            {
+                                return global::ComputeSharp.D2D1.Interop.D2D1PixelShaderEffect.CreateEffectUnsafe<MyShader>(effectImpl);
+                            }
+
+                            return (nint)(delegate* unmanaged[Stdcall]<void**, int>)&EffectFactory;
+                        }
+                    }
+
+                    /// <inheritdoc/>
+                    [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
+                    [global::System.Diagnostics.DebuggerNonUserCode]
+                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.ConstantBufferSize => 12;
 
                     /// <inheritdoc/>
@@ -1051,6 +1108,25 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string? global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectAuthor => null;
+
+                    /// <inheritdoc/>
+                    [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
+                    [global::System.Diagnostics.DebuggerNonUserCode]
+                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                    static unsafe nint global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectFactory
+                    {
+                        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                        get
+                        {
+                            [global::System.Runtime.InteropServices.UnmanagedCallersOnly(CallConvs = [typeof(global::System.Runtime.CompilerServices.CallConvStdcall)])]
+                            static int EffectFactory(void** effectImpl)
+                            {
+                                return global::ComputeSharp.D2D1.Interop.D2D1PixelShaderEffect.CreateEffectUnsafe<MyShader>(effectImpl);
+                            }
+
+                            return (nint)(delegate* unmanaged[Stdcall]<void**, int>)&EffectFactory;
+                        }
+                    }
 
                     /// <inheritdoc/>
                     [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
@@ -1351,6 +1427,25 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                    static unsafe nint global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectFactory
+                    {
+                        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                        get
+                        {
+                            [global::System.Runtime.InteropServices.UnmanagedCallersOnly(CallConvs = [typeof(global::System.Runtime.CompilerServices.CallConvStdcall)])]
+                            static int EffectFactory(void** effectImpl)
+                            {
+                                return global::ComputeSharp.D2D1.Interop.D2D1PixelShaderEffect.CreateEffectUnsafe<MyShader>(effectImpl);
+                            }
+
+                            return (nint)(delegate* unmanaged[Stdcall]<void**, int>)&EffectFactory;
+                        }
+                    }
+
+                    /// <inheritdoc/>
+                    [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
+                    [global::System.Diagnostics.DebuggerNonUserCode]
+                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static int global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.ConstantBufferSize => 0;
 
                     /// <inheritdoc/>
@@ -1629,6 +1724,25 @@ public class Test_D2DPixelShaderDescriptorGenerator
                     [global::System.Diagnostics.DebuggerNonUserCode]
                     [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
                     static string? global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectAuthor => null;
+
+                    /// <inheritdoc/>
+                    [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]
+                    [global::System.Diagnostics.DebuggerNonUserCode]
+                    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+                    static unsafe nint global::ComputeSharp.D2D1.Descriptors.ID2D1PixelShaderDescriptor<MyShader>.EffectFactory
+                    {
+                        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+                        get
+                        {
+                            [global::System.Runtime.InteropServices.UnmanagedCallersOnly(CallConvs = [typeof(global::System.Runtime.CompilerServices.CallConvStdcall)])]
+                            static int EffectFactory(void** effectImpl)
+                            {
+                                return global::ComputeSharp.D2D1.Interop.D2D1PixelShaderEffect.CreateEffectUnsafe<MyShader>(effectImpl);
+                            }
+
+                            return (nint)(delegate* unmanaged[Stdcall]<void**, int>)&EffectFactory;
+                        }
+                    }
 
                     /// <inheritdoc/>
                     [global::System.CodeDom.Compiler.GeneratedCode("ComputeSharp.D2D1.D2DPixelShaderDescriptorGenerator", <ASSEMBLY_VERSION>)]

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/Test_D2DPixelShaderDescriptorGenerator_Analyzers.cs
@@ -69,6 +69,8 @@ public class Test_D2DPixelShaderDescriptorGenerator_Analyzers
 
                 public static string? EffectAuthor => throw new NotImplementedException();
 
+                public static nint EffectFactory => throw new NotImplementedException();
+
                 public static int ConstantBufferSize => throw new NotImplementedException();
 
                 public static int InputCount => throw new NotImplementedException();


### PR DESCRIPTION
### Description

The ComputeSharp.D2D1 infrastructure is currently relying on `Marshal.GetFunctionPointerForDelegate` to marshal a wrapper object for a given `T` in a non-generic way, such that the internal `ID2D1EffectImpl` object can call the methods on it. This works, but it's not efficient, and also means you cannot use ComputeSharp in heavily constrained/sandboxed environments, where `Marshal.GetFunctionPointerForDelegate` is not allowed (as it requires the runtime to allocate a thunk of executable memory at runtime). This PR addresses both problems having the generator emit a non-generic native factory instead.