### PR TITLE
Parenthesize coordinate arguments for D2D input sampling intrinsics

### DIFF
--- a/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
+++ b/src/ComputeSharp.D2D1.SourceGenerators/Mappings/HlslKnownMethods.cs
@@ -21,6 +21,22 @@ partial class HlslKnownMethods
         return name is "ComputeSharp.D2D1.D2D.GetScenePosition" or "ComputeSharp.D2D1.D2D.SampleInputAtPosition";
     }
 
+    /// <summary>
+    /// Checks whether or not a method name (previous matched with <see cref="TryGetMappedName(string, out string?)"/>)
+    /// maps to a function-like macro from <c>d2d1effecthelpers.hlsli</c> that requires its coordinate argument (ie. the
+    /// second argument) to be parenthesized. This is needed because those macros paste their arguments into expressions
+    /// without parenthesizing them, which would otherwise break the expression semantics with compound arguments.
+    /// </summary>
+    /// <param name="name">The fully qualified metadata name.</param>
+    /// <returns>Whether the method needs its coordinate argument to be parenthesized.</returns>
+    public static bool NeedsParenthesizedCoordinateArgument(string name)
+    {
+        return name is
+            "ComputeSharp.D2D1.D2D.SampleInput" or
+            "ComputeSharp.D2D1.D2D.SampleInputAtOffset" or
+            "ComputeSharp.D2D1.D2D.SampleInputAtPosition";
+    }
+
     /// <inheritdoc/>
     private static partial Dictionary<string, string?> BuildKnownResourceSamplers()
     {

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/ShaderSourceRewriter.cs
@@ -543,6 +543,20 @@ internal sealed partial class ShaderSourceRewriter(
                         return namedIntrinsic;
                     }
 
+#if !D3D12_SOURCE_GENERATOR
+                    // Special case: handle D2D intrinsics that map to function-like macros sampling an input
+                    // texture (eg. 'D2D.SampleInputAtOffset'). These macros paste their coordinate argument
+                    // into an expression without parenthesizing it, so the argument is wrapped in parentheses
+                    // to preserve the original expression semantics (eg. with compound expression arguments).
+                    // See https://github.com/Sergio0694/ComputeSharp/issues/929 for more info.
+                    if (HlslKnownMethods.NeedsParenthesizedCoordinateArgument(metadataName))
+                    {
+                        ExpressionSyntax coordinateExpression = updatedNode.ArgumentList.Arguments[1].Expression;
+
+                        updatedNode = updatedNode.ReplaceNode(coordinateExpression, ParenthesizedExpression(coordinateExpression));
+                    }
+#endif
+
                     return updatedNode.WithExpression(IdentifierName(mapping!));
                 }
 

--- a/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/StaticFieldRewriter.cs
+++ b/src/ComputeSharp.SourceGeneration.Hlsl/SyntaxRewriters/StaticFieldRewriter.cs
@@ -114,6 +114,16 @@ internal sealed partial class StaticFieldRewriter(
                     return namedIntrinsic;
                 }
 
+#if !D3D12_SOURCE_GENERATOR
+                // Parenthesize the coordinate argument for D2D input sampling intrinsics (see ShaderSourceRewriter for more info)
+                if (HlslKnownMethods.NeedsParenthesizedCoordinateArgument(method.GetFullyQualifiedMetadataName()))
+                {
+                    ExpressionSyntax coordinateExpression = updatedNode.ArgumentList.Arguments[1].Expression;
+
+                    updatedNode = updatedNode.ReplaceNode(coordinateExpression, ParenthesizedExpression(coordinateExpression));
+                }
+#endif
+
                 return updatedNode.WithExpression(IdentifierName(mapping!));
             }
         }

--- a/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/D2D1ReflectionServicesTests.cs
@@ -40,7 +40,7 @@ public partial class D2D1ReflectionServicesTests
                 int2 xy = (int2)D2DGetScenePosition().xy;
                 float4 input0 = D2DGetInput(0);
                 float4 input1 = D2DGetInput(1);
-                float4 input2 = D2DSampleInputAtPosition(2, xy + offset);
+                float4 input2 = D2DSampleInputAtPosition(2, (xy + offset));
                 float value3 = __reserved__buffer[0];
                 float4 value4 = __reserved__texture.Sample(__sampler____reserved__texture, float2(0, asfloat(1056964608U)));
                 return input0 + input1 + input2 + value3 + value4;

--- a/tests/ComputeSharp.D2D1.Tests/ShaderRewriterTests.cs
+++ b/tests/ComputeSharp.D2D1.Tests/ShaderRewriterTests.cs
@@ -237,4 +237,51 @@ public partial class ShaderRewriterTests
             return default;
         }
     }
+
+    // See https://github.com/Sergio0694/ComputeSharp/issues/929
+    [TestMethod]
+    public void D2DSampleInputIntrinsics_WithCompoundExpressions_AreRewrittenCorrectly()
+    {
+        D2D1ShaderInfo shaderInfo = D2D1ReflectionServices.GetShaderInfo<D2DSampleInputIntrinsicsWithCompoundExpressionsShader>();
+
+        Assert.AreEqual("""
+            #define D2D_INPUT_COUNT 1
+            #define D2D_INPUT0_COMPLEX
+            #define D2D_REQUIRES_SCENE_POSITION
+
+            #include "d2d1effecthelpers.hlsli"
+
+            float2 samplePosition;
+
+            D2D_PS_ENTRY(Execute)
+            {
+                float2 scenePosition = D2DGetScenePosition().xy;
+                float4 uv = D2DGetInputCoordinate(0);
+                float4 a = D2DSampleInput(0, (uv.xy + samplePosition));
+                float4 b = D2DSampleInputAtOffset(0, (samplePosition - scenePosition));
+                float4 c = D2DSampleInputAtPosition(0, (samplePosition - scenePosition));
+                return a + b + c;
+            }
+            """, shaderInfo.HlslSource);
+    }
+
+    [D2DInputCount(1)]
+    [D2DInputComplex(0)]
+    [D2DRequiresScenePosition]
+    [D2DShaderProfile(D2D1ShaderProfile.PixelShader50)]
+    [D2DGeneratedPixelShaderDescriptor]
+    internal readonly partial struct D2DSampleInputIntrinsicsWithCompoundExpressionsShader(float2 samplePosition) : ID2D1PixelShader
+    {
+        public float4 Execute()
+        {
+            float2 scenePosition = D2D.GetScenePosition().XY;
+            float4 uv = D2D.GetInputCoordinate(0);
+
+            float4 a = D2D.SampleInput(0, uv.XY + samplePosition);
+            float4 b = D2D.SampleInputAtOffset(0, samplePosition - scenePosition);
+            float4 c = D2D.SampleInputAtPosition(0, samplePosition - scenePosition);
+
+            return a + b + c;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #929

The `D2DSampleInput`, `D2DSampleInputAtOffset` and `D2DSampleInputAtPosition` macros in `d2d1effecthelpers.hlsli` paste their coordinate argument into an expression without parenthesizing it. When the C# argument is a compound expression, operator precedence tears it apart after macro expansion — the shader compiles cleanly but samples wrong coordinates. For example:

```csharp
float4 color = D2D.SampleInputAtOffset(0, samplePosition - scenePosition);
```

expanded to:

```hlsl
InputTexture0.Sample(InputSampler0, __d2dstatic_uv0.xy + samplePosition - scenePosition * __d2dstatic_uv0.zw)
```

where only `scenePosition` gets scaled by the texel size, instead of the whole difference.

## Changes

- The source generator now always wraps the coordinate argument (ie. the second argument) in parentheses when lowering `D2D.SampleInput`, `D2D.SampleInputAtOffset` and `D2D.SampleInputAtPosition`, so the emitted HLSL is eg. `D2DSampleInputAtOffset(0, (samplePosition - scenePosition))`. The input index argument is left untouched, as the macros rely on token pasting for it (`InputTexture##index`).
- The fix is deliberately in the generator rather than in the embedded `d2d1effecthelpers.hlsli` copy, which stays byte-for-byte identical to the Windows SDK header (and remains safe to refresh from future SDK versions). `D2D.SampleInput` is included as well even though its macro is currently safe, so the emitted code doesn't depend on macro hygiene in any given header version.
- The new logic is guarded with `#if !D3D12_SOURCE_GENERATOR`, so the DX12 generator is unaffected.

## Tests

- New regression test in `ShaderRewriterTests` covering compound expression arguments for all three sampling intrinsics (including the exact repro from #929).
- Updated the one affected HLSL snapshot in `D2D1ReflectionServicesTests`.
- All D2D1 runtime tests (including the end-to-end image comparison tests for `BokehBlurEffect`/`PixelateEffect`, which exercise these intrinsics on the GPU), D2D1 source generator tests, and DX12 source generator tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)