### PR TITLE
Centralize NuGet package versions

### DIFF
--- a/ComputeSharp.slnx
+++ b/ComputeSharp.slnx
@@ -107,6 +107,7 @@
     <File Path=".globalconfig" />
     <File Path="build/Directory.Build.props" />
     <File Path="build/Directory.Build.targets" />
+    <File Path="Directory.Packages.props" />
     <File Path="global.json" />
     <File Path="LICENSE" />
     <File Path="README.md" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,39 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="AutoConstructor" Version="5.6.0" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.11" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
+    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageVersion Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250402" />
+    <PackageVersion Include="CommunityToolkit.Uwp.Media" Version="8.2.250402" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.3.260402-preview2" />
+    <PackageVersion Include="CommunityToolkit.WinUI.Media" Version="8.3.260402-preview2" />
+    <PackageVersion Include="ComputeSharp" Version="$(PackageVersion)" />
+    <PackageVersion Include="ComputeSharp.Core" Version="$(PackageVersion)" />
+    <PackageVersion Include="ComputeSharp.Dxc" Version="$(PackageVersion)" />
+    <PackageVersion Include="ComputeSharp.Pix" Version="$(PackageVersion)" />
+    <PackageVersion Include="FSharp.Core" Version="9.0.202" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3179.45" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.333" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.1.6" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.WinUI" Version="2.3.6" />
+    <PackageVersion Include="MSTest" Version="3.8.3" />
+    <PackageVersion Include="PublishAotCompressed" Version="1.0.2" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageVersion Include="TerraFX.Interop.D3D12MemoryAllocator" Version="2.0.1.5" />
+    <PackageVersion Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
+    <PackageVersion Include="Win2D.uwp" Version="1.28.3" />
+  </ItemGroup>
+</Project>

--- a/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
+++ b/samples/ComputeSharp.Benchmark/ComputeSharp.Benchmark.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
+++ b/samples/ComputeSharp.ImageProcessing/ComputeSharp.ImageProcessing.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
+    <PackageReference Include="SixLabors.ImageSharp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
+++ b/samples/ComputeSharp.Sample.FSharp/ComputeSharp.Sample.FSharp.fsproj
@@ -4,10 +4,11 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="9.0.202" />
+    <PackageReference Include="FSharp.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.Cli/ComputeSharp.SwapChain.Cli.csproj
@@ -47,7 +47,7 @@
 
   <!-- If requested, also reference the UPX compression package -->
   <ItemGroup Condition="'$(PUBLISH_AOT_COMPRESSED)' == 'true'">
-    <PackageReference Include="PublishAotCompressed" Version="1.0.2" />
+    <PackageReference Include="PublishAotCompressed" />
   </ItemGroup>
 
   <ItemGroup>
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
+    <PackageReference Include="TerraFX.Interop.Windows" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
+++ b/samples/ComputeSharp.SwapChain.D2D1.Cli/ComputeSharp.SwapChain.D2D1.Cli.csproj
@@ -57,7 +57,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
+    <PackageReference Include="TerraFX.Interop.Windows" />
   </ItemGroup>
 
   <!-- Note: using SetPlatform="Platform=AnyCPU" for the analyzers to avoid issues (see https://github.com/dotnet/roslyn/issues/70148) -->

--- a/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
+++ b/samples/ComputeSharp.SwapChain.Uwp/ComputeSharp.SwapChain.Uwp.csproj
@@ -29,12 +29,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" Version="8.2.250402" />
-    <PackageReference Include="CommunityToolkit.Uwp.Media" Version="8.2.250402" />
+    <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="CommunityToolkit.Uwp.Controls.Primitives" />
+    <PackageReference Include="CommunityToolkit.Uwp.Media" />
 
     <!-- Remove all WebView2 assets (transitive from WinUI 2), since we don't need it at all -->
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3179.45" IncludeAssets="none" />
+    <PackageReference Include="Microsoft.Web.WebView2" IncludeAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
+++ b/samples/ComputeSharp.SwapChain.WinUI/ComputeSharp.SwapChain.WinUI.csproj
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" Version="8.3.260402-preview2" />
-    <PackageReference Include="CommunityToolkit.WinUI.Media" Version="8.3.260402-preview2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" />
+    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" />
+    <PackageReference Include="CommunityToolkit.WinUI.Media" />
 
     <!--
       This app is packaged and uses the framework dependent deployment model, so it needs the Windows App SDK
@@ -40,8 +40,8 @@
       a newer 'Microsoft.WindowsAppSDK.InteractiveExperiences' than the one 'Microsoft.WindowsAppSDK.WinUI' pulls
       in. Reference it explicitly to line the two up, which is also what the aggregate package resolves to.
     -->
-    <PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.1.6" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.Runtime" Version="2.4.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.Runtime" />
   </ItemGroup>
 
   <!-- 

--- a/samples/ComputeSharp.SwapChain/ComputeSharp.SwapChain.csproj
+++ b/samples/ComputeSharp.SwapChain/ComputeSharp.SwapChain.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
+    <PackageReference Include="TerraFX.Interop.Windows" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.CodeFixers/ComputeSharp.CodeFixers.csproj
+++ b/src/ComputeSharp.CodeFixers/ComputeSharp.CodeFixers.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.Core.SourceGenerators/ComputeSharp.Core.SourceGenerators.csproj
+++ b/src/ComputeSharp.Core.SourceGenerators/ComputeSharp.Core.SourceGenerators.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.CodeFixers/ComputeSharp.D2D1.CodeFixers.csproj
+++ b/src/ComputeSharp.D2D1.CodeFixers/ComputeSharp.D2D1.CodeFixers.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.SourceGenerators/ComputeSharp.D2D1.SourceGenerators.csproj
@@ -82,8 +82,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" Pack="false" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.333" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.Uwp.CodeFixers/ComputeSharp.D2D1.Uwp.CodeFixers.csproj
+++ b/src/ComputeSharp.D2D1.Uwp.CodeFixers/ComputeSharp.D2D1.Uwp.CodeFixers.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.Uwp.SourceGenerators/ComputeSharp.D2D1.Uwp.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.Uwp.SourceGenerators/ComputeSharp.D2D1.Uwp.SourceGenerators.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
+++ b/src/ComputeSharp.D2D1.Uwp/ComputeSharp.D2D1.Uwp.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Win2D.uwp" Version="1.28.3" />
+    <PackageReference Include="Win2D.uwp" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.WinUI.CodeFixers/ComputeSharp.D2D1.WinUI.CodeFixers.csproj
+++ b/src/ComputeSharp.D2D1.WinUI.CodeFixers/ComputeSharp.D2D1.WinUI.CodeFixers.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.WinUI.SourceGenerators/ComputeSharp.D2D1.WinUI.SourceGenerators.csproj
+++ b/src/ComputeSharp.D2D1.WinUI.SourceGenerators/ComputeSharp.D2D1.WinUI.SourceGenerators.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Pack="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
+++ b/src/ComputeSharp.D2D1.WinUI/ComputeSharp.D2D1.WinUI.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.D3D12MemoryAllocator/ComputeSharp.D3D12MemoryAllocator.csproj
+++ b/src/ComputeSharp.D3D12MemoryAllocator/ComputeSharp.D3D12MemoryAllocator.csproj
@@ -9,6 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="TerraFX.Interop.D3D12MemoryAllocator" Version="2.0.1.5" />
+    <PackageReference Include="TerraFX.Interop.D3D12MemoryAllocator" />
   </ItemGroup>
 </Project>

--- a/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
+++ b/src/ComputeSharp.SourceGenerators/ComputeSharp.SourceGenerators.csproj
@@ -66,8 +66,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" Pack="false" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.333" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
+++ b/src/ComputeSharp.WinUI/ComputeSharp.WinUI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="2.3.6" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes/ComputeSharp.D2D1.Tests.AssemblyLevelAttributes.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="3.8.3" />
+    <PackageReference Include="MSTest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.Tests.SourceGenerators/ComputeSharp.D2D1.Tests.SourceGenerators.csproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.11" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net100" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.Tests/ComputeSharp.D2D1.Tests.csproj
@@ -8,10 +8,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
+    <PackageReference Include="AutoConstructor" PrivateAssets="all" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="TerraFX.Interop.Windows" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators/ComputeSharp.D2D1.WinUI.Tests.SourceGenerators.csproj
@@ -11,11 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.11" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net100" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
+++ b/tests/ComputeSharp.D2D1.WinUI.Tests/ComputeSharp.D2D1.WinUI.Tests.csproj
@@ -56,10 +56,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" ExcludeAssets="build" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
+    <PackageReference Include="AutoConstructor" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" ExcludeAssets="build" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="TerraFX.Interop.Windows" />
 
     <!--
       Same as in 'ComputeSharp.SwapChain.WinUI': this test app is packaged and framework dependent, so it needs
@@ -67,9 +67,9 @@
       WinUI packages itself (it only gets Win2D through 'ComputeSharp.D2D1.WinUI'), so the components the runtime
       package expects are referenced explicitly here as well.
     -->
-    <PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" Version="2.1.6" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.Runtime" Version="2.4.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" Version="2.3.6" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.InteractiveExperiences" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.Runtime" />
+    <PackageReference Include="Microsoft.WindowsAppSDK.WinUI" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/tests/ComputeSharp.Dxc.NuGet/ComputeSharp.Dxc.NuGet.csproj
+++ b/tests/ComputeSharp.Dxc.NuGet/ComputeSharp.Dxc.NuGet.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ComputeSharp.Core" Version="$(PackageVersion)" />
-    <PackageReference Include="ComputeSharp" Version="$(PackageVersion)" />
-    <PackageReference Include="ComputeSharp.Dxc" Version="$(PackageVersion)" />
+    <PackageReference Include="ComputeSharp.Core" />
+    <PackageReference Include="ComputeSharp" />
+    <PackageReference Include="ComputeSharp.Dxc" />
   </ItemGroup>
 </Project>

--- a/tests/ComputeSharp.NuGet/ComputeSharp.NuGet.csproj
+++ b/tests/ComputeSharp.NuGet/ComputeSharp.NuGet.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ComputeSharp.Core" Version="$(PackageVersion)" />
-    <PackageReference Include="ComputeSharp" Version="$(PackageVersion)" />
+    <PackageReference Include="ComputeSharp.Core" />
+    <PackageReference Include="ComputeSharp" />
   </ItemGroup>
 </Project>

--- a/tests/ComputeSharp.Pix.NuGet/ComputeSharp.Pix.NuGet.csproj
+++ b/tests/ComputeSharp.Pix.NuGet/ComputeSharp.Pix.NuGet.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ComputeSharp.Core" Version="$(PackageVersion)" />
-    <PackageReference Include="ComputeSharp" Version="$(PackageVersion)" />
-    <PackageReference Include="ComputeSharp.Pix" Version="$(PackageVersion)" />
+    <PackageReference Include="ComputeSharp.Core" />
+    <PackageReference Include="ComputeSharp" />
+    <PackageReference Include="ComputeSharp.Pix" />
   </ItemGroup>
 </Project>

--- a/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
+++ b/tests/ComputeSharp.Tests.DeviceLost/ComputeSharp.Tests.DeviceLost.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
+    <PackageReference Include="AutoConstructor" PrivateAssets="all" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="TerraFX.Interop.Windows" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
+++ b/tests/ComputeSharp.Tests.DisableDynamicCompilation/ComputeSharp.Tests.DisableDynamicCompilation.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
+    <PackageReference Include="AutoConstructor" PrivateAssets="all" />
+    <PackageReference Include="MSTest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
+++ b/tests/ComputeSharp.Tests.Internals/ComputeSharp.Tests.Internals.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
+    <PackageReference Include="AutoConstructor" PrivateAssets="all" />
+    <PackageReference Include="MSTest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
+++ b/tests/ComputeSharp.Tests.NativeLibrariesResolver/ComputeSharp.Tests.NativeLibrariesResolver.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="3.8.3" />
+    <PackageReference Include="MSTest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
+++ b/tests/ComputeSharp.Tests.SourceGenerators/ComputeSharp.Tests.SourceGenerators.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Basic.Reference.Assemblies.Net100" Version="1.8.11" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
+    <PackageReference Include="Basic.Reference.Assemblies.Net100" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="MSTest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
+++ b/tests/ComputeSharp.Tests/ComputeSharp.Tests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoConstructor" Version="5.6.0" PrivateAssets="all" />
-    <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
-    <PackageReference Include="MSTest" Version="3.8.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageReference Include="TerraFX.Interop.Windows" Version="10.0.26100.2" />
+    <PackageReference Include="AutoConstructor" PrivateAssets="all" />
+    <PackageReference Include="CommunityToolkit.HighPerformance" />
+    <PackageReference Include="MSTest" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="TerraFX.Interop.Windows" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description

Migrates repository package references to NuGet Central Package Management.

- Adds a root `Directory.Packages.props` with authoritative versions for all CPM-owned packages.
- Preserves package metadata, conditions, dynamic local-package versions, and the resolved dependency graph.
- Converts the F# SDK's implicit `FSharp.Core` reference to an explicit centrally versioned reference.
- Keeps `Microsoft.Windows.CsWinRT` inline because NuGet requires implicit package versions on the `PackageReference` itself.
- Adds the central package file to the solution items.

### Additional context

This work was originally stacked on #934, which has now merged. The PR therefore targets `main` directly.

The installed .NET SDK does not provide a supported CPM migration command, so the migration was performed surgically after auditing all tracked MSBuild project, props, and targets inputs.